### PR TITLE
enable argument templates and parsing

### DIFF
--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -48,10 +48,22 @@
     "configuration": {
       "title": ".NET Interactive Notebook",
       "properties": {
-        "dotnet-interactive.kernelTransportArgsOverride": {
+        "dotnet-interactive.kernelTransportArgs": {
           "type": "array",
-          "default": [],
-          "description": "Override command line arguments passed to start an interactive session."
+          "default": [
+            "{dotnet_path}",
+            "tool",
+            "run",
+            "dotnet-interactive",
+            "--",
+            "stdio"
+          ],
+          "description": "Command and arguments used to start a notebook session."
+        },
+        "dotnet-interactive.kernelTransportWorkingDirectory": {
+          "type": "string",
+          "default": "{global_storage_path}",
+          "description": "The working directory in which the kernel transport process is started."
         },
         "dotnet-interactive.interactiveToolSource": {
           "type": "string",

--- a/src/dotnet-interactive-vscode/src/interfaces.ts
+++ b/src/dotnet-interactive-vscode/src/interfaces.ts
@@ -2,6 +2,12 @@ export interface IsValidToolVersion {
     (actualVersion: string, minSupportedVersion: string): boolean;
 }
 
+export interface ProcessStart {
+    command: string;
+    args: Array<string>;
+    workingDirectory: string;
+}
+
 export interface RawNotebookCell {
     language: string;
     contents: Array<string>;

--- a/src/dotnet-interactive-vscode/src/stdioKernelTransport.ts
+++ b/src/dotnet-interactive-vscode/src/stdioKernelTransport.ts
@@ -1,13 +1,14 @@
 import * as cp from 'child_process';
 import { DisposableSubscription, KernelCommand, KernelCommandType, KernelEventEnvelope, KernelEventEnvelopeObserver } from "./contracts";
+import { ProcessStart } from './interfaces';
 
 export class StdioKernelTransport {
     private buffer: string = '';
     private childProcess: cp.ChildProcessWithoutNullStreams;
     private subscribers: Array<KernelEventEnvelopeObserver> = [];
 
-    constructor(command: string, args: Array<string>, workingDirectory?: string | undefined) {
-        this.childProcess = cp.spawn(command, args, { cwd: workingDirectory });
+    constructor(processStart: ProcessStart) {
+        this.childProcess = cp.spawn(processStart.command, processStart.args, { cwd: processStart.workingDirectory });
         this.childProcess.on('exit', (_code: number, _signal: string) => {
             //
             let x = 1;

--- a/src/dotnet-interactive-vscode/src/tests/integration/suite/extension.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/integration/suite/extension.test.ts
@@ -7,7 +7,15 @@ import { CellOutput, CellOutputKind } from '../../../interfaces/vscode';
 
 suite('Extension Test Suite', () => {
     test('Execute against real kernel', async () => {
-        let clientMapper = new ClientMapper(() => new StdioKernelTransport('dotnet', ['interactive', 'stdio']));
+        let processStart = {
+            command: 'dotnet',
+            args: [
+                'interactive',
+                'stdio'
+            ],
+            workingDirectory: __dirname
+        };
+        let clientMapper = new ClientMapper(() => new StdioKernelTransport(processStart));
         let client = clientMapper.getOrAddClient({ path: 'some/path' });
         let code = '1+1';
         let result: Array<CellOutput> = [];

--- a/src/dotnet-interactive-vscode/src/tests/unit/misc.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/misc.test.ts
@@ -1,0 +1,31 @@
+import { expect } from 'chai';
+
+import { processArguments } from '../../utilities';
+
+describe('Miscellaneous tests', () => {
+    it(`verify command and argument replacement is as expected`, () => {
+        let template = {
+            args: [
+                '{dotnet_path}',
+                'tool',
+                'run',
+                'dotnet-interactive',
+                '--',
+                'stdio'
+            ],
+            workingDirectory: '{global_storage_path}'
+        };
+        let actual = processArguments(template, 'replacement-dotnet-path', 'replacement-global-storage-path');
+        expect(actual).to.deep.equal({
+            command: 'replacement-dotnet-path',
+            args: [
+                'tool',
+                'run',
+                'dotnet-interactive',
+                '--',
+                'stdio'
+            ],
+            workingDirectory: 'replacement-global-storage-path'
+        });
+    });
+});

--- a/src/dotnet-interactive-vscode/src/utilities.ts
+++ b/src/dotnet-interactive-vscode/src/utilities.ts
@@ -1,3 +1,28 @@
+import { ProcessStart } from "./interfaces";
+
+export function processArguments(template: { args: Array<string>, workingDirectory: string }, dotnetPath: string, globalStoragePath: string): ProcessStart {
+    let map: { [key: string]: string } = {
+        'dotnet_path': dotnetPath,
+        'global_storage_path': globalStoragePath
+    };
+    let processed = template.args.map(a => performReplacement(a, map));
+    return {
+        command: processed[0],
+        args: [...processed.slice(1)],
+        workingDirectory: performReplacement(template.workingDirectory, map)
+    };
+}
+
+function performReplacement(template: string, map: { [key: string]: string }): string {
+    let result = template;
+    for (let key in map) {
+        let fullKey = `{${key}}`;
+        result = result.replace(fullKey, map[key]);
+    }
+
+    return result;
+}
+
 export function trimTrailingCarriageReturn(value: string): string {
     if (value.endsWith('\r')) {
         return value.substr(0, value.length - 1);


### PR DESCRIPTION
Modify the interactive tool starting to mimic Jupyter with known placeholder values.  This way it's possible for a user to fully override the launching of a notebook in their personal settings to be something like:

``` js
//...
"dotnet-interactive.kernelTransportArgs": [
    "MyCustomApp.exe", // or this could even be the path to a very specific version of `dotnet.exe` that they want to use
    "/startAsInteractiveServer",
    "/someOtherOption"
],
"dotnet-interactive.kernelTransportWorkingDirectory": "C:/Users/brettfo/Desktop"
//...
```

The current set of known argument replacements are `{dotnet_path}` and `{global_storage_location}`.  The shape of the `processArguments()` function ensures we can't add argument replacements that won't be honored everywhere.