### PR TITLE
Replace RestoreSources with #i

### DIFF
--- a/Microsoft.DotNet.Interactive.CSharp/CSharpKernelExtensions.cs
+++ b/Microsoft.DotNet.Interactive.CSharp/CSharpKernelExtensions.cs
@@ -63,15 +63,20 @@ using static {typeof(Kernel).FullName};
 
         private static Command i(PackageRestoreContext restoreContext)
         {
-            return new Command("#i")
+            var iDirective = new Command("#i")
             {
-
+                new Argument<string>("source")
             };
+            iDirective.Handler = CommandHandler.Create<string,KernelInvocationContext>((source,context) =>
+            {
+                restoreContext.AddRestoreSource(source);
+            });
+            return iDirective;
         }
 
         private static Command r(PackageRestoreContext restoreContext)
         {
-            var poundR = new Command("#r")
+            var rDirective = new Command("#r")
             {
                 new Argument<PackageReference>(
                     result =>
@@ -83,7 +88,7 @@ using static {typeof(Kernel).FullName};
                         }
                         else
                         {
-                            result.ErrorMessage = $"Could not parse \"{token}\" as a package reference.";
+                            result.ErrorMessage = $"Unable to parse package reference: \"{token}\"";
                             return null;
                         }
                     })
@@ -92,9 +97,9 @@ using static {typeof(Kernel).FullName};
                 }
             };
 
-            poundR.Handler = CommandHandler.Create<PackageReference, KernelInvocationContext>(HandleAddPackageReference);
+            rDirective.Handler = CommandHandler.Create<PackageReference, KernelInvocationContext>(HandleAddPackageReference);
 
-            return poundR;
+            return rDirective;
 
             async Task HandleAddPackageReference(
                 PackageReference package, 

--- a/Microsoft.DotNet.Interactive.CSharp/CSharpKernelExtensions.cs
+++ b/Microsoft.DotNet.Interactive.CSharp/CSharpKernelExtensions.cs
@@ -67,9 +67,9 @@ using static {typeof(Kernel).FullName};
             {
                 new Argument<string>("source")
             };
-            iDirective.Handler = CommandHandler.Create<string,KernelInvocationContext>((source,context) =>
+            iDirective.Handler = CommandHandler.Create<string, KernelInvocationContext>((source, context) =>
             {
-                restoreContext.AddRestoreSource(source);
+                restoreContext.AddRestoreSource(source.Replace("nuget:", ""));
             });
             return iDirective;
         }

--- a/Microsoft.DotNet.Interactive.CSharp/CSharpKernelExtensions.cs
+++ b/Microsoft.DotNet.Interactive.CSharp/CSharpKernelExtensions.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Formatting;
-using static Microsoft.DotNet.Interactive.Formatting.PocketViewTags;
 
 namespace Microsoft.DotNet.Interactive.CSharp
 {
@@ -44,36 +43,12 @@ using static {typeof(Kernel).FullName};
 
         public static CSharpKernel UseNugetDirective(this CSharpKernel kernel)
         {
-            var packageRefArg = new Argument<PackageReference>(
-                result =>
-                {
-                    var token = result.Tokens.Select(t => t.Value).SingleOrDefault();
-                    if (PackageReference.TryParse(token, out var reference))
-                    {
-                        return reference;
-                    }
-                    else
-                    {
-                        result.ErrorMessage = $"Could not parse \"{token}\" as a package reference.";
-                        return null;
-                    }
-                })
-            {
-                Name = "package"
-            };
-
-            var poundR = new Command("#r")
-            {
-                packageRefArg
-            };
-
             var restoreContext = new PackageRestoreContext();
             kernel.SetProperty(restoreContext);
             kernel.RegisterForDisposal(restoreContext);
 
-            poundR.Handler = CommandHandler.Create<PackageReference, KernelInvocationContext>(HandleAddPackageReference);
-
-            kernel.AddDirective(poundR);
+            kernel.AddDirective(i(restoreContext));
+            kernel.AddDirective(r(restoreContext));
 
             var restore = new Command("#!nuget-restore")
             {
@@ -84,8 +59,46 @@ using static {typeof(Kernel).FullName};
             kernel.AddDirective(restore);
 
             return kernel;
+        }
 
-            async Task HandleAddPackageReference(PackageReference package, KernelInvocationContext pipelineContext)
+        private static Command i(PackageRestoreContext restoreContext)
+        {
+            return new Command("#i")
+            {
+
+            };
+        }
+
+        private static Command r(PackageRestoreContext restoreContext)
+        {
+            var poundR = new Command("#r")
+            {
+                new Argument<PackageReference>(
+                    result =>
+                    {
+                        var token = result.Tokens.Select(t => t.Value).SingleOrDefault();
+                        if (PackageReference.TryParse(token, out var reference))
+                        {
+                            return reference;
+                        }
+                        else
+                        {
+                            result.ErrorMessage = $"Could not parse \"{token}\" as a package reference.";
+                            return null;
+                        }
+                    })
+                {
+                    Name = "package"
+                }
+            };
+
+            poundR.Handler = CommandHandler.Create<PackageReference, KernelInvocationContext>(HandleAddPackageReference);
+
+            return poundR;
+
+            async Task HandleAddPackageReference(
+                PackageReference package, 
+                KernelInvocationContext pipelineContext)
             {
                 var addPackage = new AddPackage(package)
                 {
@@ -107,8 +120,7 @@ using static {typeof(Kernel).FullName};
                         {
                             var added = restoreContext.GetOrAddPackageReference(
                                 package.PackageName,
-                                package.PackageVersion,
-                                package.RestoreSources);
+                                package.PackageVersion);
 
                             if (added is null)
                             {
@@ -122,20 +134,24 @@ using static {typeof(Kernel).FullName};
                 };
 
                 await pipelineContext.HandlingKernel.SendAsync(addPackage);
-            }
 
-            static string GenerateErrorMessage(
-                PackageReference requested,
-                PackageReference existing = null)
-            {
-                if (existing != null &&
-                    !string.IsNullOrEmpty(requested.PackageName) &&
-                    !string.IsNullOrEmpty(requested.PackageVersion))
+                static string GenerateErrorMessage(
+                    PackageReference requested,
+                    PackageReference existing = null)
                 {
-                    return $"{requested.PackageName} version {requested.PackageVersion} cannot be added because version {existing.PackageVersion} was added previously.";
-                }
+                    if (existing != null)
+                    {
+                        if (!string.IsNullOrEmpty(requested.PackageName))
+                        {
+                            if (!string.IsNullOrEmpty(requested.PackageVersion))
+                            {
+                                return $"{requested.PackageName} version {requested.PackageVersion} cannot be added because version {existing.PackageVersion} was added previously.";
+                            }
+                        }
+                    }
 
-                return $"Invalid Package specification: '{requested}'";
+                    return $"Invalid Package specification: '{requested}'";
+                }
             }
         }
 
@@ -151,14 +167,7 @@ using static {typeof(Kernel).FullName};
 
             public static string GetDisplayValueId(PackageReference package)
             {
-                var value = package.PackageName;
-
-                if (string.IsNullOrWhiteSpace(value))
-                {
-                    value = package.RestoreSources;
-                }
-
-                return value.ToLowerInvariant();
+                return package.PackageName.ToLowerInvariant();
             }
         }
 
@@ -172,26 +181,16 @@ using static {typeof(Kernel).FullName};
                 {
                     var messages = new Dictionary<PackageReference, string>(new PackageReferenceComparer());
 
-                    // FIX: (DoNugetRestore) only display for the requested package, not ones that were added in previous submissions
-
                     foreach (var package in restoreContext.RequestedPackageReferences)
                     {
-                        if (string.IsNullOrWhiteSpace(package.PackageName) && 
-                            string.IsNullOrWhiteSpace(package.RestoreSources))
-                        {
-                            context.Publish(new ErrorProduced($"Invalid Package Id: '{package.PackageName}'{Environment.NewLine}"));
-                        }
-                        else
-                        {
-                            // FIX: (DoNugetRestore) for RestoreSources-only #r's, use a clearer message
-                            var message =  InstallingPackageMessage(package) + "...";
-                            context.Publish(
-                                new DisplayedValueProduced(
-                                    message, 
-                                    context.Command, 
-                                    valueId: PackageReferenceComparer.GetDisplayValueId(package)));
-                            messages.Add(package, message);
-                        }
+
+                        var message = InstallingPackageMessage(package) + "...";
+                        context.Publish(
+                            new DisplayedValueProduced(
+                                message,
+                                context.Command,
+                                valueId: PackageReferenceComparer.GetDisplayValueId(package)));
+                        messages.Add(package, message);
                     }
 
                     // Restore packages
@@ -258,10 +257,6 @@ using static {typeof(Kernel).FullName};
                         message += $", version {package.PackageVersion}";
                     }
 
-                }
-                else if (!string.IsNullOrEmpty(package.RestoreSources))
-                {
-                    message += $"    RestoreSources: {package.RestoreSources}" + br;
                 }
 
                 return message;

--- a/Microsoft.DotNet.Interactive.Tests/LanguageKernelExtensionLoadingTests.cs
+++ b/Microsoft.DotNet.Interactive.Tests/LanguageKernelExtensionLoadingTests.cs
@@ -5,12 +5,8 @@ using System;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.DotNet.Interactive.Commands;
-using Microsoft.DotNet.Interactive.CSharp;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Extensions;
-using Microsoft.DotNet.Interactive.FSharp;
-using Microsoft.DotNet.Interactive.Jupyter;
-using Microsoft.DotNet.Interactive.PowerShell;
 using Xunit;
 using Xunit.Abstractions;
 using static Microsoft.DotNet.Interactive.Tests.KernelExtensionTestHelper;
@@ -95,13 +91,16 @@ namespace Microsoft.DotNet.Interactive.Tests
             var kernel = CreateKernel(Language.CSharp);
 
             await kernel.SubmitCodeAsync($@"
-#r ""nuget:RestoreSources={nupkg.Directory.FullName}""
+#i ""nuget:{nupkg.Directory.FullName}""
 #r ""nuget:{packageName},{packageVersion}""            ");
 
             KernelEvents.Should()
-                        .ContainSingle<ReturnValueProduced>(
-                            e =>
-                                e.Value.ToString().Contains(guid));
+                        .ContainSingle<ReturnValueProduced>()
+                        .Which
+                        .Value
+                        .As<string>()
+                        .Should()
+                        .Contain(guid);
         }
     }
 }

--- a/Microsoft.DotNet.Interactive.Tests/LanguageKernelExtensionLoadingTests.cs
+++ b/Microsoft.DotNet.Interactive.Tests/LanguageKernelExtensionLoadingTests.cs
@@ -103,5 +103,27 @@ namespace Microsoft.DotNet.Interactive.Tests
                             e =>
                                 e.Value.ToString().Contains(guid));
         }
+
+        [Fact]
+        public async Task BUG()
+        {
+
+            var kernel = CreateKernel(Language.CSharp);
+
+            await kernel.SubmitCodeAsync("#r nuget:RxClockExtension");
+
+            await kernel.SubmitCodeAsync("DateTime.Now");
+
+            KernelEvents.Should()
+                        .ContainSingle<ReturnValueProduced>()
+                        .Which
+                        .FormattedValues
+                        .Should()
+                        .ContainSingle(v => v.MimeType == "text/html")
+                        .Which
+                        .Value
+                        .Should()
+                        .Contain("<circle");
+        }
     }
 }

--- a/Microsoft.DotNet.Interactive.Tests/LanguageKernelExtensionLoadingTests.cs
+++ b/Microsoft.DotNet.Interactive.Tests/LanguageKernelExtensionLoadingTests.cs
@@ -103,27 +103,5 @@ namespace Microsoft.DotNet.Interactive.Tests
                             e =>
                                 e.Value.ToString().Contains(guid));
         }
-
-        [Fact]
-        public async Task BUG()
-        {
-
-            var kernel = CreateKernel(Language.CSharp);
-
-            await kernel.SubmitCodeAsync("#r nuget:RxClockExtension");
-
-            await kernel.SubmitCodeAsync("DateTime.Now");
-
-            KernelEvents.Should()
-                        .ContainSingle<ReturnValueProduced>()
-                        .Which
-                        .FormattedValues
-                        .Should()
-                        .ContainSingle(v => v.MimeType == "text/html")
-                        .Which
-                        .Value
-                        .Should()
-                        .Contain("<circle");
-        }
     }
 }

--- a/Microsoft.DotNet.Interactive.Tests/LanguageKernelExtensionLoadingTests.cs
+++ b/Microsoft.DotNet.Interactive.Tests/LanguageKernelExtensionLoadingTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.DotNet.Interactive.Commands;

--- a/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
+++ b/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
@@ -459,7 +459,7 @@ Formatter<DataFrame>.Register((df, writer) =>
         }
 
         [Fact]
-        public async Task Pound_r_nuget_allows_RestoreSources_package_specification()
+        public async Task Pound_i_nuget_allows_RestoreSources_package_specification()
         {
             var kernel = CreateKernel(Language.CSharp);
 
@@ -475,7 +475,7 @@ Formatter<DataFrame>.Register((df, writer) =>
         }
 
         [Fact]
-        public async Task Pound_r_nuget_allows_duplicate_sources_package_specification_single_cell()
+        public async Task Pound_i_nuget_allows_duplicate_sources_package_specification_single_cell()
         {
             var kernel = CreateKernel(Language.CSharp);
 
@@ -492,7 +492,7 @@ Formatter<DataFrame>.Register((df, writer) =>
         }
 
         [Fact]
-        public async Task Pound_r_nuget_allows_duplicate_sources_package_specification_multiple_cells()
+        public async Task Pound_i_nuget_allows_duplicate_sources_package_specification_multiple_cells()
         {
             var kernel = CreateKernel(Language.CSharp);
 
@@ -514,7 +514,7 @@ Formatter<DataFrame>.Register((df, writer) =>
         }
 
         [Fact]
-        public async Task Pound_r_nuget_allows_multiple_sources_package_specification_single_cell()
+        public async Task Pound_i_nuget_allows_multiple_sources_package_specification_single_cell()
         {
             var kernel = CreateKernel(Language.CSharp);
 
@@ -530,7 +530,7 @@ Formatter<DataFrame>.Register((df, writer) =>
         }
 
         [Fact]
-        public async Task Pound_r_nuget_allows_multiple_sources_package_specification_multiple_cells()
+        public async Task Pound_i_nuget_allows_multiple_package_sources_to_be_specified_in_multiple_cells()
         {
             var kernel = CreateKernel(Language.CSharp);
 

--- a/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
+++ b/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
@@ -372,7 +372,7 @@ catch (Exception e)
             using var events = kernel.KernelEvents.ToSubscribedList();
 
             await kernel.SubmitCodeAsync(@"#!time
-#r ""nuget:RestoreSources=https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json""
+#i ""nuget:https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json""
 #r ""nuget:Microsoft.ML.AutoML,0.16.0-preview""
 #r ""nuget:Microsoft.Data.DataFrame,1.0.0-e190910-1""
 ");
@@ -428,11 +428,12 @@ Formatter<DataFrame>.Register((df, writer) =>
 ");
 
             events
-                .OfType<ErrorProduced>()
-                .Last()
-                .Value
                 .Should()
-                .Be($"Invalid Package Id: ''{Environment.NewLine}");
+                .ContainSingle<CommandFailed>()
+                .Which
+                .Message
+                .Should()
+                .Be("Unable to parse package reference: \"nuget:\"");
         }
 
         [Fact]
@@ -449,11 +450,12 @@ Formatter<DataFrame>.Register((df, writer) =>
 ");
 
             events
-                .OfType<ErrorProduced>()
-                .Last()
-                .Value
                 .Should()
-                .Be($"Invalid Package Id: ''{Environment.NewLine}");
+                .ContainSingle<CommandFailed>()
+                .Which
+                .Message
+                .Should()
+                .Be("Unable to parse package reference: \"nuget:,1.0.0\"");
         }
 
         [Fact]
@@ -466,7 +468,7 @@ Formatter<DataFrame>.Register((df, writer) =>
             await kernel.SubmitCodeAsync(
                 @"
 #!time
-#r ""nuget:RestoreSources=https://completelyFakerestoreSource""
+#i ""nuget:https://completelyFakerestoreSource""
 ");
 
             events.Should().NotContainErrors();
@@ -482,8 +484,8 @@ Formatter<DataFrame>.Register((df, writer) =>
             await kernel.SubmitCodeAsync(
                 @"
 #!time
-#r ""nuget:RestoreSources=https://completelyFakerestoreSource""
-#r ""nuget:RestoreSources=https://completelyFakerestoreSource""
+#i ""nuget:https://completelyFakerestoreSource""
+#i ""nuget:https://completelyFakerestoreSource""
 ");
 
             events.Should().NotContainErrors();
@@ -499,13 +501,13 @@ Formatter<DataFrame>.Register((df, writer) =>
             await kernel.SubmitCodeAsync(
                 @"
 #!time
-#r ""nuget:RestoreSources=https://completelyFakerestoreSource""
+#i ""nuget:https://completelyFakerestoreSource""
 ");
 
             await kernel.SubmitCodeAsync(
                 @"
 #!time
-#r ""nuget:RestoreSources=https://completelyFakerestoreSource""
+#i ""nuget:https://completelyFakerestoreSource""
 ");
 
             events.Should().NotContainErrors();
@@ -521,7 +523,7 @@ Formatter<DataFrame>.Register((df, writer) =>
             await kernel.SubmitCodeAsync(
                 @"
 #!time
-#r ""nuget:RestoreSources=https://completelyFakerestoreSource""
+#i ""nuget:https://completelyFakerestoreSource""
 ");
 
             events.Should().NotContainErrors();
@@ -537,14 +539,14 @@ Formatter<DataFrame>.Register((df, writer) =>
             await kernel.SubmitCodeAsync(
                 @"
 #!time
-#r ""nuget:RestoreSources=https://completelyFakerestoreSource""
+#i ""nuget:https://completelyFakerestoreSource""
 ");
             events.Should().NotContainErrors();
 
             await kernel.SubmitCodeAsync(
                 @"
 #!time
-#r ""nuget:RestoreSources=https://anotherCompletelyFakerestoreSource""
+#i ""nuget:https://anotherCompletelyFakerestoreSource""
 ");
 
             events.Should().NotContainErrors();

--- a/Microsoft.DotNet.Interactive.Tests/PackageReferenceTests.cs
+++ b/Microsoft.DotNet.Interactive.Tests/PackageReferenceTests.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.Interactive.Tests
 {
     public class PackageReferenceTests
     {
-        [Theory(Timeout = 45000)]
+        [Theory]
         [InlineData("nuget:PocketLogger")]
         [InlineData("nuget:PocketLogger,1.2.3")]
         [InlineData("nuget:PocketLogger, 1.2.3")]
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Interactive.Tests
             reference.PackageName.Should().Be("PocketLogger");
         }
 
-        [Theory(Timeout = 45000)]
+        [Theory]
         [InlineData("nuget:PocketLogger", "")]
         [InlineData("nuget:PocketLogger,1.2.3", "1.2.3")]
         [InlineData("nuget:PocketLogger, 1.2.3", "1.2.3")]

--- a/Microsoft.DotNet.Interactive/KernelInvocationContextExtensions.cs
+++ b/Microsoft.DotNet.Interactive/KernelInvocationContextExtensions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Formatting;
 
@@ -11,25 +10,28 @@ namespace Microsoft.DotNet.Interactive
 {
     public static class KernelInvocationContextExtensions
     {
-        public static async Task<DisplayedValue> DisplayAsync(
+        public static Task<DisplayedValue> DisplayAsync(
             this KernelInvocationContext context,
-            object value, 
+            object value,
             string mimeType = null)
         {
             var displayId = Kernel.DisplayIdGenerator?.Invoke() ??
                             Guid.NewGuid().ToString();
 
-             mimeType ??= Formatter.PreferredMimeTypeFor(value.GetType());
+            mimeType ??= Formatter.PreferredMimeTypeFor(value.GetType());
 
-            var formatted = new FormattedValue(
+            var formattedValue = new FormattedValue(
                 mimeType,
                 value.ToDisplayString(mimeType));
 
-            var kernel = context.HandlingKernel ?? context.CurrentKernel;
+            context.Publish(
+                new DisplayedValueProduced(
+                    value,
+                    context?.Command,
+                    new[] { formattedValue },
+                    displayId));
 
-            await kernel.SendAsync(new DisplayValue(value, formatted, displayId));
-
-            return new DisplayedValue(displayId, mimeType, context);
+            return Task.FromResult(new DisplayedValue(displayId, mimeType, context));
         }
     }
 }

--- a/Microsoft.DotNet.Interactive/KernelInvocationContextExtensions.cs
+++ b/Microsoft.DotNet.Interactive/KernelInvocationContextExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.Interactive
 
             await kernel.SendAsync(new DisplayValue(value, formatted, displayId));
 
-            return new DisplayedValue(displayId, mimeType);
+            return new DisplayedValue(displayId, mimeType, context);
         }
     }
 }

--- a/Microsoft.DotNet.Interactive/PackageReference.cs
+++ b/Microsoft.DotNet.Interactive/PackageReference.cs
@@ -43,7 +43,14 @@ namespace Microsoft.DotNet.Interactive
                 return false;
             }
 
-            var packageName = parts[0].Substring(6);
+            var packageName = parts[0].Substring(6).Trim();
+
+            if (string.IsNullOrWhiteSpace(packageName))
+            {
+                reference = null;
+                return false;
+            }
+
             var packageVersion = parts.Length > 1
                                      ? parts[1]
                                      : null;

--- a/Microsoft.DotNet.Interactive/PackageReference.cs
+++ b/Microsoft.DotNet.Interactive/PackageReference.cs
@@ -3,48 +3,57 @@
 
 using System;
 using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.Interactive
 {
     public class PackageReference
     {
-        private static readonly Regex _regex = new Regex(
-            @"(?<moniker>nuget)(?<colon>\s*:\s*)(?<packageName>(?!RestoreSources\s*=\s*)[^,]+)*(\s*,\s*(?<packageVersion>(?!RestoreSources\s*=\s*)[^,]+))*(?<comma>\s*,\s*)*(RestoreSources\s*=\s*(?<restoreSources>[^,]+)*)*",
-            RegexOptions.Compiled |
-            RegexOptions.CultureInvariant |
-            RegexOptions.Singleline);
-
-        public PackageReference(string packageName, string packageVersion = null, string restoreSources = null)
+        public PackageReference(string packageName, string packageVersion = null)
         {
-            PackageName = packageName ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(packageName))
+            {
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(packageName));
+            }
+
+            PackageName = packageName ;
             PackageVersion = packageVersion ?? string.Empty;
-            RestoreSources = restoreSources ?? string.Empty;
         }
 
         public string PackageName { get; }
 
         public string PackageVersion { get; }
 
-        public string RestoreSources { get; }
-
         public static bool TryParse(string value, out PackageReference reference)
         {
-            var result = _regex.Match(value);
+            value = value.Trim();
 
-            if (!result.Success)
+            if (!value.StartsWith("nuget:"))
             {
                 reference = null;
                 return false;
             }
 
-            var packageName = result.Groups["packageName"].Value;
-            var packageVersion = result.Groups["packageVersion"].Value;
-            var restoreSources = result.Groups["restoreSources"].Value;
-            reference = new PackageReference(packageName, packageVersion, restoreSources);
+            var parts = value.Split(",", 2)
+                             .Select(v => v.Trim())
+                             .ToArray();
+
+            if (parts.Length == 0)
+            {
+                reference = null;
+                return false;
+            }
+
+            var packageName = parts[0].Substring(6);
+            var packageVersion = parts.Length > 1
+                                     ? parts[1]
+                                     : null;
+
+            reference = new PackageReference(packageName, packageVersion);
 
             return true;
         }
+
+        public bool IsPackageVersionSpecified => !string.IsNullOrWhiteSpace(PackageVersion) || PackageVersion == "*";
 
         public override string ToString()
         {

--- a/Microsoft.DotNet.Interactive/SubmissionSplitter.cs
+++ b/Microsoft.DotNet.Interactive/SubmissionSplitter.cs
@@ -53,7 +53,8 @@ namespace Microsoft.DotNet.Interactive
 
                         var runDirective = new DirectiveCommand(parseResult);
 
-                        if (command.Name == "#r")
+                        if (command.Name == "#r" || 
+                            command.Name == "#i")
                         {
                             packageCommands.Add(runDirective);
                         }

--- a/Microsoft.DotNet.Interactive/SubmissionSplitter.cs
+++ b/Microsoft.DotNet.Interactive/SubmissionSplitter.cs
@@ -28,66 +28,70 @@ namespace Microsoft.DotNet.Interactive
                 submitCode.Code.Split(new[] { "\r\n", "\n" },
                                       StringSplitOptions.None));
 
-            var nonDirectiveLines = new List<string>();
+            var linesToForward = new List<string>();
             var commands = new List<IKernelCommand>();
-            var hoistedCommands = new List<IKernelCommand>();
+            var packageCommands = new List<IKernelCommand>();
             var commandWasSplit = false;
 
             while (lines.Count > 0)
             {
                 var currentLine = lines.Dequeue();
 
-                if (string.IsNullOrWhiteSpace(currentLine))
+                if (currentLine.TrimStart().StartsWith("#"))
                 {
-                    nonDirectiveLines.Add(currentLine);
-                    continue;
-                }
+                    var parseResult = directiveParser.Parse(currentLine);
+                    var command = parseResult.CommandResult.Command;
 
-                var parseResult = directiveParser.Parse(currentLine);
-                var command = parseResult.CommandResult.Command;
-
-                if (parseResult.Errors.Count == 0)
-                {
-                    commandWasSplit = true;
-
-                    if (AccumulatedSubmission() is { } cmd)
+                    if (parseResult.Errors.Count == 0)
                     {
-                        commands.Add(cmd);
-                    }
+                        commandWasSplit = true;
 
-                    var runDirective = new DirectiveCommand(parseResult);
+                        if (AccumulatedSubmission() is { } cmd)
+                        {
+                            commands.Add(cmd);
+                        }
 
-                    if (command.Name == "#r")
-                    {
-                        hoistedCommands.Add(runDirective);
+                        var runDirective = new DirectiveCommand(parseResult);
+
+                        if (command.Name == "#r")
+                        {
+                            packageCommands.Add(runDirective);
+                        }
+                        else
+                        {
+                            commands.Add(runDirective);
+                        }
                     }
                     else
                     {
-                        commands.Add(runDirective);
+                        if (command == parseResult.Parser.Configuration.RootCommand)
+                        {
+                            linesToForward.Add(currentLine);
+                        }
+                        else if (IsDirectiveSupportedByCompiler(command, parseResult))
+                        {
+                            linesToForward.Add(currentLine);
+                        }
+                        else
+                        {
+                            commands.Clear();
+                            commands.Add(
+                                new AnonymousKernelCommand((kernelCommand, context) =>
+                                {
+                                    var message =
+                                        string.Join(Environment.NewLine,
+                                                    parseResult.Errors
+                                                               .Select(e => e.ToString()));
+
+                                    context.Fail(message: message);
+                                    return Task.CompletedTask;
+                                }));
+                        }
                     }
                 }
                 else
                 {
-                    if (command == parseResult.Parser.Configuration.RootCommand ||
-                        command.Name == "#r")
-                    {
-                        nonDirectiveLines.Add(currentLine);
-                    }
-                    else
-                    {
-                        var message =
-                            string.Join(Environment.NewLine,
-                                        parseResult.Errors
-                                                   .Select(e => e.ToString()));
-
-                        commands.Clear();
-                        commands.Add(
-                            new AnonymousKernelCommand((kernelCommand, context) =>
-                            {
-                                 context.Fail(message: message);
-                                 return Task.CompletedTask;
-                            }));
-                    }
+                    linesToForward.Add(currentLine);
                 }
             }
 
@@ -103,22 +107,22 @@ namespace Microsoft.DotNet.Interactive
                 commands.Add(submitCode);
             }
 
-            if (hoistedCommands.Count > 0)
+            if (packageCommands.Count > 0)
             {
                 var parseResult = directiveParser.Parse("#!nuget-restore");
 
-                hoistedCommands.Add(new DirectiveCommand(parseResult));
+                packageCommands.Add(new DirectiveCommand(parseResult));
             }
 
-            return hoistedCommands.Concat(commands).ToArray();
+            return packageCommands.Concat(commands).ToArray();
 
             IKernelCommand AccumulatedSubmission()
             {
-                if (nonDirectiveLines.Any())
+                if (linesToForward.Any())
                 {
-                    var code = string.Join(Environment.NewLine, nonDirectiveLines);
+                    var code = string.Join(Environment.NewLine, linesToForward);
 
-                    nonDirectiveLines.Clear();
+                    linesToForward.Clear();
 
                     if (!string.IsNullOrWhiteSpace(code))
                     {
@@ -127,6 +131,25 @@ namespace Microsoft.DotNet.Interactive
                 }
 
                 return null;
+            }
+        }
+
+        private static bool IsDirectiveSupportedByCompiler(
+            ICommand command,
+            ParseResult parseResult)
+        {
+            switch (command.Name)
+            {
+                case "#r":
+                    if (parseResult.Errors.Any(e => e.Message.Contains("nuget:")))
+                    {
+                        return false;
+                    }
+
+                    return true;
+
+                default:
+                    return false;
             }
         }
 


### PR DESCRIPTION
This replaces `#r "nuget:RestoreSources=/path/to/nuget/source"` with `#i "nuget:/path/to/nuget/source"` for the C# kernel. It still supports both URLs and directory paths.

The goal is to make this gesture work eventually in both C# script and FSI but we can pre-polyfill this for now in .NET Interactive's middleware to try it out and work out the details.

 

