### PR TITLE
Fix directive Lexing

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Tests/Parsing/SubmissionParserTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Parsing/SubmissionParserTests.cs
@@ -41,7 +41,7 @@ x
 
             tree.GetRoot()
                 .Should()
-                .ContainSingle<LanguageNode>(n => n.Text == "#r \"/path/to/a.dll\"\n");
+                .ContainSingle<LanguageNode>(n => n.Text == "#r \"/path/to/a.dll\"");
         }
 
         [Fact]

--- a/src/Microsoft.DotNet.Interactive/Parsing/PolyglotLexer.cs
+++ b/src/Microsoft.DotNet.Interactive/Parsing/PolyglotLexer.cs
@@ -164,8 +164,6 @@ namespace Microsoft.DotNet.Interactive.Parsing
 
                     case '\r':
                     case '\n':
-                        _textWindow.Advance();
-
                         if (foundArgs)
                         {
                             FlushToken(TokenKind.DirectiveArgs);

--- a/src/Microsoft.DotNet.Interactive/Parsing/PolyglotLexer.cs
+++ b/src/Microsoft.DotNet.Interactive/Parsing/PolyglotLexer.cs
@@ -163,9 +163,6 @@ namespace Microsoft.DotNet.Interactive.Parsing
                         break;
 
                     case '\r':
-                        _textWindow.Advance();
-                        break;
-
                     case '\n':
                         _textWindow.Advance();
 


### PR DESCRIPTION
Boof!!!! i think I have it.

A couple of tests were failing when run in parallel, this behaviour started, with the Parser rewrite. A couple of weeks ago.  We only saw intermittent failures, though I suppose because the order the two tests could run in.

Prior to that change, it always passed, after would it would intermittently but noticabley fail.

I finally tracked down, why the failure happened.  The issue is that the notebook batches package resolutions, such that all packages in a cell are resolved together.

However, due to a minor bug in how the parser treated newline/end of line characters, the parser would split up the batches and do them in separate passes.
