### PR TITLE
Set the execution policy to be RemoteSigned on Windows

### DIFF
--- a/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -101,7 +101,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.0-rc.1" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.0-rc.2" />
   </ItemGroup>
 
   <!-- Copies anything in the Modules folder into the output (including the helper module's module manifest) -->

--- a/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -35,7 +35,14 @@ namespace Microsoft.DotNet.Interactive.PowerShell
                 Environment.SetEnvironmentVariable("POWERSHELL_DISTRIBUTION_CHANNEL", "dotnet-interactive-powershell");
 
                 // Create PowerShell instance
-                var runspace = RunspaceFactory.CreateRunspace(InitialSessionState.CreateDefault());
+                var iss = InitialSessionState.CreateDefault();
+                if(Platform.IsWindows)
+                {
+                    // This sets the execution policy on Windows to RemoteSigned.
+                    iss.ExecutionPolicy = Microsoft.PowerShell.ExecutionPolicy.RemoteSigned;
+                }
+
+                var runspace = RunspaceFactory.CreateRunspace(iss);
                 runspace.Open();
                 var pwsh = PowerShell.Create(runspace);
 


### PR DESCRIPTION
Set the execution policy to be `RemoteSigned` on Windows, so that the user can execute scripts or import a script module in Jupyter on Windows.