### PR TITLE
$PROFILE support for PowerShell

### DIFF
--- a/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Tests
         [Fact]
         public async Task GetCorrectProfilePaths()
         {
-            using var kernel = new PowerShellKernel();
+            using var kernel = new PowerShellKernel().UseProfiles();
 
             // Set variables we will retrieve later.
             await kernel.SubmitCodeAsync("$currentUserCurrentHost = $PROFILE.CurrentUserCurrentHost");
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Tests
 
             try
             {
-                using var kernel = new PowerShellKernel();
+                using var kernel = new PowerShellKernel().UseProfiles();
 
                 // trigger first time setup.
                 await kernel.SubmitCodeAsync("Get-Date");

--- a/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Management.Automation;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
@@ -11,6 +12,8 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Tests
 {
     public class PowerShellKernelTests
     {
+        private readonly string _allUsersCurrentHostProfilePath = Path.Combine(Path.GetDirectoryName(typeof(PSObject).Assembly.Location), "Microsoft.dotnet-interactive_profile.ps1");
+
         [Theory]
         [InlineData(@"$x = New-Object -TypeName System.IO.FileInfo -ArgumentList c:\temp\some.txt", typeof(FileInfo))]
         [InlineData("$x = \"hello!\"", typeof(string))]
@@ -23,6 +26,63 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Tests
             kernel.TryGetVariable("x", out var fi).Should().BeTrue();
 
             fi.Should().BeOfType(expectedType);
+        }
+
+        [Fact]
+        public async Task GetCorrectProfilePaths()
+        {
+            using var kernel = new PowerShellKernel();
+
+            // Set variables we will retrieve later.
+            await kernel.SubmitCodeAsync("$currentUserCurrentHost = $PROFILE.CurrentUserCurrentHost");
+            await kernel.SubmitCodeAsync("$allUsersCurrentHost = $PROFILE.AllUsersCurrentHost");
+
+            kernel.TryGetVariable("currentUserCurrentHost", out var profileObj).Should().BeTrue();
+            profileObj.Should().BeOfType<string>();
+            string currentUserCurrentHost = profileObj.As<string>();
+
+            // Get $PROFILE default.
+            kernel.TryGetVariable("PROFILE", out profileObj).Should().BeTrue();
+            profileObj.Should().BeOfType<string>();
+            string profileDefault = profileObj.As<string>();
+
+            // Check that $PROFILE is not null or empty and it is the same as
+            // $PROFILE.CurrentUserCurrentHost
+            profileDefault.Should().NotBeNullOrEmpty();
+            profileDefault.Should().Be(currentUserCurrentHost);
+
+            kernel.TryGetVariable("allUsersCurrentHost", out profileObj).Should().BeTrue();
+            profileObj.Should().BeOfType<string>();
+            string allUsersCurrentHost = profileObj.As<string>();
+
+            // Check that $PROFILE.AllUsersCurrentHost is what we expect it is:
+            // $PSHOME + Microsoft.dotnet-interactive_profile.ps1
+            allUsersCurrentHost.Should().Be(_allUsersCurrentHostProfilePath);
+        }
+
+        [Fact]
+        public async Task VerifyAllUsersProfileRuns()
+        {
+            var randomVariableName = Path.GetRandomFileName().Split('.')[0];
+            File.WriteAllText(_allUsersCurrentHostProfilePath, $"$global:{randomVariableName} = $true");
+
+            try
+            {
+                using var kernel = new PowerShellKernel();
+
+                // trigger first time setup.
+                await kernel.SubmitCodeAsync("Get-Date");
+
+                kernel.TryGetVariable(randomVariableName, out var profileObj).Should().BeTrue();
+
+                profileObj.Should().BeOfType<bool>();
+                profileObj.As<bool>().Should().BeTrue();
+            }
+            finally
+            {
+                
+                File.Delete(_allUsersCurrentHostProfilePath);
+            }
         }
     }
 }

--- a/Microsoft.DotNet.Interactive.PowerShell/DollarProfileHelper.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/DollarProfileHelper.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Host
             pwsh.Runspace.SessionStateProxy.SetVariable("PROFILE", dollarProfile);
         }
 
-        public static void RunProfilesIfNeeded(PowerShell pwsh, PowerShellKernel pwshKernel)
+        public static void RunProfilesIfNeeded(PowerShellKernel pwshKernel)
         {
             if (pwshKernel.HasRunProfiles)
             {
@@ -52,12 +52,12 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Host
             // Run the PROFILE scripts if they exist.
             if (File.Exists(_allUsersCurrentHost))
             {
-                pwshKernel.RunSubmitCodeLocally(pwsh, _allUsersCurrentHost);
+                pwshKernel.RunSubmitCodeLocally(_allUsersCurrentHost);
             }
 
             if (File.Exists(_currentUserCurrentHost))
             {
-                pwshKernel.RunSubmitCodeLocally(pwsh, _currentUserCurrentHost);
+                pwshKernel.RunSubmitCodeLocally(_currentUserCurrentHost);
             }
         }
     }

--- a/Microsoft.DotNet.Interactive.PowerShell/DollarProfileHelper.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/DollarProfileHelper.cs
@@ -4,7 +4,7 @@
 using System;
 using System.IO;
 
-namespace Microsoft.DotNet.Interactive.PowerShell.Host
+namespace Microsoft.DotNet.Interactive.PowerShell
 {
     using System.Management.Automation;
     using System.Text;

--- a/Microsoft.DotNet.Interactive.PowerShell/DollarProfileHelper.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/DollarProfileHelper.cs
@@ -12,8 +12,8 @@ namespace Microsoft.DotNet.Interactive.PowerShell
     {
         private const string _profileName = "Microsoft.dotnet-interactive_profile.ps1";
 
-        internal readonly static string AllUsersCurrentHost = GetFullProfileFilePath(forCurrentUser: false);
-        internal readonly static string CurrentUserCurrentHost = GetFullProfileFilePath(forCurrentUser: true);
+        internal static readonly string AllUsersCurrentHost = GetFullProfileFilePath(forCurrentUser: false);
+        internal static readonly string CurrentUserCurrentHost = GetFullProfileFilePath(forCurrentUser: true);
 
         private static string GetFullProfileFilePath(bool forCurrentUser)
         {

--- a/Microsoft.DotNet.Interactive.PowerShell/DollarProfileHelper.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/DollarProfileHelper.cs
@@ -49,6 +49,8 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Host
                 return;
             }
 
+            pwshKernel.HasRunProfiles = true;
+
             // Run the PROFILE scripts if they exist.
             if (File.Exists(_allUsersCurrentHost))
             {

--- a/Microsoft.DotNet.Interactive.PowerShell/DollarProfileHelper.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/DollarProfileHelper.cs
@@ -15,8 +15,6 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Host
         private static readonly string _allUsersCurrentHost = DollarProfileHelper.GetFullProfileFilePath(forCurrentUser: false);
         private static readonly string _currentUserCurrentHost = DollarProfileHelper.GetFullProfileFilePath(forCurrentUser: true);
 
-        private static bool _haveRunProfiles;
-
         private static string GetFullProfileFilePath(bool forCurrentUser)
         {
             if (!forCurrentUser)

--- a/Microsoft.DotNet.Interactive.PowerShell/DollarProfileHelper.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/DollarProfileHelper.cs
@@ -25,15 +25,9 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Host
                 return Path.Combine(pshome, _profileName);
             }
 
-            string configPath;
-            if (Platform.IsWindows)
-            {
-                configPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), "PowerShell");
-            }
-            else
-            {
-                configPath = Platform.SelectProductNameForDirectory(Platform.XDG_Type.CONFIG);
-            }
+            string configPath = Platform.IsWindows
+                ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), "PowerShell")
+                : Platform.SelectProductNameForDirectory(Platform.XDG_Type.CONFIG);
 
             return Path.Combine(configPath, _profileName);
         }

--- a/Microsoft.DotNet.Interactive.PowerShell/DollarProfileHelper.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/DollarProfileHelper.cs
@@ -19,8 +19,8 @@ namespace Microsoft.DotNet.Interactive.PowerShell
                 BindingFlags.Static | BindingFlags.NonPublic)
             .GetValue(null) as string;
 
-        internal static readonly string AllUsersCurrentHost = GetFullProfileFilePath(forCurrentUser: false);
-        internal static readonly string CurrentUserCurrentHost = GetFullProfileFilePath(forCurrentUser: true);
+        internal static string AllUsersCurrentHost { get; } = GetFullProfileFilePath(forCurrentUser: false);
+        internal static string CurrentUserCurrentHost { get; } = GetFullProfileFilePath(forCurrentUser: true);
 
         private static string GetFullProfileFilePath(bool forCurrentUser)
         {

--- a/Microsoft.DotNet.Interactive.PowerShell/DollarProfileHelper.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/DollarProfileHelper.cs
@@ -7,10 +7,17 @@ using System.IO;
 namespace Microsoft.DotNet.Interactive.PowerShell
 {
     using System.Management.Automation;
+    using System.Reflection;
 
     internal static class DollarProfileHelper
     {
         private const string _profileName = "Microsoft.dotnet-interactive_profile.ps1";
+
+        // This is the easiest way to get the config directory (where the PROFILE lives), unfortunately.
+        private static readonly string _configPath = typeof(Platform).GetField(
+                "ConfigDirectory",
+                BindingFlags.Static | BindingFlags.NonPublic)
+            .GetValue(null) as string;
 
         internal static readonly string AllUsersCurrentHost = GetFullProfileFilePath(forCurrentUser: false);
         internal static readonly string CurrentUserCurrentHost = GetFullProfileFilePath(forCurrentUser: true);
@@ -23,11 +30,7 @@ namespace Microsoft.DotNet.Interactive.PowerShell
                 return Path.Combine(pshome, _profileName);
             }
 
-            string configPath = Platform.IsWindows
-                ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), "PowerShell")
-                : Platform.SelectProductNameForDirectory(Platform.XDG_Type.CONFIG);
-
-            return Path.Combine(configPath, _profileName);
+            return Path.Combine(_configPath, _profileName);
         }
 
         public static PSObject GetProfileValue()

--- a/Microsoft.DotNet.Interactive.PowerShell/DollarProfileHelper.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/DollarProfileHelper.cs
@@ -7,14 +7,13 @@ using System.IO;
 namespace Microsoft.DotNet.Interactive.PowerShell
 {
     using System.Management.Automation;
-    using System.Text;
 
     internal static class DollarProfileHelper
     {
         private const string _profileName = "Microsoft.dotnet-interactive_profile.ps1";
 
-        internal static string AllUsersCurrentHost => GetFullProfileFilePath(forCurrentUser: false);
-        internal static string CurrentUserCurrentHost => GetFullProfileFilePath(forCurrentUser: true);
+        internal readonly static string AllUsersCurrentHost = GetFullProfileFilePath(forCurrentUser: false);
+        internal readonly static string CurrentUserCurrentHost = GetFullProfileFilePath(forCurrentUser: true);
 
         private static string GetFullProfileFilePath(bool forCurrentUser)
         {
@@ -39,21 +38,6 @@ namespace Microsoft.DotNet.Interactive.PowerShell
             // TODO: Decide on whether or not we want to support running the AllHosts profiles
 
             return dollarProfile;
-        }
-
-        public static string GetProfileScript()
-        {
-            var profileScript = new StringBuilder();
-            if (File.Exists(AllUsersCurrentHost))
-            {
-                profileScript.AppendLine($"& '{AllUsersCurrentHost}'");
-            }
-            if (File.Exists(CurrentUserCurrentHost))
-            {
-                profileScript.AppendLine($"& '{CurrentUserCurrentHost}'");
-            }
-
-            return profileScript.ToString();
         }
     }
 }

--- a/Microsoft.DotNet.Interactive.PowerShell/DollarProfileHelper.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/DollarProfileHelper.cs
@@ -12,13 +12,8 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Host
     {
         private const string _profileName = "Microsoft.dotnet-interactive_profile.ps1";
 
-        private static Lazy<string> _lazyAllUsersCurrentHost = new Lazy<string>(() =>
-            DollarProfileHelper.GetFullProfileFilePath(forCurrentUser: false));
-        private static Lazy<string> _lazyCurrentUserCurrentHost = new Lazy<string>(() =>
-            DollarProfileHelper.GetFullProfileFilePath(forCurrentUser: true));
-
-        private static string _allUsersCurrentHost => _lazyAllUsersCurrentHost.Value;
-        private static string _currentUserCurrentHost => _lazyCurrentUserCurrentHost.Value;
+        private static readonly string _allUsersCurrentHost = DollarProfileHelper.GetFullProfileFilePath(forCurrentUser: false);
+        private static readonly string _currentUserCurrentHost = DollarProfileHelper.GetFullProfileFilePath(forCurrentUser: true);
 
         private static bool _haveRunProfiles;
 
@@ -55,12 +50,10 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Host
 
         public static void RunProfilesIfNeeded(PowerShell pwsh, PowerShellKernel pwshKernel)
         {
-            if (_haveRunProfiles)
+            if (pwshKernel.HasRunProfiles)
             {
                 return;
             }
-
-            _haveRunProfiles = true;
 
             // Run the PROFILE scripts if they exist.
             if (File.Exists(_allUsersCurrentHost))

--- a/Microsoft.DotNet.Interactive.PowerShell/Host/DollarProfileHelper.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/Host/DollarProfileHelper.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Management.Automation;
+using System.Reflection;
+
+namespace Microsoft.DotNet.Interactive.PowerShell.Host
+{
+    internal static class DollarProfileHelper
+    {
+        public delegate string GetFullProfileFileNameDelegate(
+            string hostId,
+            bool forCurrentUser);
+
+        private static Lazy<GetFullProfileFileNameDelegate> s_LazyGetFullProfileFileName =
+            new Lazy<GetFullProfileFileNameDelegate>(() =>
+            {
+                // Grab GetFullProfileName static method which handles a lot of the profile
+                // path generation.
+                MethodInfo method = typeof(HostUtilities).GetMethod(
+                    "GetFullProfileFileName",
+                    BindingFlags.Static | BindingFlags.NonPublic,
+                    null,
+                    new [] { typeof(string), typeof(bool) },
+                    null);
+
+                return (GetFullProfileFileNameDelegate)method.CreateDelegate(typeof(GetFullProfileFileNameDelegate));
+            });
+
+        public static GetFullProfileFileNameDelegate GetFullProfileFileName = s_LazyGetFullProfileFileName.Value;
+
+        public static PSObject GetDollarProfile(string allUsersCurrentHost, string currentUserCurrentHost)
+        {
+            PSObject returnValue = new PSObject(currentUserCurrentHost);
+            returnValue.Properties.Add(new PSNoteProperty("AllUsersCurrentHost", allUsersCurrentHost));
+            returnValue.Properties.Add(new PSNoteProperty("CurrentUserCurrentHost", currentUserCurrentHost));
+
+            // TODO: Decide on whether or not we want to support running the AllHosts profiles
+            return returnValue;
+        }
+    }
+}

--- a/Microsoft.DotNet.Interactive.PowerShell/Host/PSKernelHost.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/Host/PSKernelHost.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Host
 {
     public class PSKernelHost : PSHost, IHostSupportsInteractiveSession
     {
-        private const string HostName = "PowerShell .NET Interactive Host";
+        private const string HostName = ".NET Interactive Host";
 
         private readonly Version _hostVersion;
         private readonly Guid _instanceId;

--- a/Microsoft.DotNet.Interactive.PowerShell/Host/PSKernelHost.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/Host/PSKernelHost.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Host
 {
     public class PSKernelHost : PSHost, IHostSupportsInteractiveSession
     {
-        private const string HostName = "Microsoft.dotnet-interactive";
+        private const string HostName = "PowerShell .NET Interactive Host";
 
         private readonly Version _hostVersion;
         private readonly Guid _instanceId;

--- a/Microsoft.DotNet.Interactive.PowerShell/Host/PSKernelHost.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/Host/PSKernelHost.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Host
 {
     public class PSKernelHost : PSHost, IHostSupportsInteractiveSession
     {
-        private const string HostName = "PowerShell Jupyter Host";
+        private const string HostName = "Microsoft.dotnet-interactive";
 
         private readonly Version _hostVersion;
         private readonly Guid _instanceId;

--- a/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Management.Automation.Language;

--- a/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -31,6 +31,9 @@ namespace Microsoft.DotNet.Interactive.PowerShell
         private readonly PSKernelHost _psHost;
         private readonly Lazy<PowerShell> _lazyPwsh;
 
+        internal Lazy<bool> _lazyHasRunProfile;
+        internal bool HasRunProfiles => _lazyHasRunProfile.Value;
+
         public Func<string, string> ReadInput { get; set; }
         public Func<string, PasswordString> ReadPassword { get; set; }
 
@@ -71,6 +74,10 @@ namespace Microsoft.DotNet.Interactive.PowerShell
         {
             _psHost = new PSKernelHost();
             _lazyPwsh = new Lazy<PowerShell>(CreatePowerShell);
+            _lazyHasRunProfile = new Lazy<bool>(() => {
+                DollarProfileHelper.RunProfilesIfNeeded(_lazyPwsh.Value, this);
+                return true;
+            });
         }
 
         private PowerShell CreatePowerShell()

--- a/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -36,7 +36,6 @@ namespace Microsoft.DotNet.Interactive.PowerShell
         public Func<string, PasswordString> ReadPassword { get; set; }
 
         internal AzShellConnectionUtils AzShell { get; set; }
-        internal bool HasRunProfiles { get; set; }
         internal int DefaultRunspaceId
         {
             get { return _lazyPwsh.IsValueCreated ? Pwsh.Runspace.Id : -1; }

--- a/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -104,6 +104,24 @@ namespace Microsoft.DotNet.Interactive.PowerShell
                 PSModulePathEnvName,
                 $"{psJupyterModulePath}{Path.PathSeparator}{psModulePath}");
 
+            // Set $PROFILE.
+            string allUsersCurrentHost = DollarProfileHelper.GetFullProfileFileName(_psHost.Name, forCurrentUser: false);
+            string currentUserCurrentHost = DollarProfileHelper.GetFullProfileFileName(_psHost.Name, forCurrentUser: true);
+            PSObject dollarProfile = DollarProfileHelper.GetDollarProfile(allUsersCurrentHost, currentUserCurrentHost);
+
+            pwsh.Runspace.SessionStateProxy.SetVariable("PROFILE", dollarProfile);
+
+            // Run the PROFILE scripts if they exist.
+            if (File.Exists(allUsersCurrentHost))
+            {
+                pwsh.AddScript(allUsersCurrentHost).InvokeAndClearCommands();
+            }
+
+            if (File.Exists(currentUserCurrentHost))
+            {
+                pwsh.AddScript(currentUserCurrentHost).InvokeAndClearCommands();
+            }
+
             RegisterForDisposal(pwsh);
             return pwsh;
         }

--- a/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -105,22 +105,7 @@ namespace Microsoft.DotNet.Interactive.PowerShell
                 $"{psJupyterModulePath}{Path.PathSeparator}{psModulePath}");
 
             // Set $PROFILE.
-            string allUsersCurrentHost = DollarProfileHelper.GetFullProfileFilePath(forCurrentUser: false);
-            string currentUserCurrentHost = DollarProfileHelper.GetFullProfileFilePath(forCurrentUser: true);
-            PSObject dollarProfile = DollarProfileHelper.GetDollarProfile(allUsersCurrentHost, currentUserCurrentHost);
-
-            pwsh.Runspace.SessionStateProxy.SetVariable("PROFILE", dollarProfile);
-
-            // Run the PROFILE scripts if they exist.
-            if (File.Exists(allUsersCurrentHost))
-            {
-                pwsh.AddScript(allUsersCurrentHost).InvokeAndClearCommands();
-            }
-
-            if (File.Exists(currentUserCurrentHost))
-            {
-                pwsh.AddScript(currentUserCurrentHost).InvokeAndClearCommands();
-            }
+            DollarProfileHelper.SetDollarProfile(pwsh);
 
             RegisterForDisposal(pwsh);
             return pwsh;
@@ -188,6 +173,8 @@ namespace Microsoft.DotNet.Interactive.PowerShell
                 context.Fail(null, "Command cancelled");
                 return;
             }
+
+            DollarProfileHelper.RunProfilesIfNeeded(pwsh, this);
 
             if (AzShell != null)
             {
@@ -267,7 +254,7 @@ namespace Microsoft.DotNet.Interactive.PowerShell
             }
         }
 
-        private void RunSubmitCodeLocally(PowerShell pwsh, string code)
+        internal void RunSubmitCodeLocally(PowerShell pwsh, string code)
         {
             try
             {

--- a/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -31,13 +31,11 @@ namespace Microsoft.DotNet.Interactive.PowerShell
         private readonly PSKernelHost _psHost;
         private readonly Lazy<PowerShell> _lazyPwsh;
 
-        internal Lazy<bool> _lazyHasRunProfile;
-        internal bool HasRunProfiles => _lazyHasRunProfile.Value;
-
         public Func<string, string> ReadInput { get; set; }
         public Func<string, PasswordString> ReadPassword { get; set; }
 
         internal AzShellConnectionUtils AzShell { get; set; }
+        internal bool HasRunProfiles { get; set; }
         internal int DefaultRunspaceId
         {
             get { return _lazyPwsh.IsValueCreated ? _lazyPwsh.Value.Runspace.Id : -1; }
@@ -74,10 +72,6 @@ namespace Microsoft.DotNet.Interactive.PowerShell
         {
             _psHost = new PSKernelHost();
             _lazyPwsh = new Lazy<PowerShell>(CreatePowerShell);
-            _lazyHasRunProfile = new Lazy<bool>(() => {
-                DollarProfileHelper.RunProfilesIfNeeded(_lazyPwsh.Value, this);
-                return true;
-            });
         }
 
         private PowerShell CreatePowerShell()

--- a/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -105,8 +105,8 @@ namespace Microsoft.DotNet.Interactive.PowerShell
                 $"{psJupyterModulePath}{Path.PathSeparator}{psModulePath}");
 
             // Set $PROFILE.
-            string allUsersCurrentHost = DollarProfileHelper.GetFullProfileFileName(_psHost.Name, forCurrentUser: false);
-            string currentUserCurrentHost = DollarProfileHelper.GetFullProfileFileName(_psHost.Name, forCurrentUser: true);
+            string allUsersCurrentHost = DollarProfileHelper.GetFullProfileFilePath(forCurrentUser: false);
+            string currentUserCurrentHost = DollarProfileHelper.GetFullProfileFilePath(forCurrentUser: true);
             PSObject dollarProfile = DollarProfileHelper.GetDollarProfile(allUsersCurrentHost, currentUserCurrentHost);
 
             pwsh.Runspace.SessionStateProxy.SetVariable("PROFILE", dollarProfile);

--- a/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernelExtensions.cs
+++ b/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernelExtensions.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using Microsoft.DotNet.Interactive.Commands;
+
+namespace Microsoft.DotNet.Interactive.PowerShell
+{
+    public static class PowerShellKernelExtensions
+    {
+        public static PowerShellKernel UseProfiles(
+            this PowerShellKernel kernel)
+        {
+            if (File.Exists(DollarProfileHelper.AllUsersCurrentHost))
+            {
+                var command = new SubmitCode(". $PROFILE.AllUsersCurrentHost");
+                kernel.DeferCommand(command);
+            }
+
+            if (File.Exists(DollarProfileHelper.CurrentUserCurrentHost))
+            {
+                var command = new SubmitCode(". $PROFILE");
+                kernel.DeferCommand(command);
+            }
+
+            return kernel;
+        }
+    }
+}

--- a/dotnet-interactive/CommandLine/CommandLineParser.cs
+++ b/dotnet-interactive/CommandLine/CommandLineParser.cs
@@ -357,7 +357,8 @@ namespace Microsoft.DotNet.Interactive.App.CommandLine
             compositeKernel.Add(
                 new PowerShellKernel()
                     .UseJupyterHelpers()
-                    .UseXplot(),
+                    .UseXplot()
+                    .UseProfiles(),
                 new[] { "pwsh" });
 
             compositeKernel.Add(


### PR DESCRIPTION
fixes #139 

This adds `$PROFILE` support to the PowerShell subkernel - it uses a PowerShell internal method called `GetFullProfileFileName` which get's the proper path (the logic in PowerShell is surprisingly complex...)

The result is:

```
CurentUserCurrentHost:
/Users/tyleonha/.config/powershell/Microsoft.dotnet-interactive_profile.ps1

AllUsersCurrentHost:
/Users/tyleonha/.dotnet/tools/.store/microsoft.dotnet-interactive/0.0.0/microsoft.dotnet-interactive/0.0.0/tools/netcoreapp3.1/any/runtimes/unix/lib/netcoreapp3.1/Microsoft.dotnet-interactive_profile.ps1
```

![image](https://user-images.githubusercontent.com/2644648/79168358-8c472900-7d9e-11ea-9c7f-8fa5eb7a5edb.png)

We might only need the first but we can decide here - it's easy to take out.

Also, #139 was with a conflicting idea with whether we should run the `CurrentUserAllHosts` profile since this is another Host... however, since there is not real prompt, this could lead to bad things...so I think we should defer that for now.

If you think this is the right approach, I can probably add a test or 2 for it as well.