### PR TITLE
fix version of locally build/installed package

### DIFF
--- a/dotnet-interactive/build-and-install-dotnet-interactive.ps1
+++ b/dotnet-interactive/build-and-install-dotnet-interactive.ps1
@@ -16,7 +16,7 @@ if (Test-Path 'env:DisableArcade') {
     }
 
     $script:toolLocation = "$thisDir\..\artifacts\packages\Debug\Shipping"
-    $script:toolVersion = "1.0.44142.42"
+    $script:toolVersion = "1.0.0-dev"
 }
 
 if (Get-Command dotnet-interactive -ErrorAction SilentlyContinue) {


### PR DESCRIPTION
Recently the version number calculation was changed to be more in line with arcade standards and the helper script needs to be updated.

Local testing shows:

```
Tool 'microsoft.dotnet-interactive' (version '1.0.20072.3') was successfully uninstalled.
You can invoke the tool using the following command: dotnet-interactive
Tool 'microsoft.dotnet-interactive' (version '1.0.0-dev') was successfully installed.
```