### PR TITLE
publish packages via arcade

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,8 +5,6 @@
   <Import Project="eng\targets\NuGet.targets" />
 
   <PropertyGroup>
-    <!-- Always use shipping version instead of dummy version -->
-    <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
     <!-- private repo, don't do source-link -->
     <DeterministicSourcePaths>false</DeterministicSourcePaths>
     <EnableSourceLink>false</EnableSourceLink>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -20,6 +20,4 @@
     <PackageReference Update="FSharp.Compiler.Service" Version="31.0.0" />
   </ItemGroup>
 
-  <Import Project="eng\targets\Versions.targets" Condition="'$(UseStableVersion)' == 'true'" />
-
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ variables:
   - name: _BuildConfig
     value: Release
   - name: _PublishUsingPipelines
-    value: false
+    value: true
   - name: _DotNetArtifactsCategory
     value: .NETCore
   - name: DotNetSdkVersion
@@ -29,7 +29,7 @@ stages:
       enableMicrobuild: true
       enablePublishBuildArtifacts: true
       enablePublishTestResults: true
-      enablePublishBuildAssets: false
+      enablePublishBuildAssets: true
       enablePublishUsingPipelines: $(_PublishUsingPipelines)
       enableTelemetry: true
       helixRepo: dotnet/interactive
@@ -44,21 +44,27 @@ stages:
         variables:
         # Enable signing for internal, non-PR builds
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+          - group: DotNet-Blob-Feed
           - group: DotNet-Symbol-Server-Pats
           - name: _SignType
             value: Real
+          - name: _DotNetPublishToBlobFeed
+            value: true
           - name: _BuildArgs
             value: /p:SignType=$(_SignType)
                    /p:DotNetSignType=$(_SignType)
                    /p:MicroBuild_SigningEnabled=true
                    /p:OverridePackageSource=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
                    /p:TeamName=$(_TeamName)
+                   /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
+                   /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+                   /p:DotNetPublishToBlobFeed=true
                    /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
                    /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
-                   /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-                   /p:PublishToSymbolServer=true
                    /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
                    /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+                   /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+                   /p:PublishToSymbolServer=true
         # else
         - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
           - name: _SignType
@@ -95,7 +101,7 @@ stages:
           displayName: Build / Test
           env:
             TRYDOTNET_PACKAGES_PATH: $(TryDotNetPackagesPath)
-       
+
         - task: PublishBuildArtifacts@1
           displayName: Publish packages to artifacts container
           inputs:
@@ -109,7 +115,7 @@ stages:
       enablePublishBuildArtifacts: true
       enablePublishTestResults: true
       enablePublishBuildAssets: false
-      enablePublishUsingPipelines: $(_PublishUsingPipelines)
+      enablePublishUsingPipelines: false
       enableTelemetry: true
       helixRepo: dotnet/interactive
       jobs:
@@ -159,6 +165,17 @@ stages:
           displayName: Build / Test
           env:
             TRYDOTNET_PACKAGES_PATH: $(TryDotNetPackagesPath)
+
+#---------------------------------------------------------------------------------------------------------------------#
+#                                                    Post Build                                                       #
+#---------------------------------------------------------------------------------------------------------------------#
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - template: eng/common/templates/post-build/post-build.yml
+    parameters:
+      # Symbol validation is not entirely reliable as of yet, so should be turned off until https://github.com/dotnet/arcade/issues/2871 is resolved.
+      enableSymbolValidation: false
+      # SourceLink improperly looks for generated files.  See https://github.com/dotnet/arcade/issues/3069
+      enableSourceLinkValidation: false
 
 #---------------------------------------------------------------------------------------------------------------------#
 #                                                  Package upload                                                     #

--- a/dotnet-interactive/Directory.Build.Props
+++ b/dotnet-interactive/Directory.Build.Props
@@ -1,9 +1,0 @@
-<Project>
-
-  <PropertyGroup>
-    <UseStableVersion>true</UseStableVersion>
-  </PropertyGroup>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-
-</Project>

--- a/dotnet-interactive/dotnet-interactive.csproj
+++ b/dotnet-interactive/dotnet-interactive.csproj
@@ -15,6 +15,8 @@
     <PackageDescription>Command line tool for interactive programming with C# and F#, including support for Jupyter Notebooks.</PackageDescription>
     <PackageTags>dotnet interactive Jupyter</PackageTags>
     <PackAsTool>true</PackAsTool>
+    <AutoGenerateAssemblyVersion>false</AutoGenerateAssemblyVersion>
+    <PreReleaseVersionLabel></PreReleaseVersionLabel>
     <Description>.NET Interactive</Description>
     <NoWarn>$(NoWarn);8002</NoWarn><!-- Markdig isn't strongly signed -->
     <NoWarn>$(NoWarn);NU5129</NoWarn><!-- Improper warning about missing props file.  See https://github.com/NuGet/Home/issues/8627 -->

--- a/eng/CIBuild.cmd
+++ b/eng/CIBuild.cmd
@@ -1,2 +1,2 @@
 @echo off
-powershell -noprofile -executionPolicy RemoteSigned -file "%~dp0build.ps1" -ci -restore -build -pack -binaryLog %*
+powershell -noprofile -executionPolicy RemoteSigned -file "%~dp0build.ps1" -ci -restore -build -pack -publish -binaryLog %*

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,49 +1,13 @@
 <Project>
 
   <ItemGroup>
-    <FileSignInfo Include="Mono.Security.dll" CertificateName="None" />
-    <FileSignInfo Include="mscorlib.dll" CertificateName="None" />
-    <FileSignInfo Include="netstandard.dll" CertificateName="None" />
-    <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="None" />
-    <FileSignInfo Include="System.Core.dll" CertificateName="None" />
-    <FileSignInfo Include="System.Data.dll" CertificateName="None" />
-    <FileSignInfo Include="System.dll" CertificateName="None" />
-    <FileSignInfo Include="System.Drawing.dll" CertificateName="None" />
-    <FileSignInfo Include="System.Drawing.Common.dll" CertificateName="None" />
-    <FileSignInfo Include="System.IO.Compression.dll" CertificateName="None" />
-    <FileSignInfo Include="System.IO.Compression.FileSystem.dll" CertificateName="None" />
-    <FileSignInfo Include="System.Linq.dll" CertificateName="None" />
-    <FileSignInfo Include="System.Net.Http.dll" CertificateName="None" />
-    <FileSignInfo Include="System.Numerics.dll" CertificateName="None" />
-    <FileSignInfo Include="System.Runtime.Serialization.dll" CertificateName="None" />
-    <FileSignInfo Include="System.ServiceModel.Internals.dll" CertificateName="None" />
-    <FileSignInfo Include="System.Transactions.dll" CertificateName="None" />
-    <FileSignInfo Include="System.Web.Services.dll" CertificateName="None" />
-    <FileSignInfo Include="System.Xml.dll" CertificateName="None" />
-    <FileSignInfo Include="System.Xml.Linq.dll" CertificateName="None" />
-
-    <FileSignInfo Include="AsyncIO.dll" CertificateName="None" />
-    <FileSignInfo Include="Buildalyzer.dll" CertificateName="None" />
-    <FileSignInfo Include="Buildalyzer.Logger.dll" CertificateName="None" />
-    <FileSignInfo Include="MsBuildPipeLogger.Logger.dll" CertificateName="None" />
-    <FileSignInfo Include="Buildalyzer.Workspaces.dll" CertificateName="None" />
-    <FileSignInfo Include="Clockwise.dll" CertificateName="None" />
-    <FileSignInfo Include="HtmlAgilityPack.dll" CertificateName="None" />
-    <FileSignInfo Include="Markdig.dll" CertificateName="None" />
-    <FileSignInfo Include="MessagePack.dll" CertificateName="None" />
-    <FileSignInfo Include="Mono.Cecil.Mdb.dll" CertificateName="None" />
-    <FileSignInfo Include="Mono.Cecil.Pdb.dll" CertificateName="None" />
-    <FileSignInfo Include="Mono.Cecil.Rocks.dll" CertificateName="None" />
-    <FileSignInfo Include="Mono.Cecil.dll" CertificateName="None" />
-    <FileSignInfo Include="StructuredLogger.dll" CertificateName="None" />
-    <FileSignInfo Include="MsBuildPipeLogger.Server.dll" CertificateName="None" />
-    <FileSignInfo Include="NetMQ.dll" CertificateName="None" />
-    <FileSignInfo Include="Octokit.dll" CertificateName="None" />
-    <FileSignInfo Include="Serilog.dll" CertificateName="None" />
-    <FileSignInfo Include="Serilog.Sinks.RollingFileAlternate.dll" CertificateName="None" />
-    <FileSignInfo Include="XPlot.Plotly.dll" CertificateName="None" />
-
-    <FileSignInfo Include="materialdesignicons-webfont.ttf" CertificateName="None" />
+    <FileSignInfo Include="AsyncIO.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Clockwise.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Markdig.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="NetMQ.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Serilog.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Serilog.Sinks.RollingFileAlternate.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="XPlot.Plotly.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
 
 </Project>

--- a/eng/cibuild.sh
+++ b/eng/cibuild.sh
@@ -16,4 +16,4 @@ scriptroot="$( cd -P "$( dirname "$source" )" && pwd)"
 echo "Building this commit:"
 git show --no-patch --pretty=raw HEAD
 
-. "$scriptroot/build.sh" --ci --restore --build --pack --binaryLog "$@"
+. "$scriptroot/build.sh" --ci --restore --build --pack --publish --binaryLog "$@"

--- a/eng/targets/Versions.targets
+++ b/eng/targets/Versions.targets
@@ -1,7 +1,0 @@
-<Project>
-
-  <Target Name="_InitializeAssemblyVersion">
-    <!-- don't let Arcade override assembly versions -->
-  </Target>
-
-</Project>


### PR DESCRIPTION
This enables packages from this repo to be published to the division-managed package feeds.  The actual feed that they're published to is handled by the internal `darc` tool.

Test builds show that the packages are being appropriately published to the `General Testing` feed, so this can be modified internally as needed.