### PR TITLE
Fix building nuget package for the PowerShell sub kernel

### DIFF
--- a/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -27,17 +27,22 @@
 
   <!-- PowerShell Module Package References -->
   <ItemGroup>
-    <PackageReference Include="PackageManagement" Version="$(PackageManagementVersion)" />
-    <PackageReference Include="PowerShellGet" Version="$(PowerShellGetVersion)" />
-    <PackageReference Include="Microsoft.PowerShell.Archive" Version="$(MicrosoftPowerShellArchiveVersion)" />
-    <PackageReference Include="ThreadJob" Version="$(ThreadJobVersion)" />
+    <PackageReference Include="PackageManagement" Version="$(PackageManagementVersion)">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="PowerShellGet" Version="$(PowerShellGetVersion)">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.PowerShell.Archive" Version="$(MicrosoftPowerShellArchiveVersion)">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="ThreadJob" Version="$(ThreadJobVersion)">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <!-- Get NuGetPackageRoot if it's not defined -->
-  <Target
-    Name="GetNuGetPackageRoot"
-    Condition=" '$(NuGetPackageRoot)' == '' "
-  >
+  <Target Name="GetNuGetPackageRoot" Condition=" '$(NuGetPackageRoot)' == '' ">
     <Exec Command="dotnet nuget locals global-packages --list --force-english-output" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
     </Exec>
@@ -49,37 +54,39 @@
     </PropertyGroup>
   </Target>
 
-  <!-- Copy restored contents of PowerShell module nuget pacakges into output -->
-  <ItemGroup>
-    <Content
-      Include="$(NuGetPackageRoot)packagemanagement\$(PackageManagementVersion)\**"
-      Exclude="$(NuGetPackageRoot)**\*.nupkg;$(NuGetPackageRoot)**\*.sha512"
-      PackageCopyToOutput="true">
-      <Link>Modules\PackageManagement\%(RecursiveDir)\%(FileName)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content
-      Include="$(NuGetPackageRoot)powershellget\$(PowerShellGetVersion)\**"
-      Exclude="$(NuGetPackageRoot)**\*.nupkg;$(NuGetPackageRoot)**\*.sha512"
-      PackageCopyToOutput="true">
-      <Link>Modules\PowerShellGet\%(RecursiveDir)\%(FileName)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content
-      Include="$(NuGetPackageRoot)microsoft.powershell.archive\$(MicrosoftPowerShellArchiveVersion)\**"
-      Exclude="$(NuGetPackageRoot)**\*.nupkg;$(NuGetPackageRoot)**\*.sha512"
-      PackageCopyToOutput="true">
-      <Link>Modules\Microsoft.PowerShell.Archive\%(RecursiveDir)\%(FileName)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content
-      Include="$(NuGetPackageRoot)threadjob\$(ThreadJobVersion)\**"
-      Exclude="$(NuGetPackageRoot)**\*.nupkg;$(NuGetPackageRoot)**\*.sha512"
-      PackageCopyToOutput="true">
-      <Link>Modules\ThreadJob\%(RecursiveDir)\%(FileName)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+  <Target Name="CopyGalleryModules" AfterTargets="Restore">
+    <!-- PackageManagement -->
+    <CreateItem Include="$(NuGetPackageRoot)packagemanagement\$(PackageManagementVersion)\**"
+                Exclude="$(NuGetPackageRoot)**\*.nupkg;$(NuGetPackageRoot)**\*.nuspec;$(NuGetPackageRoot)**\*.sha512;$(NuGetPackageRoot)**\fullclr\**">
+      <Output ItemName="PackageManagementFiles" TaskParameter="Include" />
+    </CreateItem>
+    <Copy SourceFiles="@(PackageManagementFiles)"
+          DestinationFolder="$(MSBuildThisFileDirectory)Modules\PackageManagement\%(RecursiveDir)"/>
+
+    <!-- PowerShellGet -->
+    <CreateItem Include="$(NuGetPackageRoot)powershellget\$(PowerShellGetVersion)\**"
+                Exclude="$(NuGetPackageRoot)**\*.nupkg;$(NuGetPackageRoot)**\*.nuspec;$(NuGetPackageRoot)**\*.sha512">
+      <Output ItemName="PowerShellGetFiles" TaskParameter="Include" />
+    </CreateItem>
+    <Copy SourceFiles="@(PowerShellGetFiles)"
+          DestinationFolder="$(MSBuildThisFileDirectory)Modules\PowerShellGet\%(RecursiveDir)"/>
+
+    <!-- Microsoft.PowerShell.Archive -->
+    <CreateItem Include="$(NuGetPackageRoot)microsoft.powershell.archive\$(MicrosoftPowerShellArchiveVersion)\**"
+                Exclude="$(NuGetPackageRoot)**\*.nupkg;$(NuGetPackageRoot)**\*.nuspec;$(NuGetPackageRoot)**\*.sha512">
+      <Output ItemName="ArchiveFiles" TaskParameter="Include" />
+    </CreateItem>
+    <Copy SourceFiles="@(ArchiveFiles)"
+          DestinationFolder="$(MSBuildThisFileDirectory)Modules\Microsoft.PowerShell.Archive\%(RecursiveDir)"/>
+
+    <!-- ThreadJob -->
+    <CreateItem Include="$(NuGetPackageRoot)threadjob\$(ThreadJobVersion)\**"
+                Exclude="$(NuGetPackageRoot)**\*.nupkg;$(NuGetPackageRoot)**\*.nuspec;$(NuGetPackageRoot)**\*.sha512">
+      <Output ItemName="ThreadJobFiles" TaskParameter="Include" />
+    </CreateItem>
+    <Copy SourceFiles="@(ThreadJobFiles)"
+          DestinationFolder="$(MSBuildThisFileDirectory)Modules\ThreadJob\%(RecursiveDir)"/>
+  </Target>
 
   <!-- The dependencies for this project -->
   <ItemGroup>

--- a/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>;NU5104;2003;8002</NoWarn>
+    <NoWarn>;NU5104;NU5100;2003;8002</NoWarn>
   </PropertyGroup>
 
   <!-- PowerShell Module Versions -->
@@ -49,19 +49,19 @@
 
     <PropertyGroup>
       <RegexForOutputOfExec>info : global-packages: (.*)</RegexForOutputOfExec>
-      <RegexMatch>$([System.Text.RegularExpressions.Regex]::Match($(OutputOfExec), $(RegexForOutputOfExec)).Groups[2].Value)</RegexMatch>
+      <RegexMatch>$([System.Text.RegularExpressions.Regex]::Match($(OutputOfExec), $(RegexForOutputOfExec)).Groups[1].Value)</RegexMatch>
       <NuGetPackageRoot>$(RegexMatch)</NuGetPackageRoot>
     </PropertyGroup>
   </Target>
 
-  <Target Name="CopyGalleryModules" AfterTargets="Restore">
+  <Target Name="CopyGalleryModules" AfterTargets="Restore;CollectPackageReferences">
     <!-- PackageManagement -->
     <CreateItem Include="$(NuGetPackageRoot)packagemanagement\$(PackageManagementVersion)\**"
                 Exclude="$(NuGetPackageRoot)**\*.nupkg;$(NuGetPackageRoot)**\*.nuspec;$(NuGetPackageRoot)**\*.sha512;$(NuGetPackageRoot)**\fullclr\**">
       <Output ItemName="PackageManagementFiles" TaskParameter="Include" />
     </CreateItem>
     <Copy SourceFiles="@(PackageManagementFiles)"
-          DestinationFolder="$(MSBuildThisFileDirectory)Modules\PackageManagement\%(RecursiveDir)"/>
+          DestinationFolder="$(MSBuildProjectDirectory)\Modules\PackageManagement\%(RecursiveDir)"/>
 
     <!-- PowerShellGet -->
     <CreateItem Include="$(NuGetPackageRoot)powershellget\$(PowerShellGetVersion)\**"
@@ -69,7 +69,7 @@
       <Output ItemName="PowerShellGetFiles" TaskParameter="Include" />
     </CreateItem>
     <Copy SourceFiles="@(PowerShellGetFiles)"
-          DestinationFolder="$(MSBuildThisFileDirectory)Modules\PowerShellGet\%(RecursiveDir)"/>
+          DestinationFolder="$(MSBuildProjectDirectory)\Modules\PowerShellGet\%(RecursiveDir)"/>
 
     <!-- Microsoft.PowerShell.Archive -->
     <CreateItem Include="$(NuGetPackageRoot)microsoft.powershell.archive\$(MicrosoftPowerShellArchiveVersion)\**"
@@ -77,7 +77,7 @@
       <Output ItemName="ArchiveFiles" TaskParameter="Include" />
     </CreateItem>
     <Copy SourceFiles="@(ArchiveFiles)"
-          DestinationFolder="$(MSBuildThisFileDirectory)Modules\Microsoft.PowerShell.Archive\%(RecursiveDir)"/>
+          DestinationFolder="$(MSBuildProjectDirectory)\Modules\Microsoft.PowerShell.Archive\%(RecursiveDir)"/>
 
     <!-- ThreadJob -->
     <CreateItem Include="$(NuGetPackageRoot)threadjob\$(ThreadJobVersion)\**"
@@ -85,7 +85,7 @@
       <Output ItemName="ThreadJobFiles" TaskParameter="Include" />
     </CreateItem>
     <Copy SourceFiles="@(ThreadJobFiles)"
-          DestinationFolder="$(MSBuildThisFileDirectory)Modules\ThreadJob\%(RecursiveDir)"/>
+          DestinationFolder="$(MSBuildProjectDirectory)\Modules\ThreadJob\%(RecursiveDir)"/>
   </Target>
 
   <!-- The dependencies for this project -->


### PR DESCRIPTION
Fix #272

Two major changes:
- Specify `<PrivateAssets>all</PrivateAssets>` for all PowerShell module nuget packages, so they are not treated as dependencies when building the package for PS kernel.
- Filter the `.nuspec` files and `fullclr` folder for `PackageManagement`.
- Instead of directly depending on `<Content ..>` to copy all module files from the nuget packages folder to the output directory, I add a target that copy those modules to `Microsoft.Dotnet.Interactive.PowerShell/Modules`, and then rely on the only one `<Content ..>` to get everything under `Microsoft.Dotnet.Interactive.PowerShell/Modules` to the output/publish directory.

/cc @TylerLeonhardt, please help validate if this change is good, thanks!