### PR TITLE
don't check authenticode signature for third-party assemly

### DIFF
--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -1,0 +1,1 @@
+Microsoft.Management.Infrastructure.dll;Microsoft.dotnet-interactive.*.nupkg;


### PR DESCRIPTION
As discovered in PR #9, the `Microsoft.Management.Infrastructure.dll` assembly has different signatures based on the various architectures/runtimes and this causes validation to fail.  This PR marks that specific file to be ignored during the internal signing check.  Verified via internal build [here](https://dev.azure.com/dnceng/internal/_build/results?buildId=505785&view=results).