### PR TITLE
don't save incomplete symbols packages

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,6 +102,11 @@ stages:
           env:
             TRYDOTNET_PACKAGES_PATH: $(TryDotNetPackagesPath)
 
+        # Prevent symbols packages from being saved in the following `packages` artifact because they're incomplete.
+        # See `eng/AfterSolutionBuild.targets:StripFilesFromSymbolPackages` for details.
+        - script: del /S $(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)\*.symbols.nupkg
+          displayName: Clean symbol packages
+
         - task: PublishBuildArtifacts@1
           displayName: Publish packages to artifacts container
           inputs:


### PR DESCRIPTION
As a follow-up to issues we saw yesterday, this PR deletes the incomplete `*.symbols.nupkg` before they can be attached to an artifact.  Verified via [internal build](https://dev.azure.com/dnceng/internal/_build/results?buildId=507045&view=results).