### PR TITLE
update fsharp components

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,9 +15,10 @@
 
   <!-- Consolidate FSharp package versions -->
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.7.2-beta.20202.2" />
-    <PackageReference Update="FSharp.Compiler.Private.Scripting" Version="10.8.1-beta.20202.2" />
+    <PackageReference Update="FSharp.Core" Version="4.7.3-beta.20254.4" />
+    <PackageReference Update="FSharp.Compiler.Private.Scripting" Version="10.10.0-beta.20254.4" />
     <PackageReference Update="FSharp.Compiler.Service" Version="31.0.0" />
+    <PackageReference Update="Microsoft.DotNet.DependencyManager" Version="10.10.0-beta.20254.4" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
@@ -23,7 +23,7 @@ using Microsoft.DotNet.Interactive.Extensions;
 using Microsoft.DotNet.Interactive.Formatting;
 using Microsoft.DotNet.Interactive.LanguageService;
 using Microsoft.DotNet.Interactive.Utility;
-using Microsoft.Interactive.DependencyManager;
+using Microsoft.DotNet.DependencyManager;
 using XPlot.Plotly;
 using Task = System.Threading.Tasks.Task;
 

--- a/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
@@ -19,7 +19,7 @@ open Microsoft.DotNet.Interactive.Events
 open Microsoft.DotNet.Interactive.Extensions
 open Microsoft.DotNet.Interactive.Utility
 
-open Microsoft.Interactive.DependencyManager;
+open Microsoft.DotNet.DependencyManager;
 open FSharp.Compiler.Interactive.Shell
 open FSharp.Compiler.Scripting
 open FSharp.Compiler.SourceCodeServices

--- a/src/Microsoft.DotNet.Interactive.Tests/PackageRestoreContextTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/PackageRestoreContextTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 using Xunit.Abstractions;
 using System.Collections.Generic;
 using Microsoft.DotNet.Interactive.Utility;
-using Microsoft.Interactive.DependencyManager;
+using Microsoft.DotNet.DependencyManager;
 
 namespace Microsoft.DotNet.Interactive.Tests
 {

--- a/src/Microsoft.DotNet.Interactive/ISupportNuget.cs
+++ b/src/Microsoft.DotNet.Interactive/ISupportNuget.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using Microsoft.Interactive.DependencyManager;
+using Microsoft.DotNet.DependencyManager;
 using Microsoft.DotNet.Interactive.Utility;
 
 namespace Microsoft.DotNet.Interactive

--- a/src/Microsoft.DotNet.Interactive/PackageRestoreContext.cs
+++ b/src/Microsoft.DotNet.Interactive/PackageRestoreContext.cs
@@ -13,7 +13,7 @@ using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.Utility;
 using Pocket;
 using static Pocket.Logger;
-using Microsoft.Interactive.DependencyManager;
+using Microsoft.DotNet.DependencyManager;
 using System.Runtime.InteropServices.ComTypes;
 using System.Collections.ObjectModel;
 using System.Globalization;

--- a/src/dotnet-interactive/build-and-install-dotnet-interactive.ps1
+++ b/src/dotnet-interactive/build-and-install-dotnet-interactive.ps1
@@ -10,12 +10,12 @@ if (Test-Path 'env:DisableArcade') {
     $script:toolVersion = "0.0.0"
 } else {
     if ($IsLinux -or $IsMacOS) {
-        & "$thisDir\..\build.sh" --pack
+        & "$thisDir\..\..\build.sh" --pack
     } else {
-        & "$thisDir\..\build.cmd" -pack
+        & "$thisDir\..\..\build.cmd" -pack
     }
 
-    $script:toolLocation = "$thisDir\..\artifacts\packages\Debug\Shipping"
+    $script:toolLocation = "$thisDir\..\..\artifacts\packages\Debug\Shipping"
     $script:toolVersion = "1.0.0-dev"
 }
 


### PR DESCRIPTION
Update FSharp.Components included in the dotnet interactive to match VS 2019 16.7 previews.

Includes namespace change for Dependency Manager apis.
From:  using Microsoft.Interactive.DependencyManager;
To:       using Microsoft.DotNet.DependencyManager;

Also updates: build-and-install-dotnet-interactive.ps1
Which seems to have not kept up, but I still use.
