### PR TITLE
establish connection and event tracing

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/signalr-client.ts
+++ b/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/signalr-client.ts
@@ -63,5 +63,6 @@ export async function signalTransportFactory(rootUrl: string): Promise<KernelTra
         }
     };
 
+    await connection.send("connect");
     return Promise.resolve(eventStream);
 }

--- a/src/dotnet-interactive/CommandLine/CommandLineParser.cs
+++ b/src/dotnet-interactive/CommandLine/CommandLineParser.cs
@@ -322,10 +322,7 @@ namespace Microsoft.DotNet.Interactive.App.CommandLine
             services
                 .AddSingleton(_ =>
                 {
-                    var frontendEnvironment = new BrowserFrontendEnvironment
-                    {
-                        ApiUri = new Uri($"http://localhost:{startupOptions.HttpPort.PortNumber}")
-                    };
+                    var frontendEnvironment = new BrowserFrontendEnvironment();
                     return frontendEnvironment;
                 })
                 .AddSingleton(c =>

--- a/src/dotnet-interactive/Http/KernelHub.cs
+++ b/src/dotnet-interactive/Http/KernelHub.cs
@@ -1,50 +1,12 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Disposables;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Server;
 
 namespace Microsoft.DotNet.Interactive.App.Http
 {
-    public class KernelHubConnection : IDisposable
-    {
-        private readonly CompositeDisposable _disposables = new CompositeDisposable();
-        private bool _registered;
-        public CompositeKernel Kernel { get; }
-
-        public KernelHubConnection(CompositeKernel kernel)
-        {
-            Kernel = kernel;
-        }
-
-        public void RegisterContext(IHubContext<KernelHub> hubContext)
-        {
-            if (!_registered)
-            {
-                _registered = true;
-                _disposables.Add(Kernel.KernelEvents.Subscribe(onNext: async kernelEvent =>
-                    await PublishEventToContext(kernelEvent, hubContext)));
-            }
-        }
-
-        private async Task PublishEventToContext(IKernelEvent kernelEvent, IHubContext<KernelHub> hubContext)
-        {
-            var eventEnvelope = KernelEventEnvelope.Create(kernelEvent);
-
-            await hubContext.Clients.All.SendAsync("kernelEvent", KernelEventEnvelope.Serialize(eventEnvelope));
-        }
-
-        public void Dispose()
-        {
-            _disposables.Dispose();
-            _registered = false;
-        }
-    }
-
     public class KernelHub : Hub
     {
         private readonly KernelHubConnection _connection;

--- a/src/dotnet-interactive/Http/KernelHubConnection.cs
+++ b/src/dotnet-interactive/Http/KernelHubConnection.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Reactive.Disposables;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;

--- a/src/dotnet-interactive/Http/KernelHubConnection.cs
+++ b/src/dotnet-interactive/Http/KernelHubConnection.cs
@@ -1,7 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
-using System;
+﻿using System;
 using System.Reactive.Disposables;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
@@ -43,29 +40,5 @@ namespace Microsoft.DotNet.Interactive.App.Http
             _disposables.Dispose();
             _registered = false;
         }
-    }
-
-    public class KernelHub : Hub
-    {
-        private readonly KernelHubConnection _connection;
-
-        public KernelHub(KernelHubConnection connection,  IHubContext<KernelHub> hubContext)
-        {
-            _connection = connection;
-            _connection.RegisterContext(hubContext);
-        }
-
-        public async Task SubmitCommand(string kernelCommandEnvelope)
-        {
-            var envelope = KernelCommandEnvelope.Deserialize(kernelCommandEnvelope);
-            var command = envelope.Command;
-            await _connection.Kernel.SendAsync(command);
-        }
-
-        public async  Task Connect()
-        {
-            await Clients.Caller.SendAsync("connected");
-        }
-
     }
 }

--- a/src/dotnet-interactive/Startup.cs
+++ b/src/dotnet-interactive/Startup.cs
@@ -36,6 +36,7 @@ namespace Microsoft.DotNet.Interactive.App
         {
             if (StartupOptions.EnableHttpApi)
             {
+                services.AddSingleton((c) => new KernelHubConnection(c.GetRequiredService<CompositeKernel>()));
                 services.AddRouting();
                 services.AddCors(options =>
                 {


### PR DESCRIPTION
hubs are transient and events are subscribed at each hub creation, this change trigger a first call to establish the subscription to kernel events and ensure all clients receive all events.
