### PR TITLE
Support platform specific libraries in notebook #r nuget"

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,8 +15,8 @@
 
   <!-- Consolidate FSharp package versions -->
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.7.2-beta.20173.1" />
-    <PackageReference Update="FSharp.Compiler.Private.Scripting" Version="10.8.1-beta.20173.1" />
+    <PackageReference Update="FSharp.Core" Version="4.7.2-beta.20180.1" />
+    <PackageReference Update="FSharp.Compiler.Private.Scripting" Version="10.8.1-beta.20180.1" />
     <PackageReference Update="FSharp.Compiler.Service" Version="31.0.0" />
   </ItemGroup>
 

--- a/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
+++ b/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
@@ -1014,15 +1014,6 @@ typeof(System.Device.Gpio.GpioController).Assembly.Location
                     .Which
                     .Value
                     .As<string>()
-                    .EndsWith(@"runtimes\win\lib\netstandard2.0\System.Device.Gpio.dll")
-                    .Should()
-                    .Be(true);
-                KernelEvents
-                    .Should()
-                    .ContainSingle<ReturnValueProduced>()
-                    .Which
-                    .Value
-                    .As<string>()
                     .EndsWith(@"runtimes/linux/lib/netstandard2.0/System.Device.Gpio.dll")
                     .Should()
                     .Be(true);


### PR DESCRIPTION
Updates to the latest signed fsharp build from master branch.  Which enables platform specific libraries to be addressed from the notebook.

C#
![image](https://user-images.githubusercontent.com/5175830/77979961-efbf5a00-72ba-11ea-9d7a-9b690d1e24ab.png)

F#
![image](https://user-images.githubusercontent.com/5175830/77979993-01a0fd00-72bb-11ea-87af-5fa401ee3c1b.png)


/cc @colombod 