### PR TITLE
make kernel server honor `--log-path` and listen to kernel logging events

### DIFF
--- a/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
+++ b/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
@@ -1,15 +1,20 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.CommandLine.Binding;
 using System.CommandLine.IO;
 using System.CommandLine.Parsing;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.DotNet.Interactive.App.CommandLine;
+using Microsoft.DotNet.Interactive.Commands;
+using Microsoft.DotNet.Interactive.Server;
 using Microsoft.DotNet.Interactive.Telemetry;
+using Microsoft.DotNet.Interactive.Utility;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using Xunit.Abstractions;
@@ -145,6 +150,53 @@ namespace Microsoft.DotNet.Interactive.App.Tests.CommandLine
             await _parser.InvokeAsync("jupyter", testConsole);
 
             testConsole.Error.ToString().Should().Contain("Required argument missing for command: jupyter");
+        }
+
+        [Fact]
+        public async Task kernel_server_honors_log_path()
+        {
+            using var logPath = DisposableDirectory.Create();
+            using var outputReceived = new ManualResetEvent(false);
+            var errorLines = new List<string>();
+
+            // start as external process
+            var dotnet = new Dotnet(logPath.Directory);
+            using var kernelServerProcess = dotnet.StartProcess(
+                args: $@"""{typeof(Program).Assembly.Location}"" kernel-server --log-path ""{logPath.Directory.FullName}""",
+                output: _line => { outputReceived.Set(); },
+                error: errorLines.Add);
+
+            // wait for log file to be created
+            var logFile = await logPath.Directory.WaitForFile(
+                timeout: TimeSpan.FromSeconds(2),
+                predicate: _file => true); // any matching file is the one we want
+            errorLines.Should().BeEmpty();
+            logFile.Should().NotBeNull("unable to find created log file");
+
+            // submit code
+            var submission = new SubmitCode("1+1");
+            var submissionJson = KernelCommandEnvelope.Serialize(KernelCommandEnvelope.Create(submission));
+            await kernelServerProcess.StandardInput.WriteLineAsync(submissionJson);
+            await kernelServerProcess.StandardInput.FlushAsync();
+
+            // wait for output to proceed
+            var gotOutput = outputReceived.WaitOne(timeout: TimeSpan.FromSeconds(2));
+            gotOutput.Should().BeTrue("expected to receive on stdout");
+
+            // kill
+            kernelServerProcess.StandardInput.Close(); // simulate Ctrl+C
+            await Task.Delay(TimeSpan.FromSeconds(2)); // allow logs to be flushed
+            kernelServerProcess.Kill();
+            kernelServerProcess.WaitForExit(2000).Should().BeTrue();
+            errorLines.Should().BeEmpty();
+
+            // check log file for expected contents
+            (await logFile.WaitForFileCondition(
+                timeout: TimeSpan.FromSeconds(2),
+                predicate: file => file.Length > 0))
+                .Should().BeTrue("expected non-empty log file");
+            var logFileContents = File.ReadAllText(logFile.FullName);
+            logFileContents.Should().Contain("ℹ OnAssemblyLoad: ");
         }
     }
 }

--- a/dotnet-interactive.Tests/DirectoryTestHelper.cs
+++ b/dotnet-interactive.Tests/DirectoryTestHelper.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Interactive.App.Tests
+{
+    public static class DirectoryTestHelper
+    {
+        public static async Task<bool> WaitForFileCondition(this FileInfo file, TimeSpan timeout, Func<FileInfo, bool> predicate)
+        {
+            var startTime = DateTime.UtcNow;
+            while (DateTime.UtcNow < startTime + timeout)
+            {
+                if (predicate(file))
+                {
+                    return true;
+                }
+
+                await Task.Delay(200);
+                file.Refresh();
+            }
+
+            return predicate(file);
+        }
+
+        public static async Task<FileInfo> WaitForFile(this DirectoryInfo directory, TimeSpan timeout, Func<FileInfo, bool> predicate)
+        {
+            var startTime = DateTime.UtcNow;
+            while (DateTime.UtcNow < startTime + timeout)
+            {
+                var file = GetMatchingFile(directory, predicate);
+                if (file != null)
+                {
+                    return file;
+                }
+
+                // no files or no file matched
+                await Task.Delay(200);
+                directory.Refresh();
+            }
+
+            // one final check
+            return GetMatchingFile(directory, predicate);
+        }
+
+        private static FileInfo GetMatchingFile(DirectoryInfo directory, Func<FileInfo, bool> predicate)
+        {
+            return directory.EnumerateFiles().FirstOrDefault(predicate);
+        }
+    }
+}

--- a/dotnet-interactive.Tests/dotnet-interactive.Tests.csproj
+++ b/dotnet-interactive.Tests/dotnet-interactive.Tests.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\dotnet-interactive\dotnet-interactive.csproj" />
+    <ProjectReference Include="..\dotnet-interactive\dotnet-interactive.csproj" AdditionalProperties="BuildingTestProject=true" />
     <ProjectReference Include="..\Microsoft.DotNet.Interactive.Tests\Microsoft.DotNet.Interactive.Tests.csproj" />
   </ItemGroup>
 

--- a/dotnet-interactive/CommandLine/CommandLineParser.cs
+++ b/dotnet-interactive/CommandLine/CommandLineParser.cs
@@ -62,6 +62,11 @@ namespace Microsoft.DotNet.Interactive.App.CommandLine
 
             startKernelServer ??= (async (startupOptions, kernel, console) =>
             {
+                var disposable = Program.StartToolLogging(startupOptions);
+                if (kernel is KernelBase kernelBase)
+                {
+                    kernelBase.RegisterForDisposal(disposable);
+                }
                 var server = new StandardIOKernelServer(
                     kernel, 
                     Console.In, 
@@ -187,7 +192,6 @@ namespace Microsoft.DotNet.Interactive.App.CommandLine
                 {
                     defaultKernelOption,
                     logPathOption,
-                    verboseOption
                 };
 
                 startKernelServerCommand.Handler = CommandHandler.Create<StartupOptions, KernelServerOptions, IConsole, InvocationContext>(

--- a/dotnet-interactive/Program.cs
+++ b/dotnet-interactive/Program.cs
@@ -31,8 +31,9 @@ namespace Microsoft.DotNet.Interactive.App
 
         private static readonly Assembly[] _assembliesEmittingPocketLoggerLogs =
         {
-            typeof(Startup).Assembly,
-            typeof(Shell).Assembly
+            typeof(Startup).Assembly, // dotnet-interactive.dll
+            typeof(KernelBase).Assembly, // Microsoft.DotNet.Interactive.dll
+            typeof(Shell).Assembly, // Microsoft.DotNet.Interactive.Jupyter.dll
         };
 
         internal static IDisposable StartToolLogging(StartupOptions options)

--- a/dotnet-interactive/dotnet-interactive.csproj
+++ b/dotnet-interactive/dotnet-interactive.csproj
@@ -127,5 +127,13 @@
   <Target Name="ZipDotnetKernel" BeforeTargets="PrepareForBuild" DependsOnTargets="CopyKernelSpecificFiles;CopyLogoFiles">
     <ZipDirectory SourceDirectory="$(KernelDestinationDirectory)" DestinationFile="$(IntermediateOutputPath)/dotnetKernel.zip" Overwrite="true" />
   </Target>
-  
+
+  <!-- Copied from https://github.com/dotnet/sdk/issues/1675 to ensure *.runtimeconfig.json is copied to projects referencing this, e.g., test projects. -->
+  <Target Name="AddRuntimeDependenciesToContent" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" BeforeTargets="GetCopyToOutputDirectoryItems" DependsOnTargets="GenerateBuildDependencyFile;GenerateBuildRuntimeConfigurationFiles">
+    <ItemGroup>
+      <ContentWithTargetPath Include="$(ProjectDepsFilePath)" CopyToOutputDirectory="PreserveNewest" TargetPath="$(ProjectDepsFileName)" Condition="'$(BuildingTestProject)' == 'true'" />
+      <ContentWithTargetPath Include="$(ProjectRuntimeConfigFilePath)" CopyToOutputDirectory="PreserveNewest" TargetPath="$(ProjectRuntimeConfigFileName)" />
+    </ItemGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
The fix was two parts:

1. Call `Program.StartToolLogging()` in `CommandLineParser.cs`.
2. Enable events from the type `KernelBase` in `Program.cs`.

Everything else was to get a proper unit test.