### PR TITLE
Better completions for PowerShell

### DIFF
--- a/Microsoft.DotNet.Interactive.Jupyter/CompleteRequestHandler.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter/CompleteRequestHandler.cs
@@ -45,8 +45,19 @@ namespace Microsoft.DotNet.Interactive.Jupyter
         {
             var command = completionRequestCompleted.Command as RequestCompletion;
 
-            var pos = SourceUtilities.ComputeReplacementStartPosition(command.Code, command.CursorPosition);
-            var reply = new CompleteReply(pos, command.CursorPosition, matches: completionRequestCompleted.CompletionList.Select(e => e.InsertText ?? e.DisplayText).ToList());
+            int startPosition, endPosition;
+            if (completionRequestCompleted.ReplacementStartIndex != null)
+            {
+                startPosition = completionRequestCompleted.ReplacementStartIndex.Value;
+                endPosition = completionRequestCompleted.ReplacementEndIndex.Value;
+            }
+            else
+            {
+                startPosition = SourceUtilities.ComputeReplacementStartPosition(command.Code, command.CursorPosition);
+                endPosition = command.CursorPosition;
+            }
+
+            var reply = new CompleteReply(startPosition, endPosition, matches: completionRequestCompleted.CompletionList.Select(e => e.InsertText ?? e.DisplayText).ToList());
 
             jupyterMessageSender.Send(reply);
         }

--- a/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -208,10 +208,9 @@ namespace Microsoft.DotNet.Interactive.PowerShell
             context.Publish(new CompletionRequestCompleted(
                 completionList,
                 requestCompletion,
-                // PowerShell's replacement length is inclusive while Jupyter's ReplacementEndColumn is exclusive so we
-                // have to add one to the ReplaceLength for completions to be correct.
                 completion.ReplacementIndex,
-                completion.ReplacementLength + 1));
+                // The end index is the start index plus the length of the replacement.
+                completion.ReplacementIndex + completion.ReplacementLength));
 
             return Task.CompletedTask;
         }

--- a/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
+++ b/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
@@ -709,9 +709,9 @@ Console.Write(2);
         [Theory(Timeout = 45000)]
         [InlineData(Language.CSharp, "System.", "IO")]
         [InlineData(Language.FSharp, "System.", "IO")]
-        // PowerShell language completion uses a startPostion and endPosition so the result is different
-        // than other languages.
         [InlineData(Language.PowerShell, "[System.", "System.IO")]
+        // Also tests index is calculated properly.
+        [InlineData(Language.PowerShell, "$a = [System.", "System.IO")]
         public async Task it_returns_completion_list_for_types(Language language, string codeToComplete, string expectedCompletion)
         {
             var kernel = CreateKernel(language);

--- a/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
+++ b/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
@@ -707,15 +707,15 @@ Console.Write(2);
 
 
         [Theory(Timeout = 45000)]
-        [InlineData(Language.CSharp)]
-        [InlineData(Language.FSharp)]
-        public async Task it_returns_completion_list_for_types(Language language)
+        [InlineData(Language.CSharp, "System.", "IO")]
+        [InlineData(Language.FSharp, "System.", "IO")]
+        // PowerShell language completion uses a startPostion and endPosition so the result is different
+        // than other languages.
+        [InlineData(Language.PowerShell, "[System.", "System.IO")]
+        public async Task it_returns_completion_list_for_types(Language language, string codeToComplete, string expectedCompletion)
         {
             var kernel = CreateKernel(language);
-
-            var source = "System.Console."; // same code is valid regardless of the language
-
-            await kernel.SendAsync(new RequestCompletion(source, 15));
+            await kernel.SendAsync(new RequestCompletion(codeToComplete, codeToComplete.Length));
 
             KernelEvents
                 .Should()
@@ -726,7 +726,7 @@ Console.Write(2);
                 .Single()
                 .CompletionList
                 .Should()
-                .Contain(i => i.DisplayText == "ReadLine");
+                .Contain(i => i.DisplayText == expectedCompletion);
         }
 
         [Theory(Timeout = 45000)]

--- a/Microsoft.DotNet.Interactive/Events/CompletionRequestCompleted.cs
+++ b/Microsoft.DotNet.Interactive/Events/CompletionRequestCompleted.cs
@@ -9,11 +9,43 @@ namespace Microsoft.DotNet.Interactive.Events
 {
     public class CompletionRequestCompleted : KernelEventBase
     {
+        /// <summary>
+        /// The start index (inclusive) of where to replace in a completion request.
+        /// </summary>
+        public int? ReplacementStartIndex { get; }
+
+        /// <summary>
+        /// The end index (exclusive) of where to replace in a completion request.
+        /// </summary>
+        public int? ReplacementEndIndex { get; }
+
+        /// <summary>
+        /// The list of completion options.
+        /// </summary>
         public IEnumerable<CompletionItem> CompletionList { get; }
 
-        public CompletionRequestCompleted(IEnumerable<CompletionItem> completionList, IKernelCommand command) : base(command)
+        public CompletionRequestCompleted(
+            IEnumerable<CompletionItem> completionList,
+            IKernelCommand command,
+            int? replacementStartIndex = null,
+            int? replacementEndIndex = null) : base(command)
         {
             CompletionList = completionList ?? throw new ArgumentNullException(nameof(completionList));
+
+            // replacementStartIndex and replacementEndIndex must either both be null
+            // or both be defined.
+            if (replacementStartIndex != null && replacementEndIndex == null)
+            {
+                throw new ArgumentNullException(nameof(replacementEndIndex));
+            }
+
+            if (replacementStartIndex == null && replacementEndIndex != null)
+            {
+                throw new ArgumentNullException(nameof(replacementStartIndex));
+            }
+
+            ReplacementStartIndex = replacementStartIndex;
+            ReplacementEndIndex = replacementEndIndex;
         }
     }
 }


### PR DESCRIPTION
Fixes #265

This allows us to plumb the completion replacement start and end index into the result to jupyter.

All of these scenarios below were broken... now you see they work:

before complete:
![image](https://user-images.githubusercontent.com/2644648/76797568-1180f300-678b-11ea-835a-4bfb08fa8c62.png)
after complete:
![image](https://user-images.githubusercontent.com/2644648/76797582-1776d400-678b-11ea-893a-3023f3cc6783.png)

before complete:
![image](https://user-images.githubusercontent.com/2644648/76797630-31181b80-678b-11ea-8cbc-5ebfd2f7b99c.png)
after complete:
![image](https://user-images.githubusercontent.com/2644648/76797648-3a08ed00-678b-11ea-9c4f-b53b03177ca6.png)

before complete:
![image](https://user-images.githubusercontent.com/2644648/76797670-468d4580-678b-11ea-84d3-358744625a4b.png)
after complete:
![image](https://user-images.githubusercontent.com/2644648/76797688-4e4cea00-678b-11ea-91e1-f98e6cb02204.png)

before complete:
![image](https://user-images.githubusercontent.com/2644648/76797797-86ecc380-678b-11ea-97f9-f9d853dad144.png)
after complete:
![image](https://user-images.githubusercontent.com/2644648/76797808-8eac6800-678b-11ea-93f4-523c8cd263f0.png)

cc @jonsequitur @SteveL-MSFT 