### PR TITLE
only evaluate a JS cell if global function exists

### DIFF
--- a/dotnet-interactive.Tests/FormatterConfigurationTests.cs
+++ b/dotnet-interactive.Tests/FormatterConfigurationTests.cs
@@ -77,10 +77,12 @@ namespace Microsoft.DotNet.Interactive.App.Tests
                 script.ToDisplayString(mimeType));
 
             formattedValue.MimeType.Should().Be("text/html");
-            formattedValue.Value.Should().Be($@"<script type=""text/javascript"">createDotnetInteractiveClient('http://12.12.12.12:4242/').then(function (interactive) {{
+            formattedValue.Value.Should().Be($@"<script type=""text/javascript"">if (typeof window.createDotnetInteractiveClient === typeof Function) {{
+createDotnetInteractiveClient('http://12.12.12.12:4242/').then(function (interactive) {{
 let notebookScope = getDotnetInteractiveScope('http://12.12.12.12:4242/');
 alert('hello');
-}});</script>");
+}});
+}}</script>");
         }
 
         [Fact]

--- a/dotnet-interactive/CommandLine/CommandLineParser.cs
+++ b/dotnet-interactive/CommandLine/CommandLineParser.cs
@@ -336,10 +336,12 @@ namespace Microsoft.DotNet.Interactive.App.CommandLine
                     Formatter<MathString>.Register((math, writer) => writer.Write(math.ToString()), "text/latex");
                     Formatter<ScriptContent>.Register((script, writer) =>
                     {
-                        var fullCode = $@"createDotnetInteractiveClient('{browserFrontendEnvironment.ApiUri.AbsoluteUri}').then(function (interactive) {{
+                        var fullCode = $@"if (typeof window.createDotnetInteractiveClient === typeof Function) {{
+createDotnetInteractiveClient('{browserFrontendEnvironment.ApiUri.AbsoluteUri}').then(function (interactive) {{
 let notebookScope = getDotnetInteractiveScope('{browserFrontendEnvironment.ApiUri.AbsoluteUri}');
 {script.ScriptValue}
-}});";
+}});
+}}";
                         IHtmlContent content = PocketViewTags.script[type: "text/javascript"](fullCode.ToHtmlContent());
                         content.WriteTo(writer, HtmlEncoder.Default);
                     }, HtmlFormatter.MimeType);


### PR DESCRIPTION
This will prevent JavaScript errors from occuring when re-opening a previously saved notebook.  Once the notebook is re-evaluated, that global function suddenly exists and the host/port info is re-populated so it'll continue like before.