### PR TITLE
return proper hover info for C#

### DIFF
--- a/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
+++ b/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
@@ -137,20 +137,10 @@ namespace Microsoft.DotNet.Interactive.CSharp
                 return null;
             }
 
-            var markdown = info.ToMarkdownString();
-            if (string.IsNullOrWhiteSpace(markdown))
-            {
-                return null;
-            }
-
             var linePosSpan = text.Lines.GetLinePositionSpan(info.Span);
             return new TextDocumentHoverResponse()
             {
-                Contents = new MarkupContent()
-                {
-                    Kind = MarkupKind.Markdown,
-                    Value = markdown,
-                },
+                Contents = info.ToMarkupContent(),
                 Range = linePosSpan.ToLspRange(),
             };
         }

--- a/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
+++ b/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
@@ -124,7 +124,11 @@ namespace Microsoft.DotNet.Interactive.CSharp
 
         public async Task<TextDocumentHoverResponse> TextDocumentHover(HoverParams hoverParams)
         {
-            var documentContents = hoverParams.TextDocument.Uri.DecodeDocumentFromDataUri();
+            if (!hoverParams.TextDocument.Uri.TryDecodeDocumentFromDataUri(out var documentContents))
+            {
+                return null;
+            }
+
             var document = await GetDocumentWithCodeAsync(documentContents);
 
             var text = await document.GetTextAsync();

--- a/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
+++ b/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
@@ -22,7 +22,6 @@ using Microsoft.DotNet.Interactive.Extensions;
 using Microsoft.DotNet.Interactive.Formatting;
 using Microsoft.DotNet.Interactive.LanguageService;
 using Microsoft.DotNet.Interactive.Utility;
-using Newtonsoft.Json.Linq;
 using XPlot.Plotly;
 using Task = System.Threading.Tasks.Task;
 
@@ -30,7 +29,8 @@ namespace Microsoft.DotNet.Interactive.CSharp
 {
     public class CSharpKernel :
         KernelBase,
-        IExtensibleKernel
+        IExtensibleKernel,
+        ISupportHover
     {
         internal const string DefaultKernelName = "csharp";
 
@@ -104,25 +104,7 @@ namespace Microsoft.DotNet.Interactive.CSharp
             return false;
         }
 
-        public override async Task<LspResponse> LspMethod(string methodName, JObject request)
-        {
-            LspResponse result;
-            switch (methodName)
-            {
-                case "textDocument/hover":
-                    // https://microsoft.github.io/language-server-protocol/specification#textDocument_hover
-                    var hoverParams = request.ToLspObject<HoverParams>();
-                    result = await TextDocumentHover(hoverParams);
-                    break;
-                default:
-                    result = null;
-                    break;
-            }
-
-            return result;
-        }
-
-        public async Task<TextDocumentHoverResponse> TextDocumentHover(HoverParams hoverParams)
+        public async Task<TextDocumentHoverResponse> Hover(HoverParams hoverParams)
         {
             if (!hoverParams.TextDocument.Uri.TryDecodeDocumentFromDataUri(out var documentContents))
             {

--- a/Microsoft.DotNet.Interactive.CSharp/LanguageServiceExtensions.cs
+++ b/Microsoft.DotNet.Interactive.CSharp/LanguageServiceExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.Interactive.CSharp
             };
         }
 
-        public static string ToMarkdownString(this QuickInfoItem info)
+        public static MarkupContent ToMarkupContent(this QuickInfoItem info)
         {
             var stringBuilder = new StringBuilder();
             var description = info.Sections.FirstOrDefault(s => QuickInfoSectionKinds.Description.Equals(s.Kind))?.Text ?? string.Empty;
@@ -44,7 +44,11 @@ namespace Microsoft.DotNet.Interactive.CSharp
                 }
             }
 
-            return stringBuilder.ToString();
+            return new MarkupContent()
+            {
+                Kind = MarkupKind.Markdown,
+                Value = stringBuilder.ToString(),
+            };
         }
     }
 }

--- a/Microsoft.DotNet.Interactive.CSharp/LanguageServiceExtensions.cs
+++ b/Microsoft.DotNet.Interactive.CSharp/LanguageServiceExtensions.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis.QuickInfo;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.DotNet.Interactive.LanguageService;
+
+namespace Microsoft.DotNet.Interactive.CSharp
+{
+    public static class LanguageServiceExtensions
+    {
+        public static Position ToLspPosition(this LinePosition linePos)
+        {
+            return new Position()
+            {
+                Line = linePos.Line,
+                Character = linePos.Character,
+            };
+        }
+
+        public static Range ToLspRange(this LinePositionSpan linePosSpan)
+        {
+            return new Range()
+            {
+                Start = linePosSpan.Start.ToLspPosition(),
+                End = linePosSpan.End.ToLspPosition(),
+            };
+        }
+
+        public static string ToMarkdownString(this QuickInfoItem info)
+        {
+            var stringBuilder = new StringBuilder();
+            var description = info.Sections.FirstOrDefault(s => QuickInfoSectionKinds.Description.Equals(s.Kind))?.Text ?? string.Empty;
+            var documentation = info.Sections.FirstOrDefault(s => QuickInfoSectionKinds.DocumentationComments.Equals(s.Kind))?.Text ?? string.Empty;
+
+            if (!string.IsNullOrEmpty(description))
+            {
+                stringBuilder.Append(description);
+                if (!string.IsNullOrEmpty(documentation))
+                {
+                    stringBuilder.Append("\r\n> ").Append(documentation);
+                }
+            }
+
+            return stringBuilder.ToString();
+        }
+    }
+}

--- a/Microsoft.DotNet.Interactive.CSharp/LanguageServiceExtensions.cs
+++ b/Microsoft.DotNet.Interactive.CSharp/LanguageServiceExtensions.cs
@@ -20,6 +20,11 @@ namespace Microsoft.DotNet.Interactive.CSharp
             };
         }
 
+        public static LinePosition SubtractLineOffset(this LinePosition linePos, LinePosition offset)
+        {
+            return new LinePosition(linePos.Line - offset.Line, linePos.Character);
+        }
+
         public static Range ToLspRange(this LinePositionSpan linePosSpan)
         {
             return new Range()
@@ -27,6 +32,13 @@ namespace Microsoft.DotNet.Interactive.CSharp
                 Start = linePosSpan.Start.ToLspPosition(),
                 End = linePosSpan.End.ToLspPosition(),
             };
+        }
+
+        public static LinePositionSpan SubtractLineOffset(this LinePositionSpan linePosSpan, LinePosition offset)
+        {
+            return new LinePositionSpan(
+                linePosSpan.Start.SubtractLineOffset(offset),
+                linePosSpan.End.SubtractLineOffset(offset));
         }
 
         public static MarkupContent ToMarkupContent(this QuickInfoItem info)

--- a/Microsoft.DotNet.Interactive.Tests/LanguageServiceSerializationTests.cs
+++ b/Microsoft.DotNet.Interactive.Tests/LanguageServiceSerializationTests.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Microsoft.DotNet.Interactive.LanguageService;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.DotNet.Interactive.Tests
+{
+    public class LanguageServiceSerializationTests
+    {
+        private T Parse<T>(string json)
+        {
+            var jo = JObject.Parse(json);
+            return jo.ToLspObject<T>();
+        }
+
+        private void VerifyRoundTrip<T>(T original)
+        {
+            var json = original.SerializeLspObject();
+            var roundTripped = Parse<T>(json);
+            roundTripped.Should().BeEquivalentTo(original);
+        }
+
+        [Fact]
+        public void HoverParams_can_be_deserialized()
+        {
+            using var _ = new AssertionScope();
+            var hover = Parse<HoverParams>(@"
+{
+    ""textDocument"": {
+        ""uri"": ""document-uri-contents""
+    },
+    ""position"": {
+        ""line"": 1,
+        ""character"": 2
+    }
+}");
+            hover.TextDocument.Uri.Should().Be("document-uri-contents");
+            hover.Position.Line.Should().Be(1);
+            hover.Position.Character.Should().Be(2);
+        }
+
+        [Fact]
+        public void HoverParams_can_be_round_tripped()
+        {
+            var hover = new HoverParams()
+            {
+                TextDocument = new TextDocument("document-uri-contents"),
+                Position = new Position(1, 2)
+            };
+            VerifyRoundTrip(hover);
+        }
+    }
+}

--- a/Microsoft.DotNet.Interactive/KernelBase.cs
+++ b/Microsoft.DotNet.Interactive/KernelBase.cs
@@ -14,9 +14,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
-using Microsoft.DotNet.Interactive.LanguageService;
 using Microsoft.DotNet.Interactive.Utility;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.DotNet.Interactive
 {
@@ -191,12 +189,7 @@ namespace Microsoft.DotNet.Interactive
 
         public abstract bool TryGetVariable(string name, out object value);
 
-        public void AddDirective(Command command) => _submissionParser.AddDirective(command); 
-        
-        public virtual Task<LspResponse> LspMethod(string methodName, JObject request)
-        {
-            return Task.FromResult<LspResponse>(null);
-        }
+        public void AddDirective(Command command) => _submissionParser.AddDirective(command);
 
         private class KernelOperation
         {

--- a/Microsoft.DotNet.Interactive/KernelBase.cs
+++ b/Microsoft.DotNet.Interactive/KernelBase.cs
@@ -303,7 +303,7 @@ namespace Microsoft.DotNet.Interactive
             }
         }
 
-        internal Task RunDeferredCommandsAsync()
+        public Task RunDeferredCommandsAsync()
         {
             var tcs = new TaskCompletionSource<Unit>();
             UndeferCommands();

--- a/Microsoft.DotNet.Interactive/LanguageService/ISupportHover.cs
+++ b/Microsoft.DotNet.Interactive/LanguageService/ISupportHover.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Interactive.LanguageService
+{
+    public interface ISupportHover
+    {
+        public Task<TextDocumentHoverResponse> Hover(HoverParams hoverParams);
+    }
+}

--- a/Microsoft.DotNet.Interactive/LanguageService/LanguageServiceExtensions.cs
+++ b/Microsoft.DotNet.Interactive/LanguageService/LanguageServiceExtensions.cs
@@ -33,36 +33,37 @@ namespace Microsoft.DotNet.Interactive.LanguageService
 
         private const string DataUriPrefix = "data:";
 
-        public static string DecodeDocumentFromDataUri(this string dataUri)
+        public static bool TryDecodeDocumentFromDataUri(this string dataUri, out string result)
         {
             // from https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs, basic format is
             // data:[<mime_type>][;base64],<data>
+            result = null;
             if (!dataUri.StartsWith(DataUriPrefix))
             {
-                throw new FormatException($"Expected string to start with '{DataUriPrefix}'");
+                return false;
             }
 
             var headerEnd = dataUri.IndexOf(',');
             if (headerEnd < 0)
             {
-                throw new FormatException("Expected ',' before data.");
+                return false;
             }
 
             var header = dataUri.Substring(DataUriPrefix.Length, headerEnd - DataUriPrefix.Length);
             var isBase64Encoded = header.EndsWith(";base64");
 
-            var data = dataUri.Substring(headerEnd + 1);
+            result = dataUri.Substring(headerEnd + 1);
             if (isBase64Encoded)
             {
-                var bytes = Convert.FromBase64String(data);
-                data = System.Text.Encoding.UTF8.GetString(bytes);
+                var bytes = Convert.FromBase64String(result);
+                result = System.Text.Encoding.UTF8.GetString(bytes);
             }
             else
             {
-                data = HttpUtility.UrlDecode(data);
+                result = HttpUtility.UrlDecode(result);
             }
 
-            return data;
+            return true;
         }
     }
 }

--- a/Microsoft.DotNet.Interactive/LanguageService/LanguageServiceExtensions.cs
+++ b/Microsoft.DotNet.Interactive/LanguageService/LanguageServiceExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Web;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
@@ -27,6 +29,40 @@ namespace Microsoft.DotNet.Interactive.LanguageService
         public static T ToLspObject<T>(this JObject obj)
         {
             return obj.ToObject<T>(_jsonSerializer);
+        }
+
+        private const string DataUriPrefix = "data:";
+
+        public static string DecodeDocumentFromDataUri(this string dataUri)
+        {
+            // from https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs, basic format is
+            // data:[<mime_type>][;base64],<data>
+            if (!dataUri.StartsWith(DataUriPrefix))
+            {
+                throw new FormatException($"Expected string to start with '{DataUriPrefix}'");
+            }
+
+            var headerEnd = dataUri.IndexOf(',');
+            if (headerEnd < 0)
+            {
+                throw new FormatException("Expected ',' before data.");
+            }
+
+            var header = dataUri.Substring(DataUriPrefix.Length, headerEnd - DataUriPrefix.Length);
+            var isBase64Encoded = header.EndsWith(";base64");
+
+            var data = dataUri.Substring(headerEnd + 1);
+            if (isBase64Encoded)
+            {
+                var bytes = Convert.FromBase64String(data);
+                data = System.Text.Encoding.UTF8.GetString(bytes);
+            }
+            else
+            {
+                data = HttpUtility.UrlDecode(data);
+            }
+
+            return data;
         }
     }
 }

--- a/Microsoft.DotNet.Interactive/LanguageService/Position.cs
+++ b/Microsoft.DotNet.Interactive/LanguageService/Position.cs
@@ -7,5 +7,11 @@ namespace Microsoft.DotNet.Interactive.LanguageService
     {
         public int Line { get; set; }
         public int Character { get; set; }
+
+        public Position(int line, int character)
+        {
+            Line = line;
+            Character = character;
+        }
     }
 }

--- a/Microsoft.DotNet.Interactive/LanguageService/TextDocument.cs
+++ b/Microsoft.DotNet.Interactive/LanguageService/TextDocument.cs
@@ -1,10 +1,24 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Text;
+
 namespace Microsoft.DotNet.Interactive.LanguageService
 {
     public class TextDocument
     {
         public string Uri { get; set; }
+
+        public TextDocument(string uri)
+        {
+            Uri = uri;
+        }
+
+        public static TextDocument FromDocumentContents(string code)
+        {
+            var encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(code));
+            return new TextDocument($"data:text/plain;base64,{encoded}");
+        }
     }
 }

--- a/dotnet-interactive.Tests/LanguageServiceTests.cs
+++ b/dotnet-interactive.Tests/LanguageServiceTests.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Microsoft.DotNet.Interactive.CSharp;
+using Microsoft.DotNet.Interactive.LanguageService;
+using Xunit;
+
+namespace Microsoft.DotNet.Interactive.App.Tests
+{
+    public class LanguageServiceTests
+    {
+        [Fact]
+        public async Task textDocument_hover_handles_growing_script_offsets()
+        {
+            using var kernel = new CSharpKernel();
+
+            // evaluate some code
+            await kernel.SubmitCodeAsync("var one = 1;");
+
+            // get hover info
+            var code = "Console.WriteLine(one);";
+            //                             ^ (0, 20)
+            var hoverRequest = new HoverParams()
+            {
+                TextDocument = TextDocument.FromDocumentContents(code),
+                Position = new Position(0, 20),
+            };
+
+            var hoverResponse = await kernel.Hover(hoverRequest);
+
+            // ensure the position information is correct, e.g., line 0 not line 1
+            using var _ = new AssertionScope();
+            hoverResponse.Range.Start.Line.Should().Be(0);
+            hoverResponse.Range.Start.Character.Should().Be(18);
+            hoverResponse.Range.End.Line.Should().Be(0);
+            hoverResponse.Range.End.Character.Should().Be(21);
+        }
+    }
+}

--- a/dotnet-interactive/HttpRouting/LspRouter.cs
+++ b/dotnet-interactive/HttpRouting/LspRouter.cs
@@ -44,11 +44,13 @@ namespace Microsoft.DotNet.Interactive.App.HttpRouting
                     // TODO: figure out how to switch kernels based on #!fsharp, etc.
                     if (targetKernel is CompositeKernel composite)
                     {
+                        await composite.RunDeferredCommandsAsync();
                         targetKernel = composite.ChildKernels.FirstOrDefault(k => k.Name == composite.DefaultKernelName);
                     }
 
                     if (targetKernel is KernelBase kernelBase)
                     {
+                        await kernelBase.RunDeferredCommandsAsync();
                         var methodName = segments[1];
                         var lspBodyReader = new StreamReader(context.HttpContext.Request.Body);
                         var stringBody = await lspBodyReader.ReadToEndAsync();

--- a/dotnet-interactive/HttpRouting/LspRouter.cs
+++ b/dotnet-interactive/HttpRouting/LspRouter.cs
@@ -53,7 +53,20 @@ namespace Microsoft.DotNet.Interactive.App.HttpRouting
                         var lspBodyReader = new StreamReader(context.HttpContext.Request.Body);
                         var stringBody = await lspBodyReader.ReadToEndAsync();
                         var request = JObject.Parse(stringBody);
-                        var response = await kernelBase.LspMethod(methodName, request);
+
+                        LspResponse response = null;
+                        switch (methodName)
+                        {
+                            case "textDocument/hover":
+                                // https://microsoft.github.io/language-server-protocol/specification#textDocument_hover
+                                var hoverParams = request.ToLspObject<HoverParams>();
+                                if (kernelBase is ISupportHover hover)
+                                {
+                                    response = await hover.Hover(hoverParams);
+                                }
+                                break;
+                        }
+
                         var responseJson = response.SerializeLspObject();
                         context.Handler = async httpContext =>
                         {

--- a/dotnet-interactive/resources/code-mirror-lsp.js
+++ b/dotnet-interactive/resources/code-mirror-lsp.js
@@ -60,7 +60,9 @@
                 }
 
                 if (foundColumn) {
-                    global.Lsp.textDocumentHover(element, lineNumber, columnNumber).then(function (result) {
+                    let content = element.CodeMirror.doc.getValue();
+                    let textDocument = 'data:text/plain;base64,' + btoa(content);
+                    global.Lsp.textDocumentHover(element, textDocument, lineNumber, columnNumber).then(function (result) {
                         hoverDiv.style.top = `${event.pageY}px`;
                         hoverDiv.style.left = `${event.pageX}px`;
                         hoverDiv.style.display = 'inline';

--- a/dotnet-interactive/resources/lsp.js
+++ b/dotnet-interactive/resources/lsp.js
@@ -9,12 +9,12 @@ define(function () {
         init: function (global) {
             let lsp = {};
 
-            lsp.textDocumentHover = async function (element, line, column) {
+            lsp.textDocumentHover = async function (element, textDocument, line, column) {
                 let host = getHostFromElement(element);
                 let url = `${host}lsp/textDocument/hover`;
                 let request = {
                     textDocument: {
-                        uri: "TODO: what does a file path mean?"
+                        uri: textDocument
                     },
                     position: {
                         line: line,


### PR DESCRIPTION
Return proper C# QuickInfo for the LSP method `textDocument/hover` to remove the hard-coded placeholder.

The `hover` method requires a document URI, but in notebooks, there's no meaningful definition of 'document', so I utilized the URI field to data-encode the cell contents.  Given that there are no execution order guarantees in notebooks, this seemed the best way to ensure that `textDocument/hover` always did something meaningful.

The Roslyn LSP implementation is written as a `net472` console app that communicates over stdio, so it couldn't be repurposed for this, but the code was small so I copied where appropriate from [here](https://github.com/dotnet/roslyn/blob/e0a1787d544c8e7c5fef2007dbc8ef6592d8c028/src/Features/LanguageServer/Protocol/Handler/Hover/HoverHandler.cs).

![image](https://user-images.githubusercontent.com/926281/76890035-dabae380-6843-11ea-9817-340e160aeb4c.png)
