### PR TITLE
Use 'PSNotImplementedException' for not-yet-implemented IHostSupportsInteractiveSession members

### DIFF
--- a/Microsoft.DotNet.Interactive.PowerShell.Tests/Microsoft.DotNet.Interactive.PowerShell.Tests.csproj
+++ b/Microsoft.DotNet.Interactive.PowerShell.Tests/Microsoft.DotNet.Interactive.PowerShell.Tests.csproj
@@ -17,4 +17,8 @@
     <ProjectReference Include="..\Microsoft.DotNet.Interactive.PowerShell\Microsoft.DotNet.Interactive.PowerShell.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.0" />
+  </ItemGroup>
+
 </Project>

--- a/Microsoft.DotNet.Interactive.PowerShell/Host/PSKernelHost.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/Host/PSKernelHost.cs
@@ -44,12 +44,12 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Host
 
         public override void EnterNestedPrompt()
         {
-            throw new NotImplementedException("Nested prompt support is coming soon.");
+            throw new PSNotImplementedException("Nested prompt support is coming soon.");
         }
 
         public override void ExitNestedPrompt()
         {
-            throw new NotImplementedException("Nested prompt support is coming soon.");
+            throw new PSNotImplementedException("Nested prompt support is coming soon.");
         }
 
         public override void NotifyBeginApplication()
@@ -71,18 +71,18 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Host
 
         #region "IHostSupportsInteractiveSession Implementation"
 
-        public bool IsRunspacePushed => throw new NotImplementedException("IHostSupportsInteractiveSession support is coming soon.");
+        public bool IsRunspacePushed => false;
 
-        public Runspace Runspace => throw new NotImplementedException("IHostSupportsInteractiveSession support is coming soon.");
+        public Runspace Runspace => throw new PSNotImplementedException("IHostSupportsInteractiveSession support is coming soon.");
 
         public void PopRunspace()
         {
-            throw new NotImplementedException("IHostSupportsInteractiveSession support is coming soon.");
+            throw new PSNotImplementedException("IHostSupportsInteractiveSession support is coming soon.");
         }
 
         public void PushRunspace(Runspace runspace)
         {
-            throw new NotImplementedException("IHostSupportsInteractiveSession support is coming soon.");
+            throw new PSNotImplementedException("IHostSupportsInteractiveSession support is coming soon.");
         }
 
         #endregion

--- a/Microsoft.DotNet.Interactive.PowerShell/Host/Progress/ProgressPane.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/Host/Progress/ProgressPane.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Host.Progress
         /// </summary>
         internal void Hide()
         {
-            _displayValue.Update(string.Empty);
+            _displayValue?.Update(string.Empty);
         }
 
         /// <summary>

--- a/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -31,7 +31,6 @@
     <PackageReference Include="PowerShellGet" Version="$(PowerShellGetVersion)" />
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="$(MicrosoftPowerShellArchiveVersion)" />
     <PackageReference Include="ThreadJob" Version="$(ThreadJobVersion)" />
-    <PackageReference Include="FluentAssertions" Version="5.10.0" />
   </ItemGroup>
 
   <!-- Get NuGetPackageRoot if it's not defined -->


### PR DESCRIPTION
Fix #260
Use 'PSNotImplementedException' for not-yet-implemented `IHostSupportsInteractiveSession` members, so that `Invoke-Command` can continue to work.
Also fix a possible `NullReferenceException` that could be thrown from `Hide()`.