### PR TITLE
allow F# kernel to return JSON variables

### DIFF
--- a/Microsoft.DotNet.Interactive.Tests/Language.cs
+++ b/Microsoft.DotNet.Interactive.Tests/Language.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#pragma warning disable 8509
 namespace Microsoft.DotNet.Interactive.Tests
 {
     public enum Language
@@ -8,5 +9,18 @@ namespace Microsoft.DotNet.Interactive.Tests
         CSharp = 0,
         FSharp = 1,
         PowerShell = 2,
+    }
+
+    public static class LanguageExtensions
+    {
+        public static string LanguageName(this Language language)
+        {
+            return language switch
+            {
+                Language.CSharp => "csharp",
+                Language.FSharp => "fsharp",
+                Language.PowerShell => "pwsh",
+            };
+        }
     }
 }


### PR DESCRIPTION
Building on #206, the F# kernel had a mechanism to return all available variables so it was a simple refactor to also enable fetching individual values.