### PR TITLE
do not enrich html formatters if is not jupyter 

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Tests/PackageRestoreContextTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/PackageRestoreContextTests.cs
@@ -8,9 +8,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
-using System.Collections.Generic;
-using Microsoft.DotNet.Interactive.Utility;
-using Microsoft.DotNet.DependencyManager;
 
 namespace Microsoft.DotNet.Interactive.Tests
 {

--- a/src/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
+++ b/src/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
@@ -178,7 +178,7 @@ namespace Microsoft.DotNet.Interactive.App.Tests.CommandLine
         }
 
         [Fact]
-        public async Task http_command_does_not_registers_JupyterFrontedEnvironment()
+        public async Task http_command_does_not_register_JupyterFrontedEnvironment()
         {
             await _parser.InvokeAsync($"http");
 

--- a/src/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
+++ b/src/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
@@ -169,7 +169,6 @@ namespace Microsoft.DotNet.Interactive.App.Tests.CommandLine
         {
             await _parser.InvokeAsync($"http");
 
-            using var scope = new AssertionScope();
             _serviceCollection
                 .FirstOrDefault(s => s.ServiceType == typeof(BrowserFrontendEnvironment))
                 .Should()
@@ -182,7 +181,6 @@ namespace Microsoft.DotNet.Interactive.App.Tests.CommandLine
         {
             await _parser.InvokeAsync($"http");
 
-            using var scope = new AssertionScope();
             _serviceCollection
                 .FirstOrDefault(s => s.ServiceType == typeof(JupyterFrontedEnvironment))
                 .Should()
@@ -213,7 +211,7 @@ namespace Microsoft.DotNet.Interactive.App.Tests.CommandLine
                 .NotBeNull();
 
             _serviceCollection
-                .FirstOrDefault(s => s.ServiceType == typeof(BrowserFrontendEnvironment))
+                .FirstOrDefault(s => s.ServiceType == typeof(FrontendEnvironment))
                 .Should()
                 .NotBeNull();
 
@@ -223,6 +221,7 @@ namespace Microsoft.DotNet.Interactive.App.Tests.CommandLine
         public async Task jupyter_command_returns_error_if_connection_file_path_is_not_passed()
         {
             var testConsole = new TestConsole();
+            
             await _parser.InvokeAsync("jupyter", testConsole);
 
             testConsole.Error.ToString().Should().Contain("Required argument missing for command: jupyter");

--- a/src/dotnet-interactive.Tests/FormatterConfigurationTests.cs
+++ b/src/dotnet-interactive.Tests/FormatterConfigurationTests.cs
@@ -20,9 +20,9 @@ namespace Microsoft.DotNet.Interactive.App.Tests
 
         public FormatterConfigurationTests()
         {
-            var frontendEnvironment = new BrowserFrontendEnvironment
+            var frontendEnvironment = new JupyterFrontedEnvironment
             {
-                ApiUri = new Uri("http://12.12.12.12:4242")
+                DiscoveredUri = new Uri("http://12.12.12.12:4242")
             };
 
             CommandLineParser.SetUpFormatters(frontendEnvironment, new StartupOptions());
@@ -81,13 +81,13 @@ namespace Microsoft.DotNet.Interactive.App.Tests
         }
 
         [Fact]
-        public void ScriptContent_type_is_wrapped_when_http_is_enabled_and_flavor_is_jupyter()
+        public void ScriptContent_type_is_wrapped_when_http_and_the_frontendEnvironment_is_JupyterFrontedEnvironment()
         {
-            var frontendEnvironment = new BrowserFrontendEnvironment
+            var frontendEnvironment = new JupyterFrontedEnvironment
             {
-                ApiUri = new Uri("http://12.12.12.12:4242"),
-                Flavor = "jupyter"
+                DiscoveredUri = new Uri("http://12.12.12.12:4242")
             };
+
             CommandLineParser.SetUpFormatters(frontendEnvironment, new StartupOptions(httpPort: new HttpPort(4242)));
             var script = new ScriptContent("alert('hello');");
             var mimeType = Formatter.PreferredMimeTypeFor(script.GetType());

--- a/src/dotnet-interactive.Tests/FormatterConfigurationTests.cs
+++ b/src/dotnet-interactive.Tests/FormatterConfigurationTests.cs
@@ -81,11 +81,12 @@ namespace Microsoft.DotNet.Interactive.App.Tests
         }
 
         [Fact]
-        public void ScriptContent_type_is_wrapped_when_http_is_enabled()
+        public void ScriptContent_type_is_wrapped_when_http_is_enabled_and_flavor_is_jupyter()
         {
             var frontendEnvironment = new BrowserFrontendEnvironment
             {
-                ApiUri = new Uri("http://12.12.12.12:4242")
+                ApiUri = new Uri("http://12.12.12.12:4242"),
+                Flavor = "jupyter"
             };
             CommandLineParser.SetUpFormatters(frontendEnvironment, new StartupOptions(httpPort: new HttpPort(4242)));
             var script = new ScriptContent("alert('hello');");

--- a/src/dotnet-interactive/CommandLine/BrowserFrontendEnvironment.cs
+++ b/src/dotnet-interactive/CommandLine/BrowserFrontendEnvironment.cs
@@ -8,5 +8,6 @@ namespace Microsoft.DotNet.Interactive.App.CommandLine
     public class BrowserFrontendEnvironment : FrontendEnvironment
     {
         public Uri ApiUri { get; set; }
+        public string Flavor { get; set; }
     }
 }

--- a/src/dotnet-interactive/CommandLine/BrowserFrontendEnvironment.cs
+++ b/src/dotnet-interactive/CommandLine/BrowserFrontendEnvironment.cs
@@ -7,7 +7,11 @@ namespace Microsoft.DotNet.Interactive.App.CommandLine
 {
     public class BrowserFrontendEnvironment : FrontendEnvironment
     {
-        public Uri ApiUri { get; set; }
-        public string Flavor { get; set; }
+        
+    }
+
+    public class JupyterFrontedEnvironment : BrowserFrontendEnvironment
+    {
+        public Uri DiscoveredUri { get; set; }
     }
 }

--- a/src/dotnet-interactive/CommandLine/JupyterFrontedEnvironment.cs
+++ b/src/dotnet-interactive/CommandLine/JupyterFrontedEnvironment.cs
@@ -1,10 +1,12 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace Microsoft.DotNet.Interactive.App.CommandLine
 {
-    public class BrowserFrontendEnvironment : FrontendEnvironment
+    public class JupyterFrontedEnvironment : BrowserFrontendEnvironment
     {
-        
+        public Uri DiscoveredUri { get; set; }
     }
 }

--- a/src/dotnet-interactive/Http/DiscoveryRouter.cs
+++ b/src/dotnet-interactive/Http/DiscoveryRouter.cs
@@ -12,9 +12,9 @@ namespace Microsoft.DotNet.Interactive.App.Http
 {
     public class DiscoveryRouter : IRouter
     {
-        private readonly BrowserFrontendEnvironment _frontendEnvironment;
+        private readonly JupyterFrontedEnvironment _frontendEnvironment;
 
-        public DiscoveryRouter(BrowserFrontendEnvironment frontendEnvironment)
+        public DiscoveryRouter(JupyterFrontedEnvironment frontendEnvironment)
         {
             _frontendEnvironment = frontendEnvironment;
         }
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.Interactive.App.Http
                     using var reader = new StreamReader(context.HttpContext.Request.Body);
                     var source = await reader.ReadToEndAsync();
                     var apiUri = new Uri( source);
-                    _frontendEnvironment.ApiUri = apiUri;
+                    _frontendEnvironment.DiscoveredUri = apiUri;
 
                     // Do something
                     context.Handler = async httpContext =>

--- a/src/dotnet-interactive/HttpApiBootstrapper.cs
+++ b/src/dotnet-interactive/HttpApiBootstrapper.cs
@@ -87,13 +87,10 @@ function loadDotnetInteractiveApi() {
             }
         
             dotnet_require([
-                    'dotnet-interactive/dotnet-interactive',
-                    'dotnet-interactive/lsp',
-                    'dotnet-interactive/editor-detection'
+                    'dotnet-interactive/dotnet-interactive'
                 ],
-                function (dotnet, lsp, editor) {
+                function (dotnet) {
                     dotnet.init(window);
-                    $LSP$
                 },
                 function (error) {
                     console.log(error);
@@ -104,15 +101,9 @@ function loadDotnetInteractiveApi() {
     }
     </script>
 </div>";
-
-            var lspInit = @"
-                    lsp.init(window);
-                    editor.init(window, document, root, document.getElementById('dotnet-interactive-this-cell-$SEED$'));
-";
             
             var jsProbingUris = $"[{ string.Join(", ", probingUris.Select(a => $"\"{a.AbsoluteUri}\"")) }]";
             var code = template;
-            code = code.Replace("$LSP$", enableLsp ? lspInit : string.Empty);
             code = code.Replace("$ADDRESSES$", jsProbingUris);
             code = code.Replace("$CACHE_BUSTER$", apiCacheBuster);
             code = code.Replace("$SEED$", seed);

--- a/src/dotnet-interactive/Startup.cs
+++ b/src/dotnet-interactive/Startup.cs
@@ -70,7 +70,12 @@ namespace Microsoft.DotNet.Interactive.App
                 app.UseRouting();
                 app.UseRouter(r =>
                 {
-                    r.Routes.Add(new DiscoveryRouter(serviceProvider.GetRequiredService<BrowserFrontendEnvironment>()));
+                    var frontendEnvironment = serviceProvider.GetService<JupyterFrontedEnvironment>();
+                    if (frontendEnvironment != null)
+                    {
+                        r.Routes.Add(new DiscoveryRouter(frontendEnvironment));
+                    }
+
                     r.Routes.Add(new VariableRouter(serviceProvider.GetRequiredService<IKernel>()));
                     r.Routes.Add(new KernelsRouter(serviceProvider.GetRequiredService<IKernel>()));
                 });


### PR DESCRIPTION
When starting with http api enabled the formatting of js and html is enriched only during the execution  of juptyer command