### PR TITLE
consume F# packages from dnceng feed

### DIFF
--- a/Binder Dependencies/NuGet.config
+++ b/Binder Dependencies/NuGet.config
@@ -6,8 +6,8 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet3-dev" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1/nuget/v3/index.json" />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
-    <add key="dotnet-fsharp" value="https://dotnet.myget.org/F/fsharp/api/v3/index.json" />
     <add key="dotnet-try" value="https://dotnet.myget.org/F/dotnet-try/api/v3/index.json" />
     <add key="roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
     <add key="dotnet-corefxlab" value="https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,8 +15,8 @@
 
   <!-- Consolidate FSharp package versions -->
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.7.2-beta.20201.3" />
-    <PackageReference Update="FSharp.Compiler.Private.Scripting" Version="10.8.1-beta.20201.3" />
+    <PackageReference Update="FSharp.Core" Version="4.7.2-beta.20202.2" />
+    <PackageReference Update="FSharp.Compiler.Private.Scripting" Version="10.8.1-beta.20202.2" />
     <PackageReference Update="FSharp.Compiler.Service" Version="31.0.0" />
   </ItemGroup>
 

--- a/NuGet.config
+++ b/NuGet.config
@@ -7,8 +7,8 @@
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
+    <add key="dotnet3-dev" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1/nuget/v3/index.json" />
     <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
-    <add key="dotnet-fsharp" value="https://dotnet.myget.org/F/fsharp/api/v3/index.json" />
     <add key="dotnet-try" value="https://dotnet.myget.org/F/dotnet-try/api/v3/index.json" />
     <add key="roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
     <add key="dotnet-corefxlab" value="https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -26,7 +26,7 @@
       $(RestoreSources);
       https://dotnet.myget.org/F/dotnet-try/api/v3/index.json;
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
-      https://dotnet.myget.org/F/fsharp/api/v3/index.json
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1/nuget/v3/index.json;
     </RestoreSources>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
The F# MyGet feeds will eventually be decommissioned, so I'm changing the feeds right now so we don't forget later.  Also updated to a new version of F# bits that was freshly uploaded to the dnceng feed.