### PR TITLE
publish to MyGet from PackageArtifacts

### DIFF
--- a/eng/upload/upload-packages.yml
+++ b/eng/upload/upload-packages.yml
@@ -18,10 +18,10 @@ stages:
       displayName: Download package artifacts
       inputs:
         buildType: current
-        artifactName: packages
+        artifactName: PackageArtifacts
     - task: PowerShell@2
       displayName: Upload packages to MyGet
       inputs:
         filePath: $(Build.SourcesDirectory)/eng/upload/scripts/UploadPackages.ps1
-        arguments: -apiKey $(MyGetAPIKey) -feedUrl $(FeedUrl) -packagesDir $(Build.ArtifactStagingDirectory)\packages\Shipping
+        arguments: -apiKey $(MyGetAPIKey) -feedUrl $(FeedUrl) -packagesDir $(Build.ArtifactStagingDirectory)\PackageArtifacts
       condition: and(succeeded(), eq(variables['Build.SourceBranch'], '${{ parameters.branchToUpload }}'))


### PR DESCRIPTION
Use the `PackageArtifacts` artifact to publish to MyGet.  The `packages` artifact contains `*.symbols.nupkg` packages that had to have some assemblies stripped out for symbol archiving and those were being mistakenly published to MyGet.