### PR TITLE
acquire `dotnet-interactive` as a local tool if necessary

### DIFF
--- a/src/dotnet-interactive-vscode/package-lock.json
+++ b/src/dotnet-interactive-vscode/package-lock.json
@@ -36,6 +36,16 @@
 			"integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==",
 			"dev": true
 		},
+		"@types/chai-fs": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@types/chai-fs/-/chai-fs-2.0.2.tgz",
+			"integrity": "sha512-nS385nRPNvi9UjSUCDE7f84IXZnIzooPh7Ky88kdRfSFk72juvQENqrqyrKkJeXJsN9bMG9/5zVGr06GcBRB5g==",
+			"dev": true,
+			"requires": {
+				"@types/chai": "*",
+				"@types/node": "*"
+			}
+		},
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -87,6 +97,12 @@
 			"version": "13.11.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.0.tgz",
 			"integrity": "sha512-uM4mnmsIIPK/yeO+42F2RQhGUIs39K2RFmugcJANppXe6J1nvH87PvzPZYpza7Xhhs8Yn9yIAVdLZ84z61+0xQ==",
+			"dev": true
+		},
+		"@types/tmp": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.0.tgz",
+			"integrity": "sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ==",
 			"dev": true
 		},
 		"@types/vscode": {
@@ -244,6 +260,16 @@
 				"sprintf-js": "~1.0.2"
 			}
 		},
+		"array-events": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/array-events/-/array-events-0.2.0.tgz",
+			"integrity": "sha1-/0KsU+ZvSF1viDI0wyJSvCKGEw4=",
+			"dev": true,
+			"requires": {
+				"async-arrays": "*",
+				"extended-emitter": "*"
+			}
+		},
 		"assertion-error": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -255,6 +281,15 @@
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
 			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
 			"dev": true
+		},
+		"async-arrays": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/async-arrays/-/async-arrays-1.0.1.tgz",
+			"integrity": "sha1-NHrytw8qeldnotVnnMQrvxwiD9k=",
+			"dev": true,
+			"requires": {
+				"sift": "*"
+			}
 		},
 		"azure-devops-node-api": {
 			"version": "7.2.0",
@@ -279,6 +314,15 @@
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
 			"integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
 			"dev": true
+		},
+		"bit-mask": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bit-mask/-/bit-mask-1.0.2.tgz",
+			"integrity": "sha512-UGtq08LSiazxL4zVmBzrhdCWnT4RWx3JhhD/3crhfv8xxjnVHxf/WoVjEstjSUaZeZRP7kZrWNqup1VvUClCaQ==",
+			"dev": true,
+			"requires": {
+				"array-events": "^0.2.0"
+			}
 		},
 		"boolbase": {
 			"version": "1.0.0",
@@ -317,6 +361,12 @@
 			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
 			"dev": true
 		},
+		"call-me-maybe": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+			"dev": true
+		},
 		"callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -341,6 +391,16 @@
 				"get-func-name": "^2.0.0",
 				"pathval": "^1.1.0",
 				"type-detect": "^4.0.5"
+			}
+		},
+		"chai-fs": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/chai-fs/-/chai-fs-2.0.0.tgz",
+			"integrity": "sha1-Na4Dn7uwcQ9RIqrhf6uh6PQRB8Y=",
+			"dev": true,
+			"requires": {
+				"bit-mask": "^1.0.1",
+				"readdir-enhanced": "^1.4.0"
 			}
 		},
 		"chalk": {
@@ -824,6 +884,16 @@
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
 		},
+		"extended-emitter": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/extended-emitter/-/extended-emitter-1.0.3.tgz",
+			"integrity": "sha512-gdaWWszJmr2oq6rKSxPmuclQtEwfzt4JwmGrEqTnE89GQHqZyvPZ/NWj6fBgK3IKufvRyJDnLZviUFPrrJf36Q==",
+			"dev": true,
+			"requires": {
+				"sift": "*",
+				"wolfy87-eventemitter": "*"
+			}
+		},
 		"external-editor": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -833,6 +903,17 @@
 				"chardet": "^0.7.0",
 				"iconv-lite": "^0.4.24",
 				"tmp": "^0.0.33"
+			},
+			"dependencies": {
+				"tmp": {
+					"version": "0.0.33",
+					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+					"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+					"dev": true,
+					"requires": {
+						"os-tmpdir": "~1.0.2"
+					}
+				}
 			}
 		},
 		"fast-deep-equal": {
@@ -983,6 +1064,12 @@
 			"requires": {
 				"is-glob": "^4.0.1"
 			}
+		},
+		"glob-to-regexp": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+			"dev": true
 		},
 		"globals": {
 			"version": "12.4.0",
@@ -1855,6 +1942,17 @@
 				"mute-stream": "~0.0.4"
 			}
 		},
+		"readdir-enhanced": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/readdir-enhanced/-/readdir-enhanced-1.5.2.tgz",
+			"integrity": "sha1-YUYwSGkKxqRVt1ti+nioj43IXlM=",
+			"dev": true,
+			"requires": {
+				"call-me-maybe": "^1.0.1",
+				"es6-promise": "^4.1.0",
+				"glob-to-regexp": "^0.3.0"
+			}
+		},
 		"readdirp": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
@@ -1956,6 +2054,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"dev": true
+		},
+		"sift": {
+			"version": "12.0.1",
+			"resolved": "https://registry.npmjs.org/sift/-/sift-12.0.1.tgz",
+			"integrity": "sha512-TVJzYmDLSSK2Qmps/SG16y1UfgQJAB5urJ6iIYNO7Ok+EHnQu/Mh5p31gCLkFMubtOSqWZk7fycRVcsrupQF+w==",
 			"dev": true
 		},
 		"signal-exit": {
@@ -2144,12 +2248,23 @@
 			"dev": true
 		},
 		"tmp": {
-			"version": "0.0.33",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+			"integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
 			"dev": true,
 			"requires": {
-				"os-tmpdir": "~1.0.2"
+				"rimraf": "^3.0.0"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
 			}
 		},
 		"to-regex-range": {
@@ -2376,6 +2491,12 @@
 					}
 				}
 			}
+		},
+		"wolfy87-eventemitter": {
+			"version": "5.2.9",
+			"resolved": "https://registry.npmjs.org/wolfy87-eventemitter/-/wolfy87-eventemitter-5.2.9.tgz",
+			"integrity": "sha512-P+6vtWyuDw+MB01X7UeF8TaHBvbCovf4HPEMF/SV7BdDc1SMTiBy13SRD71lQh4ExFTG1d/WNzDGDCyOKSMblw==",
+			"dev": true
 		},
 		"word-wrap": {
 			"version": "1.2.3",

--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -22,7 +22,9 @@
     "Other"
   ],
   "activationEvents": [
-    "onNotebookEditor:dotnet-interactive"
+    "onNotebookEditor:dotnet-interactive",
+    "onCommand:dotnet-interactive.acquire",
+    "onCommand:dotnet-interactive.reportInteractiveVersion"
   ],
   "main": "./out/extension.js",
   "extensionDependencies": [
@@ -45,6 +47,14 @@
     ],
     "commands": [
       {
+        "command": "dotnet-interactive.acquire",
+        "title": "Install .NET Interactive"
+      },
+      {
+        "command": "dotnet-interactive.reportInteractiveVersion",
+        "title": "Report installed version for .NET Interactive"
+      },
+      {
         "command": "dotnet-interactive.exportAsJupyterNotebook",
         "title": "DotNet Interactive: Export as Jupyter Notebook"
       }
@@ -64,18 +74,22 @@
   },
   "devDependencies": {
     "@types/chai": "4.2.11",
+    "@types/chai-fs": "2.0.2",
     "@types/glob": "7.1.1",
     "@types/mocha": "7.0.2",
     "@types/node": "13.11.0",
+    "@types/tmp": "0.2.0",
     "@types/vscode": "1.44.0",
     "@typescript-eslint/eslint-plugin": "2.26.0",
     "@typescript-eslint/parser": "2.26.0",
     "chai": "4.2.0",
+    "chai-fs": "2.0.0",
     "eslint": "6.8.0",
     "glob": "7.1.6",
     "mocha": "7.1.1",
     "mocha-multi-reporters": "1.1.7",
     "mocha-trx-reporter": "3.2.4",
+    "tmp": "0.2.1",
     "typescript": "3.8.3",
     "vsce": "1.75.0",
     "vscode-test": "1.3.0"

--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -48,6 +48,11 @@
     "configuration": {
       "title": ".NET Interactive Notebook",
       "properties": {
+        "dotnet-interactive.kernelTransportArgsOverride": {
+          "type": "array",
+          "default": [],
+          "description": "Override command line arguments passed to start an interactive session."
+        },
         "dotnet-interactive.interactiveToolSource": {
           "type": "string",
           "default": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json",

--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -45,6 +45,26 @@
         ]
       }
     ],
+    "configuration": {
+      "title": ".NET Interactive Notebook",
+      "properties": {
+        "dotnet-interactive.interactiveToolSource": {
+          "type": "string",
+          "default": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json",
+          "description": "The NuGet source to use when acquiring the .NET Interactive tool."
+        },
+        "dotnet-interactive.minimumDotNetSdkVersion": {
+          "type": "string",
+          "default": "3.1",
+          "description": "The minimum required version of the .NET SDK."
+        },
+        "dotnet-interactive.minimumInteractiveToolVersion": {
+          "type": "string",
+          "default": "1.0.126201",
+          "description": "The minimum required version of the .NET Interactive tool."
+        }
+      }
+    },
     "commands": [
       {
         "command": "dotnet-interactive.acquire",

--- a/src/dotnet-interactive-vscode/src/acquisition.ts
+++ b/src/dotnet-interactive-vscode/src/acquisition.ts
@@ -1,0 +1,129 @@
+import * as vscode from 'vscode';
+import * as cp from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { InteractiveLaunchOptions } from './interfaces';
+import { IDotnetAcquireResult } from './interfaces/dotnet';
+import * as versions from './minVersions';
+
+import compareVersions = require("../node_modules/compare-versions");
+
+export async function getInteractiveLaunchOptions(globalStoragePath: string): Promise<{ dotnetPath: string, launchOptions: InteractiveLaunchOptions }> {
+    const dotnetPath = await getDotnetPath();
+    const launchOptions = await getArgsToLaunchInteractive(dotnetPath, globalStoragePath);
+    return {
+        dotnetPath,
+        launchOptions
+    };
+}
+
+async function getDotnetPath(): Promise<string> {
+    // ensure valid `dotnet`
+    const { code, output } = await processExitCodeAndOutput('dotnet', ['--version']);
+    if (code === 0 && compareVersions.compare(output, versions.minimumDotNetSdkVersion, '>=')) {
+        // global `dotnet` is present and good
+        return 'dotnet';
+    }
+
+    // need to acquire one
+    vscode.window.showInformationMessage(`Acquiring .NET SDK version ${versions.minimumDotNetSdkVersion}...`); // don't block, just show and go
+    const commandResult = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', { version: versions.minimumDotNetSdkVersion });
+    if (commandResult) {
+        return commandResult.dotnetPath;
+    }
+
+    throw new Error(`Unable to find or acquire .NET SDK >= ${versions.minimumDotNetSdkVersion}`);
+}
+
+async function getArgsToLaunchInteractive(dotnetPath: string, globalStoragePath: string): Promise<InteractiveLaunchOptions> {
+    // ensure valid `dotnet-interactive`
+
+    // the possible arguments to invoke `interactive` are:
+    //   interactive
+    //   tool run dotnet-interactive --
+    // and both need to be tried
+    let localToolArguments = [
+        'tool',
+        'run',
+        'dotnet-interactive',
+        '--'
+    ];
+    let launchOptionSets = [
+        ['interactive'], // when launched as a global tool; working directory is irrelevant
+        localToolArguments // when launched as a local tool; working directory is possibly relevant
+    ];
+    let workingDirectory: string | undefined = undefined;
+    if (fs.existsSync(globalStoragePath)) {
+        // can't launch a process with a non-existent working directory
+        workingDirectory = globalStoragePath;
+    }
+    for (let launchOptions of launchOptionSets) {
+        let versionArguments = [...launchOptions];
+        versionArguments.push('--version');
+        let result = await processExitCodeAndOutput(dotnetPath, versionArguments, workingDirectory);
+        if (result.code === 0) {
+            // the interactive command was found, but maybe not the right version
+            const validDotnetInteractiveDevVersion: RegExp = /^.*-dev$/; // e.g., 1.0.0-dev
+            if (validDotnetInteractiveDevVersion.test(result.output)) {
+                // locally built versions are always assumed to be valid
+                return {
+                    args: launchOptions,
+                    workingDirectory
+                };
+            }
+
+            // otherwise we have to check the version
+            if (compareVersions.compare(result.output, versions.minimumDotNetInteractiveVersion, '>=')) {
+                return {
+                    args: launchOptions,
+                    workingDirectory
+                };
+            }
+        }
+    }
+
+    // if we got here there wasn't an appropriate version installed, so we'll install a local tool
+    // at this point the global storage path _must_ exist
+    // vs code doesn't guarantee that it exists, but does guarantee that we can create it
+    await vscode.workspace.fs.createDirectory(vscode.Uri.file(globalStoragePath));
+
+    // first ensure a tool manifest file exists
+    let localToolManifestFile = path.join(globalStoragePath, '.config', 'dotnet-tools.json');
+    if (!fs.existsSync(localToolManifestFile)) {
+        const { code } = await processExitCodeAndOutput(dotnetPath, ['new', 'tool-manifest', '--output', globalStoragePath]);
+        if (code !== 0) {
+            throw new Error('Unable to create local tool manifest file.');
+        }
+    }
+
+    // then acquire the tool and add it to the manifest
+    vscode.window.showInformationMessage('Acquiring latest `dotnet-interactive` tool.');
+    let toolSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json';
+    const result = await processExitCodeAndOutput(dotnetPath, ['tool', 'install', '--add-source', toolSource, 'Microsoft.dotnet-interactive', '--tool-manifest', localToolManifestFile]);
+    if (result.code !== 0) {
+        throw new Error('Unable to install local tool.');
+    }
+
+    // at this point the interactive tool is invoked as a local tool
+    return {
+        args: localToolArguments,
+        workingDirectory: globalStoragePath
+    };
+}
+
+function processExitCodeAndOutput(command: string, args: Array<string>, workingDirectory?: string | undefined): Promise<{ code: number, output: string, error: string }> {
+    return new Promise<{ code: number, output: string, error: string }>((resolve, reject) => {
+        let output = '';
+        let error = '';
+        let childProcess = cp.spawn(command, args, { cwd: workingDirectory });
+        childProcess.stdout.on('data', data => output += data);
+        childProcess.stderr.on('data', data => error += data);
+        childProcess.on('exit', (code: number, _signal: string) => {
+            resolve({
+                code: code,
+                output: output.trim(),
+                error: error.trim()
+            });
+        });
+    });
+}

--- a/src/dotnet-interactive-vscode/src/acquisition.ts
+++ b/src/dotnet-interactive-vscode/src/acquisition.ts
@@ -28,12 +28,6 @@ export async function acquireDotnetInteractive(
     }
 
     const launchOptions: InteractiveLaunchOptions = {
-        args: [
-            'tool',
-            'run',
-            'dotnet-interactive',
-            '--'
-        ],
         workingDirectory: globalStoragePath
     };
 

--- a/src/dotnet-interactive-vscode/src/acquisition.ts
+++ b/src/dotnet-interactive-vscode/src/acquisition.ts
@@ -1,16 +1,13 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { InstallInteractiveTool, InstallInteractiveArgs, CreateToolManifest, GetCurrentInteractiveVersion, InteractiveLaunchOptions, ReportInstallationStarted, ReportInstallationFinished } from './interfaces';
-import * as versions from './minVersions';
 
 import compareVersions = require("../node_modules/compare-versions");
-
-// TODO: make setting
-export const interactiveToolSource: string = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json';
 
 // The acquisition function.  Uses predefined callbacks for external command invocations to make testing easier.
 export async function acquireDotnetInteractive(
     args: InstallInteractiveArgs,
+    minDotNetInteractiveVersion: string,
     globalStoragePath: string,
     getInteractiveVersion: GetCurrentInteractiveVersion,
     createToolManifest: CreateToolManifest,
@@ -41,7 +38,7 @@ export async function acquireDotnetInteractive(
     };
 
     // determine if acquisition is necessary
-    const requiredVersion = args.toolVersion ?? versions.minimumDotNetInteractiveVersion;
+    const requiredVersion = args.toolVersion ?? minDotNetInteractiveVersion;
     const currentVersion = await getInteractiveVersion(args.dotnetPath, globalStoragePath);
     if (currentVersion && compareVersions.compare(currentVersion, requiredVersion, '>=')) {
         // current is acceptable
@@ -49,11 +46,12 @@ export async function acquireDotnetInteractive(
     }
 
     // no current version installed or it's out of date
-    reportInstallationStarted();
+    reportInstallationStarted(requiredVersion);
     await installInteractive({
-        dotnetPath: args.dotnetPath,
-        toolVersion: requiredVersion
-    }, globalStoragePath);
+            dotnetPath: args.dotnetPath,
+            toolVersion: requiredVersion
+        },
+        globalStoragePath);
     reportInstallationFinished();
 
     return launchOptions;

--- a/src/dotnet-interactive-vscode/src/acquisition.ts
+++ b/src/dotnet-interactive-vscode/src/acquisition.ts
@@ -1,129 +1,60 @@
-import * as vscode from 'vscode';
-import * as cp from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
-import { InteractiveLaunchOptions } from './interfaces';
-import { IDotnetAcquireResult } from './interfaces/dotnet';
+import { InstallInteractiveTool, InstallInteractiveArgs, CreateToolManifest, GetCurrentInteractiveVersion, InteractiveLaunchOptions, ReportInstallationStarted, ReportInstallationFinished } from './interfaces';
 import * as versions from './minVersions';
 
 import compareVersions = require("../node_modules/compare-versions");
 
-export async function getInteractiveLaunchOptions(globalStoragePath: string): Promise<{ dotnetPath: string, launchOptions: InteractiveLaunchOptions }> {
-    const dotnetPath = await getDotnetPath();
-    const launchOptions = await getArgsToLaunchInteractive(dotnetPath, globalStoragePath);
-    return {
-        dotnetPath,
-        launchOptions
-    };
-}
+// TODO: make setting
+export const interactiveToolSource: string = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json';
 
-async function getDotnetPath(): Promise<string> {
-    // ensure valid `dotnet`
-    const { code, output } = await processExitCodeAndOutput('dotnet', ['--version']);
-    if (code === 0 && compareVersions.compare(output, versions.minimumDotNetSdkVersion, '>=')) {
-        // global `dotnet` is present and good
-        return 'dotnet';
+// The acquisition function.  Uses predefined callbacks for external command invocations to make testing easier.
+export async function acquireDotnetInteractive(
+    args: InstallInteractiveArgs,
+    globalStoragePath: string,
+    getInteractiveVersion: GetCurrentInteractiveVersion,
+    createToolManifest: CreateToolManifest,
+    reportInstallationStarted: ReportInstallationStarted,
+    installInteractive: InstallInteractiveTool,
+    reportInstallationFinished: ReportInstallationFinished
+    ): Promise<InteractiveLaunchOptions | undefined>
+{
+    // Ensure `globalStoragePath` exists.  This prevents a bunch of issues with spawned processes and working directories.
+    if (!fs.existsSync(globalStoragePath)) {
+        fs.mkdirSync(globalStoragePath);
     }
 
-    // need to acquire one
-    vscode.window.showInformationMessage(`Acquiring .NET SDK version ${versions.minimumDotNetSdkVersion}...`); // don't block, just show and go
-    const commandResult = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', { version: versions.minimumDotNetSdkVersion });
-    if (commandResult) {
-        return commandResult.dotnetPath;
+    // create tool manifest if necessary
+    const toolManifestFile = path.join(globalStoragePath, '.config', 'dotnet-tools.json');
+    if (!fs.existsSync(toolManifestFile)) {
+        await createToolManifest(args.dotnetPath, globalStoragePath);
     }
 
-    throw new Error(`Unable to find or acquire .NET SDK >= ${versions.minimumDotNetSdkVersion}`);
-}
-
-async function getArgsToLaunchInteractive(dotnetPath: string, globalStoragePath: string): Promise<InteractiveLaunchOptions> {
-    // ensure valid `dotnet-interactive`
-
-    // the possible arguments to invoke `interactive` are:
-    //   interactive
-    //   tool run dotnet-interactive --
-    // and both need to be tried
-    let localToolArguments = [
-        'tool',
-        'run',
-        'dotnet-interactive',
-        '--'
-    ];
-    let launchOptionSets = [
-        ['interactive'], // when launched as a global tool; working directory is irrelevant
-        localToolArguments // when launched as a local tool; working directory is possibly relevant
-    ];
-    let workingDirectory: string | undefined = undefined;
-    if (fs.existsSync(globalStoragePath)) {
-        // can't launch a process with a non-existent working directory
-        workingDirectory = globalStoragePath;
-    }
-    for (let launchOptions of launchOptionSets) {
-        let versionArguments = [...launchOptions];
-        versionArguments.push('--version');
-        let result = await processExitCodeAndOutput(dotnetPath, versionArguments, workingDirectory);
-        if (result.code === 0) {
-            // the interactive command was found, but maybe not the right version
-            const validDotnetInteractiveDevVersion: RegExp = /^.*-dev$/; // e.g., 1.0.0-dev
-            if (validDotnetInteractiveDevVersion.test(result.output)) {
-                // locally built versions are always assumed to be valid
-                return {
-                    args: launchOptions,
-                    workingDirectory
-                };
-            }
-
-            // otherwise we have to check the version
-            if (compareVersions.compare(result.output, versions.minimumDotNetInteractiveVersion, '>=')) {
-                return {
-                    args: launchOptions,
-                    workingDirectory
-                };
-            }
-        }
-    }
-
-    // if we got here there wasn't an appropriate version installed, so we'll install a local tool
-    // at this point the global storage path _must_ exist
-    // vs code doesn't guarantee that it exists, but does guarantee that we can create it
-    await vscode.workspace.fs.createDirectory(vscode.Uri.file(globalStoragePath));
-
-    // first ensure a tool manifest file exists
-    let localToolManifestFile = path.join(globalStoragePath, '.config', 'dotnet-tools.json');
-    if (!fs.existsSync(localToolManifestFile)) {
-        const { code } = await processExitCodeAndOutput(dotnetPath, ['new', 'tool-manifest', '--output', globalStoragePath]);
-        if (code !== 0) {
-            throw new Error('Unable to create local tool manifest file.');
-        }
-    }
-
-    // then acquire the tool and add it to the manifest
-    vscode.window.showInformationMessage('Acquiring latest `dotnet-interactive` tool.');
-    let toolSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json';
-    const result = await processExitCodeAndOutput(dotnetPath, ['tool', 'install', '--add-source', toolSource, 'Microsoft.dotnet-interactive', '--tool-manifest', localToolManifestFile]);
-    if (result.code !== 0) {
-        throw new Error('Unable to install local tool.');
-    }
-
-    // at this point the interactive tool is invoked as a local tool
-    return {
-        args: localToolArguments,
+    const launchOptions: InteractiveLaunchOptions = {
+        args: [
+            'tool',
+            'run',
+            'dotnet-interactive',
+            '--'
+        ],
         workingDirectory: globalStoragePath
     };
-}
 
-function processExitCodeAndOutput(command: string, args: Array<string>, workingDirectory?: string | undefined): Promise<{ code: number, output: string, error: string }> {
-    return new Promise<{ code: number, output: string, error: string }>((resolve, reject) => {
-        let output = '';
-        let error = '';
-        let childProcess = cp.spawn(command, args, { cwd: workingDirectory });
-        childProcess.stdout.on('data', data => output += data);
-        childProcess.stderr.on('data', data => error += data);
-        childProcess.on('exit', (code: number, _signal: string) => {
-            resolve({
-                code: code,
-                output: output.trim(),
-                error: error.trim()
-            });
-        });
-    });
+    // determine if acquisition is necessary
+    const requiredVersion = args.toolVersion ?? versions.minimumDotNetInteractiveVersion;
+    const currentVersion = await getInteractiveVersion(args.dotnetPath, globalStoragePath);
+    if (currentVersion && compareVersions.compare(currentVersion, requiredVersion, '>=')) {
+        // current is acceptable
+        return launchOptions;
+    }
+
+    // no current version installed or it's out of date
+    reportInstallationStarted();
+    await installInteractive({
+        dotnetPath: args.dotnetPath,
+        toolVersion: requiredVersion
+    }, globalStoragePath);
+    reportInstallationFinished();
+
+    return launchOptions;
 }

--- a/src/dotnet-interactive-vscode/src/extension.ts
+++ b/src/dotnet-interactive-vscode/src/extension.ts
@@ -1,19 +1,16 @@
 import * as vscode from 'vscode';
-import * as cp from 'child_process';
 import { ClientMapper } from './clientMapper';
+
 import { DotNetInteractiveNotebookContentProvider } from './vscode/notebookProvider';
 import { StdioKernelTransport } from './stdioKernelTransport';
 import { registerLanguageProviders } from './vscode/languageProvider';
 import { registerCommands } from './vscode/commands';
-import { IDotnetAcquireResult } from './interfaces/dotnet';
-import * as versions from './minVersions';
 
-import compareVersions = require("../node_modules/compare-versions");
+import * as acquisition from './acquisition';
 
 export async function activate(context: vscode.ExtensionContext) {
-    const dotnet = await getDotnetPath();
-    await ensureDotnetInteractive(dotnet);
-    const clientMapper = new ClientMapper(() => new StdioKernelTransport(dotnet));
+    const { dotnetPath, launchOptions } = await acquisition.getInteractiveLaunchOptions(context.globalStoragePath);
+    const clientMapper = new ClientMapper(() => new StdioKernelTransport(dotnetPath, launchOptions));
     context.subscriptions.push(vscode.notebook.registerNotebookContentProvider('dotnet-interactive', new DotNetInteractiveNotebookContentProvider(clientMapper)));
     context.subscriptions.push(vscode.notebook.onDidCloseNotebookDocument(notebookDocument => clientMapper.closeClient(notebookDocument.uri)));
     context.subscriptions.push(registerLanguageProviders(clientMapper));
@@ -21,61 +18,4 @@ export async function activate(context: vscode.ExtensionContext) {
 }
 
 export function deactivate() {
-}
-
-async function getDotnetPath(): Promise<string> {
-    // ensure valid `dotnet`
-    const { code, output } = await processExitCodeAndOutput('dotnet', ['--version']);
-    let dotnetPath: string;
-    if (code === 0 && compareVersions.compare(output, versions.minimumDotNetSdkVersion, '>=')) {
-        // global `dotnet` is present and good
-        dotnetPath = 'dotnet';
-    } else {
-        // need to acquire one
-        // don't block, just show and go
-        vscode.window.showInformationMessage(`Acquiring .NET SDK version ${versions.minimumDotNetSdkVersion}...`);
-        const commandResult = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', { version: versions.minimumDotNetSdkVersion });
-        if (commandResult) {
-            dotnetPath = commandResult.dotnetPath;
-        } else {
-            throw new Error(`Unable to find or acquire .NET SDK >= ${versions.minimumDotNetSdkVersion}`);
-        }
-    }
-
-    return dotnetPath;
-}
-
-async function ensureDotnetInteractive(dotnetPath: string): Promise<void> {
-    // ensure valid `dotnet-interactive`
-    const validDotnetInteractiveDevVersion: RegExp = /^.*-dev$/; // e.g., 1.0.0-dev.  Locally produced versions are always assumed to be good.
-    const { code, output } = await processExitCodeAndOutput(dotnetPath, ['interactive', '--version']);
-    if (code === 0) {
-        if (validDotnetInteractiveDevVersion.test(output)) {
-            // locally built versions are always assumed to be valid
-            return;
-        }
-
-        // otherwise we have to check the version
-        if (compareVersions.compare(output, versions.minimumDotNetInteractiveVersion, '<')) {
-            // TODO: acquire it for them
-            await vscode.window.showErrorMessage(`Unsupported \`dotnet-interactive\` version, '${output}'.  Minimum required is '${versions.minimumDotNetInteractiveVersion}'.`);
-            throw new Error('aborting');
-        }
-
-        // good to go
-    }
-}
-
-function processExitCodeAndOutput(command: string, args?: Array<string> | undefined): Promise<{ code: number, output: string }> {
-    return new Promise<{ code: number, output: string }>((resolve, reject) => {
-        let output = '';
-        let childProcess = cp.spawn(command, args || []);
-        childProcess.stdout.on('data', data => output += data);
-        childProcess.on('exit', (code: number, _signal: string) => {
-            resolve({
-                code: code,
-                output: output.trim()
-            });
-        });
-    });
 }

--- a/src/dotnet-interactive-vscode/src/extension.ts
+++ b/src/dotnet-interactive-vscode/src/extension.ts
@@ -7,18 +7,21 @@ import { registerLanguageProviders } from './vscode/languageProvider';
 import { execute, registerCommands } from './vscode/commands';
 
 import { IDotnetAcquireResult } from './interfaces/dotnet';
-import * as versions from './minVersions';
 import { InteractiveLaunchOptions, InstallInteractiveArgs } from './interfaces';
 
 import compareVersions = require("../node_modules/compare-versions");
 
 export async function activate(context: vscode.ExtensionContext) {
     // install dotnet or use global
+    const config = vscode.workspace.getConfiguration('dotnet-interactive');
+    const minDotNetSdkVersion = config.get<string>('minimumDotNetSdkVersion') || '3.1'; // some sensible fallback
     let dotnetPath: string;
-    if (await isDotnetUpToDate()) {
+    if (await isDotnetUpToDate(minDotNetSdkVersion)) {
         dotnetPath = 'dotnet';
     } else {
-        const commandResult = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', { version: versions.minimumDotNetSdkVersion });
+        
+        config.get('');
+        const commandResult = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', { version: minDotNetSdkVersion });
         dotnetPath = commandResult!.dotnetPath;
     }
 
@@ -41,7 +44,7 @@ export async function activate(context: vscode.ExtensionContext) {
 export function deactivate() {
 }
 
-async function isDotnetUpToDate(): Promise<boolean> {
+async function isDotnetUpToDate(minVersion: string): Promise<boolean> {
     const result = await execute('dotnet', ['--version']);
-    return result.code === 0 && compareVersions.compare(result.output, versions.minimumDotNetSdkVersion, '>=');
+    return result.code === 0 && compareVersions.compare(result.output, minVersion, '>=');
 }

--- a/src/dotnet-interactive-vscode/src/interactiveNotebook.ts
+++ b/src/dotnet-interactive-vscode/src/interactiveNotebook.ts
@@ -75,6 +75,14 @@ export function parseNotebook(contents: string): NotebookFile {
         addCell();
     }
 
+    if (cells.length === 0) {
+        // ensure there's at least one cell available
+        cells.push({
+            language: 'csharp',
+            contents: []
+        });
+    }
+
     return {
         cells
     };

--- a/src/dotnet-interactive-vscode/src/interfaces.ts
+++ b/src/dotnet-interactive-vscode/src/interfaces.ts
@@ -34,7 +34,7 @@ export interface GetCurrentInteractiveVersion {
 }
 
 export interface ReportInstallationStarted {
-    (): void;
+    (version: string): void;
 }
 
 export interface InstallInteractiveTool {

--- a/src/dotnet-interactive-vscode/src/interfaces.ts
+++ b/src/dotnet-interactive-vscode/src/interfaces.ts
@@ -14,7 +14,6 @@ export interface DocumentWithCells {
 // interactive acquisition
 
 export interface InteractiveLaunchOptions {
-    args: Array<string>;
     workingDirectory: string;
 }
 

--- a/src/dotnet-interactive-vscode/src/interfaces.ts
+++ b/src/dotnet-interactive-vscode/src/interfaces.ts
@@ -1,3 +1,8 @@
+export interface InteractiveLaunchOptions {
+    args: Array<string>;
+    workingDirectory?: string | undefined;
+}
+
 export interface RawNotebookCell {
     language: string;
     contents: Array<string>;

--- a/src/dotnet-interactive-vscode/src/interfaces.ts
+++ b/src/dotnet-interactive-vscode/src/interfaces.ts
@@ -1,6 +1,5 @@
-export interface InteractiveLaunchOptions {
-    args: Array<string>;
-    workingDirectory?: string | undefined;
+export interface IsValidToolVersion {
+    (actualVersion: string, minSupportedVersion: string): boolean;
 }
 
 export interface RawNotebookCell {
@@ -10,4 +9,38 @@ export interface RawNotebookCell {
 
 export interface DocumentWithCells {
     cells: Array<RawNotebookCell>;
+}
+
+// interactive acquisition
+
+export interface InteractiveLaunchOptions {
+    args: Array<string>;
+    workingDirectory: string;
+}
+
+export interface InstallInteractiveArgs {
+    dotnetPath: string;
+    toolVersion?: string;
+}
+
+// acquisition callbacks
+
+export interface CreateToolManifest {
+    (dotnetPath: string, globalStoragePath: string): Promise<void>;
+}
+
+export interface GetCurrentInteractiveVersion {
+    (dotnetPath: string, globalStoragePath: string): Promise<string | undefined>;
+}
+
+export interface ReportInstallationStarted {
+    (): void;
+}
+
+export interface InstallInteractiveTool {
+    (args: InstallInteractiveArgs, globalStoragePath: string): Promise<void>;
+}
+
+export interface ReportInstallationFinished {
+    (): void;
 }

--- a/src/dotnet-interactive-vscode/src/minVersions.ts
+++ b/src/dotnet-interactive-vscode/src/minVersions.ts
@@ -1,2 +1,2 @@
 export const minimumDotNetSdkVersion: string = '3.1';
-export const minimumDotNetInteractiveVersion: string = '1.0.125402';
+export const minimumDotNetInteractiveVersion: string = '1.0.126201';

--- a/src/dotnet-interactive-vscode/src/minVersions.ts
+++ b/src/dotnet-interactive-vscode/src/minVersions.ts
@@ -1,2 +1,0 @@
-export const minimumDotNetSdkVersion: string = '3.1';
-export const minimumDotNetInteractiveVersion: string = '1.0.126201';

--- a/src/dotnet-interactive-vscode/src/minVersions.ts
+++ b/src/dotnet-interactive-vscode/src/minVersions.ts
@@ -1,0 +1,2 @@
+export const minimumDotNetSdkVersion: string = '3.1';
+export const minimumDotNetInteractiveVersion: string = '1.0.125402';

--- a/src/dotnet-interactive-vscode/src/stdioKernelTransport.ts
+++ b/src/dotnet-interactive-vscode/src/stdioKernelTransport.ts
@@ -1,5 +1,6 @@
 import * as cp from 'child_process';
 import { DisposableSubscription, KernelCommand, KernelCommandType, KernelEventEnvelope, KernelEventEnvelopeObserver } from "./contracts";
+import { InteractiveLaunchOptions } from './interfaces';
 
 
 export class StdioKernelTransport {
@@ -7,9 +8,11 @@ export class StdioKernelTransport {
     private childProcess: cp.ChildProcessWithoutNullStreams;
     private subscribers: Array<KernelEventEnvelopeObserver> = [];
 
-    constructor(readonly dotnetPath: string) {
-        this.childProcess = cp.spawn(this.dotnetPath, ['interactive', 'stdio']);
-        this.childProcess.on('exit', (code: number, _signal: string) => {
+    constructor(dotnetPath: string, launchOptions: InteractiveLaunchOptions) {
+        let stdioArguments = [...launchOptions.args];
+        stdioArguments.push('stdio');
+        this.childProcess = cp.spawn(dotnetPath, stdioArguments, { cwd: launchOptions.workingDirectory });
+        this.childProcess.on('exit', (_code: number, _signal: string) => {
             //
             let x = 1;
         });

--- a/src/dotnet-interactive-vscode/src/stdioKernelTransport.ts
+++ b/src/dotnet-interactive-vscode/src/stdioKernelTransport.ts
@@ -1,17 +1,13 @@
 import * as cp from 'child_process';
 import { DisposableSubscription, KernelCommand, KernelCommandType, KernelEventEnvelope, KernelEventEnvelopeObserver } from "./contracts";
-import { InteractiveLaunchOptions } from './interfaces';
-
 
 export class StdioKernelTransport {
     private buffer: string = '';
     private childProcess: cp.ChildProcessWithoutNullStreams;
     private subscribers: Array<KernelEventEnvelopeObserver> = [];
 
-    constructor(dotnetPath: string, launchOptions: InteractiveLaunchOptions) {
-        let stdioArguments = [...launchOptions.args];
-        stdioArguments.push('stdio');
-        this.childProcess = cp.spawn(dotnetPath, stdioArguments, { cwd: launchOptions.workingDirectory });
+    constructor(command: string, args: Array<string>, workingDirectory?: string | undefined) {
+        this.childProcess = cp.spawn(command, args, { cwd: workingDirectory });
         this.childProcess.on('exit', (_code: number, _signal: string) => {
             //
             let x = 1;

--- a/src/dotnet-interactive-vscode/src/tests/integration/suite/extension.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/integration/suite/extension.test.ts
@@ -6,7 +6,7 @@ import { CellOutput, CellOutputKind } from '../../../interfaces/vscode';
 
 suite('Extension Test Suite', () => {
     test('Execute against real kernel', async () => {
-        let clientMapper = new ClientMapper(() => new StdioKernelTransport('dotnet')); // assume it's globally installed for this test
+        let clientMapper = new ClientMapper(() => new StdioKernelTransport('dotnet', { args: ['interactive'] }));
         let client = clientMapper.getOrAddClient({ path: 'some/path' });
         let code = '1+1';
         let result: Array<CellOutput> = [];

--- a/src/dotnet-interactive-vscode/src/tests/integration/suite/extension.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/integration/suite/extension.test.ts
@@ -4,9 +4,10 @@ import { StdioKernelTransport } from '../../../stdioKernelTransport';
 import { ClientMapper } from '../../../clientMapper';
 import { CellOutput, CellOutputKind } from '../../../interfaces/vscode';
 
+
 suite('Extension Test Suite', () => {
     test('Execute against real kernel', async () => {
-        let clientMapper = new ClientMapper(() => new StdioKernelTransport('dotnet', { args: ['interactive'] }));
+        let clientMapper = new ClientMapper(() => new StdioKernelTransport('dotnet', ['interactive', 'stdio']));
         let client = clientMapper.getOrAddClient({ path: 'some/path' });
         let code = '1+1';
         let result: Array<CellOutput> = [];

--- a/src/dotnet-interactive-vscode/src/tests/unit/acquisition.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/acquisition.test.ts
@@ -76,10 +76,8 @@ describe('Acquisition tests', () => {
         // noop
     }
 
-    it("global storage doesn't exist", async () => {
-        // this tests the scenario where the extension launches for the first time and nothing exists
+    it("simulate first launch when global storage doesn't exist", async () => {
         await withFakeGlobalStorageLocation(false, async globalStoragePath => {
-            expect(globalStoragePath).to.not.be.a.path(); // sanity check that it doesn't exist
             const args = {
                 dotnetPath: 'dotnet',
                 toolVersion: undefined
@@ -115,14 +113,12 @@ describe('Acquisition tests', () => {
         });
     });
 
-    it("global storage exists, tool manifest doesn't", async () => {
-        // this tests the scenario where the global storage may have been cleared, but the directory wasn't removed
+    it("simulate global storage existing, but empty", async () => {
         await withFakeGlobalStorageLocation(true, async globalStoragePath => {
             const args = {
                 dotnetPath: 'dotnet',
                 toolVersion: undefined
             };
-            expect(globalStoragePath).to.be.a.directory(); // sanity check that it already exists
             const manifestPath = path.join(globalStoragePath, '.config', 'dotnet-tools.json');
             expect(manifestPath).to.not.be.a.path();
             const launchOptions = await acquireDotnetInteractive(
@@ -152,14 +148,12 @@ describe('Acquisition tests', () => {
         });
     });
 
-    it("global storage exsits, tool manifest exists, local tool doesn't exist", async () => {
-        // this tests the scenario where an earlier attempt to install a local interactive tool may have been interrupted
+    it("simulate global storage and tool manifest exist; local tool doesn't exist, but is added to the manifest", async () => {
         await withFakeGlobalStorageLocation(true, async globalStoragePath => {
             const args = {
                 dotnetPath: 'dotnet',
                 toolVersion: undefined
             };
-            expect(globalStoragePath).to.be.a.directory(); // sanity check that it already exists
             // prepopulate tool manifest
             await createEmptyToolManifest(args.dotnetPath, globalStoragePath);
 
@@ -191,14 +185,12 @@ describe('Acquisition tests', () => {
         });
     });
 
-    it("global storage exists, tool manifest exists, local tool exists, but is out of date with unspecified version", async () => {
-        // this tests the scenario where a local tool has already been installed, but is out of date
+    it("simulate local tool exists, is out of date, and is updated to the auto min version", async () => {
         await withFakeGlobalStorageLocation(true, async globalStoragePath => {
             const args = {
                 dotnetPath: 'dotnet',
                 toolVersion: undefined // install whatever you can
             };
-            expect(globalStoragePath).to.be.a.directory(); // sanity check that it already exists
             // prepopulate tool manifest...
             await createEmptyToolManifest(args.dotnetPath, globalStoragePath);
 
@@ -230,14 +222,12 @@ describe('Acquisition tests', () => {
         });
     });
 
-    it("global storage exists, tool manifest exists, local tool exists, but is out of date with specified version", async () => {
-        // this tests the scenario where a local tool has already been installed, but is out of date
+    it("simulate local tool exists, is out of date, and is updated to the specified min version", async () => {
         await withFakeGlobalStorageLocation(true, async globalStoragePath => {
             const args = {
                 dotnetPath: 'dotnet',
                 toolVersion: '42.42.42' // install exactly this
             };
-            expect(globalStoragePath).to.be.a.directory(); // sanity check that it already exists
             // prepopulate tool manifest...
             await createEmptyToolManifest(args.dotnetPath, globalStoragePath);
 
@@ -269,14 +259,12 @@ describe('Acquisition tests', () => {
         });
     });
 
-    it("global storage exists, tool manifest exists, local tool exists and is up to date", async () => {
-        // this tests the scenario where a local tool has already been installed and is ready to go
+    it("simulate local tool exists and is already up to date", async () => {
         await withFakeGlobalStorageLocation(true, async globalStoragePath => {
             const args = {
                 dotnetPath: 'dotnet',
                 toolVersion: '42.42.42' // request at least this version
             };
-            expect(globalStoragePath).to.be.a.directory(); // sanity check that it already exists
             // prepopulate tool manifest...
             await createEmptyToolManifest(args.dotnetPath, globalStoragePath);
             // ...with existing version
@@ -306,6 +294,24 @@ describe('Acquisition tests', () => {
                         ]
                     }
                 }
+            });
+        });
+    });
+
+    it("helper method doesn't create global storage location when it shouldn't", async () => {
+        await withFakeGlobalStorageLocation(false, globalStoragePath => {
+            return new Promise((resolve, reject) => {
+                expect(globalStoragePath).to.not.be.a.path();
+                resolve();
+            });
+        });
+    });
+
+    it("helper method creates global storage location when it should", async () => {
+        await withFakeGlobalStorageLocation(true, globalStoragePath => {
+            return new Promise((resolve, reject) => {
+                expect(globalStoragePath).to.be.a.directory();
+                resolve();
             });
         });
     });

--- a/src/dotnet-interactive-vscode/src/tests/unit/acquisition.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/acquisition.test.ts
@@ -86,6 +86,7 @@ describe('Acquisition tests', () => {
             };
             const launchOptions = await acquireDotnetInteractive(
                 args,
+                '42.42.42', // min version
                 globalStoragePath,
                 getInteractiveVersionThatReturnsNoVersionFound, // report no version installed
                 createEmptyToolManifest, // create manifest when asked
@@ -132,6 +133,7 @@ describe('Acquisition tests', () => {
             expect(manifestPath).to.not.be.a.path();
             const launchOptions = await acquireDotnetInteractive(
                 args,
+                '42.42.42', // min version
                 globalStoragePath,
                 getInteractiveVersionThatReturnsNoVersionFound, // report no version installed
                 createEmptyToolManifest, // create manifest when asked
@@ -169,6 +171,7 @@ describe('Acquisition tests', () => {
 
             const launchOptions = await acquireDotnetInteractive(
                 args,
+                '42.42.42', // min version
                 globalStoragePath,
                 getInteractiveVersionThatReturnsNoVersionFound, // report no version found
                 createToolManifestThatThrows, // throw if acquisition tries to create another manifest
@@ -207,6 +210,7 @@ describe('Acquisition tests', () => {
 
             const launchOptions = await acquireDotnetInteractive(
                 args,
+                '42.42.42', // min version
                 globalStoragePath,
                 getInteractiveVersionThatReturnsSpecificValue('0.0.0'), // report existing version 0.0.0 is installed
                 createToolManifestThatThrows, // throw if acquisition tries to create another manifest
@@ -245,6 +249,7 @@ describe('Acquisition tests', () => {
 
             const launchOptions = await acquireDotnetInteractive(
                 args,
+                '42.42.42', // min version
                 globalStoragePath,
                 getInteractiveVersionThatReturnsSpecificValue('0.0.0'), // report existing version 0.0.0 is installed
                 createToolManifestThatThrows, // throw if acquisition tries to create another manifest
@@ -285,6 +290,7 @@ describe('Acquisition tests', () => {
 
             const launchOptions = await acquireDotnetInteractive(
                 args,
+                '42.42.42', // min version
                 globalStoragePath,
                 getInteractiveVersionThatReturnsSpecificValue('43.43.43'), // report existing version 43.43.43 is installed
                 createToolManifestThatThrows, // throw if acquisition tries to create another manifest

--- a/src/dotnet-interactive-vscode/src/tests/unit/acquisition.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/acquisition.test.ts
@@ -1,0 +1,333 @@
+import { expect, use } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as tmp from 'tmp';
+
+use(require('chai-fs'));
+
+import { acquireDotnetInteractive } from '../../acquisition';
+import { InstallInteractiveArgs } from '../../interfaces';
+
+describe('Acquisition tests', () => {
+
+    function getInteractiveVersionThatReturnsNoVersionFound(dotnetPath: string, globalStoragePath: string): Promise<string | undefined> {
+        return new Promise<string | undefined>((resolve, reject) => {
+            resolve(undefined);
+        });
+    }
+
+    function getInteractiveVersionThatReturnsSpecificValue(version: string): { (dotnetPath: string, globalStoragePath: string): Promise<string | undefined> } {
+        return function(dotnetPath: string, globalStoragePath: string): Promise<string | undefined> {
+            return new Promise<string | undefined>((resolve, reject) => {
+                resolve(version);
+            });
+        };
+    }
+
+    function createEmptyToolManifest(dotnetPath: string, globalStoragePath: string): Promise<void> {
+        return new Promise((resolve, reject) => {
+            const manifestDir = path.join(globalStoragePath, '.config');
+            fs.mkdirSync(manifestDir);
+            const manifestPath = path.join(manifestDir, 'dotnet-tools.json');
+            const manfiestContent = {
+                version: 1,
+                isRoot: true,
+                tools: {}
+            };
+            fs.writeFile(manifestPath, JSON.stringify(manfiestContent), () => resolve());
+        });
+    }
+
+    function createToolManifestThatThrows(dotnetPath: string, globalStoragePath: string): Promise<void> {
+        throw new Error('This function should have never been called.');
+    }
+
+    function installInteractiveTool(args: InstallInteractiveArgs, globalStoragePath: string): Promise<void> {
+        return new Promise((resolve, reject) => {
+            const manifestPath = path.join(globalStoragePath, '.config', 'dotnet-tools.json');
+            fs.readFile(manifestPath, (err, data) => {
+                let manifestContent = JSON.parse(data.toString());
+                manifestContent.tools['microsoft.dotnet-interactive'] = {
+                    version: args!.toolVersion,
+                    commands: [
+                        'dotnet-interactive'
+                    ]
+                };
+                fs.writeFile(manifestPath, JSON.stringify(manifestContent), () => resolve());
+            });
+        });
+    }
+
+    function installInteractiveToolWithSpecificVersion(version: string): { (args: InstallInteractiveArgs, globalStoragePath: string): Promise<void> } {
+        const overrideArgs = {
+            dotnetPath: 'dotnet',
+            toolVersion: version
+        };
+        return (args: InstallInteractiveArgs, globalStoragePath: string) => {
+            return installInteractiveTool(overrideArgs, globalStoragePath);
+        };
+    }
+
+    function installInteractiveToolThatAlwaysThrows(args: InstallInteractiveArgs, globalStoragePath: string): Promise<void> {
+        throw new Error('This function should have never been called.');
+    }
+
+    function report() {
+        // noop
+    }
+
+    it("global storage doesn't exist", async () => {
+        // this tests the scenario where the extension launches for the first time and nothing exists
+        await withFakeGlobalStorageLocation(false, async globalStoragePath => {
+            expect(globalStoragePath).to.not.be.a.path(); // sanity check that it doesn't exist
+            const args = {
+                dotnetPath: 'dotnet',
+                toolVersion: undefined
+            };
+            const launchOptions = await acquireDotnetInteractive(
+                args,
+                globalStoragePath,
+                getInteractiveVersionThatReturnsNoVersionFound, // report no version installed
+                createEmptyToolManifest, // create manifest when asked
+                report,
+                installInteractiveToolWithSpecificVersion('42.42.42'), // 'install' this version when asked
+                report);
+            expect(launchOptions).to.deep.equal({
+                args: [
+                    'tool',
+                    'run',
+                    'dotnet-interactive',
+                    '--'
+                ],
+                workingDirectory: globalStoragePath
+            });
+            expect(globalStoragePath).to.be.a.directory();
+            const manifestPath = path.join(globalStoragePath, '.config', 'dotnet-tools.json');
+            expect(manifestPath).to.be.file().with.json;
+            const jsonContent = JSON.parse(fs.readFileSync(manifestPath).toString());
+            expect(jsonContent).to.deep.equal({
+                version: 1,
+                isRoot: true,
+                tools: {
+                    'microsoft.dotnet-interactive': {
+                        version: '42.42.42',
+                        commands: [
+                            'dotnet-interactive'
+                        ]
+                    }
+                }
+            });
+        });
+    });
+
+    it("global storage exists, tool manifest doesn't", async () => {
+        // this tests the scenario where the global storage may have been cleared, but the directory wasn't removed
+        await withFakeGlobalStorageLocation(true, async globalStoragePath => {
+            const args = {
+                dotnetPath: 'dotnet',
+                toolVersion: undefined
+            };
+            expect(globalStoragePath).to.be.a.directory(); // sanity check that it already exists
+            const manifestPath = path.join(globalStoragePath, '.config', 'dotnet-tools.json');
+            expect(manifestPath).to.not.be.a.path();
+            const launchOptions = await acquireDotnetInteractive(
+                args,
+                globalStoragePath,
+                getInteractiveVersionThatReturnsNoVersionFound, // report no version installed
+                createEmptyToolManifest, // create manifest when asked
+                report,
+                installInteractiveToolWithSpecificVersion('42.42.42'), // 'install' this version when asked
+                report);
+            expect(globalStoragePath).to.be.a.directory();
+            expect(manifestPath).to.be.file().with.json;
+            const jsonContent = JSON.parse(fs.readFileSync(manifestPath).toString());
+            expect(jsonContent).to.deep.equal({
+                version: 1,
+                isRoot: true,
+                tools: {
+                    'microsoft.dotnet-interactive': {
+                        version: '42.42.42',
+                        commands: [
+                            'dotnet-interactive'
+                        ]
+                    }
+                }
+            });
+        });
+    });
+
+    it("global storage exsits, tool manifest exists, local tool doesn't exist", async () => {
+        // this tests the scenario where an earlier attempt to install a local interactive tool may have been interrupted
+        await withFakeGlobalStorageLocation(true, async globalStoragePath => {
+            const args = {
+                dotnetPath: 'dotnet',
+                toolVersion: undefined
+            };
+            expect(globalStoragePath).to.be.a.directory(); // sanity check that it already exists
+            // prepopulate tool manifest
+            await createEmptyToolManifest(args.dotnetPath, globalStoragePath);
+
+            const launchOptions = await acquireDotnetInteractive(
+                args,
+                globalStoragePath,
+                getInteractiveVersionThatReturnsNoVersionFound, // report no version found
+                createToolManifestThatThrows, // throw if acquisition tries to create another manifest
+                report,
+                installInteractiveToolWithSpecificVersion('42.42.42'), // 'install' this version when asked
+                report);
+            expect(globalStoragePath).to.be.a.directory();
+            const manifestPath = path.join(globalStoragePath, '.config', 'dotnet-tools.json');
+            expect(manifestPath).to.be.file().with.json;
+            const jsonContent = JSON.parse(fs.readFileSync(manifestPath).toString());
+            expect(jsonContent).to.deep.equal({
+                version: 1,
+                isRoot: true,
+                tools: {
+                    'microsoft.dotnet-interactive': {
+                        version: '42.42.42',
+                        commands: [
+                            'dotnet-interactive'
+                        ]
+                    }
+                }
+            });
+        });
+    });
+
+    it("global storage exists, tool manifest exists, local tool exists, but is out of date with unspecified version", async () => {
+        // this tests the scenario where a local tool has already been installed, but is out of date
+        await withFakeGlobalStorageLocation(true, async globalStoragePath => {
+            const args = {
+                dotnetPath: 'dotnet',
+                toolVersion: undefined // install whatever you can
+            };
+            expect(globalStoragePath).to.be.a.directory(); // sanity check that it already exists
+            // prepopulate tool manifest...
+            await createEmptyToolManifest(args.dotnetPath, globalStoragePath);
+
+            const launchOptions = await acquireDotnetInteractive(
+                args,
+                globalStoragePath,
+                getInteractiveVersionThatReturnsSpecificValue('0.0.0'), // report existing version 0.0.0 is installed
+                createToolManifestThatThrows, // throw if acquisition tries to create another manifest
+                report,
+                installInteractiveToolWithSpecificVersion('42.42.42'), // 'install' this version when asked
+                report);
+            expect(globalStoragePath).to.be.a.directory();
+            const manifestPath = path.join(globalStoragePath, '.config', 'dotnet-tools.json');
+            expect(manifestPath).to.be.file().with.json;
+            const jsonContent = JSON.parse(fs.readFileSync(manifestPath).toString());
+            expect(jsonContent).to.deep.equal({
+                version: 1,
+                isRoot: true,
+                tools: {
+                    'microsoft.dotnet-interactive': {
+                        version: '42.42.42',
+                        commands: [
+                            'dotnet-interactive'
+                        ]
+                    }
+                }
+            });
+        });
+    });
+
+    it("global storage exists, tool manifest exists, local tool exists, but is out of date with specified version", async () => {
+        // this tests the scenario where a local tool has already been installed, but is out of date
+        await withFakeGlobalStorageLocation(true, async globalStoragePath => {
+            const args = {
+                dotnetPath: 'dotnet',
+                toolVersion: '42.42.42' // install exactly this
+            };
+            expect(globalStoragePath).to.be.a.directory(); // sanity check that it already exists
+            // prepopulate tool manifest...
+            await createEmptyToolManifest(args.dotnetPath, globalStoragePath);
+
+            const launchOptions = await acquireDotnetInteractive(
+                args,
+                globalStoragePath,
+                getInteractiveVersionThatReturnsSpecificValue('0.0.0'), // report existing version 0.0.0 is installed
+                createToolManifestThatThrows, // throw if acquisition tries to create another manifest
+                report,
+                installInteractiveToolWithSpecificVersion('42.42.42'), // 'install' this version when asked
+                report);
+            expect(globalStoragePath).to.be.a.directory();
+            const manifestPath = path.join(globalStoragePath, '.config', 'dotnet-tools.json');
+            expect(manifestPath).to.be.file().with.json;
+            const jsonContent = JSON.parse(fs.readFileSync(manifestPath).toString());
+            expect(jsonContent).to.deep.equal({
+                version: 1,
+                isRoot: true,
+                tools: {
+                    'microsoft.dotnet-interactive': {
+                        version: '42.42.42',
+                        commands: [
+                            'dotnet-interactive'
+                        ]
+                    }
+                }
+            });
+        });
+    });
+
+    it("global storage exists, tool manifest exists, local tool exists and is up to date", async () => {
+        // this tests the scenario where a local tool has already been installed and is ready to go
+        await withFakeGlobalStorageLocation(true, async globalStoragePath => {
+            const args = {
+                dotnetPath: 'dotnet',
+                toolVersion: '42.42.42' // request at least this version
+            };
+            expect(globalStoragePath).to.be.a.directory(); // sanity check that it already exists
+            // prepopulate tool manifest...
+            await createEmptyToolManifest(args.dotnetPath, globalStoragePath);
+            // ...with existing version
+            await installInteractiveTool({ dotnetPath: 'dotnet', toolVersion: '43.43.43' }, globalStoragePath);
+
+            const launchOptions = await acquireDotnetInteractive(
+                args,
+                globalStoragePath,
+                getInteractiveVersionThatReturnsSpecificValue('43.43.43'), // report existing version 43.43.43 is installed
+                createToolManifestThatThrows, // throw if acquisition tries to create another manifest
+                report,
+                installInteractiveToolThatAlwaysThrows, // throw if acquisition tries to install
+                report);
+            expect(globalStoragePath).to.be.a.directory();
+            const manifestPath = path.join(globalStoragePath, '.config', 'dotnet-tools.json');
+            expect(manifestPath).to.be.file().with.json;
+            const jsonContent = JSON.parse(fs.readFileSync(manifestPath).toString());
+            expect(jsonContent).to.deep.equal({
+                version: 1,
+                isRoot: true,
+                tools: {
+                    'microsoft.dotnet-interactive': {
+                        version: '43.43.43',
+                        commands: [
+                            'dotnet-interactive'
+                        ]
+                    }
+                }
+            });
+        });
+    });
+
+    function withFakeGlobalStorageLocation(createLocation: boolean, callback: {(globalStoragePath: string): Promise<void> }) {
+        return new Promise<void>((resolve, reject) => {
+            tmp.dir({ unsafeCleanup: true }, (err, dir) => {
+                if (err) {
+                    reject();
+                    throw err;
+                }
+
+                // VS Code doesn't guarantee that the global storage path is present, so we have to go one directory deeper
+                let globalStoragePath = path.join(dir, 'globalStoragePath');
+                if (createLocation) {
+                    fs.mkdirSync(globalStoragePath);
+                }
+
+                callback(globalStoragePath).then(() => {
+                    resolve();
+                });
+            });
+        });
+    };
+});

--- a/src/dotnet-interactive-vscode/src/tests/unit/acquisition.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/acquisition.test.ts
@@ -94,12 +94,6 @@ describe('Acquisition tests', () => {
                 installInteractiveToolWithSpecificVersion('42.42.42'), // 'install' this version when asked
                 report);
             expect(launchOptions).to.deep.equal({
-                args: [
-                    'tool',
-                    'run',
-                    'dotnet-interactive',
-                    '--'
-                ],
                 workingDirectory: globalStoragePath
             });
             expect(globalStoragePath).to.be.a.directory();

--- a/src/dotnet-interactive-vscode/src/tests/unit/parsing.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/parsing.test.ts
@@ -177,10 +177,15 @@ asdf
         });
     });
 
-    it('empty file parses as valid', () => {
+    it('empty file parses as a single empty cell', () => {
         let notebook = parseNotebook('');
         expect(notebook).to.deep.equal({
-            cells: []
+            cells: [
+                {
+                    language: 'csharp',
+                    contents: []
+                }
+            ]
         });
     });
 

--- a/src/dotnet-interactive-vscode/src/vscode/commands.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/commands.ts
@@ -1,7 +1,10 @@
 import * as vscode from 'vscode';
+import * as cp from 'child_process';
 import * as jp from '../interop/jupyter';
+import { acquireDotnetInteractive, interactiveToolSource } from '../acquisition';
+import { InstallInteractiveArgs, InteractiveLaunchOptions } from '../interfaces';
 
-export function registerCommands(context: vscode.ExtensionContext) {
+export function registerCommands(context: vscode.ExtensionContext, dotnetPath: string) {
     context.subscriptions.push(vscode.commands.registerCommand('dotnet-interactive.exportAsJupyterNotebook', async () => {
         if (vscode.notebook.activeNotebookEditor) {
             const uri = await vscode.window.showSaveDialog({
@@ -18,4 +21,98 @@ export function registerCommands(context: vscode.ExtensionContext) {
             await vscode.workspace.fs.writeFile(uri, Buffer.from(JSON.stringify(jupyter, null, 1)));
         }
     }));
+
+    context.subscriptions.push(vscode.commands.registerCommand('dotnet-interactive.acquire', async (args?: InstallInteractiveArgs | undefined): Promise<InteractiveLaunchOptions | undefined> => {
+        if (!args) {
+            args = {
+                dotnetPath: dotnetPath,
+                toolVersion: undefined
+            };
+        }
+
+        const launchOptions = await acquireDotnetInteractive(
+            args,
+            context.globalStoragePath,
+            getInteractiveVersion,
+            createToolManifest,
+            () => { vscode.window.showInformationMessage('Installing .NET Interactive...'); },
+            installInteractiveTool,
+            () => { vscode.window.showInformationMessage('.NET Interactive installation complete.'); });
+        return launchOptions;
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand('dotnet-interactive.reportInteractiveVersion', async (args?: InstallInteractiveArgs | undefined) => {
+        const interactiveVersrion = await getInteractiveVersion(dotnetPath, context.globalStoragePath);
+        if (interactiveVersrion) {
+            vscode.window.showInformationMessage(`.NET Interactive tool version: ${interactiveVersrion}.`);
+        } else {
+            vscode.window.showWarningMessage('Unable to determine .NET Interactive tool version.');
+        }
+    }));
+}
+
+// callbacks used to install interactive tool
+
+async function getInteractiveVersion(dotnetPath: string, globalStoragePath: string): Promise<string | undefined> {
+    const result = await execute(dotnetPath, ['tool', 'run', 'dotnet-interactive', '--', '--version'], globalStoragePath);
+    if (result.code === 0) {
+        return result.output;
+    }
+
+    return undefined;
+}
+
+async function createToolManifest(dotnetPath: string, globalStoragePath: string): Promise<void> {
+    const result = await execute(dotnetPath, ['new', 'tool-manifest'], globalStoragePath);
+    if (result.code !== 0) {
+        throw new Error('Unable to create local tool manifest.');
+    }
+}
+
+async function installInteractiveTool(args: InstallInteractiveArgs, globalStoragePath: string): Promise<void> {
+    // remove previous tool; swallow errors in case it's not already installed
+    let uninstallArgs = [
+        'tool',
+        'uninstall',
+        'Microsoft.dotnet-interactive'
+    ];
+    await execute(args.dotnetPath, uninstallArgs, globalStoragePath);
+
+    let toolArgs = [
+        'tool',
+        'install',
+        '--add-source',
+        interactiveToolSource,
+        'Microsoft.dotnet-interactive'
+    ];
+    if (args.toolVersion) {
+        toolArgs.push('--version', args.toolVersion);
+    }
+
+    return new Promise(async (resolve, reject) => {
+        const result = await execute(args.dotnetPath, toolArgs, globalStoragePath);
+        if (result.code === 0) {
+            resolve();
+        }
+
+        reject();
+    });
+}
+
+export function execute(command: string, args: Array<string>, workingDirectory?: string | undefined): Promise<{ code: number, output: string, error: string }> {
+    return new Promise<{ code: number, output: string, error: string }>((resolve, reject) => {
+        let output = '';
+        let error = '';
+
+        let childProcess = cp.spawn(command, args, { cwd: workingDirectory });
+        childProcess.stdout.on('data', data => output += data);
+        childProcess.stderr.on('data', data => error += data);
+        childProcess.on('exit', (code: number, _signal: string) => {
+            resolve({
+                code: code,
+                output: output.trim(),
+                error: error.trim()
+            });
+        });
+    });
 }


### PR DESCRIPTION
This feels complicated, but it's not too bad.

In `extension.ts` the command `dotnet --version` is run.  If that errors out or if the version is less than the setting `dotnet-interactive.minimumDotNetSdkVersion` (specified in `package.json`), then a version of .NET will be acquired for you.  This is all using the `ms-dotnettools.vscode-dotnet-runtime` extension.

Next, dotnet is run with `tool run dotnet-interactive -- --version`.  If that fails (because the local tool isn't installed), or if the version is less than the setting `dotnet-interactive.minimumInteractiveToolVersion`, then the local tool version will be acquired for you using the package feed `dotnet-interactive.interactiveToolSource`.

All of those settings can be overridden by a user.

Finally, the args passed to dotnet to start an interactive session can be overrided by the `dotnet-interactive.kernelTransportArgsOverride` setting.  If not specified or empty, the default args are `['tool', 'run', 'dotnet-interactive', '--', 'stdio']`.  To run a local dev build you could set it to `['path/to/Microsoft.DotNet.Interactive.App.dll', '--', 'stdio']` (or you could do something even more crazy).
