### PR TITLE
ensure appropriate version of `dotnet-interactive` is present

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/contracts.ts
+++ b/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/contracts.ts
@@ -240,11 +240,14 @@ export interface KernelEventEnvelopeObserver {
     (eventEnvelope: KernelEventEnvelope): void;
 }
 
-export interface DisposableSubscription {
+export interface Disposable {
     dispose(): void;
 }
 
-export interface KernelTransport {
+export interface DisposableSubscription extends Disposable {
+}
+
+export interface KernelTransport extends Disposable {
     subscribeToKernelEvents(observer: KernelEventEnvelopeObserver): DisposableSubscription;
     submitCommand(command: KernelCommand, commandType: KernelCommandType, token: string): Promise<void>;
 }

--- a/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/signalr-client.ts
+++ b/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/signalr-client.ts
@@ -60,6 +60,9 @@ export async function signalTransportFactory(rootUrl: string): Promise<KernelTra
                 token: token,
             };
             return connection.send("submitCommand", JSON.stringify(envelope));
+        },
+
+        dispose: (): void => {
         }
     };
 

--- a/src/Microsoft.DotNet.Interactive.Js/tests/testSupport.ts
+++ b/src/Microsoft.DotNet.Interactive.Js/tests/testSupport.ts
@@ -39,6 +39,9 @@ export class MockKernelTransport implements KernelTransport {
         });
         return Promise.resolve();
     }
+
+    public dispose() {
+    }
 }
 
 export function createMockKernelTransport(rootUrl: string): Promise<KernelTransport> {

--- a/src/dotnet-interactive-vscode/README.md
+++ b/src/dotnet-interactive-vscode/README.md
@@ -1,15 +1,25 @@
-# dotnet-interactive-vscode README
+👉👉👉 This extension is still **under development**.
+
+👉👉👉 Latest **VS Code Insiders** is required and at times this extension might be broken.
+
+---
+
+# DotNet Interactive Notebooks
+
+This extension adds support for using the `dotnet-interactive` global tool from within VS Code in a notebook-like environment.
+
+### Getting Started
+
+1. Install the [.NET SDK 3.1](https://dotnet.microsoft.com/download/visual-studio-sdks).
+1. Install latest [DotNet Interactive Global Tool](https://www.nuget.org/packages/Microsoft.dotnet-interactive/).
+1. Install latest [VS Code Insiders](https://code.visualstudio.com/insiders/).
+1. Open this directory with `code-insiders` and F5
+1. Open a file with the `.dotnet-interactive` extension.
 
 ### Development
 
-Open this directory in [VS Code Insiders](https://code.visualstudio.com/insiders/) then F5.  The extension is
-triggered by opening an existing file with the `.dotnet-interactive` extension.
-
-The `dotnet-interactive` global tool is assumed to be installed and on the path.
-
-Some APIs used in this extension are only in VS Code Insiders builds, and the file `./src/vscode.proposed.d.ts` is
-required to be present.  A fresh copy of that file can be obtained from https://github.com/microsoft/vscode/blob/master/src/vs/vscode.proposed.d.ts.
-A convenience script is located at `./update-proposed-api.ps1` that will fetch a fresh copy.
+Same steps as in [Getting Started](#Getting-Started).  Periodically the notebook APIs will change; the latest API can
+be obtained by running the `.\update-proposed-api.ps1` script.
 
 ### Deployment
 

--- a/src/dotnet-interactive-vscode/package-lock.json
+++ b/src/dotnet-interactive-vscode/package-lock.json
@@ -144,6 +144,14 @@
 				"lodash": "^4.17.15",
 				"semver": "^6.3.0",
 				"tsutils": "^3.17.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
 		"acorn": {
@@ -460,6 +468,11 @@
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"dev": true
 		},
+		"compare-versions": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
+			"integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA=="
+		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -721,6 +734,12 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
 					"integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				}
 			}
@@ -1916,12 +1935,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true
-		},
-		"semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 			"dev": true
 		},
 		"set-blocking": {

--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -25,6 +25,9 @@
     "onNotebookEditor:dotnet-interactive"
   ],
   "main": "./out/extension.js",
+  "extensionDependencies": [
+    "ms-dotnettools.vscode-dotnet-runtime"
+  ],
   "contributes": {
     "notebookProvider": [
       {
@@ -76,5 +79,8 @@
     "typescript": "3.8.3",
     "vsce": "1.75.0",
     "vscode-test": "1.3.0"
+  },
+  "dependencies": {
+    "compare-versions": "3.6.0"
   }
 }

--- a/src/dotnet-interactive-vscode/src/clientMapper.ts
+++ b/src/dotnet-interactive-vscode/src/clientMapper.ts
@@ -34,4 +34,13 @@ export class ClientMapper {
 
         return client;
     }
+
+    closeClient(uri: HasPath) {
+        let key = ClientMapper.keyFromUri(uri);
+        let client = this.clientMap.get(key);
+        if (client) {
+            client.dispose();
+            this.clientMap.delete(key);
+        }
+    }
 }

--- a/src/dotnet-interactive-vscode/src/contracts.ts
+++ b/src/dotnet-interactive-vscode/src/contracts.ts
@@ -240,11 +240,14 @@ export interface KernelEventEnvelopeObserver {
     (eventEnvelope: KernelEventEnvelope): void;
 }
 
-export interface DisposableSubscription {
+export interface Disposable {
     dispose(): void;
 }
 
-export interface KernelTransport {
+export interface DisposableSubscription extends Disposable {
+}
+
+export interface KernelTransport extends Disposable {
     subscribeToKernelEvents(observer: KernelEventEnvelopeObserver): DisposableSubscription;
     submitCommand(command: KernelCommand, commandType: KernelCommandType, token: string): Promise<void>;
 }

--- a/src/dotnet-interactive-vscode/src/extension.ts
+++ b/src/dotnet-interactive-vscode/src/extension.ts
@@ -8,6 +8,7 @@ import { registerCommands } from './vscode/commands';
 export function activate(context: vscode.ExtensionContext) {
     let clientMapper = new ClientMapper(() => new StdioKernelTransport());
     context.subscriptions.push(vscode.notebook.registerNotebookContentProvider('dotnet-interactive', new DotNetInteractiveNotebookContentProvider(clientMapper)));
+    context.subscriptions.push(vscode.notebook.onDidCloseNotebookDocument(notebookDocument => clientMapper.closeClient(notebookDocument.uri)));
     context.subscriptions.push(registerLanguageProviders(clientMapper));
     registerCommands(context);
 }

--- a/src/dotnet-interactive-vscode/src/extension.ts
+++ b/src/dotnet-interactive-vscode/src/extension.ts
@@ -1,12 +1,18 @@
 import * as vscode from 'vscode';
+import * as cp from 'child_process';
 import { ClientMapper } from './clientMapper';
 import { DotNetInteractiveNotebookContentProvider } from './vscode/notebookProvider';
 import { StdioKernelTransport } from './stdioKernelTransport';
 import { registerLanguageProviders } from './vscode/languageProvider';
 import { registerCommands } from './vscode/commands';
+import { IDotnetAcquireResult } from './interfaces/dotnet';
 
-export function activate(context: vscode.ExtensionContext) {
-    let clientMapper = new ClientMapper(() => new StdioKernelTransport());
+import compareVersions = require("../node_modules/compare-versions");
+
+export async function activate(context: vscode.ExtensionContext) {
+    const dotnet = await getDotnetPath();
+    await ensureDotnetInteractive(dotnet);
+    const clientMapper = new ClientMapper(() => new StdioKernelTransport(dotnet));
     context.subscriptions.push(vscode.notebook.registerNotebookContentProvider('dotnet-interactive', new DotNetInteractiveNotebookContentProvider(clientMapper)));
     context.subscriptions.push(vscode.notebook.onDidCloseNotebookDocument(notebookDocument => clientMapper.closeClient(notebookDocument.uri)));
     context.subscriptions.push(registerLanguageProviders(clientMapper));
@@ -14,4 +20,61 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 export function deactivate() {
+}
+
+async function getDotnetPath(): Promise<string> {
+    // ensure valid `dotnet`
+    const validDotnetVersion: RegExp = /^(3|5)\./; // 3.x and 5.x
+    const { code, output } = await processExitCodeAndOutput('dotnet', ['--version']);
+    let dotnetPath: string;
+    if (code === 0 && validDotnetVersion.test(output)) {
+        // global `dotnet` is present and good
+        dotnetPath = 'dotnet';
+    } else {
+        // need to acquire one
+        const commandResult = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', { version: '3.1' });
+        if (commandResult) {
+            dotnetPath = commandResult.dotnetPath;
+        } else {
+            throw new Error('Unable to find or acquire appropriate version of the `dotnet` CLI.');
+        }
+    }
+
+    return dotnetPath;
+}
+
+async function ensureDotnetInteractive(dotnetPath: string): Promise<void> {
+    // ensure valid `dotnet-interactive`
+    const minRequiredVersion = '1.0.125402';
+    const validDotnetInteractiveDevVersion: RegExp = /^.*-dev$/; // e.g., 1.0.0-dev.  Locally produced versions are always assumed to be good.
+    const { code, output } = await processExitCodeAndOutput(dotnetPath, ['interactive', '--version']);
+    if (code === 0) {
+        if (validDotnetInteractiveDevVersion.test(output)) {
+            // locally built versions are always assumed to be valid
+            return;
+        }
+
+        // otherwise we have to check the version
+        if (compareVersions.compare(output, minRequiredVersion, '<')) {
+            // TODO: acquire it for them
+            await vscode.window.showErrorMessage(`Unsupported \`dotnet-interactive\` version, '${output}'.  Minimum required is '${minRequiredVersion}'.`);
+            throw new Error('aborting');
+        }
+
+        // good to go
+    }
+}
+
+function processExitCodeAndOutput(command: string, args?: Array<string> | undefined): Promise<{ code: number, output: string }> {
+    return new Promise<{ code: number, output: string }>((resolve, reject) => {
+        let output = '';
+        let childProcess = cp.spawn(command, args || []);
+        childProcess.stdout.on('data', data => output += data);
+        childProcess.on('exit', (code: number, _signal: string) => {
+            resolve({
+                code: code,
+                output: output.trim()
+            });
+        });
+    });
 }

--- a/src/dotnet-interactive-vscode/src/interactiveClient.ts
+++ b/src/dotnet-interactive-vscode/src/interactiveClient.ts
@@ -4,6 +4,7 @@ import {
     CommandHandledType,
     CompletionRequestCompleted,
     CompletionRequestCompletedType,
+    DisplayEventBase,
     DisplayedValueProducedType,
     DisplayedValueUpdatedType,
     DisposableSubscription,
@@ -21,12 +22,12 @@ import {
     RequestHoverText,
     RequestHoverTextType,
     ReturnValueProducedType,
+    StandardErrorValueProducedType,
     StandardOutputValueProduced,
     StandardOutputValueProducedType,
     SubmissionType,
     SubmitCode,
     SubmitCodeType,
-    DisplayEventBase,
 } from './contracts';
 import { CellOutput, CellErrorOutput, CellOutputKind, CellStreamOutput, CellDisplayOutput } from './interfaces/vscode';
 
@@ -62,12 +63,13 @@ export class InteractiveClient {
                             reject();
                         }
                         break;
+                    case StandardErrorValueProducedType:
                     case StandardOutputValueProducedType:
                         {
-                            let st = <StandardOutputValueProduced>eventEnvelope.event;
+                            let disp = <DisplayEventBase>eventEnvelope.event;
                             let output: CellStreamOutput = {
                                 outputKind: CellOutputKind.Text,
-                                text: st.value.toString(),
+                                text: disp.value.toString(),
                             };
                             outputs.push(output);
                             observer(outputs);

--- a/src/dotnet-interactive-vscode/src/interactiveClient.ts
+++ b/src/dotnet-interactive-vscode/src/interactiveClient.ts
@@ -157,6 +157,10 @@ export class InteractiveClient {
         return disposable;
     }
 
+    dispose() {
+        this.kernelTransport.dispose();
+    }
+
     private submitCommandAndGetResult<TEvent extends KernelEvent>(command: KernelCommand, commandType: KernelCommandType, expectedEventType: KernelEventType, token: string | undefined): Promise<TEvent> {
         return new Promise<TEvent>(async (resolve, reject) => {
             let handled = false;

--- a/src/dotnet-interactive-vscode/src/interfaces/dotnet.ts
+++ b/src/dotnet-interactive-vscode/src/interfaces/dotnet.ts
@@ -1,0 +1,5 @@
+// interface acquired from https://github.com/dotnet/vscode-dotnet-runtime/blob/6331b67af2689ba353a1a793eeb1e00131cec46b/vscode-dotnet-runtime-library/src/IDotnetAcquireResult.ts
+
+export interface IDotnetAcquireResult {
+    dotnetPath: string;
+}

--- a/src/dotnet-interactive-vscode/src/stdioKernelTransport.ts
+++ b/src/dotnet-interactive-vscode/src/stdioKernelTransport.ts
@@ -1,14 +1,14 @@
 import * as cp from 'child_process';
-import { Writable } from 'stream';
 import { DisposableSubscription, KernelCommand, KernelCommandType, KernelEventEnvelope, KernelEventEnvelopeObserver } from "./contracts";
+
 
 export class StdioKernelTransport {
     private buffer: string = '';
     private childProcess: cp.ChildProcessWithoutNullStreams;
     private subscribers: Array<KernelEventEnvelopeObserver> = [];
 
-    constructor() {
-        this.childProcess = cp.spawn('dotnet', ['interactive', 'stdio']);
+    constructor(readonly dotnetPath: string) {
+        this.childProcess = cp.spawn(this.dotnetPath, ['interactive', 'stdio']);
         this.childProcess.on('exit', (code: number, _signal: string) => {
             //
             let x = 1;

--- a/src/dotnet-interactive-vscode/src/tests/integration/suite/extension.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/integration/suite/extension.test.ts
@@ -6,7 +6,7 @@ import { CellOutput, CellOutputKind } from '../../../interfaces/vscode';
 
 suite('Extension Test Suite', () => {
     test('Execute against real kernel', async () => {
-        let clientMapper = new ClientMapper(() => new StdioKernelTransport());
+        let clientMapper = new ClientMapper(() => new StdioKernelTransport('dotnet')); // assume it's globally installed for this test
         let client = clientMapper.getOrAddClient({ path: 'some/path' });
         let code = '1+1';
         let result: Array<CellOutput> = [];

--- a/src/dotnet-interactive-vscode/src/tests/integration/suite/extension.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/integration/suite/extension.test.ts
@@ -2,20 +2,22 @@ import { expect } from 'chai';
 
 import { StdioKernelTransport } from '../../../stdioKernelTransport';
 import { ClientMapper } from '../../../clientMapper';
-import { CellOutputKind } from '../../../interfaces/vscode';
+import { CellOutput, CellOutputKind } from '../../../interfaces/vscode';
 
 suite('Extension Test Suite', () => {
     test('Execute against real kernel', async () => {
         let clientMapper = new ClientMapper(() => new StdioKernelTransport());
         let client = clientMapper.getOrAddClient({ path: 'some/path' });
         let code = '1+1';
-        await client.execute(code, 'csharp', cellOutput => {
-            expect(cellOutput).to.deep.equal({
+        let result: Array<CellOutput> = [];
+        await client.execute(code, 'csharp', outputs => result = outputs);
+        expect(result).to.deep.equal([
+            {
                 outputKind: CellOutputKind.Rich,
                 data: {
                     'text/html': '2'
                 }
-            });
-        });
+            }
+        ]);
     }).timeout(10000);
 });

--- a/src/dotnet-interactive-vscode/src/tests/unit/notebook.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/notebook.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import { ClientMapper } from './../../clientMapper';
 import { TestKernelTransport } from './testKernelTransport';
-import { CellOutputKind } from '../../interfaces/vscode';
+import { CellOutput, CellOutputKind } from '../../interfaces/vscode';
 import { CodeSubmissionReceivedType, CommandHandledType, CompleteCodeSubmissionReceivedType, DisplayedValueProducedType, DisplayedValueUpdatedType, ReturnValueProducedType, StandardOutputValueProducedType } from '../../contracts';
 
 describe('Notebook tests', () => {
@@ -48,20 +48,20 @@ describe('Notebook tests', () => {
                 ]
             }));
             let client = clientMapper.getOrAddClient({ path: 'test/path' });
-            await client.execute(code, language, outputs => {
-                expect(outputs).to.deep.equal([
-                    {
-                        outputKind: CellOutputKind.Rich,
-                        data: {
-                            'text/html': '2'
-                        }
+            let result: Array<CellOutput> = [];
+            await client.execute(code, language, outputs => result = outputs, token);
+            expect(result).to.deep.equal([
+                {
+                    outputKind: CellOutputKind.Rich,
+                    data: {
+                        'text/html': '2'
                     }
-                ]);
-            }, token);
+                }
+            ]);
         });
     }
 
-    it('multiple stdout values cause the output to grow', async (done) => {
+    it('multiple stdout values cause the output to grow', async () => {
         let token = '123';
         let code = `
 Console.WriteLine(1);
@@ -134,28 +134,25 @@ Console.WriteLine(1);
             ]
         }));
         let client = clientMapper.getOrAddClient({ path: 'test/path' });
-        await client.execute(code, 'csharp', outputs => {
-            if (outputs.length === 3) {
-                expect(outputs).to.deep.equal([
-                    {
-                        outputKind: CellOutputKind.Text,
-                        text: '1\r\n'
-                    },
-                    {
-                        outputKind: CellOutputKind.Text,
-                        text: '2\r\n'
-                    },
-                    {
-                        outputKind: CellOutputKind.Text,
-                        text: '3\r\n'
-                    }
-                ]);
-                done();
+        let result: Array<CellOutput> = [];
+        await client.execute(code, 'csharp', outputs => result = outputs, token);
+        expect(result).to.deep.equal([
+            {
+                outputKind: CellOutputKind.Text,
+                text: '1\r\n'
+            },
+            {
+                outputKind: CellOutputKind.Text,
+                text: '2\r\n'
+            },
+            {
+                outputKind: CellOutputKind.Text,
+                text: '3\r\n'
             }
-        }, token);
+        ]);
     });
 
-    it('updated values are replaced instead of added', async (done) => {
+    it('updated values are replaced instead of added', async () => {
         let token = '123';
         let code = '#r nuget:Newtonsoft.Json';
         let clientMapper = new ClientMapper(() => new TestKernelTransport({
@@ -209,28 +206,25 @@ Console.WriteLine(1);
             ]
         }));
         let client = clientMapper.getOrAddClient({ path: 'test/path' });
-        await client.execute(code, 'csharp', outputs => {
-            if (outputs.length === 2) {
-                expect(outputs).to.deep.equal([
-                    {
-                        outputKind: CellOutputKind.Rich,
-                        data: {
-                            'text/plain': 'Installed package Newtonsoft.Json version 1.2.3.4'
-                        }
-                    },
-                    {
-                        outputKind: CellOutputKind.Rich,
-                        data: {
-                            'text/plain': 'sentinel'
-                        }
-                    },
-                ]);
-                done();
-            }
-        }, token);
+        let result: Array<CellOutput> = [];
+        await client.execute(code, 'csharp', outputs => result = outputs, token);
+        expect(result).to.deep.equal([
+            {
+                outputKind: CellOutputKind.Rich,
+                data: {
+                    'text/plain': 'Installed package Newtonsoft.Json version 1.2.3.4'
+                }
+            },
+            {
+                outputKind: CellOutputKind.Rich,
+                data: {
+                    'text/plain': 'sentinel'
+                }
+            },
+        ]);
     });
 
-    it('returned json is property parsed', async (done) => {
+    it('returned json is property parsed', async () => {
         let token = '123';
         let code = 'JObject.FromObject(new { a = 1, b = false })';
         let clientMapper = new ClientMapper(() => new TestKernelTransport({
@@ -271,21 +265,18 @@ Console.WriteLine(1);
             ]
         }));
         let client = clientMapper.getOrAddClient({ path: 'test/path' });
-        await client.execute(code, 'csharp', outputs => {
-            if (outputs.length === 1) {
-                expect(outputs).to.deep.equal([
-                    {
-                        outputKind: CellOutputKind.Rich,
-                        data: {
-                            'application/json': {
-                                a: 1,
-                                b: false
-                            }
-                        }
+        let result: Array<CellOutput> = [];
+        await client.execute(code, 'csharp', outputs => result = outputs, token);
+        expect(result).to.deep.equal([
+            {
+                outputKind: CellOutputKind.Rich,
+                data: {
+                    'application/json': {
+                        a: 1,
+                        b: false
                     }
-                ]);
-                done();
+                }
             }
-        }, token);
+        ]);
     });
 });

--- a/src/dotnet-interactive-vscode/src/tests/unit/testKernelTransport.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/testKernelTransport.ts
@@ -30,4 +30,8 @@ export class TestKernelTransport {
             }
         }
     }
+
+    dispose() {
+        // noop
+    }
 }

--- a/src/dotnet-interactive-vscode/src/vscode/notebookProvider.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/notebookProvider.ts
@@ -4,7 +4,6 @@ import { NotebookFile, parseNotebook, serializeNotebook, editorLanguages } from 
 import { RawNotebookCell } from '../interfaces';
 import { JupyterNotebook } from '../interfaces/jupyter';
 import { convertFromJupyter } from '../interop/jupyter';
-import { CellOutput } from '../interfaces/vscode';
 import { trimTrailingCarriageReturn } from '../utilities';
 
 export class DotNetInteractiveNotebookContentProvider implements vscode.NotebookContentProvider {

--- a/src/interface-generator/StaticContents.ts
+++ b/src/interface-generator/StaticContents.ts
@@ -14,11 +14,14 @@ export interface KernelEventEnvelopeObserver {
     (eventEnvelope: KernelEventEnvelope): void;
 }
 
-export interface DisposableSubscription {
+export interface Disposable {
     dispose(): void;
 }
 
-export interface KernelTransport {
+export interface DisposableSubscription extends Disposable {
+}
+
+export interface KernelTransport extends Disposable {
     subscribeToKernelEvents(observer: KernelEventEnvelopeObserver): DisposableSubscription;
     submitCommand(command: KernelCommand, commandType: KernelCommandType, token: string): Promise<void>;
 }


### PR DESCRIPTION
`extension.ts` will now ensure that an appropriate version of `dotnet` is installed, or else it will acquire one for the user.  If one couldn't be acquired, it is a fatal error and nothing can be done.

A similar check is also done for `dotnet-interactive`, but it currently only continues if a valid version is present and errors otherwise.  An upcoming PR will be to acquire a local tool version of it if necessary.  If the appropriate version is not present, an error is shown in the bottom corner or the window:
![image](https://user-images.githubusercontent.com/926281/81460861-d8e31180-915c-11ea-8e4d-b69ad4009445.png)

The minimum good version of `dotnet-interactive` is the one with the recent hover text updates from a few days ago.  That version has not yet been published to NuGet.org, so when we do publish again, it should be at least that version.  A workaround is that all locally-built arcade versions of the tool are allowed (`*-dev`).

Also included are some other minor improvements like not returning from `execute()` until either `CommandHandled` or `CommandFailed` has returned.  This makes the notebook UI in VS Code much nicer.

N.b., the changes to `interactiveClient.ts` are mostly whitespace, so disabling that in the GitHub view is recommended for that file.