### PR TITLE
Update the version of 'Microsoft.Extensions.Hosting' referenced in Jupyter project

### DIFF
--- a/Microsoft.DotNet.Interactive.Jupyter/Microsoft.DotNet.Interactive.Jupyter.csproj
+++ b/Microsoft.DotNet.Interactive.Jupyter/Microsoft.DotNet.Interactive.Jupyter.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Clockwise" Version="1.0.261-beta" />
     <PackageReference Include="Markdig.Signed" Version="0.18.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.2" />
     <PackageReference Include="NetMQ" Version="4.0.0.207" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="JsonSerializationExtensions" Version="0.1.8580001">


### PR DESCRIPTION
Fix #243

The user tried to import a module that depends on `Microsoft.Extensions.DependencyInjection, Version=3.1.2.0`, and it failed because `dotnet-interactive` loads the `3.1.1.0` version of `Microsoft.Extensions.DependencyInjection` at startup and thus a higher version of the same assembly cannot be loaded into the default load context any more.

The fix here is just a mitigation by rev the version of `Microsoft.Extensions.Hosting` to `3.1.2`, which will bring in the `3.1.2.0` version of `Microsoft.Extensions.DependencyInjection` and it's bound to happen again in future.
The PowerShell team is working on the design of isolated module which loads the module into a separate assembly load context, and that will be the ultimate solution.

Before this PR:
![image](https://user-images.githubusercontent.com/127450/76474331-8c779180-63b8-11ea-81b5-bd231fac8705.png)

After this PR:
![image](https://user-images.githubusercontent.com/127450/76474355-a022f800-63b8-11ea-9026-4e0c671b813e.png)
