### PR TITLE
Add built in PowerShell modules from PowerShell Gallery

### DIFF
--- a/Binder Dependencies/NuGet.config
+++ b/Binder Dependencies/NuGet.config
@@ -11,5 +11,6 @@
     <add key="dotnet-try" value="https://dotnet.myget.org/F/dotnet-try/api/v3/index.json" />
     <add key="roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
     <add key="dotnet-corefxlab" value="https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
+    <add key="PSGallery" value="https://www.powershellgallery.com/api/v2/" />
   </packageSources>
 </configuration>

--- a/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -49,28 +49,28 @@
   <ItemGroup>
     <Content
       Include="$(NuGetPackageRoot)packagemanagement\$(PackageManagementVersion)\**"
-      Exclude="\**\*.nupkg;\**\*.sha512"
+      Exclude="$(NuGetPackageRoot)**\*.nupkg;$(NuGetPackageRoot)**\*.sha512"
       PackageCopyToOutput="true">
       <Link>Modules\PackageManagement\$(PackageManagementVersion)\%(RecursiveDir)\%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content
       Include="$(NuGetPackageRoot)powershellget\$(PowerShellGetVersion)\**"
-      Exclude="\**\*.nupkg;\**\*.sha512"
+      Exclude="$(NuGetPackageRoot)**\*.nupkg;$(NuGetPackageRoot)**\*.sha512"
       PackageCopyToOutput="true">
       <Link>Modules\PowerShellGet\$(PowerShellGetVersion)\%(RecursiveDir)\%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content
       Include="$(NuGetPackageRoot)microsoft.powershell.archive\$(MicrosoftPowerShellArchiveVersion)\**"
-      Exclude="\**\*.nupkg;\**\*.sha512"
+      Exclude="$(NuGetPackageRoot)**\*.nupkg;$(NuGetPackageRoot)**\*.sha512"
       PackageCopyToOutput="true">
       <Link>Modules\Microsoft.PowerShell.Archive\$(MicrosoftPowerShellArchiveVersion)\%(RecursiveDir)\%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content
       Include="$(NuGetPackageRoot)threadjob\$(ThreadJobVersion)\**"
-      Exclude="\**\*.nupkg;\**\*.sha512"
+      Exclude="$(NuGetPackageRoot)**\*.nupkg;$(NuGetPackageRoot)**\*.sha512"
       PackageCopyToOutput="true">
       <Link>Modules\ThreadJob\$(ThreadJobVersion)\%(RecursiveDir)\%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -49,25 +49,29 @@
   <ItemGroup>
     <Content
       Include="$(NuGetPackageRoot)packagemanagement\$(PackageManagementVersion)\**"
-      Exclude="\**\*.nupkg;\**\*.sha512">
+      Exclude="\**\*.nupkg;\**\*.sha512"
+      PackageCopyToOutput="true">
       <Link>Modules\PackageManagement\$(PackageManagementVersion)\%(RecursiveDir)\%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content
       Include="$(NuGetPackageRoot)powershellget\$(PowerShellGetVersion)\**"
-      Exclude="\**\*.nupkg;\**\*.sha512">
+      Exclude="\**\*.nupkg;\**\*.sha512"
+      PackageCopyToOutput="true">
       <Link>Modules\PowerShellGet\$(PowerShellGetVersion)\%(RecursiveDir)\%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content
-      Include="$(NuGetPackageRoot)microsoft.powerShell.archive\$(MicrosoftPowerShellArchiveVersion)\**"
-      Exclude="\**\*.nupkg;\**\*.sha512">
+      Include="$(NuGetPackageRoot)microsoft.powershell.archive\$(MicrosoftPowerShellArchiveVersion)\**"
+      Exclude="\**\*.nupkg;\**\*.sha512"
+      PackageCopyToOutput="true">
       <Link>Modules\Microsoft.PowerShell.Archive\$(MicrosoftPowerShellArchiveVersion)\%(RecursiveDir)\%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content
       Include="$(NuGetPackageRoot)threadjob\$(ThreadJobVersion)\**"
-      Exclude="\**\*.nupkg;\**\*.sha512">
+      Exclude="\**\*.nupkg;\**\*.sha512"
+      PackageCopyToOutput="true">
       <Link>Modules\ThreadJob\$(ThreadJobVersion)\%(RecursiveDir)\%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -1,5 +1,79 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <NoWarn>$(NoWarn);2003;CS8002;NU1608;</NoWarn> <!-- AssemblyInformationalVersionAttribute contains a non-standard value -->
+    <Deterministic Condition="'$(NCrunch)' == '1'">false</Deterministic>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>;NU5104;2003;8002</NoWarn>
+  </PropertyGroup>
+
+  <!-- PowerShell Module Versions -->
+  <PropertyGroup>
+    <PackageManagementVersion>1.4.6</PackageManagementVersion>
+    <PowerShellGetVersion>2.2.3</PowerShellGetVersion>
+    <MicrosoftPowerShellArchiveVersion>1.2.4</MicrosoftPowerShellArchiveVersion>
+    <ThreadJobVersion>2.0.3</ThreadJobVersion>
+  </PropertyGroup>
+
+  <!-- PowerShell Module Package References -->
+  <ItemGroup>
+    <PackageReference Include="PackageManagement" Version="$(PackageManagementVersion)" />
+    <PackageReference Include="PowerShellGet" Version="$(PowerShellGetVersion)" />
+    <PackageReference Include="Microsoft.PowerShell.Archive" Version="$(MicrosoftPowerShellArchiveVersion)" />
+    <PackageReference Include="ThreadJob" Version="$(ThreadJobVersion)" />
+  </ItemGroup>
+
+  <!-- Get NuGetPackageRoot if it's not defined -->
+  <Target
+    Name="GetNuGetPackageRoot"
+    AfterTargets="Restore"
+    BeforeTargets="Build"
+    Condition=" '$(NuGetPackageRoot)' == '' "
+  >
+    <Exec Command="dotnet nuget locals global-packages --list --force-english-output" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
+    </Exec>
+
+    <PropertyGroup>
+      <RegexForOutputOfExec>info : global-packages: (.*)</RegexForOutputOfExec>
+      <RegexMatch>$([System.Text.RegularExpressions.Regex]::Match($(OutputOfExec), $(RegexForOutputOfExec)).Groups[2].Value)</RegexMatch>
+      <NuGetPackageRoot>$(RegexMatch)</NuGetPackageRoot>
+    </PropertyGroup>
+  </Target>
+
+  <!-- Copy restored contents of PowerShell module nuget pacakges into output -->
+  <ItemGroup>
+    <Content
+      Include="$(NuGetPackageRoot)packagemanagement\$(PackageManagementVersion)\**"
+      Exclude="\**\*.nupkg;\**\*.sha512">
+      <Link>Modules\PackageManagement\$(PackageManagementVersion)\%(RecursiveDir)\%(FileName)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content
+      Include="$(NuGetPackageRoot)powershellget\$(PowerShellGetVersion)\**"
+      Exclude="\**\*.nupkg;\**\*.sha512">
+      <Link>Modules\PowerShellGet\$(PowerShellGetVersion)\%(RecursiveDir)\%(FileName)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content
+      Include="$(NuGetPackageRoot)microsoft.powerShell.archive\$(MicrosoftPowerShellArchiveVersion)\**"
+      Exclude="\**\*.nupkg;\**\*.sha512">
+      <Link>Modules\Microsoft.PowerShell.Archive\$(MicrosoftPowerShellArchiveVersion)\%(RecursiveDir)\%(FileName)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content
+      Include="$(NuGetPackageRoot)threadjob\$(ThreadJobVersion)\**"
+      Exclude="\**\*.nupkg;\**\*.sha512">
+      <Link>Modules\ThreadJob\$(ThreadJobVersion)\%(RecursiveDir)\%(FileName)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <!-- Restore the module manifests for built in modules. This is temporary until https://github.com/PowerShell/PowerShell/issues/11783 is fixed. -->
   <Target Name="PSRestoreBuiltInModules" AfterTargets="Restore" BeforeTargets="Build">
     <PropertyGroup>
       <PSUtilityUrl>https://raw.githubusercontent.com/PowerShell/PowerShell/v7.0.0-rc.2/src/Modules/Windows/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1</PSUtilityUrl>
@@ -18,17 +92,7 @@
     <DownloadFile SourceUrl="$(PSManagementUrl)" DestinationFolder="$(PSManagementFolder)" />
   </Target>
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <NoWarn>$(NoWarn);2003;CS8002;NU1608;</NoWarn> <!-- AssemblyInformationalVersionAttribute contains a non-standard value -->
-    <Deterministic Condition="'$(NCrunch)' == '1'">false</Deterministic>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>;NU5104;2003;8002</NoWarn>
-  </PropertyGroup>
-
+  <!-- The dependencies for this project -->
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.Interactive.Formatting\Microsoft.DotNet.Interactive.Formatting.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Interactive\Microsoft.DotNet.Interactive.csproj" />
@@ -37,6 +101,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.0-rc.1" />
   </ItemGroup>
+
+  <!-- Copies anything in the Modules folder into the output (including the helper module's module manifest) -->
   <ItemGroup>
     <Content Include="Modules\**" PackageCopyToOutput="true">
       <Link>Modules\%(RecursiveDir)\%(FileName)%(Extension)</Link>

--- a/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk" InitialTargets="PSRestoreBuiltInModules;GetNuGetPackageRoot">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -10,6 +10,25 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <NoWarn>;NU5104;2003;8002</NoWarn>
   </PropertyGroup>
+
+  <!-- Restore the module manifests for built in modules. This is temporary until https://github.com/PowerShell/PowerShell/issues/11783 is fixed. -->
+  <Target Name="PSRestoreBuiltInModules">
+    <PropertyGroup>
+      <PSUtilityUrl>https://raw.githubusercontent.com/PowerShell/PowerShell/v7.0.0-rc.2/src/Modules/Windows/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1</PSUtilityUrl>
+      <PSManagementUrl>https://raw.githubusercontent.com/PowerShell/PowerShell/v7.0.0-rc.2/src/Modules/Windows/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1</PSManagementUrl>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <PSUtilityFolder>$(MSBuildProjectDirectory)\Modules\Microsoft.PowerShell.Utility</PSUtilityFolder>
+      <PSManagementFolder>$(MSBuildProjectDirectory)\Modules\Microsoft.PowerShell.Management</PSManagementFolder>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(PSUtilityFolder)" />
+    <MakeDir Directories="$(PSManagementFolder)" />
+
+    <DownloadFile SourceUrl="$(PSUtilityUrl)" DestinationFolder="$(PSUtilityFolder)" />
+    <DownloadFile SourceUrl="$(PSManagementUrl)" DestinationFolder="$(PSManagementFolder)" />
+  </Target>
 
   <!-- PowerShell Module Versions -->
   <PropertyGroup>
@@ -30,8 +49,6 @@
   <!-- Get NuGetPackageRoot if it's not defined -->
   <Target
     Name="GetNuGetPackageRoot"
-    AfterTargets="Restore"
-    BeforeTargets="Build"
     Condition=" '$(NuGetPackageRoot)' == '' "
   >
     <Exec Command="dotnet nuget locals global-packages --list --force-english-output" ConsoleToMSBuild="true">
@@ -51,50 +68,31 @@
       Include="$(NuGetPackageRoot)packagemanagement\$(PackageManagementVersion)\**"
       Exclude="$(NuGetPackageRoot)**\*.nupkg;$(NuGetPackageRoot)**\*.sha512"
       PackageCopyToOutput="true">
-      <Link>Modules\PackageManagement\$(PackageManagementVersion)\%(RecursiveDir)\%(FileName)%(Extension)</Link>
+      <Link>Modules\PackageManagement\%(RecursiveDir)\%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content
       Include="$(NuGetPackageRoot)powershellget\$(PowerShellGetVersion)\**"
       Exclude="$(NuGetPackageRoot)**\*.nupkg;$(NuGetPackageRoot)**\*.sha512"
       PackageCopyToOutput="true">
-      <Link>Modules\PowerShellGet\$(PowerShellGetVersion)\%(RecursiveDir)\%(FileName)%(Extension)</Link>
+      <Link>Modules\PowerShellGet\%(RecursiveDir)\%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content
       Include="$(NuGetPackageRoot)microsoft.powershell.archive\$(MicrosoftPowerShellArchiveVersion)\**"
       Exclude="$(NuGetPackageRoot)**\*.nupkg;$(NuGetPackageRoot)**\*.sha512"
       PackageCopyToOutput="true">
-      <Link>Modules\Microsoft.PowerShell.Archive\$(MicrosoftPowerShellArchiveVersion)\%(RecursiveDir)\%(FileName)%(Extension)</Link>
+      <Link>Modules\Microsoft.PowerShell.Archive\%(RecursiveDir)\%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content
       Include="$(NuGetPackageRoot)threadjob\$(ThreadJobVersion)\**"
       Exclude="$(NuGetPackageRoot)**\*.nupkg;$(NuGetPackageRoot)**\*.sha512"
       PackageCopyToOutput="true">
-      <Link>Modules\ThreadJob\$(ThreadJobVersion)\%(RecursiveDir)\%(FileName)%(Extension)</Link>
+      <Link>Modules\ThreadJob\%(RecursiveDir)\%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-
-  <!-- Restore the module manifests for built in modules. This is temporary until https://github.com/PowerShell/PowerShell/issues/11783 is fixed. -->
-  <Target Name="PSRestoreBuiltInModules" AfterTargets="Restore" BeforeTargets="Build">
-    <PropertyGroup>
-      <PSUtilityUrl>https://raw.githubusercontent.com/PowerShell/PowerShell/v7.0.0-rc.2/src/Modules/Windows/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1</PSUtilityUrl>
-      <PSManagementUrl>https://raw.githubusercontent.com/PowerShell/PowerShell/v7.0.0-rc.2/src/Modules/Windows/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1</PSManagementUrl>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <PSUtilityFolder>$(MSBuildProjectDirectory)\Modules\Microsoft.PowerShell.Utility</PSUtilityFolder>
-      <PSManagementFolder>$(MSBuildProjectDirectory)\Modules\Microsoft.PowerShell.Management</PSManagementFolder>
-    </PropertyGroup>
-
-    <MakeDir Directories="$(PSUtilityFolder)" />
-    <MakeDir Directories="$(PSManagementFolder)" />
-
-    <DownloadFile SourceUrl="$(PSUtilityUrl)" DestinationFolder="$(PSUtilityFolder)" />
-    <DownloadFile SourceUrl="$(PSManagementUrl)" DestinationFolder="$(PSManagementFolder)" />
-  </Target>
 
   <!-- The dependencies for this project -->
   <ItemGroup>

--- a/NotebookExamples/powershell/Samples/Managing-Azure.ipynb
+++ b/NotebookExamples/powershell/Samples/Managing-Azure.ipynb
@@ -4,7 +4,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Creating an Azure VM "
+    "# Working with Azure PowerShell\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "You'll need to install the Az.Resources module to create resource groups."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Install-Module Az.Resources -Force"
    ]
   },
   {
@@ -44,7 +57,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create a resource group with the New-AzResourceGroup command.\n",
+    "## Create a resource group with the New-AzResourceGroup command\n",
     "\n",
     "An Azure resource group is a logical container into which Azure resources are deployed and managed. A resource group must be created before a virtual machine. In the following example, a resource group named myResourceGroupVM is created in the EastUS region:"
    ]
@@ -64,23 +77,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When creating a VM, several options are available like operating system image, network configuration, and administrative credentials. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "New-AzVm `\n",
-    "    -ResourceGroupName \"myResourceGroupVM\" `\n",
-    "    -Name \"myVM\" `\n",
-    "    -Location \"EastUS\" `\n",
-    "    -VirtualNetworkName \"myVnet\" `\n",
-    "    -SubnetName \"mySubnet\" `\n",
-    "    -SecurityGroupName \"myNetworkSecurityGroup\" `\n",
-    "    -PublicIpAddressName \"myPublicIpAddress\" `"
+    "#### Coming soon\n",
+    "\n",
+    "* Creating a VM"
    ]
   }
  ],
@@ -99,5 +98,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/NuGet.config
+++ b/NuGet.config
@@ -12,5 +12,6 @@
     <add key="roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
     <add key="dotnet-corefxlab" value="https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
     <add key="MachineLearning" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/MachineLearning/nuget/v3/index.json" />
+    <add key="PSGallery" value="https://www.powershellgallery.com/api/v2/" />
   </packageSources>
 </configuration>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -9,6 +9,7 @@
     <FileSignInfo Include="Namotion.Reflection.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="NetMQ.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="NJsonSchema.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="PackageManagement.cat" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Serilog.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Serilog.Sinks.RollingFileAlternate.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="XPlot.Plotly.dll" CertificateName="3PartySHA2" />

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -9,7 +9,7 @@
     <FileSignInfo Include="Namotion.Reflection.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="NetMQ.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="NJsonSchema.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="Modules\PackageManagement\*" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Modules\PackageManagement\**\*" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Serilog.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Serilog.Sinks.RollingFileAlternate.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="XPlot.Plotly.dll" CertificateName="3PartySHA2" />

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -9,30 +9,30 @@
     <FileSignInfo Include="Namotion.Reflection.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="NetMQ.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="NJsonSchema.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="PackageManagement.cat" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="PackageManagement.format.ps1xml" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="PackageManagement.psd1" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="PackageManagement.psm1" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="PackageManagement.Resources.psd1" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="PackageProviderFunctions.psm1" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="Microsoft.PackageManagement.ArchiverProviders.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="Microsoft.PackageManagement.CoreProviders.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="Microsoft.PackageManagement.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="Microsoft.PackageManagement.MetaProvider.PowerShell.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="Microsoft.PackageManagement.NuGetProvider.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="Microsoft.PowerShell.PackageManagement.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="Microsoft.PackageManagement.MsiProvider.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="Microsoft.PackageManagement.MsuProvider.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="PackageManagementDscUtilities.psm1" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="PackageManagementDscUtilities.strings.psd1" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="MSFT_PackageManagement.psm1" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="MSFT_PackageManagement.schema.mfl" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="MSFT_PackageManagement.schema.mof" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="MSFT_PackageManagement.strings.psd1" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="MSFT_PackageManagementSource.psm1" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="MSFT_PackageManagementSource.schema.mfl" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="MSFT_PackageManagementSource.schema.mof" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="MSFT_PackageManagementSource.strings.psd1" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="PackageManagement.cat" CertificateName="None" />
+    <FileSignInfo Include="PackageManagement.format.ps1xml" CertificateName="None" />
+    <FileSignInfo Include="PackageManagement.psd1" CertificateName="None" />
+    <FileSignInfo Include="PackageManagement.psm1" CertificateName="None" />
+    <FileSignInfo Include="PackageManagement.Resources.psd1" CertificateName="None" />
+    <FileSignInfo Include="PackageProviderFunctions.psm1" CertificateName="None" />
+    <FileSignInfo Include="Microsoft.PackageManagement.ArchiverProviders.dll" CertificateName="None" />
+    <FileSignInfo Include="Microsoft.PackageManagement.CoreProviders.dll" CertificateName="None" />
+    <FileSignInfo Include="Microsoft.PackageManagement.dll" CertificateName="None" />
+    <FileSignInfo Include="Microsoft.PackageManagement.MetaProvider.PowerShell.dll" CertificateName="None" />
+    <FileSignInfo Include="Microsoft.PackageManagement.NuGetProvider.dll" CertificateName="None" />
+    <FileSignInfo Include="Microsoft.PowerShell.PackageManagement.dll" CertificateName="None" />
+    <FileSignInfo Include="Microsoft.PackageManagement.MsiProvider.dll" CertificateName="None" />
+    <FileSignInfo Include="Microsoft.PackageManagement.MsuProvider.dll" CertificateName="None" />
+    <FileSignInfo Include="PackageManagementDscUtilities.psm1" CertificateName="None" />
+    <FileSignInfo Include="PackageManagementDscUtilities.strings.psd1" CertificateName="None" />
+    <FileSignInfo Include="MSFT_PackageManagement.psm1" CertificateName="None" />
+    <FileSignInfo Include="MSFT_PackageManagement.schema.mfl" CertificateName="None" />
+    <FileSignInfo Include="MSFT_PackageManagement.schema.mof" CertificateName="None" />
+    <FileSignInfo Include="MSFT_PackageManagement.strings.psd1" CertificateName="None" />
+    <FileSignInfo Include="MSFT_PackageManagementSource.psm1" CertificateName="None" />
+    <FileSignInfo Include="MSFT_PackageManagementSource.schema.mfl" CertificateName="None" />
+    <FileSignInfo Include="MSFT_PackageManagementSource.schema.mof" CertificateName="None" />
+    <FileSignInfo Include="MSFT_PackageManagementSource.strings.psd1" CertificateName="None" />
     <FileSignInfo Include="Serilog.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Serilog.Sinks.RollingFileAlternate.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="XPlot.Plotly.dll" CertificateName="3PartySHA2" />

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -9,7 +9,7 @@
     <FileSignInfo Include="Namotion.Reflection.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="NetMQ.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="NJsonSchema.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="PackageManagement.cat" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Modules\PackageManagement\*" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Serilog.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Serilog.Sinks.RollingFileAlternate.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="XPlot.Plotly.dll" CertificateName="3PartySHA2" />

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -9,7 +9,30 @@
     <FileSignInfo Include="Namotion.Reflection.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="NetMQ.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="NJsonSchema.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="Modules\PackageManagement\**\*" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="PackageManagement.cat" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="PackageManagement.format.ps1xml" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="PackageManagement.psd1" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="PackageManagement.psm1" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="PackageManagement.Resources.psd1" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="PackageProviderFunctions.psm1" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Microsoft.PackageManagement.ArchiverProviders.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Microsoft.PackageManagement.CoreProviders.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Microsoft.PackageManagement.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Microsoft.PackageManagement.MetaProvider.PowerShell.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Microsoft.PackageManagement.NuGetProvider.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Microsoft.PowerShell.PackageManagement.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Microsoft.PackageManagement.MsiProvider.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Microsoft.PackageManagement.MsuProvider.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="PackageManagementDscUtilities.psm1" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="PackageManagementDscUtilities.strings.psd1" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="MSFT_PackageManagement.psm1" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="MSFT_PackageManagement.schema.mfl" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="MSFT_PackageManagement.schema.mof" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="MSFT_PackageManagement.strings.psd1" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="MSFT_PackageManagementSource.psm1" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="MSFT_PackageManagementSource.schema.mfl" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="MSFT_PackageManagementSource.schema.mof" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="MSFT_PackageManagementSource.strings.psd1" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Serilog.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Serilog.Sinks.RollingFileAlternate.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="XPlot.Plotly.dll" CertificateName="3PartySHA2" />

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -9,6 +9,19 @@
     <FileSignInfo Include="Namotion.Reflection.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="NetMQ.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="NJsonSchema.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Serilog.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Serilog.Sinks.RollingFileAlternate.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="XPlot.Plotly.dll" CertificateName="3PartySHA2" />
+
+    <!-- PowerShell Modules that are shipped with the PowerShell subkernel -->
+
+    <!-- Microsoft.PowerShell.Archive -->
+    <FileSignInfo Include="Microsoft.PowerShell.Archive.cat" CertificateName="None" />
+    <FileSignInfo Include="Microsoft.PowerShell.Archive.psd1" CertificateName="None" />
+    <FileSignInfo Include="Microsoft.PowerShell.Archive.psm1" CertificateName="None" />
+    <FileSignInfo Include="ArchiveResources.psd1" CertificateName="None" />
+
+    <!-- PackageManagement -->
     <FileSignInfo Include="PackageManagement.cat" CertificateName="None" />
     <FileSignInfo Include="PackageManagement.format.ps1xml" CertificateName="None" />
     <FileSignInfo Include="PackageManagement.psd1" CertificateName="None" />
@@ -33,9 +46,28 @@
     <FileSignInfo Include="MSFT_PackageManagementSource.schema.mfl" CertificateName="None" />
     <FileSignInfo Include="MSFT_PackageManagementSource.schema.mof" CertificateName="None" />
     <FileSignInfo Include="MSFT_PackageManagementSource.strings.psd1" CertificateName="None" />
-    <FileSignInfo Include="Serilog.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="Serilog.Sinks.RollingFileAlternate.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="XPlot.Plotly.dll" CertificateName="3PartySHA2" />
+    
+    <!-- PowerShellGet -->
+    <FileSignInfo Include="PowerShellGet.cat" CertificateName="None" />
+    <FileSignInfo Include="PowerShellGet.psd1" CertificateName="None" />
+    <FileSignInfo Include="PSGet.Format.ps1xml" CertificateName="None" />
+    <FileSignInfo Include="PSGet.Resource.psd1" CertificateName="None" />
+    <FileSignInfo Include="PSModule.psm1" CertificateName="None" />
+    <FileSignInfo Include="MSFT_PSRepository.psm1" CertificateName="None" />
+    <FileSignInfo Include="MSFT_PSRepository.schema.mfl" CertificateName="None" />
+    <FileSignInfo Include="MSFT_PSRepository.schema.mof" CertificateName="None" />
+    <FileSignInfo Include="MSFT_PSRepository.strings.psd1" CertificateName="None" />
+    <FileSignInfo Include="MSFT_PSModule.psm1" CertificateName="None" />
+    <FileSignInfo Include="MSFT_PSModule.schema.mfl" CertificateName="None" />
+    <FileSignInfo Include="MSFT_PSModule.schema.mof" CertificateName="None" />
+    <FileSignInfo Include="MSFT_PSModule.strings.psd1" CertificateName="None" />
+    <FileSignInfo Include="PowerShellGet.ResourceHelper.psm1" CertificateName="None" />
+    <FileSignInfo Include="PowerShellGet.ResourceHelper.strings.psd1" CertificateName="None" />
+    <FileSignInfo Include="PowerShellGet.LocalizationHelper.psm1" CertificateName="None" />
+
+    <!-- ThreadJob -->
+    <FileSignInfo Include="Microsoft.PowerShell.ThreadJob.dll" CertificateName="None" />
+    <FileSignInfo Include="ThreadJob.psd1" CertificateName="None" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
So the past day or so I've been trying to pull in the PowerShell modules that PowerShell itself ships... one of which is the package manager: PowerShellGet.

Here's what we do in PowerShell:
We have a csproj here:
https://github.com/PowerShell/PowerShell/blob/master/src/Modules/PSGalleryModules.csproj

And then we use this PowerShell script to grab the contents out of the nuget cache:
https://github.com/PowerShell/PowerShell/blob/master/build.psm1#L2377-L2434

In an attempt to keep this project only using msbuild, I have replicated most of that script to msbuild.

Thankfully the PowerShell Gallery (the nuget.org of PowerShell) is just a nuget repository... but the structure of the nupkg seems to be different so we can't simply do PrivateAssets=all.

The gist is:

* For each PowerShell Module, restore the package
* Figure out the path to the nuget cache if needed
* Grab the contents of the package from the nuget cache and put it in the output