### PR TITLE
Emptypackages

### DIFF
--- a/Microsoft.DotNet.Interactive/PackageRestoreContext.cs
+++ b/Microsoft.DotNet.Interactive/PackageRestoreContext.cs
@@ -279,18 +279,18 @@ namespace s
             <NuGetPackageVersion>%(__InteractiveReferencedAssembliesCopyLocal.NuGetPackageVersion)</NuGetPackageVersion>
         </InteractiveResolvedFile>
 
-        <NativeIncludeRoots
-            Include="@(Compile)"
-            Condition="'%(Compile.NugetItemType)' == 'Compile' and $([System.String]::Copy('%(Compile.Identity)').IndexOf('contentFiles', System.StringComparison.InvariantCultureIgnoreCase)) != -1"
-            KeepDuplicates="false">
+        <ContentIncludeRoots
+            Include=""@(Compile)""
+            Condition=""'%(Compile.NugetItemType)' == 'Compile' and $([System.String]::Copy('%(Compile.Identity)').IndexOf('contentFiles', System.StringComparison.InvariantCultureIgnoreCase)) != -1""
+            KeepDuplicates=""false"">
             <PositionPathInPackage>$([System.String]::Copy('%(Compile.Identity)').IndexOf('contentFiles', System.StringComparison.InvariantCultureIgnoreCase))</PositionPathInPackage>
-            <Path>$([System.String]::Copy('%(Compile.Identity)').Substring(0, %(NativeIncludeRoots.PositionPathInPackage)))</Path>
-        </NativeIncludeRoots>
+            <Path>$([System.String]::Copy('%(Compile.Identity)').Substring(0, %(ContentIncludeRoots.PositionPathInPackage)))</Path>
+        </ContentIncludeRoots>
 
         <NativeIncludeRoots
             Include=""@(RuntimeTargetsCopyLocalItems)""
             Condition=""'%(RuntimeTargetsCopyLocalItems.AssetType)' == 'native'""
-            KeepDuplicates="false">
+            KeepDuplicates=""false"">
             <Path>$([MSBuild]::EnsureTrailingSlash('$([System.String]::Copy('%(FullPath)').Substring(0, $([System.String]::Copy('%(FullPath)').LastIndexOf('runtimes'))))'))</Path>
         </NativeIncludeRoots>
       </ItemGroup>
@@ -303,7 +303,8 @@ namespace s
 
     <ItemGroup>
       <ResolvedReferenceLines Remove='*' />
-      <ResolvedReferenceLines Include='%(InteractiveResolvedFile.NugetPackageId),%(InteractiveResolvedFile.NugetPackageVersion),%(InteractiveResolvedFile.Identity),%(NativeIncludeRoots.Path),$(AppHostRuntimeIdentifier)' KeepDuplicates="false" />
+      <ResolvedReferenceLines Include='%(InteractiveResolvedFile.NugetPackageId),%(InteractiveResolvedFile.NugetPackageVersion),%(InteractiveResolvedFile.Identity),%(NativeIncludeRoots.Path),$(AppHostRuntimeIdentifier)' KeepDuplicates=""false"" />
+      <ResolvedReferenceLines Include='%(ContentIncludeRoots.NugetPackageId),%(ContentIncludeRoots.NugetPackageVersion),,%(ContentIncludeRoots.Path),$(AppHostRuntimeIdentifier)' KeepDuplicates=""false"" />
     </ItemGroup>
 
     <WriteLinesToFile Lines='@(ResolvedReferenceLines)' 

--- a/Microsoft.DotNet.Interactive/PackageRestoreContext.cs
+++ b/Microsoft.DotNet.Interactive/PackageRestoreContext.cs
@@ -280,8 +280,17 @@ namespace s
         </InteractiveResolvedFile>
 
         <NativeIncludeRoots
+            Include="@(Compile)"
+            Condition="'%(Compile.NugetItemType)' == 'Compile' and $([System.String]::Copy('%(Compile.Identity)').IndexOf('contentFiles', System.StringComparison.InvariantCultureIgnoreCase)) != -1"
+            KeepDuplicates="false">
+            <PositionPathInPackage>$([System.String]::Copy('%(Compile.Identity)').IndexOf('contentFiles', System.StringComparison.InvariantCultureIgnoreCase))</PositionPathInPackage>
+            <Path>$([System.String]::Copy('%(Compile.Identity)').Substring(0, %(NativeIncludeRoots.PositionPathInPackage)))</Path>
+        </NativeIncludeRoots>
+
+        <NativeIncludeRoots
             Include=""@(RuntimeTargetsCopyLocalItems)""
-            Condition=""'%(RuntimeTargetsCopyLocalItems.AssetType)' == 'native'"">
+            Condition=""'%(RuntimeTargetsCopyLocalItems.AssetType)' == 'native'""
+            KeepDuplicates="false">
             <Path>$([MSBuild]::EnsureTrailingSlash('$([System.String]::Copy('%(FullPath)').Substring(0, $([System.String]::Copy('%(FullPath)').LastIndexOf('runtimes'))))'))</Path>
         </NativeIncludeRoots>
       </ItemGroup>
@@ -294,7 +303,7 @@ namespace s
 
     <ItemGroup>
       <ResolvedReferenceLines Remove='*' />
-      <ResolvedReferenceLines Include='%(InteractiveResolvedFile.NugetPackageId),%(InteractiveResolvedFile.NugetPackageVersion),%(InteractiveResolvedFile.Identity),%(NativeIncludeRoots.Path),$(AppHostRuntimeIdentifier)' />
+      <ResolvedReferenceLines Include='%(InteractiveResolvedFile.NugetPackageId),%(InteractiveResolvedFile.NugetPackageVersion),%(InteractiveResolvedFile.Identity),%(NativeIncludeRoots.Path),$(AppHostRuntimeIdentifier)' KeepDuplicates="false" />
     </ItemGroup>
 
     <WriteLinesToFile Lines='@(ResolvedReferenceLines)' 


### PR DESCRIPTION
So ...

we can't detect package roots for packages that don't participate in the build.  A nuget package that has no dll's to reference is a content assembly.  Content assemblies do participate in the build.  So if no assemblies are referenced it must provide content.

E.g ...
````
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <id>EmptyPackage</id>
    <version>1.0.0</version>
   ...
  </metadata>
  <files>
    <file src="TextFile1.txt" target="contentFiles/any/any/TextFile1.txt" />
  </files>
</package>
````
