### PR TITLE
don't publish ReturnValueProduced for unit

### DIFF
--- a/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
+++ b/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
@@ -109,7 +109,7 @@ type FSharpKernel() as this =
             match result with
             | Ok(result) ->
                 match result with
-                | Some(value) ->
+                | Some(value) when value.ReflectionType <> typeof<unit>  ->
                     let value = value.ReflectionValue
                     let formattedValues = FormattedValue.FromObject(value)
                     context.Publish(ReturnValueProduced(value, codeSubmission, formattedValues))

--- a/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
+++ b/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
@@ -113,6 +113,7 @@ type FSharpKernel() as this =
                     let value = value.ReflectionValue
                     let formattedValues = FormattedValue.FromObject(value)
                     context.Publish(ReturnValueProduced(value, codeSubmission, formattedValues))
+                | Some(value) -> ()
                 | None -> ()
             | Error(ex) ->
                 if not (tokenSource.IsCancellationRequested) then

--- a/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -28,12 +28,44 @@
 
   <ItemGroup>
     <Content Include="$(MSBuildThisFileDirectory)Modules\**"
-             Link="Modules\%(RecursiveDir)%(FileName)%(Extension)"
-             PackagePath="contentFiles/any/any/Modules"
-             PackageCopyToOutput="true"
-             CopyToOutputDirectory="PreserveNewest" />
+            Link="Modules\%(RecursiveDir)%(FileName)%(Extension)"
+            PackagePath="contentFiles/any/any/Modules"
+            PackageCopyToOutput="true"
+            CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 
-  
+  <ItemGroup>
+    <Content Include="$(PkgPackageManagement)\**"
+             Exclude="$(PkgPackageManagement)\**\*.nupkg;$(PkgPackageManagement)\**\*.nuspec;$(PkgPackageManagement)\**\*.sha512;$(PkgPackageManagement)\**\fullclr\**"
+             Link="Modules\PackageManagement\%(RecursiveDir)%(FileName)%(Extension)"
+             PackagePath="contentFiles/any/any/Modules/PackageManagement"
+             PackageCopyToOutput="true"
+             CopyToOutputDirectory="PreserveNewest" 
+             Condition="'$(PkgPackageManagement)' != ''" />
+
+    <Content Include="$(PkgPowerShellGet)\**"
+             Exclude="$(PkgPowerShellGet)\**\*.nupkg;$(PkgPowerShellGet)\**\*.nuspec;$(PkgPowerShellGet)\**\*.sha512"
+             Link="Modules\PowerShellGet\%(RecursiveDir)%(FileName)%(Extension)"
+             PackagePath="contentFiles/any/any/Modules/PowerShellGet"
+             PackageCopyToOutput="true"
+             CopyToOutputDirectory="PreserveNewest" 
+             Condition="'$(PkgPowerShellGet)' != ''" />
+
+    <Content Include="$(PkgMicrosoft_PowerShell_Archive)\**"
+             Exclude="$(PkgMicrosoft_PowerShell_Archive)\**\*.nupkg;$(PkgMicrosoft_PowerShell_Archive)\**\*.nuspec;$(PkgMicrosoft_PowerShell_Archive)\**\*.sha512"
+             Link="Modules\Microsoft.PowerShell.Archive\%(RecursiveDir)%(FileName)%(Extension)"
+             PackagePath="contentFiles/any/any/Modules/Microsoft.PowerShell.Archive"
+             PackageCopyToOutput="true"
+             CopyToOutputDirectory="PreserveNewest" 
+             Condition="'$(PkgMicrosoft_PowerShell_Archive)' != ''" />
+
+    <Content Include="$(PkgThreadJob)\**"
+             Exclude="$(PkgThreadJob)\**\*.nupkg;$(PkgThreadJob)\**\*.nuspec;$(PkgThreadJob)\**\*.sha512"
+             Link="Modules\ThreadJob\%(RecursiveDir)%(FileName)%(Extension)"
+             PackagePath="contentFiles/any/any/Modules/ThreadJob"
+             PackageCopyToOutput="true"
+             CopyToOutputDirectory="PreserveNewest" 
+             Condition="'$(PkgThreadJob)' != ''" />
 
   </ItemGroup>
 

--- a/Microsoft.DotNet.Interactive.Tests/LanguageKernelFormattingTests.cs
+++ b/Microsoft.DotNet.Interactive.Tests/LanguageKernelFormattingTests.cs
@@ -275,5 +275,16 @@ f();"
                 .And
                 .Contain("the-outer-exception");
         }
+
+        [Fact]
+        public async Task FSharpKernel_does_not_publish_return_values_for_unit()
+        {
+            var kernel = CreateKernel(Language.FSharp);
+
+            await kernel.SubmitCodeAsync("\"Hello from F#!\" |> Console.WriteLine");
+
+            KernelEvents.Should()
+                        .NotContain(e => e is ReturnValueProduced);
+        }
     }
 }


### PR DESCRIPTION
This fixes the following bug:

```
> #!fsharp
> "Hello" |> Console.WriteLine

Hello
<null>
```
