### PR TITLE
Update PowerShell sdk to 7-rc.3 to remove the download tasks

### DIFF
--- a/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" InitialTargets="PSRestoreBuiltInModules;GetNuGetPackageRoot">
+﻿<Project Sdk="Microsoft.NET.Sdk" InitialTargets="GetNuGetPackageRoot">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -11,30 +11,11 @@
     <NoWarn>;NU5104;2003;8002</NoWarn>
   </PropertyGroup>
 
-  <!-- Restore the module manifests for built in modules. This is temporary until https://github.com/PowerShell/PowerShell/issues/11783 is fixed. -->
-  <Target Name="PSRestoreBuiltInModules">
-    <PropertyGroup>
-      <PSUtilityUrl>https://raw.githubusercontent.com/PowerShell/PowerShell/v7.0.0-rc.2/src/Modules/Windows/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1</PSUtilityUrl>
-      <PSManagementUrl>https://raw.githubusercontent.com/PowerShell/PowerShell/v7.0.0-rc.2/src/Modules/Windows/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1</PSManagementUrl>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <PSUtilityFolder>$(MSBuildProjectDirectory)\Modules\Microsoft.PowerShell.Utility</PSUtilityFolder>
-      <PSManagementFolder>$(MSBuildProjectDirectory)\Modules\Microsoft.PowerShell.Management</PSManagementFolder>
-    </PropertyGroup>
-
-    <MakeDir Directories="$(PSUtilityFolder)" />
-    <MakeDir Directories="$(PSManagementFolder)" />
-
-    <DownloadFile SourceUrl="$(PSUtilityUrl)" DestinationFolder="$(PSUtilityFolder)" />
-    <DownloadFile SourceUrl="$(PSManagementUrl)" DestinationFolder="$(PSManagementFolder)" />
-  </Target>
-
   <!-- PowerShell Module Versions -->
   <PropertyGroup>
     <PackageManagementVersion>1.4.6</PackageManagementVersion>
     <PowerShellGetVersion>2.2.3</PowerShellGetVersion>
-    <MicrosoftPowerShellArchiveVersion>1.2.4</MicrosoftPowerShellArchiveVersion>
+    <MicrosoftPowerShellArchiveVersion>1.2.5</MicrosoftPowerShellArchiveVersion>
     <ThreadJobVersion>2.0.3</ThreadJobVersion>
   </PropertyGroup>
 
@@ -101,8 +82,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.0-rc.2" />
-    <PackageReference Include="FSharp.Core" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.0-rc.3" />
     <PackageReference Include="XPlot.Plotly" Version="3.0.1" />
   </ItemGroup>
 

--- a/Microsoft.DotNet.Interactive.PowerShell/Modules/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.psd1
+++ b/Microsoft.DotNet.Interactive.PowerShell/Modules/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.psd1
@@ -60,7 +60,7 @@ CmdletsToExport = @(
 )
 
 # Variables to export from this module
-VariablesToExport = '*'
+VariablesToExport = @()
 
 # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
 AliasesToExport = @(

--- a/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.Interactive.PowerShell
                 Environment.SetEnvironmentVariable("POWERSHELL_DISTRIBUTION_CHANNEL", "dotnet-interactive-powershell");
 
                 // Create PowerShell instance
-                var iss = InitialSessionState.CreateDefault();
+                var iss = InitialSessionState.CreateDefault2();
                 if(Platform.IsWindows)
                 {
                     // This sets the execution policy on Windows to RemoteSigned.

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -15,6 +15,35 @@
 
     <!-- PowerShell Modules that are shipped with the PowerShell subkernel -->
 
+    <!-- CimCmdlets -->
+    <FileSignInfo Include="CimCmdlets.psd1" CertificateName="None" />
+
+    <!-- Microsoft.PowerShell.Diagnostics -->
+    <FileSignInfo Include="Microsoft.PowerShell.Diagnostics.psd1" CertificateName="None" />
+    <FileSignInfo Include="Diagnostics.format.ps1xml" CertificateName="None" />
+    <FileSignInfo Include="Event.format.ps1xml" CertificateName="None" />
+    <FileSignInfo Include="GetEvent.types.ps1xml" CertificateName="None" />
+
+    <!-- Microsoft.PowerShell.Host -->
+    <FileSignInfo Include="Microsoft.PowerShell.Host.psd1" CertificateName="None" />
+
+    <!-- Microsoft.PowerShell.Management -->
+    <FileSignInfo Include="Microsoft.PowerShell.Management.psd1" CertificateName="None" />
+
+    <!-- Microsoft.PowerShell.Security -->
+    <FileSignInfo Include="Microsoft.PowerShell.Security.psd1" CertificateName="None" />
+
+    <!-- Microsoft.PowerShell.Utility -->
+    <FileSignInfo Include="Microsoft.PowerShell.Utility.psd1" CertificateName="None" />
+
+    <!-- Microsoft.WSMan.Management -->
+    <FileSignInfo Include="Microsoft.WSMan.Management.psd1" CertificateName="None" />
+    <FileSignInfo Include="WSMan.format.ps1xml" CertificateName="None" />
+
+    <!-- PSDiagnostics -->
+    <FileSignInfo Include="PSDiagnostics.psd1" CertificateName="None" />
+    <FileSignInfo Include="PSDiagnostics.psm1" CertificateName="None" />
+
     <!-- Microsoft.PowerShell.Archive -->
     <FileSignInfo Include="Microsoft.PowerShell.Archive.cat" CertificateName="None" />
     <FileSignInfo Include="Microsoft.PowerShell.Archive.psd1" CertificateName="None" />


### PR DESCRIPTION
Fix #136

https://github.com/PowerShell/PowerShell/issues/11783 was resolved in PowerShell 7.0.0-rc.3.
Now the rc.3 version of the `Microsoft.PowerShell.SDK` NuGet package contains the PowerShell built-in modules for both Windows and Unix platforms, and they get deployed to `runtimes/win/lib/netcoreapp3.1/Modules` and `runtimes/unix/lib/netcoreapp3.1/Modules` respectively for `dotnet build` and `dotnet publish`.

Changes in this PR are:
1. Rev the package version to rc.3, so we can remove the hacky `PSRestoreBuiltInModules` target. Now built-in modules are available in the `$PSHome` module path.
2. Remove the package reference to `FSharp.Core`. It seems nothing depends on it in the PowerShell project.
3. Change `CreateDefault` to `CreateDefault2`, to make the kernel depend on the built-in modules instead of Snapins.
4. Update `eng/Signing.props` to include the signed files. @colombod need your insight here -- the `Host`, `Security`, `Management` and `Utility` modules are included in both `runtimes/win` and `runtimes/unix` folders (they are platform specific). The files for those modules in `runtimes/win` are signed, but the files for those modules in `runtimes/unix` are not signed, even though the file names are the same for both `win` and `unix`. For now, I listed all file names in `Signing.props`, but will need your help to understand if that's correct.

Here are the modules included to `win` and `unix` by `Microsoft.PowerShell.SDK 7.0.0-rc.3`

<img width="1038" alt="Screen Shot 2020-02-22 at 11 05 29 PM" src="https://user-images.githubusercontent.com/127450/75105420-e78f4300-55c7-11ea-922c-461e83944f62.png">


