### PR TITLE
Make RestorePackageContext a public property of implementing kernels

### DIFF
--- a/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
@@ -314,7 +314,7 @@ namespace Microsoft.DotNet.Interactive.CSharp
             ScriptOptions = ScriptOptions.AddReferences(references);
         }
 
-        PackageRestoreContext ISupportNuget.PackageRestoreContext => _packageRestoreContext.Value;
+        public PackageRestoreContext PackageRestoreContext => _packageRestoreContext.Value;
 
 
         private (Document document, int offset) GetDocumentWithOffsetFromCode(string code)

--- a/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
@@ -175,6 +175,7 @@ type FSharpKernel() as this =
 
     member _.ResolvedPackageReferences = _packageRestoreContext.Value.ResolvedPackageReferences;
 
+    member _.PackageRestoreContext = _packageRestoreContext.Value
 
     // Integrate nuget package management to the F# Kernel
     interface ISupportNuget with
@@ -200,7 +201,7 @@ type FSharpKernel() as this =
             let command = new SubmitCode(sb.ToString(), "fsharp")
             this.DeferCommand(command)
 
-        member _.PackageRestoreContext = _packageRestoreContext.Value
+        member _.PackageRestoreContext = this.PackageRestoreContext
 
     interface IExtensibleKernel with
         member this.LoadExtensionsFromDirectoryAsync(directory:DirectoryInfo, context:KernelInvocationContext) =

--- a/src/dotnet-interactive/build-and-install-dotnet-interactive.ps1
+++ b/src/dotnet-interactive/build-and-install-dotnet-interactive.ps1
@@ -10,12 +10,12 @@ if (Test-Path 'env:DisableArcade') {
     $script:toolVersion = "0.0.0"
 } else {
     if ($IsLinux -or $IsMacOS) {
-        & "$thisDir\..\..\..\build.sh" --pack
+        & "$thisDir\..\..\build.sh" --pack
     } else {
-        & "$thisDir\..\..\..\build.cmd" -pack
+        & "$thisDir\..\..\build.cmd" -pack
     }
 
-    $script:toolLocation = "$thisDir\..\..\..\artifacts\packages\Debug\Shipping"
+    $script:toolLocation = "$thisDir\..\..\artifacts\packages\Debug\Shipping"
     $script:toolVersion = "1.0.0-dev"
 }
 


### PR DESCRIPTION
Developers will often use packagerestorecontext with a Kernel.  This makes the PackageRestoreContext more discoverable by making it a property on CSharpKernel and FSharpKernel.

