### PR TITLE
add command/event pair to change the current working directory

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/contracts.ts
+++ b/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/contracts.ts
@@ -2,6 +2,7 @@
 
 export const AddPackageType = "AddPackage";
 export const CancelCurrentCommandType = "CancelCurrentCommand";
+export const ChangeWorkingDirectoryType = "ChangeWorkingDirectory";
 export const DisplayErrorType = "DisplayError";
 export const DisplayValueType = "DisplayValue";
 export const RequestCompletionType = "RequestCompletion";
@@ -13,6 +14,7 @@ export const UpdateDisplayedValueType = "UpdateDisplayedValue";
 export type KernelCommandType =
       typeof AddPackageType
     | typeof CancelCurrentCommandType
+    | typeof ChangeWorkingDirectoryType
     | typeof DisplayErrorType
     | typeof DisplayValueType
     | typeof RequestCompletionType
@@ -36,6 +38,10 @@ export interface PackageReference {
 }
 
 export interface CancelCurrentCommand extends KernelCommand {
+}
+
+export interface ChangeWorkingDirectory extends KernelCommand {
+    workingDirectory: string;
 }
 
 export interface DisplayError extends KernelCommand {
@@ -105,6 +111,7 @@ export const PasswordRequestedType = "PasswordRequested";
 export const ReturnValueProducedType = "ReturnValueProduced";
 export const StandardErrorValueProducedType = "StandardErrorValueProduced";
 export const StandardOutputValueProducedType = "StandardOutputValueProduced";
+export const WorkingDirectoryChangedType = "WorkingDirectoryChanged";
 
 export type KernelEventType =
       typeof CodeSubmissionReceivedType
@@ -124,7 +131,8 @@ export type KernelEventType =
     | typeof PasswordRequestedType
     | typeof ReturnValueProducedType
     | typeof StandardErrorValueProducedType
-    | typeof StandardOutputValueProducedType;
+    | typeof StandardOutputValueProducedType
+    | typeof WorkingDirectoryChangedType;
 
 export interface CodeSubmissionReceived extends KernelEvent {
     code: string;
@@ -222,6 +230,10 @@ export interface StandardErrorValueProduced extends DisplayEventBase {
 }
 
 export interface StandardOutputValueProduced extends DisplayEventBase {
+}
+
+export interface WorkingDirectoryChanged extends KernelEvent {
+    workingDirectory: string;
 }
 
 export interface KernelEventEnvelope {

--- a/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.cs
@@ -238,8 +238,8 @@ namespace Microsoft.DotNet.Interactive.Tests.Server
                     });
 
                 yield return new WorkingDirectoryChanged(
-                    new ChangeWorkingDirectory(new DirectoryInfo("some/different/directory")),
-                    new DirectoryInfo("some/different/directory"));
+                    new DirectoryInfo("some/different/directory"),
+                    new ChangeWorkingDirectory(new DirectoryInfo("some/different/directory")));
             }
         }
     }

--- a/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.cs
@@ -108,7 +108,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Server
 
                 yield return new CancelCurrentCommand();
 
-                yield return new ChangeWorkingDirectory("some/different/directory");
+                yield return new ChangeWorkingDirectory(new DirectoryInfo("some/different/directory"));
 
                 yield return new DisplayError("oops!");
 
@@ -238,8 +238,8 @@ namespace Microsoft.DotNet.Interactive.Tests.Server
                     });
 
                 yield return new WorkingDirectoryChanged(
-                    new ChangeWorkingDirectory("some/different/directory"),
-                    "some/different/directory");
+                    new ChangeWorkingDirectory(new DirectoryInfo("some/different/directory")),
+                    new DirectoryInfo("some/different/directory"));
             }
         }
     }

--- a/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.cs
@@ -108,6 +108,8 @@ namespace Microsoft.DotNet.Interactive.Tests.Server
 
                 yield return new CancelCurrentCommand();
 
+                yield return new ChangeWorkingDirectory("some/different/directory");
+
                 yield return new DisplayError("oops!");
 
                 yield return new DisplayValue(
@@ -234,6 +236,10 @@ namespace Microsoft.DotNet.Interactive.Tests.Server
                     {
                         new FormattedValue("text/plain", "123"),
                     });
+
+                yield return new WorkingDirectoryChanged(
+                    new ChangeWorkingDirectory("some/different/directory"),
+                    "some/different/directory");
             }
         }
     }

--- a/src/Microsoft.DotNet.Interactive/Commands/ChangeWorkingDirectory.cs
+++ b/src/Microsoft.DotNet.Interactive/Commands/ChangeWorkingDirectory.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Interactive.Commands
+{
+    public class ChangeWorkingDirectory : KernelCommandBase
+    {
+        public string WorkingDirectory { get; }
+
+        public ChangeWorkingDirectory(string workingDirectory)
+        {
+            WorkingDirectory = workingDirectory;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Interactive/Commands/ChangeWorkingDirectory.cs
+++ b/src/Microsoft.DotNet.Interactive/Commands/ChangeWorkingDirectory.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
+
 namespace Microsoft.DotNet.Interactive.Commands
 {
     public class ChangeWorkingDirectory : KernelCommandBase
     {
-        public string WorkingDirectory { get; }
+        public DirectoryInfo WorkingDirectory { get; }
 
-        public ChangeWorkingDirectory(string workingDirectory)
+        public ChangeWorkingDirectory(DirectoryInfo workingDirectory)
         {
             WorkingDirectory = workingDirectory;
         }

--- a/src/Microsoft.DotNet.Interactive/Events/WorkingDirectoryChanged.cs
+++ b/src/Microsoft.DotNet.Interactive/Events/WorkingDirectoryChanged.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.Interactive.Events
     {
         public DirectoryInfo WorkingDirectory { get; }
 
-        public WorkingDirectoryChanged(IKernelCommand command, DirectoryInfo workingDirectory)
+        public WorkingDirectoryChanged(DirectoryInfo workingDirectory, IKernelCommand command = null)
             : base(command)
         {
             WorkingDirectory = workingDirectory;

--- a/src/Microsoft.DotNet.Interactive/Events/WorkingDirectoryChanged.cs
+++ b/src/Microsoft.DotNet.Interactive/Events/WorkingDirectoryChanged.cs
@@ -1,15 +1,16 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
 using Microsoft.DotNet.Interactive.Commands;
 
 namespace Microsoft.DotNet.Interactive.Events
 {
     public class WorkingDirectoryChanged : KernelEventBase
     {
-        public string WorkingDirectory { get; }
+        public DirectoryInfo WorkingDirectory { get; }
 
-        public WorkingDirectoryChanged(IKernelCommand command, string workingDirectory)
+        public WorkingDirectoryChanged(IKernelCommand command, DirectoryInfo workingDirectory)
             : base(command)
         {
             WorkingDirectory = workingDirectory;

--- a/src/Microsoft.DotNet.Interactive/Events/WorkingDirectoryChanged.cs
+++ b/src/Microsoft.DotNet.Interactive/Events/WorkingDirectoryChanged.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.Interactive.Commands;
+
+namespace Microsoft.DotNet.Interactive.Events
+{
+    public class WorkingDirectoryChanged : KernelEventBase
+    {
+        public string WorkingDirectory { get; }
+
+        public WorkingDirectoryChanged(IKernelCommand command, string workingDirectory)
+            : base(command)
+        {
+            WorkingDirectory = workingDirectory;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Interactive/KernelBase.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelBase.cs
@@ -385,7 +385,7 @@ namespace Microsoft.DotNet.Interactive
                             cwd.Handler = (_, _) =>
                             {
                                 Directory.SetCurrentDirectory(cwd.WorkingDirectory.FullName);
-                                context.Publish(new WorkingDirectoryChanged(cwd, cwd.WorkingDirectory));
+                                context.Publish(new WorkingDirectoryChanged(cwd.WorkingDirectory, cwd));
                                 return Task.CompletedTask;
                             };
                             break;

--- a/src/Microsoft.DotNet.Interactive/KernelBase.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelBase.cs
@@ -384,7 +384,7 @@ namespace Microsoft.DotNet.Interactive
                         case ChangeWorkingDirectory cwd:
                             cwd.Handler = (_, _) =>
                             {
-                                Directory.SetCurrentDirectory(cwd.WorkingDirectory);
+                                Directory.SetCurrentDirectory(cwd.WorkingDirectory.FullName);
                                 context.Publish(new WorkingDirectoryChanged(cwd, cwd.WorkingDirectory));
                                 return Task.CompletedTask;
                             };

--- a/src/Microsoft.DotNet.Interactive/KernelBase.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.CommandLine;
+using System.IO;
 using System.Linq;
 using System.Reactive;
 using System.Reactive.Disposables;
@@ -375,6 +376,17 @@ namespace Microsoft.DotNet.Interactive
                             requestCompletion.Handler = (_, invocationContext) =>
                             {
                                 return HandleRequestCompletion(requestCompletion, invocationContext);
+                            };
+                            break;
+
+                        // process management
+
+                        case ChangeWorkingDirectory cwd:
+                            cwd.Handler = (_, _) =>
+                            {
+                                Directory.SetCurrentDirectory(cwd.WorkingDirectory);
+                                context.Publish(new WorkingDirectoryChanged(cwd, cwd.WorkingDirectory));
+                                return Task.CompletedTask;
                             };
                             break;
 

--- a/src/Microsoft.DotNet.Interactive/Server/KernelCommandEnvelope.cs
+++ b/src/Microsoft.DotNet.Interactive/Server/KernelCommandEnvelope.cs
@@ -27,6 +27,7 @@ namespace Microsoft.DotNet.Interactive.Server
             {
                 [nameof(AddPackage)] = typeof(KernelCommandEnvelope<AddPackage>),
                 [nameof(CancelCurrentCommand)] = typeof(KernelCommandEnvelope<CancelCurrentCommand>),
+                [nameof(ChangeWorkingDirectory)] = typeof(KernelCommandEnvelope<ChangeWorkingDirectory>),
                 [nameof(DisplayError)] = typeof(KernelCommandEnvelope<DisplayError>),
                 [nameof(DisplayValue)] = typeof(KernelCommandEnvelope<DisplayValue>),
                 [nameof(RequestCompletion)] = typeof(KernelCommandEnvelope<RequestCompletion>),

--- a/src/Microsoft.DotNet.Interactive/Server/KernelEventEnvelope.cs
+++ b/src/Microsoft.DotNet.Interactive/Server/KernelEventEnvelope.cs
@@ -43,6 +43,7 @@ namespace Microsoft.DotNet.Interactive.Server
                 [nameof(ReturnValueProduced)] = typeof(KernelEventEnvelope<ReturnValueProduced>),
                 [nameof(StandardErrorValueProduced)] = typeof(KernelEventEnvelope<StandardErrorValueProduced>),
                 [nameof(StandardOutputValueProduced)] = typeof(KernelEventEnvelope<StandardOutputValueProduced>),
+                [nameof(WorkingDirectoryChanged)] = typeof(KernelEventEnvelope<WorkingDirectoryChanged>),
             };
 
             _eventTypesByEventTypeName = _envelopeTypesByEventTypeName

--- a/src/dotnet-interactive-vscode/src/contracts.ts
+++ b/src/dotnet-interactive-vscode/src/contracts.ts
@@ -2,6 +2,7 @@
 
 export const AddPackageType = "AddPackage";
 export const CancelCurrentCommandType = "CancelCurrentCommand";
+export const ChangeWorkingDirectoryType = "ChangeWorkingDirectory";
 export const DisplayErrorType = "DisplayError";
 export const DisplayValueType = "DisplayValue";
 export const RequestCompletionType = "RequestCompletion";
@@ -13,6 +14,7 @@ export const UpdateDisplayedValueType = "UpdateDisplayedValue";
 export type KernelCommandType =
       typeof AddPackageType
     | typeof CancelCurrentCommandType
+    | typeof ChangeWorkingDirectoryType
     | typeof DisplayErrorType
     | typeof DisplayValueType
     | typeof RequestCompletionType
@@ -36,6 +38,10 @@ export interface PackageReference {
 }
 
 export interface CancelCurrentCommand extends KernelCommand {
+}
+
+export interface ChangeWorkingDirectory extends KernelCommand {
+    workingDirectory: string;
 }
 
 export interface DisplayError extends KernelCommand {
@@ -105,6 +111,7 @@ export const PasswordRequestedType = "PasswordRequested";
 export const ReturnValueProducedType = "ReturnValueProduced";
 export const StandardErrorValueProducedType = "StandardErrorValueProduced";
 export const StandardOutputValueProducedType = "StandardOutputValueProduced";
+export const WorkingDirectoryChangedType = "WorkingDirectoryChanged";
 
 export type KernelEventType =
       typeof CodeSubmissionReceivedType
@@ -124,7 +131,8 @@ export type KernelEventType =
     | typeof PasswordRequestedType
     | typeof ReturnValueProducedType
     | typeof StandardErrorValueProducedType
-    | typeof StandardOutputValueProducedType;
+    | typeof StandardOutputValueProducedType
+    | typeof WorkingDirectoryChangedType;
 
 export interface CodeSubmissionReceived extends KernelEvent {
     code: string;
@@ -222,6 +230,10 @@ export interface StandardErrorValueProduced extends DisplayEventBase {
 }
 
 export interface StandardOutputValueProduced extends DisplayEventBase {
+}
+
+export interface WorkingDirectoryChanged extends KernelEvent {
+    workingDirectory: string;
 }
 
 export interface KernelEventEnvelope {

--- a/src/dotnet-interactive-vscode/src/interactiveClient.ts
+++ b/src/dotnet-interactive-vscode/src/interactiveClient.ts
@@ -1,4 +1,6 @@
 import {
+    ChangeWorkingDirectory,
+    ChangeWorkingDirectoryType,
     CommandFailed,
     CommandFailedType,
     CommandHandledType,
@@ -23,11 +25,12 @@ import {
     RequestHoverTextType,
     ReturnValueProducedType,
     StandardErrorValueProducedType,
-    StandardOutputValueProduced,
     StandardOutputValueProducedType,
     SubmissionType,
     SubmitCode,
     SubmitCodeType,
+    WorkingDirectoryChanged,
+    WorkingDirectoryChangedType,
 } from './contracts';
 import { CellOutput, CellErrorOutput, CellOutputKind, CellStreamOutput, CellDisplayOutput } from './interfaces/vscode';
 
@@ -119,6 +122,13 @@ export class InteractiveClient {
                 }
             }, token);
         });
+    }
+
+    changeWorkingDirectory(workingDirectory: string, token?: string | undefined): Promise<WorkingDirectoryChanged> {
+        let command: ChangeWorkingDirectory = {
+            workingDirectory
+        };
+        return this.submitCommandAndGetResult<WorkingDirectoryChanged>(command, ChangeWorkingDirectoryType, WorkingDirectoryChangedType, token);
     }
 
     completion(language: string, code: string, line: number, character: number, token?: string | undefined): Promise<CompletionRequestCompleted> {

--- a/src/dotnet-interactive-vscode/src/interactiveClient.ts
+++ b/src/dotnet-interactive-vscode/src/interactiveClient.ts
@@ -63,7 +63,7 @@ export class InteractiveClient {
                             outputs.push(output);
                             observer(outputs);
                             disposable.dispose(); // is this correct?
-                            reject();
+                            reject(err);
                         }
                         break;
                     case StandardErrorValueProducedType:
@@ -178,11 +178,18 @@ export class InteractiveClient {
             let disposable = this.subscribeToKernelTokenEvents(token, eventEnvelope => {
                 switch (eventEnvelope.eventType) {
                     case CommandFailedType:
+                        if (!handled) {
+                            handled = true;
+                            disposable.dispose();
+                            let err = <CommandFailed>eventEnvelope.event;
+                            reject(err);
+                        }
+                        break;
                     case CommandHandledType:
                         if (!handled) {
                             handled = true;
                             disposable.dispose();
-                            reject();
+                            reject('Command was handled before reporting expected result.');
                         }
                         break;
                     default:

--- a/src/dotnet-interactive-vscode/src/vscode/notebookProvider.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/notebookProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { ClientMapper } from './../clientMapper';
 import { NotebookFile, parseNotebook, serializeNotebook, editorLanguages } from '../interactiveNotebook';
 import { RawNotebookCell } from '../interfaces';
@@ -31,7 +32,10 @@ export class DotNetInteractiveNotebookContentProvider implements vscode.Notebook
                 break;
         }
 
-        this.clientMapper.getOrAddClient(uri);
+        let client = this.clientMapper.getOrAddClient(uri);
+        let notebookPath = path.dirname(uri.fsPath);
+        client.changeWorkingDirectory(notebookPath);
+
         let notebookData: vscode.NotebookData = {
             languages: editorLanguages,
             metadata: {
@@ -39,6 +43,7 @@ export class DotNetInteractiveNotebookContentProvider implements vscode.Notebook
             },
             cells: notebook.cells.map(toNotebookCellData)
         };
+
         return notebookData;
     }
 

--- a/src/dotnet-interactive-vscode/src/vscode/notebookProvider.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/notebookProvider.ts
@@ -34,8 +34,13 @@ export class DotNetInteractiveNotebookContentProvider implements vscode.Notebook
 
         let client = this.clientMapper.getOrAddClient(uri);
         let notebookPath = path.dirname(uri.fsPath);
-        client.changeWorkingDirectory(notebookPath).catch(() => {
-            vscode.window.showInformationMessage(`Unable to set notebook working directory to '${notebookPath}'.`);
+        client.changeWorkingDirectory(notebookPath).catch((err) => {
+            let message = `Unable to set notebook working directory to '${notebookPath}'.`;
+            if (err && err.message) {
+                message += '\r\n' + err.message.toString();
+            }
+
+            vscode.window.showInformationMessage(message);
         });
 
         let notebookData: vscode.NotebookData = {

--- a/src/dotnet-interactive-vscode/src/vscode/notebookProvider.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/notebookProvider.ts
@@ -37,7 +37,7 @@ export class DotNetInteractiveNotebookContentProvider implements vscode.Notebook
         client.changeWorkingDirectory(notebookPath).catch((err) => {
             let message = `Unable to set notebook working directory to '${notebookPath}'.`;
             if (err && err.message) {
-                message += '\r\n' + err.message.toString();
+                message += '\n' + err.message.toString();
             }
 
             vscode.window.showInformationMessage(message);

--- a/src/dotnet-interactive-vscode/src/vscode/notebookProvider.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/notebookProvider.ts
@@ -34,7 +34,9 @@ export class DotNetInteractiveNotebookContentProvider implements vscode.Notebook
 
         let client = this.clientMapper.getOrAddClient(uri);
         let notebookPath = path.dirname(uri.fsPath);
-        client.changeWorkingDirectory(notebookPath);
+        client.changeWorkingDirectory(notebookPath).catch(() => {
+            vscode.window.showInformationMessage(`Unable to set notebook working directory to '${notebookPath}'.`);
+        });
 
         let notebookData: vscode.NotebookData = {
             languages: editorLanguages,


### PR DESCRIPTION
This is useful for VS Code notebooks that do any local file IO; it's a reasonable assumption that file access will be performed relative to the notebook file.  I found this issue trying to port the HousingML notebook, and I noticed that downloading the CSV didn't place the file where I'd hoped/expected.

As for testing from the kernel, we can't really unit test this because either it works or it doesn't and we can't pollute the current test environment; it'll destroy everything else.  Testing from the notebook also doesn't make much sense, because we can simply fire-and-forget the command.  If it worked, it worked; if it failed, it failed, and there's nothing actionable the user can do about it.

We also can't start the stdio server in the notebook directory, because to get the local tool scenario to work, the initial working directory has to be in the extensions global storage location.

The only other possibility I can think of would be to launch with arguments like the following:

`dotnet interactive stdio --working-directory C:\directory\that\contains\notebooks`

I'm certainly open to doing that, but it seemed more useful to have the possibility of changing the working directory multiple times during notebook execution.

If we merge this I'll have to come back later and update the min required tool version where this command/event pair exist.