### PR TITLE
remove unnecessary build property

### DIFF
--- a/dotnet-interactive.Tests/dotnet-interactive.Tests.csproj
+++ b/dotnet-interactive.Tests/dotnet-interactive.Tests.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\dotnet-interactive\dotnet-interactive.csproj" AdditionalProperties="BuildingTestProject=true" />
+    <ProjectReference Include="..\dotnet-interactive\dotnet-interactive.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Interactive.Tests\Microsoft.DotNet.Interactive.Tests.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
This should help with the recent build stability problems and race conditions with MSBuild and locked files.  From an internal email, the project reference property

> creates a parallel universe of all of the (transitive) dependencies of dotnet-interactive.csproj, which then races with the real universe, hitting the problem.

The change that originally required that property has been undone, but this vestige remained.