### PR TITLE
Fix HTML Create For Sequence

### DIFF
--- a/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
+++ b/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
@@ -444,6 +444,29 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
                       .Be(
                           "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td>8</td></tr><tr><td>1</td><td>&lt;null&gt;</td></tr><tr><td>2</td><td>9</td></tr></tbody></table>");
             }
+
+            [Fact]
+            public void Sequences_contain_different_types_of_elements()
+            {
+                IEnumerable<object> GetCollection()
+                {
+                    yield return true;
+                    yield return 99;
+                    yield return "Hello, World";
+                }
+
+                var formatter = HtmlFormatter.Create(typeof(IEnumerable<object>));
+
+                var writer = new StringWriter();
+
+                formatter.Format(GetCollection(), writer);
+
+                writer.ToString().Should()
+                      .Be(
+                          "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td>True</td></tr><tr><td>1</td><td>99</td></tr><tr><td>2</td><td>Hello, World</td></tr></tbody></table>");
+            }
+
+
         }
     }
 }

--- a/Microsoft.DotNet.Interactive.Formatting/HtmlFormatter{T}.cs
+++ b/Microsoft.DotNet.Interactive.Formatting/HtmlFormatter{T}.cs
@@ -89,11 +89,11 @@ namespace Microsoft.DotNet.Interactive.Formatting
             Func<T, IEnumerable> getKeys = null;
             Func<T, IEnumerable> getValues = instance => (IEnumerable)instance;
 
-            var dictionaryGenericType = typeof(T).GetInterfaces()
+            var dictionaryGenericType = typeof(T).GetAllInterfaces()
                                                  .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>));
-            var dictionaryObjectType = typeof(T).GetInterfaces()
+            var dictionaryObjectType = typeof(T).GetAllInterfaces()
                                                 .FirstOrDefault(i => i == typeof(IDictionary));
-            var enumerableGenericType = typeof(T).GetInterfaces()
+            var enumerableGenericType = typeof(T).GetAllInterfaces()
                                                  .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>));
 
             if (dictionaryGenericType != null || dictionaryObjectType != null)

--- a/Microsoft.DotNet.Interactive.Formatting/HtmlFormatter{T}.cs
+++ b/Microsoft.DotNet.Interactive.Formatting/HtmlFormatter{T}.cs
@@ -123,9 +123,11 @@ namespace Microsoft.DotNet.Interactive.Formatting
                 }
             }
 
-            var destructurer = valueType != null
-                ? Destructurer.Create(valueType)
-                : null;
+            var destructurerCache = new Dictionary<Type, IDestructurer>();
+            if (valueType != null)
+            {
+                destructurerCache.Add(valueType, Destructurer.Create(valueType));
+            }
 
             return new HtmlFormatter<T>((instance, writer) =>
             {
@@ -161,15 +163,20 @@ namespace Microsoft.DotNet.Interactive.Formatting
                 {
                     if (index < Formatter.ListExpansionLimit)
                     {
-                        if (destructurer == null)
+                        IDestructurer destructurer;
+
+                        if (item == null)
                         {
-                            if (item != null)
+                            destructurer = NonDestructurer.Instance;
+                        }
+                        else
+                        {
+                            var itemType = item.GetType();
+
+                            if (!destructurerCache.TryGetValue(itemType, out destructurer))
                             {
                                 destructurer = Destructurer.Create(item.GetType());
-                            }
-                            else
-                            {
-                                destructurer = NonDestructurer.Instance;
+                                destructurerCache.Add(itemType, destructurer);
                             }
                         }
 

--- a/Microsoft.DotNet.Interactive.Formatting/TypeExtensions.cs
+++ b/Microsoft.DotNet.Interactive.Formatting/TypeExtensions.cs
@@ -83,6 +83,16 @@ namespace Microsoft.DotNet.Interactive.Formatting
                        .ToArray();
         }
 
+        public static IEnumerable<Type> GetAllInterfaces(this Type type)
+        {
+            if (type.IsInterface)
+            {
+                yield return type;
+            }
+            foreach (var i in type.GetInterfaces())
+                yield return i;
+        }
+
         public static bool IsAnonymous(this Type type)
         {
             if (type == null)


### PR DESCRIPTION
The CreateForSequence(bool includeInternals) api, assumes, each column has the same type.

This addresszes that by caching one for each type of item.

Here is a repro:
````
#r "nuget:Microsoft.Data.Analysis,0.2.0"
using Microsoft.Data.Analysis;

PrimitiveDataFrameColumn<DateTime> dateTimes = new PrimitiveDataFrameColumn<DateTime>("DateTimes"); // Default length is 0.
PrimitiveDataFrameColumn<int> ints = new PrimitiveDataFrameColumn<int>("Ints", 1); // Makes a column of length 3. Filled with nulls initially
StringDataFrameColumn strings = new StringDataFrameColumn("Strings", 1); // Makes a column of length 3. Filled with nulls initially

// Append 3 values to dateTimes
dateTimes.Append(DateTime.Parse("2019/01/01"));
ints[0]=1;
strings[0]="string 1";

DataFrame df = new DataFrame(dateTimes, ints, strings ); // This will throw if the columns are of different lengths
DataFrameRow row0 = df.Rows[0];
foreach(var x in row0) { Console.WriteLine("{0}", x); }
row0
````

Note that the DataFrame has a different data type for each column/

Observe the error:
````
System.InvalidCastException: Unable to cast object of type 'System.Int32' to type 'System.DateTime'.
   at Microsoft.DotNet.Interactive.Formatting.Destructurer`1.Destructure(Object instance)
   at Microsoft.DotNet.Interactive.Formatting.HtmlFormatter`1.<>c__DisplayClass7_0.<CreateForSequence>b__4(T instance, TextWriter writer)
   at Microsoft.DotNet.Interactive.Formatting.HtmlFormatter`1.Format(T instance, TextWriter writer)
   at Microsoft.DotNet.Interactive.Formatting.TypeFormatter`1.Microsoft.DotNet.Interactive.Formatting.ITypeFormatter.Format(Object instance, TextWriter writer)
   at Microsoft.DotNet.Interactive.Formatting.Formatter`1.FormatTo(T obj, TextWriter writer, String mimeType)
   at Microsoft.DotNet.Interactive.Formatting.Formatter.FormatTo[T](T obj, TextWriter writer, String mimeType)
   at Microsoft.DotNet.Interactive.Formatting.Formatter.ToDisplayString(Object obj, String mimeType)
   at Microsoft.DotNet.Interactive.FormattedValue.<>c__DisplayClass7_0.<FromObject>b__0(String mimeType)
   at System.Linq.Enumerable.SelectEnumerableIterator`2.ToArray()
   at Microsoft.DotNet.Interactive.FormattedValue.FromObject(Object value)
   at Microsoft.DotNet.Interactive.CSharp.CSharpKernel.HandleSubmitCode(SubmitCode submitCode, KernelInvocationContext context)
   at Microsoft.DotNet.Interactive.Commands.KernelCommandBase.InvokeAsync(KernelInvocationContext context)
   at Microsoft.DotNet.Interactive.KernelBase.HandleAsync(IKernelCommand command, KernelInvocationContext context)
   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(IKernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _)
   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.DotNet.Interactive.CompositeKernel.LoadExtensions(IKernelCommand command, KernelInvocationContext context, KernelPipelineContinuation next)
   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.DotNet.Interactive.KernelBase.HandleDirectivesAndSubmitCode(SubmitCode submitCode, KernelInvocationContext context, KernelPipelineContinuation continueOnCurrentPipeline)
   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.DotNet.Interactive.KernelBase.<>c.<<AddCaptureConsoleMiddleware>b__12_0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.DotNet.Interactive.KernelBase.<AddSetKernelMiddleware>b__11_0(IKernelCommand command, KernelInvocationContext context, KernelPipelineContinuation next)
   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(IKernelCommand command, KernelInvocationContext context)
   at Microsoft.DotNet.Interactive.Formatting.Destructurer`1.Destructure(Object instance)
   at Microsoft.DotNet.Interactive.Formatting.HtmlFormatter`1.<>c__DisplayClass7_0.<CreateForSequence>b__4(T instance, TextWriter writer)
   at Microsoft.DotNet.Interactive.Formatting.HtmlFormatter`1.Format(T instance, TextWriter writer)
   at Microsoft.DotNet.Interactive.Formatting.TypeFormatter`1.Microsoft.DotNet.Interactive.Formatting.ITypeFormatter.Format(Object instance, TextWriter writer)
   at Microsoft.DotNet.Interactive.Formatting.Formatter`1.FormatTo(T obj, TextWriter writer, String mimeType)
   at Microsoft.DotNet.Interactive.Formatting.Formatter.FormatTo[T](T obj, TextWriter writer, String mimeType)
   at Microsoft.DotNet.Interactive.Formatting.Formatter.ToDisplayString(Object obj, String mimeType)
   at Microsoft.DotNet.Interactive.FormattedValue.<>c__DisplayClass7_0.<FromObject>b__0(String mimeType)
   at System.Linq.Enumerable.SelectEnumerableIterator`2.ToArray()
   at Microsoft.DotNet.Interactive.FormattedValue.FromObject(Object value)
   at Microsoft.DotNet.Interactive.CSharp.CSharpKernel.HandleSubmitCode(SubmitCode submitCode, KernelInvocationContext context)
   at Microsoft.DotNet.Interactive.Commands.KernelCommandBase.InvokeAsync(KernelInvocationContext context)
   at Microsoft.DotNet.Interactive.KernelBase.HandleAsync(IKernelCommand command, KernelInvocationContext context)
   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(IKernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _)
   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.DotNet.Interactive.CompositeKernel.LoadExtensions(IKernelCommand command, KernelInvocationContext context, KernelPipelineContinuation next)
   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.DotNet.Interactive.KernelBase.HandleDirectivesAndSubmitCode(SubmitCode submitCode, KernelInvocationContext context, KernelPipelineContinuation continueOnCurrentPipeline)
   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.DotNet.Interactive.KernelBase.<>c.<<AddCaptureConsoleMiddleware>b__12_0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.DotNet.Interactive.KernelBase.<AddSetKernelMiddleware>b__11_0(IKernelCommand command, KernelInvocationContext context, KernelPipelineContinuation next)
   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(IKernelCommand command, KernelInvocationContext context)
````




