### PR TITLE
use --http-port-range

### DIFF
--- a/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
+++ b/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
@@ -116,7 +116,7 @@ namespace Microsoft.DotNet.Interactive.App.Tests.CommandLine
             result.Errors
                 .Select(e => e.Message)
                  .Should()
-                 .Contain(errorMessage => errorMessage == "Cannot specify both http-port and http-port-range together");
+                 .Contain(errorMessage => errorMessage == "Cannot specify both --http-port and --http-port-range together");
         }
 
         [Fact]

--- a/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
+++ b/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
@@ -77,7 +77,7 @@ namespace Microsoft.DotNet.Interactive.App.Tests.CommandLine
         }
 
         [Fact]
-        public void It_parses_port_range_option()
+        public void jupyter_command_parses_port_range_option()
         {
             var result = _parser.Parse($"jupyter --http-port-range 3000-4000 {_connectionFile}");
 
@@ -88,11 +88,11 @@ namespace Microsoft.DotNet.Interactive.App.Tests.CommandLine
             options
                 .HttpPortRange
                 .Should()
-                .BeEquivalentTo(new PortRange{ Start = 3000, End = 4000 });
+                .BeEquivalentTo(new PortRange(3000, 4000));
         }
 
         [Fact]
-        public void jupyter_install_parses_port_range_option()
+        public void jupyter_install_command_parses_port_range_option()
         {
             var result = _parser.Parse("jupyter install --http-port-range 3000-4000");
 
@@ -103,7 +103,7 @@ namespace Microsoft.DotNet.Interactive.App.Tests.CommandLine
             options
                 .HttpPortRange
                 .Should()
-                .BeEquivalentTo(new PortRange { Start = 3000, End = 4000 });
+                .BeEquivalentTo(new PortRange(3000, 4000));
         }
 
         [Theory]
@@ -111,12 +111,12 @@ namespace Microsoft.DotNet.Interactive.App.Tests.CommandLine
         [InlineData("jupyter --http-port-range 3000-4000 --http-port 8000")]
         public void port_range_and_port_cannot_be_specified_together(string commandLine)
         {
-            var result =  _parser.Parse(commandLine);
+            var result = _parser.Parse(commandLine);
 
-           result.Errors
-               .Select(e => e.Message)
-                .Should()
-                .Contain(errorMessage => errorMessage == "Cannot specify both http-port and http-port-range together");
+            result.Errors
+                .Select(e => e.Message)
+                 .Should()
+                 .Contain(errorMessage => errorMessage == "Cannot specify both http-port and http-port-range together");
         }
 
         [Fact]

--- a/dotnet-interactive.Tests/InMemoryJupyterKernelSpec.cs
+++ b/dotnet-interactive.Tests/InMemoryJupyterKernelSpec.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using FSharp.Compiler.SourceCodeServices;
 using Microsoft.DotNet.Interactive.Utility;
 
 namespace Microsoft.DotNet.Interactive.App.Tests
@@ -14,6 +14,7 @@ namespace Microsoft.DotNet.Interactive.App.Tests
         private readonly bool _shouldInstallSucceed;
         private readonly bool _shouldUninstallSucceed;
         private readonly IReadOnlyCollection<string> _error;
+        private List<string> _kernelSpecs = new List<string>();
 
         public InMemoryJupyterKernelSpec(
             bool shouldInstallSucceed,
@@ -25,12 +26,20 @@ namespace Microsoft.DotNet.Interactive.App.Tests
             _error = error;
         }
 
+        public List<string> InstalledKernelSpecs
+        {
+            get => _kernelSpecs;
+        }
+
         public Task<CommandLineResult> InstallKernel(DirectoryInfo directory)
         {
             if (_shouldInstallSucceed)
             {
                 var installPath = Path.Combine(Directory.GetCurrentDirectory(), directory.Name.ToLower());
-
+                foreach (var kernelSpec in directory.GetFiles("kernel.json") )
+                {
+                    InstalledKernelSpecs.Add(File.ReadAllText(kernelSpec.FullName));
+                }
                 return Task.FromResult(
                     new CommandLineResult(
                         0,

--- a/dotnet-interactive.Tests/InMemoryJupyterKernelSpec.cs
+++ b/dotnet-interactive.Tests/InMemoryJupyterKernelSpec.cs
@@ -14,7 +14,6 @@ namespace Microsoft.DotNet.Interactive.App.Tests
         private readonly bool _shouldInstallSucceed;
         private readonly bool _shouldUninstallSucceed;
         private readonly IReadOnlyCollection<string> _error;
-        private List<string> _kernelSpecs = new List<string>();
 
         public InMemoryJupyterKernelSpec(
             bool shouldInstallSucceed,
@@ -26,10 +25,7 @@ namespace Microsoft.DotNet.Interactive.App.Tests
             _error = error;
         }
 
-        public List<string> InstalledKernelSpecs
-        {
-            get => _kernelSpecs;
-        }
+        public List<string> InstalledKernelSpecs { get; } = new List<string>();
 
         public Task<CommandLineResult> InstallKernel(DirectoryInfo directory)
         {

--- a/dotnet-interactive.Tests/InMemoryJupyterKernelSpec.cs
+++ b/dotnet-interactive.Tests/InMemoryJupyterKernelSpec.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using FSharp.Compiler.SourceCodeServices;
 using Microsoft.DotNet.Interactive.Utility;
 
 namespace Microsoft.DotNet.Interactive.App.Tests

--- a/dotnet-interactive.Tests/InMemoryJupyterKernelSpec.cs
+++ b/dotnet-interactive.Tests/InMemoryJupyterKernelSpec.cs
@@ -8,7 +8,7 @@ using Microsoft.DotNet.Interactive.Utility;
 
 namespace Microsoft.DotNet.Interactive.App.Tests
 {
-    public class InMemoryJupyterKernelSpec : IJupyterKernelSpec
+    internal class InMemoryJupyterKernelSpec : IJupyterKernelSpec
     {
         private readonly bool _shouldInstallSucceed;
         private readonly bool _shouldUninstallSucceed;

--- a/dotnet-interactive.Tests/JupyterInstallCommandTests.cs
+++ b/dotnet-interactive.Tests/JupyterInstallCommandTests.cs
@@ -16,9 +16,10 @@ namespace Microsoft.DotNet.Interactive.App.Tests
         {
             var console = new TestConsole();
             var kernelSpec = new  InMemoryJupyterKernelSpec(true, null);
-            var jupyterCommandLine = new JupyterInstallCommand(console, kernelSpec , new PortRange{ Start = 100, End = 400});
+            var jupyterCommandLine = new JupyterInstallCommand(console, kernelSpec , new PortRange(100,400));
 
             await jupyterCommandLine.InvokeAsync();
+            kernelSpec.InstalledKernelSpecs.Count.Should().BeGreaterThan(0);
 
             foreach (var installedKernelSpec in kernelSpec.InstalledKernelSpecs)
             {

--- a/dotnet-interactive.Tests/JupyterInstallCommandTests.cs
+++ b/dotnet-interactive.Tests/JupyterInstallCommandTests.cs
@@ -1,15 +1,33 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.CommandLine.IO;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.DotNet.Interactive.App.CommandLine;
 using Xunit;
 
 namespace Microsoft.DotNet.Interactive.App.Tests
 {
     public class JupyterInstallCommandTests
     {
+        [Fact]
+        public async Task Appends_http_port_range_arguments()
+        {
+            var console = new TestConsole();
+            var kernelSpec = new  InMemoryJupyterKernelSpec(true, null);
+            var jupyterCommandLine = new JupyterInstallCommand(console, kernelSpec , new PortRange{ Start = 100, End = 400});
+
+            await jupyterCommandLine.InvokeAsync();
+
+            foreach (var installedKernelSpec in kernelSpec.InstalledKernelSpecs)
+            {
+                installedKernelSpec.Should().Contain("--http-port-range");
+            }
+               
+        }
+
         [Fact]
         public async Task Returns_error_when_jupyter_paths_could_not_be_obtained()
         {

--- a/dotnet-interactive.Tests/JupyterInstallCommandTests.cs
+++ b/dotnet-interactive.Tests/JupyterInstallCommandTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CommandLine.IO;
 using System.Threading.Tasks;
 using FluentAssertions;

--- a/dotnet-interactive.Tests/JupyterInstallCommandTests.cs
+++ b/dotnet-interactive.Tests/JupyterInstallCommandTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CommandLine.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.DotNet.Interactive.App.CommandLine;
@@ -19,12 +20,12 @@ namespace Microsoft.DotNet.Interactive.App.Tests
             var jupyterCommandLine = new JupyterInstallCommand(console, kernelSpec , new PortRange(100,400));
 
             await jupyterCommandLine.InvokeAsync();
-            kernelSpec.InstalledKernelSpecs.Count.Should().BeGreaterThan(0);
 
-            foreach (var installedKernelSpec in kernelSpec.InstalledKernelSpecs)
-            {
-                installedKernelSpec.Should().Contain("--http-port-range");
-            }
+            kernelSpec.InstalledKernelSpecs
+                .Should()
+                .HaveCount(3)
+                .And
+                .Match(s => s.All(k => k.Contains("--http-port-range")));
                
         }
 

--- a/dotnet-interactive/CommandLine/CommandLineParser.cs
+++ b/dotnet-interactive/CommandLine/CommandLineParser.cs
@@ -104,11 +104,10 @@ namespace Microsoft.DotNet.Interactive.App.CommandLine
                 "--http-port-range",
                 parseArgument: result =>
                 {
-                    var conflictingOption =
-                        result.Parent.Parent.Children.FirstOrDefault(c => c.Symbol == httpPortOption) as OptionResult;
-                    if (conflictingOption != null)
+                    if (result.Parent.Parent.Children.FirstOrDefault(c => c.Symbol == httpPortOption) is OptionResult conflictingOption)
                     {
-                        result.ErrorMessage = $"Cannot specify both {conflictingOption.Token.Value} and {result.Parent.ToString()} together";
+                        var parsed = result.Parent as OptionResult;
+                        result.ErrorMessage = $"Cannot specify both {conflictingOption.Token.Value} and {parsed.Token.Value} together";
                         return null;
                     }
 

--- a/dotnet-interactive/CommandLine/CommandLineParser.cs
+++ b/dotnet-interactive/CommandLine/CommandLineParser.cs
@@ -110,8 +110,6 @@ namespace Microsoft.DotNet.Interactive.App.CommandLine
                         return null;
                     }
 
-                   
-
                     var source = result.Tokens[0].Value;
 
                     if (string.IsNullOrWhiteSpace(source))

--- a/dotnet-interactive/CommandLine/CommandLineParser.cs
+++ b/dotnet-interactive/CommandLine/CommandLineParser.cs
@@ -266,7 +266,7 @@ namespace Microsoft.DotNet.Interactive.App.CommandLine
                 }
 
                 Task<int> InstallHandler(IConsole console, InvocationContext context, PortRange httpPortRange) =>
-                    new JupyterInstallCommand(console, new JupyterKernelSpec(httpPortRange)).InvokeAsync();
+                    new JupyterInstallCommand(console, new JupyterKernelSpec(), httpPortRange).InvokeAsync();
             }
 
             Command HttpServer()

--- a/dotnet-interactive/CommandLine/CommandLineParser.cs
+++ b/dotnet-interactive/CommandLine/CommandLineParser.cs
@@ -110,7 +110,7 @@ namespace Microsoft.DotNet.Interactive.App.CommandLine
                         return null;
                     }
 
-                    var pr = new PortRange();
+                   
 
                     var source = result.Tokens[0].Value;
 
@@ -130,17 +130,18 @@ namespace Microsoft.DotNet.Interactive.App.CommandLine
 
                     if (int.TryParse(parts[0], out var start) && int.TryParse(parts[1], out var end))
                     {
-                        pr.Start = start;
-                        pr.End = end;
                         if (start > end)
                         {
-                            result.ErrorMessage = "STart port must be lower then end port";
+                            result.ErrorMessage = "Start port must be lower then end port";
                             return null;
                         }
+
+                        var pr = new PortRange(start, end);
+
                         return pr;
                     }
 
-                    result.ErrorMessage = "Must specify a port range as 1000-3000";
+                    result.ErrorMessage = "Must specify a port range as StartPort-EndPort";
                     return null;
                 },
                 description: "Specifies the range of port to use to enable HTTP services");

--- a/dotnet-interactive/CommandLine/PortRange.cs
+++ b/dotnet-interactive/CommandLine/PortRange.cs
@@ -1,0 +1,11 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Interactive.App.CommandLine
+{
+    public class PortRange
+    {
+        public int Start { get; set; }
+        public int End { get; set; }
+    }
+}

--- a/dotnet-interactive/CommandLine/PortRange.cs
+++ b/dotnet-interactive/CommandLine/PortRange.cs
@@ -5,7 +5,13 @@ namespace Microsoft.DotNet.Interactive.App.CommandLine
 {
     public class PortRange
     {
-        public int Start { get; set; }
-        public int End { get; set; }
+        public PortRange(int start, int end)
+        {
+            Start = start;
+            End = end;
+        }
+
+        public int Start { get;  }
+        public int End { get;  }
     }
 }

--- a/dotnet-interactive/CommandLine/StartupOptions.cs
+++ b/dotnet-interactive/CommandLine/StartupOptions.cs
@@ -23,10 +23,12 @@ namespace Microsoft.DotNet.Interactive.App.CommandLine
 
         public StartupOptions(
             DirectoryInfo logPath = null,
-            bool verbose = false)
+            bool verbose = false,
+            PortRange httpPortRange = null)
         {
             LogPath = logPath;
             Verbose = verbose;
+            HttpPortRange = httpPortRange;
         }
 
         public DirectoryInfo LogPath { get; }
@@ -34,5 +36,7 @@ namespace Microsoft.DotNet.Interactive.App.CommandLine
         public bool Verbose { get; }
 
         public int? HttpPort { get; internal set; }
+
+        public PortRange HttpPortRange { get; }
     }
 }

--- a/dotnet-interactive/HttpProbingSettings.cs
+++ b/dotnet-interactive/HttpProbingSettings.cs
@@ -39,6 +39,8 @@ namespace Microsoft.DotNet.Interactive.App
                 }
             }
 
+            sources.Add(IPAddress.Loopback.ToString());
+
             var addresses = sources
                 .Where(s => !string.IsNullOrWhiteSpace(s))
                 .Select(s =>

--- a/dotnet-interactive/JupyterInstallCommand.cs
+++ b/dotnet-interactive/JupyterInstallCommand.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Interactive.App
 
                     if (_httpPortRange != null)
                     {
-                        await ComputeKernelSpecArgs(_httpPortRange, dotnetDirectory);
+                        ComputeKernelSpecArgs(_httpPortRange, dotnetDirectory);
                     }
                     var installErrors = 0;
                     foreach (var kernelDirectory in dotnetDirectory.GetDirectories())
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.Interactive.App
             }
         }
 
-        private async Task ComputeKernelSpecArgs(PortRange httpPortRange, DirectoryInfo directory)
+        private static void ComputeKernelSpecArgs(PortRange httpPortRange, DirectoryInfo directory)
         {
             var kernelSpecs = directory.GetFiles("kernel.json", SearchOption.AllDirectories);
 

--- a/dotnet-interactive/JupyterKernelSpec.cs
+++ b/dotnet-interactive/JupyterKernelSpec.cs
@@ -1,24 +1,16 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-using Microsoft.DotNet.Interactive.App.CommandLine;
 using Microsoft.DotNet.Interactive.Utility;
 
 namespace Microsoft.DotNet.Interactive.App
 {
     public class JupyterKernelSpec : IJupyterKernelSpec
     {
-        private readonly PortRange _httpPortRange;
-
-        public JupyterKernelSpec(PortRange httpPortRange = null)
-        {
-            _httpPortRange = httpPortRange;
-        }
 
         public async Task<CommandLineResult> ExecuteCommand(string command, string args = "")
         {

--- a/dotnet-interactive/JupyterKernelSpec.cs
+++ b/dotnet-interactive/JupyterKernelSpec.cs
@@ -6,12 +6,20 @@ using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using Microsoft.DotNet.Interactive.App.CommandLine;
 using Microsoft.DotNet.Interactive.Utility;
 
 namespace Microsoft.DotNet.Interactive.App
 {
     public class JupyterKernelSpec : IJupyterKernelSpec
     {
+        private readonly PortRange _httpPortRange;
+
+        public JupyterKernelSpec(PortRange httpPortRange = null)
+        {
+            _httpPortRange = httpPortRange;
+        }
+
         public async Task<CommandLineResult> ExecuteCommand(string command, string args = "")
         {
             if (!JupyterKernelSpecExists())


### PR DESCRIPTION
--http-port-range can be used to constrain the range of ports to use for http api.
the option is available at runtime and install time
```>dotnet interactive jupyter install --http-port-range 1000-2000```