### PR TITLE
Improve Package Management to handle reference assemblies

### DIFF
--- a/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
+++ b/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
@@ -753,7 +753,7 @@ using XPlot.Plotly;");
             var events = kernel.KernelEvents.ToSubscribedList();
 
             await kernel.SubmitCodeAsync(@"
-#r ""nuget:System.Text.Json""
+#r ""nuget:System.Text.Json, 4.6.0""
 using System.Text.Json;
 ");
             // It should work, no errors and the requested package should be added
@@ -803,6 +803,49 @@ using System.Text.Json;
 
             events.Should()
                   .ContainSingle<DisplayedValueUpdated>(e => e.Value.Equals("Installed package Its.Log version 2.10.1"));
+        }
+
+
+        [Theory(Timeout = 45000)]
+        [InlineData(Language.CSharp)]
+        // [InlineData(Language.FSharp)]    TODO -- Uncomment when FSharp is inserted
+        public async Task it_can_load_assembly_referenced_from_refs_folder_in_nugetpackage(Language language)
+        {
+            var kernel = CreateKernel(language);
+
+            var source = language switch
+            {
+                Language.FSharp => @"
+#r ""nuget:Microsoft.ML.OnnxTransformer,1.4.0""
+
+open System
+open System.Numerics.Tensors
+let inputValues = [| 12.0; 10.0; 17.0; 5.0 |]
+let tInput = new DenseTensor<float>(inputValues.AsMemory(), new ReadOnlySpan<int>([|4|]))
+tInput.Length
+",
+                Language.CSharp => @"
+#r ""nuget:Microsoft.ML.OnnxTransformer,1.4.0""
+
+using System;
+using System.Numerics.Tensors;
+var inputValues = new[] { 12f, 10f, 17f, 5f };
+var tInput = new DenseTensor<float>(inputValues.AsMemory(), new ReadOnlySpan<int>(new[] { 4 }));
+tInput.Length"
+            };
+
+            await SubmitCode(kernel, source);
+
+            KernelEvents
+                .Should()
+                .ContainSingle(e => e is ReturnValueProduced);
+
+            KernelEvents
+                .OfType<ReturnValueProduced>()
+                .Single()
+                .Value
+                .Should()
+                .Be(4);
         }
     }
 }

--- a/Microsoft.DotNet.Interactive/PackageRestoreContext.cs
+++ b/Microsoft.DotNet.Interactive/PackageRestoreContext.cs
@@ -242,30 +242,60 @@ namespace s
             }
 
             string Targets() => @"
-  <Target Name='ComputePackageRoots'
-          BeforeTargets='CoreCompile;WriteNugetAssemblyPaths'
-          DependsOnTargets='CollectPackageReferences'>
+  <Target Name=""ComputePackageRootsForInteractivePackageManagement""
+          DependsOnTargets=""ResolveReferences;ResolveSdkReferences;ResolveTargetingPackAssets;ResolveSDKReferences;GenerateBuildDependencyFile"">
+
       <ItemGroup>
-        <ResolvedFile Include='@(ResolvedCompileFileDefinitions)'>
-           <PackageRootProperty>Pkg$([System.String]::Copy('%(ResolvedCompileFileDefinitions.NugetPackageId)').Replace('.','_'))</PackageRootProperty>
-           <PackageRoot>$(%(ResolvedFile.PackageRootProperty))</PackageRoot>
-           <InitializeSourcePath>$(%(ResolvedFile.PackageRootProperty))\content\%(ResolvedCompileFileDefinitions.FileName)%(ResolvedCompileFileDefinitions.Extension).fsx</InitializeSourcePath>
-        </ResolvedFile>
+        <__InteractiveReferencedAssemblies Include = ""@(ReferencePath)"" />
+        <__InteractiveReferencedAssembliesCopyLocal Include = ""@(RuntimeCopyLocalItems)"" Condition=""'$(TargetFrameworkIdentifier)'!='.NETFramework'"" />
+        <__InteractiveReferencedAssembliesCopyLocal Include = ""@(ReferenceCopyLocalPaths)"" Condition=""'$(TargetFrameworkIdentifier)'=='.NETFramework'"" />
+        <__ConflictsList Include=""%(_ConflictPackageFiles.ConflictItemType)=%(_ConflictPackageFiles.Filename)%(_ConflictPackageFiles.Extension)"" />
+      </ItemGroup>
+      <PropertyGroup>
+        <__Conflicts>@(__ConflictsList, ';')</__Conflicts>
+      </PropertyGroup>
+
+      <ItemGroup>
+        <InteractiveResolvedFile Include=""@(__InteractiveReferencedAssemblies)""
+                                 Condition=""$([System.String]::new($(__Conflicts)).Contains($([System.String]::new('Reference=%(__InteractiveReferencedAssemblies.Filename)%(__InteractiveReferencedAssemblies.Extension)'))))""
+                                 KeepDuplicates=""false"">
+            <NormalizedIdentity Condition=""'%(Identity)'!=''"">$([System.String]::Copy('%(Identity)').Replace('\', '/'))</NormalizedIdentity>
+            <NormalizedPathInPackage Condition=""'%(__InteractiveReferencedAssemblies.PathInPackage)'!=''"">$([System.String]::Copy('%(__InteractiveReferencedAssemblies.PathInPackage)').Replace('\', '/'))</NormalizedPathInPackage>
+            <PositionPathInPackage Condition=""'%(InteractiveResolvedFile.NormalizedPathInPackage)'!=''"">$([System.String]::Copy('%(InteractiveResolvedFile.NormalizedIdentity)').IndexOf('%(InteractiveResolvedFile.NormalizedPathInPackage)'))</PositionPathInPackage>
+            <PackageRoot Condition=""'%(InteractiveResolvedFile.NormalizedPathInPackage)'!='' and '%(InteractiveResolvedFile.PositionPathInPackage)'!='-1'"">$([System.String]::Copy('%(InteractiveResolvedFile.NormalizedIdentity)').Substring(0, %(InteractiveResolvedFile.PositionPathInPackage)))</PackageRoot>
+            <InitializeSourcePath>%(InteractiveResolvedFile.PackageRoot)content\%(__InteractiveReferencedAssemblies.FileName)%(__InteractiveReferencedAssemblies.Extension).fsx</InitializeSourcePath>
+            <IsNotImplementationReference>$([System.String]::Copy('%(__InteractiveReferencedAssemblies.PathInPackage)').StartsWith('ref/'))</IsNotImplementationReference>
+            <NuGetPackageId>%(__InteractiveReferencedAssemblies.NuGetPackageId)</NuGetPackageId>
+            <NuGetPackageVersion>%(__InteractiveReferencedAssemblies.NuGetPackageVersion)</NuGetPackageVersion>
+        </InteractiveResolvedFile>
+
+        <InteractiveResolvedFile Include=""@(__InteractiveReferencedAssembliesCopyLocal)"" KeepDuplicates=""false"">
+            <NormalizedIdentity Condition=""'%(Identity)'!=''"">$([System.String]::Copy('%(Identity)').Replace('\', '/'))</NormalizedIdentity>
+            <NormalizedPathInPackage Condition=""'%(__InteractiveReferencedAssembliesCopyLocal.PathInPackage)'!=''"">$([System.String]::Copy('%(__InteractiveReferencedAssembliesCopyLocal.PathInPackage)').Replace('\', '/'))</NormalizedPathInPackage>
+            <PositionPathInPackage Condition=""'%(InteractiveResolvedFile.NormalizedPathInPackage)'!=''"">$([System.String]::Copy('%(InteractiveResolvedFile.NormalizedIdentity)').IndexOf('%(InteractiveResolvedFile.NormalizedPathInPackage)'))</PositionPathInPackage>
+            <PackageRoot Condition=""'%(InteractiveResolvedFile.NormalizedPathInPackage)'!='' and '%(InteractiveResolvedFile.PositionPathInPackage)'!='-1'"">$([System.String]::Copy('%(InteractiveResolvedFile.NormalizedIdentity)').Substring(0, %(InteractiveResolvedFile.PositionPathInPackage)))</PackageRoot>
+            <InitializeSourcePath>%(InteractiveResolvedFile.PackageRoot)content\%(__InteractiveReferencedAssembliesCopyLocal.FileName)%(__InteractiveReferencedAssembliesCopyLocal.Extension).fsx</InitializeSourcePath>
+            <IsNotImplementationReference>$([System.String]::Copy('%(__InteractiveReferencedAssembliesCopyLocal.PathInPackage)').StartsWith('ref/'))</IsNotImplementationReference>
+            <NuGetPackageId>%(__InteractiveReferencedAssembliesCopyLocal.NuGetPackageId)</NuGetPackageId>
+            <NuGetPackageVersion>%(__InteractiveReferencedAssembliesCopyLocal.NuGetPackageVersion)</NuGetPackageVersion>
+        </InteractiveResolvedFile>
+
         <NativeIncludeRoots
-            Include='@(RuntimeTargetsCopyLocalItems)'
+            Include=""@(RuntimeTargetsCopyLocalItems)""
             Condition=""'%(RuntimeTargetsCopyLocalItems.AssetType)' == 'native'"">
-           <Path>$([System.String]::Copy('%(FullPath)').Substring(0, $([System.String]::Copy('%(FullPath)').LastIndexOf('runtimes'))))</Path>
+            <Path>$([MSBuild]::EnsureTrailingSlash('$([System.String]::Copy('%(FullPath)').Substring(0, $([System.String]::Copy('%(FullPath)').LastIndexOf('runtimes'))))'))</Path>
         </NativeIncludeRoots>
       </ItemGroup>
   </Target>
 
   <Target Name='WriteNugetAssemblyPaths' 
-          DependsOnTargets='ResolvePackageAssets; ResolveReferences; ProcessFrameworkReferences' 
-          AfterTargets='PrepareForBuild'>
+          DependsOnTargets=""ComputePackageRootsForInteractivePackageManagement""
+          BeforeTargets=""CoreCompile""
+          AfterTargets=""PrepareForBuild"">
 
     <ItemGroup>
       <ResolvedReferenceLines Remove='*' />
-      <ResolvedReferenceLines Include='%(ReferencePath.NugetPackageId),%(ReferencePath.NugetPackageVersion),%(ReferencePath.OriginalItemSpec),%(NativeIncludeRoots.Path),$(AppHostRuntimeIdentifier)' />
+      <ResolvedReferenceLines Include='%(InteractiveResolvedFile.NugetPackageId),%(InteractiveResolvedFile.NugetPackageVersion),%(InteractiveResolvedFile.Identity),%(NativeIncludeRoots.Path),$(AppHostRuntimeIdentifier)' />
     </ItemGroup>
 
     <WriteLinesToFile Lines='@(ResolvedReferenceLines)' 


### PR DESCRIPTION
This is the interactive version of this pr: https://github.com/dotnet/try/pull/762

1, Clean up generated project a bit
2. New way of computing package root - collect roots for dependent packages
3. Handle references to reference assemblies.
4. Does a better job of handling Framework assembly references