### PR TITLE
Include the Utility and Management modules in PS kernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -378,3 +378,7 @@ docs/\.ionide/
 #Backup files
 *.bak
 NotebookExamples/*/Samples/housing.csv
+
+#PowerShell restored modules
+Microsoft\.DotNet\.Interactive\.PowerShell/Modules/*
+!Microsoft\.DotNet\.Interactive\.PowerShell/Modules/Microsoft\.DotNet\.Interactive\.PowerShell/*

--- a/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -1,5 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Target Name="PSRestoreBuiltInModules" AfterTargets="Restore" BeforeTargets="Build">
+    <PropertyGroup>
+      <PSUtilityUrl>https://raw.githubusercontent.com/PowerShell/PowerShell/master/src/Modules/Windows/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1</PSUtilityUrl>
+      <PSManagementUrl>https://raw.githubusercontent.com/PowerShell/PowerShell/master/src/Modules/Windows/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1</PSManagementUrl>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <PSUtilityFolder>$(MSBuildProjectDirectory)\Modules\Microsoft.PowerShell.Utility</PSUtilityFolder>
+      <PSManagementFolder>$(MSBuildProjectDirectory)\Modules\Microsoft.PowerShell.Management</PSManagementFolder>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(PSUtilityFolder)" />
+    <MakeDir Directories="$(PSManagementFolder)" />
+
+    <DownloadFile SourceUrl="$(PSUtilityUrl)" DestinationFolder="$(PSUtilityFolder)" />
+    <DownloadFile SourceUrl="$(PSManagementUrl)" DestinationFolder="$(PSManagementFolder)" />
+  </Target>
+
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>

--- a/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -1,7 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <!-- This target is used to grab the module manifests for Microsoft.PowerShell.Utility and Microsoft.PowerShell.Management,
-       because they're required for  -->
   <Target Name="PSRestoreBuiltInModules" AfterTargets="Restore" BeforeTargets="Build">
     <PropertyGroup>
       <PSUtilityUrl>https://raw.githubusercontent.com/PowerShell/PowerShell/v7.0.0-rc.2/src/Modules/Windows/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1</PSUtilityUrl>

--- a/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -1,9 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- This target is used to grab the module manifests for Microsoft.PowerShell.Utility and Microsoft.PowerShell.Management,
+       because they're required for  -->
   <Target Name="PSRestoreBuiltInModules" AfterTargets="Restore" BeforeTargets="Build">
     <PropertyGroup>
-      <PSUtilityUrl>https://raw.githubusercontent.com/PowerShell/PowerShell/master/src/Modules/Windows/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1</PSUtilityUrl>
-      <PSManagementUrl>https://raw.githubusercontent.com/PowerShell/PowerShell/master/src/Modules/Windows/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1</PSManagementUrl>
+      <PSUtilityUrl>https://raw.githubusercontent.com/PowerShell/PowerShell/v7.0.0-rc.2/src/Modules/Windows/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1</PSUtilityUrl>
+      <PSManagementUrl>https://raw.githubusercontent.com/PowerShell/PowerShell/v7.0.0-rc.2/src/Modules/Windows/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1</PSManagementUrl>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -38,11 +38,12 @@ namespace Microsoft.DotNet.Interactive.PowerShell
 
             // Add Modules directory that contains the helper modules
             string psModulePath = Environment.GetEnvironmentVariable("PSModulePath");
+            string psJupyterModulePath = Path.Join(
+                Path.GetDirectoryName(typeof(PowerShellKernel).Assembly.Location),
+                "Modules");
 
             Environment.SetEnvironmentVariable("PSModulePath",
-                psModulePath + Path.PathSeparator + Path.Join(
-                    Path.GetDirectoryName(typeof(PowerShellKernel).Assembly.Location),
-                    "Modules"));
+                $"{psJupyterModulePath}{Path.PathSeparator}{psModulePath}");
         }
 
         protected override Task HandleAsync(


### PR DESCRIPTION
- Include the Utility and Management modules in PS kernel;
- Change the module path orders.

The `ForEach-Object -Parallel` example works with this change:

![image](https://user-images.githubusercontent.com/127450/73801766-579c6d00-4770-11ea-8811-918e2a8465ad.png)
