### PR TITLE
Magic command improvements

### DIFF
--- a/Microsoft.DotNet.Interactive.CSharp/CSharpKernelExtensions.cs
+++ b/Microsoft.DotNet.Interactive.CSharp/CSharpKernelExtensions.cs
@@ -77,7 +77,8 @@ using static {typeof(Kernel).FullName};
 
             var restore = new Command("#!nuget-restore")
             {
-                Handler = CommandHandler.Create(DoNugetRestore(kernel, restoreContext))
+                Handler = CommandHandler.Create(DoNugetRestore(kernel, restoreContext)),
+                IsHidden = true
             };
 
             kernel.AddDirective(restore);

--- a/Microsoft.DotNet.Interactive.CSharp/CSharpKernelExtensions.cs
+++ b/Microsoft.DotNet.Interactive.CSharp/CSharpKernelExtensions.cs
@@ -277,13 +277,13 @@ using static {typeof(Kernel).FullName};
 
         private static Command who_and_whos()
         {
-            var command = new Command("%whos")
+            var command = new Command("#!whos")
             {
                 Handler = CommandHandler.Create((ParseResult parseResult, KernelInvocationContext context) =>
                 {
                     var alias = parseResult.CommandResult.Token.Value;
 
-                    var detailed = alias == "%whos";
+                    var detailed = alias == "#!whos";
 
                     if (context.Command is SubmitCode &&
                         context.HandlingKernel is CSharpKernel kernel)
@@ -313,7 +313,7 @@ using static {typeof(Kernel).FullName};
                 })
             };
 
-            command.AddAlias("%who");
+            command.AddAlias("#!who");
 
             return command;
         }

--- a/Microsoft.DotNet.Interactive.FSharp/FSharpKernelExtensions.fs
+++ b/Microsoft.DotNet.Interactive.FSharp/FSharpKernelExtensions.fs
@@ -57,7 +57,7 @@ open System.Linq"
 
     [<Extension>]
     static member UseWho(kernel: FSharpKernel) =
-        let detailedName = "%whos"
+        let detailedName = "#!whos"
         let command = Command(detailedName)
         command.Handler <- CommandHandler.Create(
             fun (parseResult: ParseResult) (context: KernelInvocationContext) ->
@@ -73,7 +73,7 @@ open System.Linq"
                     | _ -> ()
                 | _ -> ()
                 Task.CompletedTask)
-        command.AddAlias("%who")
+        command.AddAlias("#!who")
         kernel.AddDirective(command)
         Formatter.Register(CurrentVariablesFormatter())
         kernel

--- a/Microsoft.DotNet.Interactive.Jupyter.Tests/ExecuteRequestHandlerTests.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter.Tests/ExecuteRequestHandlerTests.cs
@@ -279,7 +279,7 @@ f();"));
         public async Task sends_ExecuteReply_message_when_submission_contains_only_a_directive()
         {
             var scheduler = CreateScheduler();
-            var request = ZeroMQMessage.Create(new ExecuteRequest("%%csharp"));
+            var request = ZeroMQMessage.Create(new ExecuteRequest("#!csharp"));
             var context = new JupyterRequestContext(JupyterMessageSender, request);
             await scheduler.Schedule(context);
 

--- a/Microsoft.DotNet.Interactive.Jupyter.Tests/MagicCommandTests.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter.Tests/MagicCommandTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
         [Fact]
         public async Task magic_command_parse_errors_are_displayed()
         {
-            var command = new Command("%oops")
+            var command = new Command("#!oops")
             {
                 new Argument<string>()
             };
@@ -38,20 +38,20 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
 
             var events = kernel.KernelEvents.ToSubscribedList();
 
-            await kernel.SubmitCodeAsync("%oops");
+            await kernel.SubmitCodeAsync("#!oops");
 
             events.Should()
                   .ContainSingle<ErrorProduced>()
                   .Which
                   .Message
                   .Should()
-                  .Be("Required argument missing for command: %oops");
+                  .Be("Required argument missing for command: #!oops");
         }
 
         [Fact]
         public async Task magic_command_parse_errors_prevent_code_submission_from_being_run()
         {
-            var command = new Command("%oops")
+            var command = new Command("#!x")
             {
                 new Argument<string>()
             };
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
 
             var events = kernel.KernelEvents.ToSubscribedList();
 
-            await kernel.SubmitCodeAsync("%oops\n123");
+            await kernel.SubmitCodeAsync("#!x\n123");
 
             events.Should().NotContain(e => e is ReturnValueProduced);
         }

--- a/Microsoft.DotNet.Interactive.Jupyter.Tests/MagicCommandTests.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter.Tests/MagicCommandTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.CommandLine;
 using FluentAssertions;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.CSharp;
 using Microsoft.DotNet.Interactive.Events;
@@ -66,6 +65,26 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
             await kernel.SubmitCodeAsync("%oops\n123");
 
             events.Should().NotContain(e => e is ReturnValueProduced);
+        }
+
+        [Fact]
+        public void Magic_commands_with_duplicate_aliases_are_not_allowed()
+        {
+            using var kernel = new CompositeKernel
+            {
+            };
+            kernel.Name = "abc";
+
+            kernel.AddDirective(new Command("#dupe"));
+
+            kernel.Invoking(k => 
+                k.AddDirective(new Command("#dupe")))
+                  .Should()
+                  .Throw<ArgumentException>()
+                  .Which
+                  .Message
+                  .Should()
+                  .Be("Directive \"#dupe\" already exists in kernel \"abc\".");
         }
     }
 }

--- a/Microsoft.DotNet.Interactive.Jupyter.Tests/MagicCommandTests.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter.Tests/MagicCommandTests.cs
@@ -70,10 +70,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
         [Fact]
         public void Magic_commands_with_duplicate_aliases_are_not_allowed()
         {
-            using var kernel = new CompositeKernel
-            {
-            };
-            kernel.Name = "abc";
+            using var kernel = new CompositeKernel();
 
             kernel.AddDirective(new Command("#dupe"));
 
@@ -84,7 +81,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
                   .Which
                   .Message
                   .Should()
-                  .Be("Directive \"#dupe\" already exists in kernel \"abc\".");
+                  .Be("Alias \'#dupe\' is already in use.");
         }
     }
 }

--- a/Microsoft.DotNet.Interactive.Jupyter.Tests/MagicCommandTests.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter.Tests/MagicCommandTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
             await kernel.SubmitCodeAsync("#!oops");
 
             events.Should()
-                  .ContainSingle<ErrorProduced>()
+                  .ContainSingle<CommandFailed>()
                   .Which
                   .Message
                   .Should()

--- a/Microsoft.DotNet.Interactive.Jupyter.Tests/MagicCommandTests.html.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter.Tests/MagicCommandTests.html.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
                 using var events = kernel.KernelEvents.ToSubscribedList();
 
                 await kernel.SendAsync(new SubmitCode(
-                                           $"%%html\n\n{html}"));
+                                           $"#!html\n\n{html}"));
 
                 var formatted =
                     events

--- a/Microsoft.DotNet.Interactive.Jupyter.Tests/MagicCommandTests.javascript.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter.Tests/MagicCommandTests.javascript.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
                 using var events = kernel.KernelEvents.ToSubscribedList();
 
                 await kernel.SendAsync(new SubmitCode(
-                                           $"%%javascript\n{scriptContent}"));
+                                           $"#!javascript\n{scriptContent}"));
 
                 var formatted =
                     events

--- a/Microsoft.DotNet.Interactive.Jupyter.Tests/MagicCommandTests.lsmagic.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter.Tests/MagicCommandTests.lsmagic.cs
@@ -27,13 +27,13 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
                                    .UseDefaultMagicCommands()
                                    .LogEventsToPocketLogger();
 
-                kernel.AddDirective(new Command("%%one"));
-                kernel.AddDirective(new Command("%%two"));
-                kernel.AddDirective(new Command("%%three"));
+                kernel.AddDirective(new Command("#!one"));
+                kernel.AddDirective(new Command("#!two"));
+                kernel.AddDirective(new Command("#!three"));
 
                 using var events = kernel.KernelEvents.ToSubscribedList();
 
-                await kernel.SendAsync(new SubmitCode("%lsmagic"));
+                await kernel.SendAsync(new SubmitCode("#!lsmagic"));
 
                 events.Should()
                       .ContainSingle(e => e is DisplayedValueProduced)
@@ -42,16 +42,16 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
                       .Value
                       .ToDisplayString("text/html")
                       .Should()
-                      .ContainAll("%lsmagic", "%%one", "%%three", "%%two");
+                      .ContainAll("#!lsmagic", "#!one", "#!three", "#!two");
             }
 
             [Fact]
             public async Task lsmagic_lists_registered_magic_commands_in_subkernels()
             {
                 var subkernel1 = new CSharpKernel();
-                subkernel1.AddDirective(new Command("%%from-subkernel-1"));
+                subkernel1.AddDirective(new Command("#!from-subkernel-1"));
                 var subkernel2 = new FSharpKernel();
-                subkernel2.AddDirective(new Command("%%from-subkernel-2"));
+                subkernel2.AddDirective(new Command("#!from-subkernel-2"));
 
                 using var compositeKernel = new CompositeKernel
                                             {
@@ -61,32 +61,32 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
                                             .UseDefaultMagicCommands()
                                             .LogEventsToPocketLogger();
 
-                compositeKernel.AddDirective(new Command("%%from-compositekernel"));
+                compositeKernel.AddDirective(new Command("#!from-compositekernel"));
 
                 using var events = compositeKernel.KernelEvents.ToSubscribedList();
 
-                await compositeKernel.SendAsync(new SubmitCode("%lsmagic"));
+                await compositeKernel.SendAsync(new SubmitCode("#!lsmagic"));
 
                 var valueProduceds = events.OfType<DisplayedValueProduced>().ToArray();
 
                 valueProduceds[0].Value
                                  .ToDisplayString("text/html")
                                  .Should()
-                                 .ContainAll("%lsmagic",
-                                             "%%csharp",
-                                             "%%fsharp",
-                                             "%%from-compositekernel");
+                                 .ContainAll("#!lsmagic",
+                                             "#!csharp",
+                                             "#!fsharp",
+                                             "#!from-compositekernel");
 
                 valueProduceds[1].Value
                                  .ToDisplayString("text/html")
                                  .Should()
-                                 .ContainAll("%lsmagic",
-                                             "%%from-subkernel-1");
+                                 .ContainAll("#!lsmagic",
+                                             "#!from-subkernel-1");
                 valueProduceds[2].Value
                                  .ToDisplayString("text/html")
                                  .Should()
-                                 .ContainAll("%lsmagic",
-                                             "%%from-subkernel-2");
+                                 .ContainAll("#!lsmagic",
+                                             "#!from-subkernel-2");
             }
         }
 
@@ -104,7 +104,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
 
             using var events = kernel.KernelEvents.ToSubscribedList();
 
-            await kernel.SendAsync(new SubmitCode("%lsmagic"));
+            await kernel.SendAsync(new SubmitCode("#!lsmagic"));
 
             events.Should()
                   .ContainSingle(e => e is DisplayedValueProduced)

--- a/Microsoft.DotNet.Interactive.Jupyter.Tests/MagicCommandTests.markdown.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter.Tests/MagicCommandTests.markdown.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
                 using var events = kernel.KernelEvents.ToSubscribedList();
 
                 await kernel.SendAsync(new SubmitCode(
-                                           $"%%markdown\n\n# Topic!\nContent"));
+                                           "#!markdown\n\n# Topic!\nContent"));
 
                 var formatted =
                     events

--- a/Microsoft.DotNet.Interactive.Jupyter.Tests/MagicCommandTests.time.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter.Tests/MagicCommandTests.time.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
 
                 await kernel.SendAsync(new SubmitCode(
                                            @"
-%%time
+#!time
 
 using System.Threading.Tasks;
 await Task.Delay(500);

--- a/Microsoft.DotNet.Interactive.Jupyter.Tests/MagicCommandTests.who_and_whos.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter.Tests/MagicCommandTests.who_and_whos.cs
@@ -58,7 +58,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
                     await kernel.SendAsync(new SubmitCode(command));
                 }
 
-                await kernel.SendAsync(new SubmitCode(@"%whos"));
+                await kernel.SendAsync(new SubmitCode("#!whos"));
 
                 events.Should()
                       .ContainSingle(e => e is DisplayedValueProduced)
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
                     await kernel.SendAsync(new SubmitCode(command));
                 }
 
-                await kernel.SendAsync(new SubmitCode(@"%who"));
+                await kernel.SendAsync(new SubmitCode("#!who"));
 
                 events.Should()
                       .ContainSingle(e => e is DisplayedValueProduced)

--- a/Microsoft.DotNet.Interactive.Jupyter/KernelExtensions.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter/KernelExtensions.cs
@@ -35,14 +35,14 @@ namespace Microsoft.DotNet.Interactive.Jupyter
         private static T UseHtml<T>(this T kernel)
             where T : KernelBase
         {
-            kernel.AddDirective(new Command("%%html")
+            kernel.AddDirective(new Command("#!html")
             {
                 Handler = CommandHandler.Create((KernelInvocationContext context) =>
                 {
                     if (context.Command is SubmitCode submitCode)
                     {
                         var htmlContent = submitCode.Code
-                                                    .Replace("%%html", "")
+                                                    .Replace("#!html", "")
                                                     .Trim();
 
                         context.Publish(new DisplayedValueProduced(
@@ -69,14 +69,14 @@ namespace Microsoft.DotNet.Interactive.Jupyter
                    .UseAdvancedExtensions()
                    .Build();
 
-            kernel.AddDirective(new Command("%%markdown")
+            kernel.AddDirective(new Command("#!markdown")
             {
                 Handler = CommandHandler.Create((KernelInvocationContext context) =>
                 {
                     if (context.Command is SubmitCode submitCode)
                     {
                         var markdown = submitCode.Code
-                                                 .Replace("%%markdown", "")
+                                                 .Replace("#!markdown", "")
                                                  .Trim();
 
                         var document = Markdown.Parse(
@@ -153,7 +153,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter
 
         private static Command lsmagic()
         {
-            return new Command("%lsmagic")
+            return new Command("#!lsmagic")
             {
                 Handler = CommandHandler.Create(async (KernelInvocationContext context) =>
                 {
@@ -161,13 +161,14 @@ namespace Microsoft.DotNet.Interactive.Jupyter
 
                     var supportedDirectives = new SupportedDirectives(currentKernel.Name);
 
-                    supportedDirectives.Commands.AddRange(currentKernel.Directives);
+                    supportedDirectives.Commands.AddRange(
+                        currentKernel.Directives.Where(d => !d.IsHidden));
 
                     context.Publish(new DisplayedValueProduced(supportedDirectives, context.Command));
 
                     await currentKernel.VisitSubkernelsAsync(async k =>
                     {
-                        if (k.Directives.Any(d => d.Name == "%lsmagic"))
+                        if (k.Directives.Any(d => d.Name == "#!lsmagic"))
                         {
                             await k.SendAsync(new SubmitCode(((SubmitCode) context.Command).Code));
                         }
@@ -178,14 +179,14 @@ namespace Microsoft.DotNet.Interactive.Jupyter
 
         private static Command javascript()
         {
-            return new Command("%%javascript")
+            return new Command("#!javascript")
             {
                 Handler = CommandHandler.Create((KernelInvocationContext context) =>
                 {
                     if (context.Command is SubmitCode submitCode)
                     {
                         var scriptContent = submitCode.Code
-                                                      .Replace("%%javascript", string.Empty)
+                                                      .Replace("#!javascript", string.Empty)
                                                       .Trim();
 
                         string value =
@@ -211,14 +212,14 @@ namespace Microsoft.DotNet.Interactive.Jupyter
 
         private static Command time()
         {
-            return new Command("%%time")
+            return new Command("#!time")
             {
                 Handler = CommandHandler.Create(async (KernelInvocationContext context) =>
                 {
                     if (context.Command is SubmitCode submitCode)
                     {
                         var code = submitCode.Code
-                                             .Replace("%%time", string.Empty)
+                                             .Replace("#!time", string.Empty)
                                              .Trim();
 
                         var timer = new Stopwatch();

--- a/Microsoft.DotNet.Interactive.Tests/CompositeKernelTests.cs
+++ b/Microsoft.DotNet.Interactive.Tests/CompositeKernelTests.cs
@@ -50,15 +50,15 @@ namespace Microsoft.DotNet.Interactive.Tests
 
             await kernel.SendAsync(
                 new SubmitCode(
-                    @"%%csharp
+                    @"#!csharp
 var x = 123;"));
             await kernel.SendAsync(
                 new SubmitCode(
-                    @"%%fake
+                    @"#!fake
 hello!"));
             await kernel.SendAsync(
                 new SubmitCode(
-                    @"%%csharp
+                    @"#!csharp
 x"));
 
             receivedOnFakeKernel

--- a/Microsoft.DotNet.Interactive.Tests/DirectiveTests.cs
+++ b/Microsoft.DotNet.Interactive.Tests/DirectiveTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
-using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.DotNet.Interactive.CSharp;
@@ -48,6 +47,31 @@ namespace Microsoft.DotNet.Interactive.Tests
 
             kernel
                 .Invoking(k => k.AddDirective(new Command($"{value}hello")))
+                .Should()
+                .Throw<ArgumentException>()
+                .Which
+                .Message
+                .Should()
+                .Be("Directives must begin with # or %");
+        }
+
+        [Theory(Timeout = 45000)]
+        [InlineData("{")]
+        [InlineData(";")]
+        [InlineData("a")]
+        [InlineData("1")]
+        public void Directives_may_not_have_aliases_that_begin_with_(string value)
+        {
+            using var kernel = new CompositeKernel();
+
+            var command = new Command("#!this-is-fine");
+            command.AddAlias($"{value}hello");
+
+            kernel
+                .Invoking(k =>
+                {
+                    kernel.AddDirective(command);
+                })
                 .Should()
                 .Throw<ArgumentException>()
                 .Which

--- a/Microsoft.DotNet.Interactive.Tests/DirectiveTests.cs
+++ b/Microsoft.DotNet.Interactive.Tests/DirectiveTests.cs
@@ -25,17 +25,6 @@ namespace Microsoft.DotNet.Interactive.Tests
                 .NotThrow();
         }
 
-        [Fact(Timeout = 45000)]
-        public void Directives_may_be_prefixed_with_percent()
-        {
-            using var kernel = new CompositeKernel();
-
-            kernel
-                .Invoking(k => k.AddDirective(new Command("%hello")))
-                .Should()
-                .NotThrow();
-        }
-
         [Theory(Timeout = 45000)]
         [InlineData("{")]
         [InlineData(";")]
@@ -52,7 +41,7 @@ namespace Microsoft.DotNet.Interactive.Tests
                 .Which
                 .Message
                 .Should()
-                .Be("Directives must begin with # or %");
+                .Be($"Invalid directive name \"{value}hello\". Directives must begin with \"#\".");
         }
 
         [Theory(Timeout = 45000)]
@@ -77,7 +66,7 @@ namespace Microsoft.DotNet.Interactive.Tests
                 .Which
                 .Message
                 .Should()
-                .Be("Directives must begin with # or %");
+                .Be($"Invalid directive name \"{value}hello\". Directives must begin with \"#\".");
         }
 
         [Fact(Timeout = 45000)]

--- a/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
+++ b/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
@@ -371,7 +371,7 @@ catch (Exception e)
 
             using var events = kernel.KernelEvents.ToSubscribedList();
 
-            await kernel.SubmitCodeAsync(@"%%time
+            await kernel.SubmitCodeAsync(@"#!time
 #r ""nuget:RestoreSources=https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json""
 #r ""nuget:Microsoft.ML.AutoML,0.16.0-preview""
 #r ""nuget:Microsoft.Data.DataFrame,1.0.0-e190910-1""
@@ -423,7 +423,7 @@ Formatter<DataFrame>.Register((df, writer) =>
 
             await kernel.SubmitCodeAsync(
                 @"
-%%time
+#!time
 #r ""nuget:""
 ");
 
@@ -444,7 +444,7 @@ Formatter<DataFrame>.Register((df, writer) =>
 
             await kernel.SubmitCodeAsync(
                 @"
-%%time
+#!time
 #r ""nuget:,1.0.0""
 ");
 
@@ -465,7 +465,7 @@ Formatter<DataFrame>.Register((df, writer) =>
 
             await kernel.SubmitCodeAsync(
                 @"
-%%time
+#!time
 #r ""nuget:RestoreSources=https://completelyFakerestoreSource""
 ");
 
@@ -481,7 +481,7 @@ Formatter<DataFrame>.Register((df, writer) =>
 
             await kernel.SubmitCodeAsync(
                 @"
-%%time
+#!time
 #r ""nuget:RestoreSources=https://completelyFakerestoreSource""
 #r ""nuget:RestoreSources=https://completelyFakerestoreSource""
 ");
@@ -498,13 +498,13 @@ Formatter<DataFrame>.Register((df, writer) =>
 
             await kernel.SubmitCodeAsync(
                 @"
-%%time
+#!time
 #r ""nuget:RestoreSources=https://completelyFakerestoreSource""
 ");
 
             await kernel.SubmitCodeAsync(
                 @"
-%%time
+#!time
 #r ""nuget:RestoreSources=https://completelyFakerestoreSource""
 ");
 
@@ -520,7 +520,7 @@ Formatter<DataFrame>.Register((df, writer) =>
 
             await kernel.SubmitCodeAsync(
                 @"
-%%time
+#!time
 #r ""nuget:RestoreSources=https://completelyFakerestoreSource""
 ");
 
@@ -536,14 +536,14 @@ Formatter<DataFrame>.Register((df, writer) =>
 
             await kernel.SubmitCodeAsync(
                 @"
-%%time
+#!time
 #r ""nuget:RestoreSources=https://completelyFakerestoreSource""
 ");
             events.Should().NotContainErrors();
 
             await kernel.SubmitCodeAsync(
                 @"
-%%time
+#!time
 #r ""nuget:RestoreSources=https://anotherCompletelyFakerestoreSource""
 ");
 
@@ -559,7 +559,7 @@ Formatter<DataFrame>.Register((df, writer) =>
 
             await kernel.SubmitCodeAsync(
                 @"
-%%time
+#!time
 #r ""nuget:Microsoft.ML.AutoML,0.16.0-preview""
 #r ""nuget:Microsoft.ML.AutoML,0.16.0-preview""
 using Microsoft.ML.AutoML;
@@ -577,14 +577,14 @@ using Microsoft.ML.AutoML;
 
             await kernel.SubmitCodeAsync(
                 @"
-%%time
+#!time
 #r ""nuget:Microsoft.ML.AutoML,0.16.0-preview"""
             );
             events.Should().NotContainErrors();
 
             await kernel.SubmitCodeAsync(
                 @"
-%%time
+#!time
 #r ""nuget:Microsoft.ML.AutoML,0.16.0-preview""
 using Microsoft.ML.AutoML;
 ");
@@ -601,7 +601,7 @@ using Microsoft.ML.AutoML;
 
             await kernel.SubmitCodeAsync(
                 @"
-%%time
+#!time
 #r ""nuget:Microsoft.ML.AutoML,0.16.0-preview""
 #r ""nuget:Microsoft.ML.AutoML,0.16.1-preview""
 using Microsoft.ML.AutoML;
@@ -624,14 +624,14 @@ using Microsoft.ML.AutoML;
 
             await kernel.SubmitCodeAsync(
                 @"
-%%time
+#!time
 #r ""nuget:Microsoft.ML.AutoML,0.16.0-preview""
 ");
             events.Should().NotContainErrors();
 
             await kernel.SubmitCodeAsync(
                 @"
-%%time
+#!time
 #r ""nuget:Microsoft.ML.AutoML,0.16.1-preview""
 using Microsoft.ML.AutoML;
 ");
@@ -700,7 +700,7 @@ using XPlot.Plotly;");
 
             await kernel.SubmitCodeAsync(
                 @"
-%%time
+#!time
 #r ""nuget: Microsoft.ML, 1.4.0""
 #r ""nuget:Microsoft.ML.AutoML,0.16.0""
 #r ""nuget:Microsoft.Data.Analysis,0.1.0""
@@ -709,7 +709,7 @@ using XPlot.Plotly;");
 
             await kernel.SubmitCodeAsync(
                 @"
-%%time
+#!time
 #r ""nuget: Google.Protobuf, 3.10.1""
 ");
 
@@ -730,7 +730,7 @@ using XPlot.Plotly;");
 
             await kernel.SubmitCodeAsync(
                 @"
-%%time
+#!time
 #r ""nuget: Microsoft.ML, 1.4.0""
 #r ""nuget:Microsoft.ML.AutoML,0.16.0""
 #r ""nuget:Microsoft.Data.Analysis,0.1.0""
@@ -739,7 +739,7 @@ using XPlot.Plotly;");
 
             await kernel.SubmitCodeAsync(
                 @"
-%%time
+#!time
 #r ""nuget: Google.Protobuf, 3.10.0""
 ");
             events.Should().NotContainErrors();

--- a/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
+++ b/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
@@ -647,9 +647,9 @@ using Microsoft.ML.AutoML;
         [Fact(Timeout = 45000)]
         public async Task cell_with_nuget_and_code_continues_executions_on_right_kernel()
         {
-
             var kernel =
-                new CompositeKernel {
+                new CompositeKernel
+                    {
                         new CSharpKernel()
                             .UseDefaultFormatting()
                             .UseNugetDirective()
@@ -658,11 +658,11 @@ using Microsoft.ML.AutoML;
                             .LogEventsToPocketLogger(),
 
                         new FSharpKernel()
-                        .UseDefaultFormatting()
-                        .UseKernelHelpers()
-                        .UseWho()
-                        .UseDefaultNamespaces()
-                        .LogEventsToPocketLogger()
+                            .UseDefaultFormatting()
+                            .UseKernelHelpers()
+                            .UseWho()
+                            .UseDefaultNamespaces()
+                            .LogEventsToPocketLogger()
                     }
                     .UseDefaultMagicCommands();
 
@@ -683,8 +683,6 @@ using XPlot.Plotly;");
             await kernel.SendAsync(command, CancellationToken.None);
 
             events.Should().NotContainErrors();
-
-
 
             events
                 .Should()

--- a/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
+++ b/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
@@ -817,7 +817,7 @@ Console.Write(2);
         {
             var kernel = CreateKernel(Language.CSharp);
 
-            var command = new SubmitCode("%whos \nvar x = 1;");
+            var command = new SubmitCode("#!whos \nvar x = 1;");
 
             await kernel.SendAsync(command);
 

--- a/Microsoft.DotNet.Interactive.Tests/Server/StandardIOKernelServerTests.cs
+++ b/Microsoft.DotNet.Interactive.Tests/Server/StandardIOKernelServerTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Server
         [Fact(Timeout = 45000)]
         public async Task It_produces_a_unique_CommandHandled_for_root_command()
         {
-            var command = new SubmitCode("%%time\ndisplay(1543); display(4567);");
+            var command = new SubmitCode("#!time\ndisplay(1543); display(4567);");
             command.SetToken("abc");
 
             await _standardIOKernelServer.WriteAsync(command);

--- a/Microsoft.DotNet.Interactive/CompositeKernel.cs
+++ b/Microsoft.DotNet.Interactive/CompositeKernel.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Interactive
                 });
             }
 
-            var chooseKernelCommand = new Command($"%%{kernel.Name}")
+            var chooseKernelCommand = new Command($"#!{kernel.Name}")
             {
                 Handler = CommandHandler.Create<KernelInvocationContext>(
                     context => { context.HandlingKernel = kernel; })

--- a/Microsoft.DotNet.Interactive/NativeAssemblyLoadHelper.cs
+++ b/Microsoft.DotNet.Interactive/NativeAssemblyLoadHelper.cs
@@ -238,8 +238,6 @@ namespace Microsoft.DotNet.Interactive
 
                     IntPtr LoadNative(string dll)
                     {
-                        // FIX: (OnAssemblyLoad) 
-
                         try
                         {
                             if (Interlocked.Increment(ref _recursionCount) == 1)

--- a/Microsoft.DotNet.Interactive/SubmissionSplitter.cs
+++ b/Microsoft.DotNet.Interactive/SubmissionSplitter.cs
@@ -161,14 +161,20 @@ namespace Microsoft.DotNet.Interactive
                 throw new ArgumentNullException(nameof(command));
             }
 
-            if (!command.Name.StartsWith("#") &&
-                !command.Name.StartsWith("%"))
+            if (HasIncorrectPrefix(command.Name) || 
+                command.RawAliases.Any(HasIncorrectPrefix))
             {
                 throw new ArgumentException("Directives must begin with # or %");
             }
 
             _directiveCommands.Add(command);
             _directiveParser = null;
+
+            bool HasIncorrectPrefix(string name)
+            {
+                return !name.StartsWith("#") &&
+                       !name.StartsWith("%");
+            }
         }
     }
 }

--- a/Microsoft.DotNet.Interactive/SubmissionSplitter.cs
+++ b/Microsoft.DotNet.Interactive/SubmissionSplitter.cs
@@ -156,10 +156,12 @@ namespace Microsoft.DotNet.Interactive
                 throw new ArgumentNullException(nameof(command));
             }
 
-            if (HasIncorrectPrefix(command.Name) || 
-                command.RawAliases.Any(HasIncorrectPrefix))
+            foreach (var name in new[] { command.Name }.Concat(command.Aliases))
             {
-                throw new ArgumentException("Directives must begin with # or %");
+                if (!name.StartsWith("#"))
+                {
+                    throw new ArgumentException($"Invalid directive name \"{name}\". Directives must begin with \"#\".");
+                }
             }
 
             EnsureRootCommandIsInitialized();
@@ -167,12 +169,6 @@ namespace Microsoft.DotNet.Interactive
             _rootCommand.Add(command);
 
             _directiveParser = null;
-
-            bool HasIncorrectPrefix(string name)
-            {
-                return !name.StartsWith("#") &&
-                       !name.StartsWith("%");
-            }
         }
 
         private void EnsureRootCommandIsInitialized()

--- a/Microsoft.DotNet.Interactive/SubmissionSplitter.cs
+++ b/Microsoft.DotNet.Interactive/SubmissionSplitter.cs
@@ -7,6 +7,7 @@ using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Parsing;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.Commands;
 
 namespace Microsoft.DotNet.Interactive
@@ -80,7 +81,14 @@ namespace Microsoft.DotNet.Interactive
                                         parseResult.Errors
                                                    .Select(e => e.ToString()));
 
-                        commands.Add(new DisplayError(message));
+                        commands.Clear();
+                        commands.Add(
+                            new AnonymousKernelCommand((kernelCommand, context) =>
+                            {
+                                 context.Fail(message: message);
+                                 return Task.CompletedTask;
+                            }));
+
                     }
                 }
             }

--- a/NotebookExamples/csharp/Docs/HTML.ipynb
+++ b/NotebookExamples/csharp/Docs/HTML.ipynb
@@ -281,7 +281,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%html\n",
+    "#!html\n",
     "\n",
     "<b>Hello!</b>"
    ]
@@ -299,7 +299,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%javascript\n",
+    "#!javascript\n",
     "\n",
     "alert(\"hello\");"
    ]
@@ -317,7 +317,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%markdown\n",
+    "#!markdown\n",
     "\n",
     "Write a **list** ...\n",
     "* first\n",

--- a/NotebookExamples/csharp/Docs/Plotting with Xplot.ipynb
+++ b/NotebookExamples/csharp/Docs/Plotting with Xplot.ipynb
@@ -138,7 +138,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%time\n",
+    "#!time\n",
     "var series = new Graph.Scattergl[10];\n",
     "\n",
     "for(var i = 0; i < series.Length; i++){\n",

--- a/NotebookExamples/csharp/Samples/HousingML.ipynb
+++ b/NotebookExamples/csharp/Samples/HousingML.ipynb
@@ -326,7 +326,7 @@
     }
    ],
    "source": [
-    "%%time\n",
+    "#!time\n",
     "\n",
     "var mlContext = new MLContext();\n",
     "\n",

--- a/NotebookExamples/fsharp/Docs/Plotting with Xplot.ipynb
+++ b/NotebookExamples/fsharp/Docs/Plotting with Xplot.ipynb
@@ -132,7 +132,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%time\n",
+    "#!time\n",
     "\n",
     "let series =\n",
     "    [|\n",

--- a/NotebookExamples/fsharp/Introduction to F#.ipynb
+++ b/NotebookExamples/fsharp/Introduction to F#.ipynb
@@ -949,7 +949,7 @@
     }
    ],
    "source": [
-    "%%time\n",
+    "#!time\n",
     "\n",
     "let bigArray = [| 0 .. 100_000 |]\n",
     "\n",
@@ -969,7 +969,7 @@
    "source": [
     "Because F# functions are first-class values, you can trivially do things like initialize expensive functions in parallel with the `Array.Parallel` module. This is quite common in numerics-intensive F# code.\n",
     "\n",
-    "Here's an example where you can compute as many fibonacci numbers as there are threads in your current process. The `%%time` magic command shows the wall-clock time it took to perform the operation:"
+    "Here's an example where you can compute as many fibonacci numbers as there are threads in your current process. The `#!time` magic command shows the wall-clock time it took to perform the operation:"
    ]
   },
   {
@@ -998,7 +998,7 @@
     }
    ],
    "source": [
-    "%%time\n",
+    "#!time\n",
     "\n",
     "// Restrict the number of threads to a max of 25\n",
     "let nThreads = min 25 Environment.ProcessorCount\n",

--- a/NotebookExamples/fsharp/Samples/HousingML.ipynb
+++ b/NotebookExamples/fsharp/Samples/HousingML.ipynb
@@ -147,7 +147,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%time\n",
+    "#!time\n",
     "\n",
     "open Microsoft.ML\n",
     "open Microsoft.ML.Data\n",


### PR DESCRIPTION
- [x] Disallow duplicate directive names / aliases
- [x] Change magic command syntax for existing magic commands to use `#!` prefixes instead of `%`/`%%` 
- [x] Disallow `%`/`%%` as prefixes
