### PR TITLE
Make sure output of native executable is captured in PowerShell kernel

### DIFF
--- a/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -41,6 +41,12 @@ namespace Microsoft.DotNet.Interactive.PowerShell
             _writeStreamProperty = typeof(PSObject).GetProperty("WriteStream", BindingFlags.Instance | BindingFlags.NonPublic);
             Type writeStreamType = typeof(PSObject).Assembly.GetType("System.Management.Automation.WriteStreamType");
             _errorStreamValue = Enum.Parse(writeStreamType, "Error");
+
+            // When the downstream cmdlet of a native executable is 'Out-Default', PowerShell assumes
+            // it's running in the console where the 'Out-Default' would be added by default. Hence,
+            // PowerShell won't redirect the standard output of the executable.
+            // To workaround that, we rename 'Out-Default' to 'Out-Default2' to make sure the standard
+            // output is captured.
             _outDefaultCommand = new CmdletInfo("Out-Default2", typeof(OutDefaultCommand));
 
             // Register type accelerators for Plotly.
@@ -164,7 +170,7 @@ namespace Microsoft.DotNet.Interactive.PowerShell
             {
                 ((PSKernelHostUserInterface)_psHost.UI).ResetProgress();
             }
-            
+
             return Task.CompletedTask;
         }
 

--- a/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.Interactive.PowerShell
             _writeStreamProperty = typeof(PSObject).GetProperty("WriteStream", BindingFlags.Instance | BindingFlags.NonPublic);
             Type writeStreamType = typeof(PSObject).Assembly.GetType("System.Management.Automation.WriteStreamType");
             _errorStreamValue = Enum.Parse(writeStreamType, "Error");
-            _outDefaultCommand = new CmdletInfo("Out-Default", typeof(OutDefaultCommand));
+            _outDefaultCommand = new CmdletInfo("Out-Default2", typeof(OutDefaultCommand));
 
             // Register type accelerators for Plotly.
             var accelerator = typeof(PSObject).Assembly.GetType("System.Management.Automation.TypeAccelerators");

--- a/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
+++ b/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
@@ -956,8 +956,9 @@ for ($j = 0; $j -le 4; $j += 4 ) {
 
             var outputs = KernelEvents.OfType<StandardOutputValueProduced>();
             outputs.Should().HaveCountGreaterThan(1);
-            outputs.First()
-                .Value.ToString().ToLowerInvariant()
+            outputs.Select(e => e.Value.ToString())
+                .First(s => s.Trim().Length > 0)
+                .ToLowerInvariant()
                 .Should().Match("*ping*data*");
         }
     }

--- a/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
+++ b/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
@@ -942,5 +942,23 @@ for ($j = 0; $j -le 4; $j += 4 ) {
                 e => e.Value.As<string>().Should().Be("Get-Verb > $null" + Environment.NewLine),
                 e => e.Value.As<string>().Should().Be("echo bar > $null" + Environment.NewLine));
         }
+
+        [Fact()]
+        public async Task PowerShell_native_executable_output_is_collected()
+        {
+            var kernel = CreateKernel(Language.PowerShell);
+
+            var command = Platform.IsWindows
+                ? new SubmitCode("ping.exe -n 1 localhost")
+                : new SubmitCode("ping -c 1 localhost");
+
+            await kernel.SendAsync(command);
+
+            var outputs = KernelEvents.OfType<StandardOutputValueProduced>();
+            outputs.Should().HaveCountGreaterThan(1);
+            outputs.First()
+                .Value.ToString().ToLowerInvariant()
+                .Should().Match("*ping*data*");
+        }
     }
 }


### PR DESCRIPTION
Fix #228

Make sure output of native executable is captured in PowerShell kernel.

When the downstream cmdlet is `Out-Default`, the `NativeCommandProcessor` believes it shouldn't redirect the output of the native executable.
The workaround is simple, just name the cmdlet `Out-Default2` when constructing the `CmdletInfo` object.

<img width="626" alt="Screen Shot 2020-03-03 at 4 26 29 PM" src="https://user-images.githubusercontent.com/127450/75832751-cd91f500-5d6b-11ea-8903-bd32fe9aa236.png">
