### PR TITLE
disable flaky test/build hackery

### DIFF
--- a/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
+++ b/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
@@ -152,7 +152,7 @@ namespace Microsoft.DotNet.Interactive.App.Tests.CommandLine
             testConsole.Error.ToString().Should().Contain("Required argument missing for command: jupyter");
         }
 
-        [Fact]
+        [Fact(Skip = "build hackery is flaky; see dotnet-interactive.csproj")]
         public async Task kernel_server_honors_log_path()
         {
             using var logPath = DisposableDirectory.Create();

--- a/dotnet-interactive/dotnet-interactive.csproj
+++ b/dotnet-interactive/dotnet-interactive.csproj
@@ -129,11 +129,12 @@
   </Target>
 
   <!-- Copied from https://github.com/dotnet/sdk/issues/1675 to ensure *.runtimeconfig.json is copied to projects referencing this, e.g., test projects. -->
-  <Target Name="AddRuntimeDependenciesToContent" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" BeforeTargets="GetCopyToOutputDirectoryItems" DependsOnTargets="GenerateBuildDependencyFile;GenerateBuildRuntimeConfigurationFiles">
+  <!-- Temporarily disabled to investigate flaky build. -->
+  <!-- <Target Name="AddRuntimeDependenciesToContent" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" BeforeTargets="GetCopyToOutputDirectoryItems" DependsOnTargets="GenerateBuildDependencyFile;GenerateBuildRuntimeConfigurationFiles">
     <ItemGroup>
       <ContentWithTargetPath Include="$(ProjectDepsFilePath)" CopyToOutputDirectory="PreserveNewest" TargetPath="$(ProjectDepsFileName)" Condition="'$(BuildingTestProject)' == 'true'" />
       <ContentWithTargetPath Include="$(ProjectRuntimeConfigFilePath)" CopyToOutputDirectory="PreserveNewest" TargetPath="$(ProjectRuntimeConfigFileName)" />
     </ItemGroup>
-  </Target>
+  </Target> -->
 
 </Project>


### PR DESCRIPTION
PR #106 introduced some build flakiness.  Backing out the MSBuild hackery and disabling the test to unblock everything else.