### PR TITLE
Fix jupyter install bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ First, make sure you have the following installed:
 > dotnet tool install -g --add-source "https://dotnet.myget.org/F/dotnet-try/api/v3/index.json" Microsoft.dotnet-interactive
 ```
 
-- Register .NET Interactive as a Jupyter kernel by running the following within your Anaconda Prompt:
+- Register .NET Interactive as a Jupyter kernel by running the following within your Anaconda Prompt (Read the [install command line documentation](dotnet-interactive/CommandLine/readme.md) for more details):
 
 ```console
 > dotnet interactive jupyter install
@@ -51,8 +51,8 @@ First, make sure you have the following installed:
 
 [InstallKernelSpec] Installed kernelspec .net-fsharp in ~\jupyter\kernels\.net-fsharp
 .NET kernel installation succeeded
-```
-    
+```   
+
 - You can now verify the installation by running the following in the Anaconda Prompt:
 
 ```console

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ First, make sure you have the following installed:
 > dotnet tool install -g --add-source "https://dotnet.myget.org/F/dotnet-try/api/v3/index.json" Microsoft.dotnet-interactive
 ```
 
-- Register .NET Interactive as a Jupyter kernel by running the following within your Anaconda Prompt (Read the [install command line documentation](dotnet-interactive/CommandLine/readme.md) for more details):
+- Register .NET Interactive as a Jupyter kernel by running the following within your Anaconda Prompt. (More details [here](dotnet-interactive/CommandLine/readme.md)):
 
 ```console
 > dotnet interactive jupyter install
@@ -85,6 +85,5 @@ As we are still in the early stages of development, we may not take any feature 
 |    [Azure Synapse Analytics ](https://azure.microsoft.com/en-us/services/synapse-analytics/)   |Azure HDInsight (HDI)  |
 |:-------------:|:-------------:|
 | Azure Synapse Analytics uses the .NET kernel to write and run quick ad-hoc queries in addition to developing complete, end-to-end big data scenarios, such as reading in data, transforming it, and visualizing it|You can launch Jupyter notebooks from your HDInsight cluster to run big data queries against the compute resources in that cluster. |
-
 
 

--- a/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
+++ b/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
@@ -108,8 +108,10 @@ namespace Microsoft.DotNet.Interactive.App.Tests.CommandLine
 
             var installedKernels = _kernelSpecInstallPath.GetDirectories();
 
-            installedKernels.Select(d => d.Name)
-                .Should().BeEquivalentTo(".net-csharp", ".net-fsharp", ".net-powershell");
+            installedKernels
+                .Select(d => d.Name)
+                .Should()
+                .BeEquivalentTo(".net-csharp", ".net-fsharp", ".net-powershell");
         }
 
         [Fact]

--- a/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
+++ b/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Interactive.App.Tests.CommandLine
             var logPath = new DirectoryInfo(Path.GetTempPath());
 
             await _parser.InvokeAsync($"jupyter --log-path {logPath} {_connectionFile}", _console);
-
+            
             _startOptions
                 .LogPath
                 .FullName
@@ -104,14 +104,12 @@ namespace Microsoft.DotNet.Interactive.App.Tests.CommandLine
         {
             Directory.CreateDirectory(_kernelSpecInstallPath.FullName);
             
-            var result = _parser.Parse($"jupyter install --path {_kernelSpecInstallPath}");
+            var result = _parser.InvokeAsync($"jupyter install --path {_kernelSpecInstallPath}");
 
-            var option = result.CommandResult.OptionResult("--path");
+            var installedKernels = _kernelSpecInstallPath.GetDirectories();
 
-            using var scope = new AssertionScope();
-
-            option.Should().NotBeNull();
-            result.FindResultFor(option.Option).GetValueOrDefault<DirectoryInfo>().FullName.Should().Be(_kernelSpecInstallPath.FullName);
+            installedKernels.Select(d => d.Name)
+                .Should().BeEquivalentTo(".net-csharp", ".net-fsharp", ".net-powershell");
         }
 
         [Fact]

--- a/dotnet-interactive.Tests/JupyterKernelSpecTests.cs
+++ b/dotnet-interactive.Tests/JupyterKernelSpecTests.cs
@@ -98,7 +98,7 @@ namespace Microsoft.DotNet.Interactive.App.Tests
 
             using var scope = new AssertionScope();
             result.Should().BeFalse();
-            error.Should().Match($"*The kernelspec path ${defaultPath.FullName} does not exist.*");
+            error.Should().Match($"*The kernelspec path {defaultPath.FullName} does not exist.*");
         }
 
         private void UnpackKernelsSpecTo(DirectoryInfo destination)

--- a/dotnet-interactive/CommandLine/CommandLineParser.cs
+++ b/dotnet-interactive/CommandLine/CommandLineParser.cs
@@ -251,8 +251,11 @@ namespace Microsoft.DotNet.Interactive.App.CommandLine
                     return jupyter(startupOptions, console, startServer, context);
                 }
 
-                Task<int> InstallHandler(IConsole console, InvocationContext context, PortRange httpPortRange, DirectoryInfo location) =>
-                    new JupyterInstallCommand(console, jupyterKernelSpecInstaller: new JupyterKernelSpecInstaller(console), httpPortRange, location).InvokeAsync();
+                Task<int> InstallHandler(IConsole console, InvocationContext context, PortRange httpPortRange, DirectoryInfo path)
+                {
+                    var jupyterInstallCommand = new JupyterInstallCommand(console, new JupyterKernelSpecInstaller(console), httpPortRange, path);
+                    return jupyterInstallCommand .InvokeAsync();
+                }
             }
 
             Command HttpServer()

--- a/dotnet-interactive/CommandLine/readme.md
+++ b/dotnet-interactive/CommandLine/readme.md
@@ -31,11 +31,10 @@ dotnet interactive jupyter install --http-port-range 8001-9000 | Enabled on auto
 
 ## Installing kernels
 
-When installing `dotnet-interactive` it is possible to provide the path for installing the kernel specs, the path msut exists.
+When installing `dotnet-interactive` you can provide a path where the kernelspec  files used by Jupyter to configure a kernel will be installed. The provided path must be an existing directory.
 
 | Command                                                      | Destination path
 |--------------------------------------------------------------|--------------------------------
 dotnet interactive jupyter install                             | Use the kernelspec module if available. If not found, attempt to use well-known platform-specific folders for Python or Anaconda .
 dotnet interactive jupyter install --path c:\my_path | Will install the kernelspecs at the location if it exists
-
 

--- a/dotnet-interactive/CommandLine/readme.md
+++ b/dotnet-interactive/CommandLine/readme.md
@@ -24,6 +24,19 @@ When installing `dotnet-interactive` as a Jupyter kernel, you can also configure
 | Command                                                      | HTTP behavior of kernel 
 |--------------------------------------------------------------|--------------------------------
 dotnet interactive jupyter install                             | Disabled
-dotnet interactive jupyter install --http-port-range 8001-9000 | Enabled on autoselected port between 8001 and 9000                       
+dotnet interactive jupyter install --http-port-range 8001-9000 | Enabled on autoselected port between 8001 and 9000                      
+
+ 
+
+
+## Installing kernels
+
+When installing `dotnet-interactive` it is possible to provide the path for installing the kernel specs, the path msut exists.
+
+| Command                                                      | Destination path
+|--------------------------------------------------------------|--------------------------------
+dotnet interactive jupyter install                             | Will use the kernelspec module if available, if it is not present will attempt ot use platform specific folders for python or anaconda paths
+dotnet interactive jupyter install --path c:\my_path | Will install the kernelspecs at the location if it exists
+
 
 

--- a/dotnet-interactive/CommandLine/readme.md
+++ b/dotnet-interactive/CommandLine/readme.md
@@ -35,8 +35,7 @@ When installing `dotnet-interactive` it is possible to provide the path for inst
 
 | Command                                                      | Destination path
 |--------------------------------------------------------------|--------------------------------
-dotnet interactive jupyter install                             | Will use the kernelspec module if available, if it is not present will attempt ot use platform specific folders for python or anaconda paths
+dotnet interactive jupyter install                             | Use the kernelspec module if available. If not found, attempt to use well-known platform-specific folders for Python or Anaconda .
 dotnet interactive jupyter install --path c:\my_path | Will install the kernelspecs at the location if it exists
-
 
 

--- a/dotnet-interactive/JupyterKernelSpecInstaller.cs
+++ b/dotnet-interactive/JupyterKernelSpecInstaller.cs
@@ -58,6 +58,7 @@ namespace Microsoft.DotNet.Interactive.App
             }
 
             destination = _kernelSpecModule.GetDefaultKernelSpecDirectory();
+
             return InstallKernelSpecToDirectory(destination, destination, kernelDisplayName);
         }
 

--- a/dotnet-interactive/JupyterKernelSpecInstaller.cs
+++ b/dotnet-interactive/JupyterKernelSpecInstaller.cs
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.Interactive.App
         {
             if (!destination.Exists)
             {
-                _console.Error.WriteLine($"The kernelspec path ${destination.FullName} does not exist.");
+                _console.Error.WriteLine($"The kernelspec path {destination.FullName} does not exist.");
                 _console.Error.WriteLine($"Failed to install \"{kernelDisplayName}\" kernel.");
 
                 return false;

--- a/dotnet-interactive/JupyterKernelSpecInstaller.cs
+++ b/dotnet-interactive/JupyterKernelSpecInstaller.cs
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.Interactive.App
 
             destination = _kernelSpecModule.GetDefaultKernelSpecDirectory();
 
-            return InstallKernelSpecToDirectory(destination, destination, kernelDisplayName);
+            return InstallKernelSpecToDirectory(sourceDirectory, destination, kernelDisplayName);
         }
 
         private bool InstallKernelSpecToDirectory(DirectoryInfo sourceDirectory, DirectoryInfo destination,
@@ -98,44 +98,44 @@ namespace Microsoft.DotNet.Interactive.App
         }
 
 
-        private bool CopyKernelSpecFiles(DirectoryInfo source, DirectoryInfo location)
+        private bool CopyKernelSpecFiles(DirectoryInfo source, DirectoryInfo destination)
         {
             if (source == null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
 
-            if (location == null)
+            if (destination == null)
             {
-                throw new ArgumentNullException(nameof(location));
+                throw new ArgumentNullException(nameof(destination));
             }
 
-            if (!location.Exists)
+            if (!destination.Exists)
             {
-                _console.Error.WriteLine($"Directory {location.FullName} does not exist.");
+                _console.Error.WriteLine($"Directory {destination.FullName} does not exist.");
                 return false;
             }
 
             try
             {
-                var destination = new DirectoryInfo(Path.Combine(location.FullName, source.Name));
-                if (destination.Exists)
+                var kernelSpecDestinationPath = new DirectoryInfo(Path.Combine(destination.FullName, source.Name));
+                if (kernelSpecDestinationPath.Exists)
                 {
-                    destination.Delete(true);
+                    kernelSpecDestinationPath.Delete(true);
                 }
 
-                destination.Create();
+                kernelSpecDestinationPath.Create();
 
                 // First create all of the directories
                 foreach (var dirPath in Directory.GetDirectories(source.FullName, "*", SearchOption.AllDirectories))
                 {
-                    Directory.CreateDirectory(dirPath.Replace(source.FullName, destination.FullName));
+                    Directory.CreateDirectory(dirPath.Replace(source.FullName, kernelSpecDestinationPath.FullName));
                 }
 
                 // Copy all the files
                 foreach (var newPath in Directory.GetFiles(source.FullName, "*.*", SearchOption.AllDirectories))
                 {
-                    File.Copy(newPath, newPath.Replace(source.FullName, destination.FullName));
+                    File.Copy(newPath, newPath.Replace(source.FullName, kernelSpecDestinationPath.FullName));
                 }
             }
             catch (IOException ioe)

--- a/dotnet-interactive/JupyterKernelSpecModule.cs
+++ b/dotnet-interactive/JupyterKernelSpecModule.cs
@@ -22,13 +22,50 @@ namespace Microsoft.DotNet.Interactive.App
 
         public  DirectoryInfo GetDefaultKernelSpecDirectory()
         {
+            
+            var directory = GetDefaultAnacondaKernelSpecDirectory();
+            if (!directory.Exists)
+            {
+                directory = GetDefaultJupyterKernelSpecDirectory();
+            }
+
+            return directory;
+        }
+
+        private static DirectoryInfo GetDefaultAnacondaKernelSpecDirectory()
+        {
             DirectoryInfo directory;
             switch (Environment.OSVersion.Platform)
             {
                 case PlatformID.Win32S:
                 case PlatformID.Win32Windows:
                 case PlatformID.Win32NT:
-                    directory = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "jupyter", "kernels"));
+                    directory = new DirectoryInfo(Path.Combine(
+                        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Continuum", "anaconda3", "share", "jupyter", "kernels"));
+                    break;
+                case PlatformID.Unix:
+                    directory = new DirectoryInfo("~/anaconda3/share/jupyter/kernels");
+                    break;
+                case PlatformID.MacOSX:
+                    directory = new DirectoryInfo("~/opt/anaconda3/share/jupyter/kernels");
+                    break;
+                default:
+                    throw new PlatformNotSupportedException();
+            }
+
+            return directory;
+        }
+
+        private static DirectoryInfo GetDefaultJupyterKernelSpecDirectory()
+        {
+            DirectoryInfo directory;
+            switch (Environment.OSVersion.Platform)
+            {
+                case PlatformID.Win32S:
+                case PlatformID.Win32Windows:
+                case PlatformID.Win32NT:
+                    directory = new DirectoryInfo(Path.Combine(
+                        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "jupyter", "kernels"));
                     break;
                 case PlatformID.Unix:
                     directory = new DirectoryInfo("~/.local/share/jupyter/kernels");

--- a/dotnet-interactive/Properties/launchSettings.json
+++ b/dotnet-interactive/Properties/launchSettings.json
@@ -30,10 +30,6 @@
     "dotnet-interactive-http": {
       "commandName": "Project",
       "commandLineArgs": "http"
-    },
-    "dotnet-interactive-install": {
-      "commandName": "Project",
-      "commandLineArgs": "jupyter install --path c:\\Users\\dicolomb\\kernelInstallPath"
     }
   }
 }

--- a/dotnet-interactive/Properties/launchSettings.json
+++ b/dotnet-interactive/Properties/launchSettings.json
@@ -30,6 +30,10 @@
     "dotnet-interactive-http": {
       "commandName": "Project",
       "commandLineArgs": "http"
+    },
+    "dotnet-interactive-install": {
+      "commandName": "Project",
+      "commandLineArgs": "jupyter install --path c:\\Users\\dicolomb\\kernelInstallPath"
     }
   }
 }


### PR DESCRIPTION
Addressing #366
--path was ignored during install
default anaconda locations not included in strategy