### PR TITLE
add kernel execution smoke tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -289,6 +289,10 @@ stages:
         pool:
           vmImage: ubuntu-16.04
         variables:
+        - name: DOTNET_TRY_CLI_TELEMETRY_OPTOUT
+          value: 1
+        - name: DOTNET_TRY_SKIP_FIRST_TIME_EXPERIENCE
+          value: 1
         # specify tool version on public CI builds
         - ${{ if eq(variables['System.TeamProject'], 'public') }}:
           - name: ToolVersionArgs

--- a/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/contracts.ts
+++ b/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/contracts.ts
@@ -85,6 +85,7 @@ export const ErrorProducedType = "ErrorProduced";
 export const HoverTextProducedType = "HoverTextProduced";
 export const IncompleteCodeSubmissionReceivedType = "IncompleteCodeSubmissionReceived";
 export const InputRequestedType = "InputRequested";
+export const KernelReadyType = "KernelReady";
 export const PackageAddedType = "PackageAdded";
 export const PasswordRequestedType = "PasswordRequested";
 export const ReturnValueProducedType = "ReturnValueProduced";
@@ -105,6 +106,7 @@ export type KernelEventType =
     | typeof HoverTextProducedType
     | typeof IncompleteCodeSubmissionReceivedType
     | typeof InputRequestedType
+    | typeof KernelReadyType
     | typeof PackageAddedType
     | typeof PasswordRequestedType
     | typeof ReturnValueProducedType
@@ -167,6 +169,9 @@ export interface IncompleteCodeSubmissionReceived extends KernelEvent {
 
 export interface InputRequested extends KernelEvent {
     prompt: string;
+}
+
+export interface KernelReady extends KernelEvent {
 }
 
 export interface PackageAdded extends KernelEvent {

--- a/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.Event_contract_has_not_been_broken.approved.KernelReady.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.Event_contract_has_not_been_broken.approved.KernelReady.json
@@ -1,0 +1,1 @@
+{"event":{},"eventType":"KernelReady","command":null}

--- a/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.cs
@@ -233,6 +233,8 @@ namespace Microsoft.DotNet.Interactive.Tests.Server
                     new[] { new FormattedValue("text/markdown", "markdown") },
                     new LinePositionSpan(new LinePosition(1, 2), new LinePosition(3, 4)));
 
+                yield return new KernelReady();
+
                 yield return new PackageAdded(
                     new ResolvedPackageReference(
                         packageName: "ThePackage",

--- a/src/Microsoft.DotNet.Interactive/Events/KernelReady.cs
+++ b/src/Microsoft.DotNet.Interactive/Events/KernelReady.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Interactive.Events
+{
+    public class KernelReady : KernelEvent
+    {
+    }
+}

--- a/src/Microsoft.DotNet.Interactive/Server/KernelEventEnvelope.cs
+++ b/src/Microsoft.DotNet.Interactive/Server/KernelEventEnvelope.cs
@@ -58,6 +58,7 @@ namespace Microsoft.DotNet.Interactive.Server
                 [nameof(IncompleteCodeSubmissionReceived)] = typeof(KernelEventEnvelope<IncompleteCodeSubmissionReceived>),
                 [nameof(InputRequested)] = typeof(KernelEventEnvelope<InputRequested>),
                 [nameof(HoverTextProduced)] = typeof(KernelEventEnvelope<HoverTextProduced>),
+                [nameof(KernelReady)] = typeof(KernelEventEnvelope<KernelReady>),
                 [nameof(PackageAdded)] = typeof(KernelEventEnvelope<PackageAdded>),
                 [nameof(PasswordRequested)] = typeof(KernelEventEnvelope<PasswordRequested>),
                 [nameof(ReturnValueProduced)] = typeof(KernelEventEnvelope<ReturnValueProduced>),

--- a/src/Microsoft.DotNet.Interactive/Server/KernelServer.cs
+++ b/src/Microsoft.DotNet.Interactive/Server/KernelServer.cs
@@ -36,6 +36,8 @@ namespace Microsoft.DotNet.Interactive.Server
                 _kernel.KernelEvents.Subscribe(WriteEventToOutput),
                 _input
             };
+
+            WriteEventToOutput(new KernelReady());
         }
 
         public bool IsStarted => _input.IsStarted;

--- a/src/dotnet-interactive-vscode/src/contracts.ts
+++ b/src/dotnet-interactive-vscode/src/contracts.ts
@@ -85,6 +85,7 @@ export const ErrorProducedType = "ErrorProduced";
 export const HoverTextProducedType = "HoverTextProduced";
 export const IncompleteCodeSubmissionReceivedType = "IncompleteCodeSubmissionReceived";
 export const InputRequestedType = "InputRequested";
+export const KernelReadyType = "KernelReady";
 export const PackageAddedType = "PackageAdded";
 export const PasswordRequestedType = "PasswordRequested";
 export const ReturnValueProducedType = "ReturnValueProduced";
@@ -105,6 +106,7 @@ export type KernelEventType =
     | typeof HoverTextProducedType
     | typeof IncompleteCodeSubmissionReceivedType
     | typeof InputRequestedType
+    | typeof KernelReadyType
     | typeof PackageAddedType
     | typeof PasswordRequestedType
     | typeof ReturnValueProducedType
@@ -167,6 +169,9 @@ export interface IncompleteCodeSubmissionReceived extends KernelEvent {
 
 export interface InputRequested extends KernelEvent {
     prompt: string;
+}
+
+export interface KernelReady extends KernelEvent {
 }
 
 export interface PackageAdded extends KernelEvent {

--- a/src/dotnet-interactive.IntegrationTests/IntegrationTheoryAttribute.cs
+++ b/src/dotnet-interactive.IntegrationTests/IntegrationTheoryAttribute.cs
@@ -10,11 +10,11 @@ namespace Microsoft.DotNet.Interactive.App.IntegrationTests
     /// Signifies that a unit test should only be run during the integration test leg and not as part of a normal test
     /// run or during the regular dev loop.
     /// 
-    /// To run locally, [<see cref="IntegrationFactAttribute"/>] will need to be replaced with [<see cref="FactAttribute"/>].
+    /// To run locally, [<see cref="IntegrationTheoryAttribute"/>] will need to be replaced with [<see cref="TheoryAttribute"/>].
     /// </summary>
-    public class IntegrationFactAttribute : FactAttribute
+    public class IntegrationTheoryAttribute : TheoryAttribute
     {
-        public IntegrationFactAttribute()
+        public IntegrationTheoryAttribute()
         {
             if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("INTEGRATION_TEST_RUN")))
             {

--- a/src/dotnet-interactive.IntegrationTests/StdioKernelTests.cs
+++ b/src/dotnet-interactive.IntegrationTests/StdioKernelTests.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.DotNet.Interactive.Commands;
+using Microsoft.DotNet.Interactive.Events;
+using Microsoft.DotNet.Interactive.Tests;
+using Microsoft.DotNet.Interactive.Tests.Utility;
+using Xunit;
+
+namespace Microsoft.DotNet.Interactive.App.IntegrationTests
+{
+    public class StdioKernelTests
+    {
+        private async Task<TestStdioClient> CreateClient()
+        {
+            var psi = new ProcessStartInfo()
+            {
+                FileName = "dotnet-interactive",
+                Arguments = "stdio",
+                WorkingDirectory = Directory.GetCurrentDirectory(),
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+            };
+            var process = Process.Start(psi);
+            var client = new TestStdioClient(process);
+            await client.WaitForReady();
+            return client;
+        }
+
+        [IntegrationTheory]
+        [InlineData(Language.CSharp)]
+        [InlineData(Language.FSharp)]
+        [InlineData(Language.PowerShell)]
+        public async Task dotnet_kernels_can_execute_code(Language language)
+        {
+            using var client = await CreateClient();
+
+            var events = client.Events.ToSubscribedList();
+
+            client.SubmitCommand(new SubmitCode("1+1", targetKernelName: language.LanguageName()));
+
+            events
+                .Should()
+                .EventuallyContainSingle<DisplayEvent>(
+                    where: d => d.FormattedValues.Any(fv => fv.Value.Trim() == "2"),
+                    timeout: 10_000);
+        }
+    }
+}

--- a/src/dotnet-interactive.IntegrationTests/TestStdioClient.cs
+++ b/src/dotnet-interactive.IntegrationTests/TestStdioClient.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Reactive.Subjects;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Interactive.Commands;
+using Microsoft.DotNet.Interactive.Events;
+using Microsoft.DotNet.Interactive.Server;
+using Newtonsoft.Json;
+using Pocket;
+
+namespace Microsoft.DotNet.Interactive.App.IntegrationTests
+{
+    public class TestStdioClient : IDisposable
+    {
+        private readonly Process _process;
+        private readonly InputTextStream _input;
+        private readonly OutputTextStream _output;
+        private readonly Subject<KernelEvent> _events = new Subject<KernelEvent>();
+        private readonly CompositeDisposable _disposables;
+        private readonly TaskCompletionSource<bool> _ready = new TaskCompletionSource<bool>();
+
+        public IObservable<KernelEvent> Events => _events;
+
+        public TestStdioClient(Process process)
+        {
+            _process = process ?? throw new ArgumentNullException(nameof(process));
+            _input = new TextReaderInputStream(process.StandardOutput);
+            _output = new TextWriterOutputStream(process.StandardInput);
+
+            _disposables = new CompositeDisposable()
+            {
+                _input.Subscribe(HandleLine),
+                _input,
+                _events,
+                _process
+            };
+        }
+
+        public Task WaitForReady()
+        {
+            return _ready.Task;
+        }
+
+        private void HandleLine(string line)
+        {
+            try
+            {
+                var eventEnvelope = KernelEventEnvelope.Deserialize(line);
+                if (eventEnvelope.Event is KernelReady)
+                {
+                    _ready.SetResult(true);
+                }
+
+                _events.OnNext(eventEnvelope.Event);
+            }
+            catch (JsonReaderException)
+            {
+            }
+        }
+
+        public void SubmitCommand(KernelCommand command)
+        {
+            var serialized = KernelCommandEnvelope.Serialize(command);
+            _output.Write(serialized);
+        }
+
+        public void Dispose()
+        {
+            _process.Kill();
+            _disposables.Dispose();
+        }
+    }
+}

--- a/src/dotnet-interactive.IntegrationTests/dotnet-interactive.IntegrationTests.csproj
+++ b/src/dotnet-interactive.IntegrationTests/dotnet-interactive.IntegrationTests.csproj
@@ -10,10 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Microsoft.DotNet.Interactive\Utility\DisposableDirectory.cs" Link="External\DisposableDirectory.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.17" />
     <PackageReference Include="pocketlogger.subscribe" Version="0.6.1">
       <PrivateAssets>all</PrivateAssets>
@@ -21,6 +17,11 @@
     </PackageReference>
     <PackageReference Include="Assent" Version="1.3.1" />
     <PackageReference Include="FluentAssertions" Version="5.10.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.DotNet.Interactive.Tests\Microsoft.DotNet.Interactive.Tests.csproj" />
+    <ProjectReference Include="..\Microsoft.DotNet.Interactive\Microsoft.DotNet.Interactive.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This adds an integration test that smoke-tests the stdio kernel.  It currently executes `1+1` in both the C# and F# kernels.  The PowerShell kernel isn't included in this test because it doesn't return a value of `2`, rather it reports a stdout value of `2\r\n`, so that'll have to be added later/separately.

The purpose of these tests is to ensure that the just built global tool can execute; it's a really high-level way of ensuring that the NuGet package was laid out correctly.

In the failure case, all of the `JObject` values that were received are output to the log to make diagnosing failures easier.