### PR TITLE
don't crash the kernel server if a command wasn't found

### DIFF
--- a/src/Microsoft.DotNet.Interactive/Server/CommandNotFoundException.cs
+++ b/src/Microsoft.DotNet.Interactive/Server/CommandNotFoundException.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.DotNet.Interactive.Server
+{
+    public class CommandNotFoundException : Exception
+    {
+        public string CommandName { get; }
+
+        public CommandNotFoundException(string commandName)
+        {
+            CommandName = commandName;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Interactive/Server/KernelCommandEnvelope.cs
+++ b/src/Microsoft.DotNet.Interactive/Server/KernelCommandEnvelope.cs
@@ -43,7 +43,15 @@ namespace Microsoft.DotNet.Interactive.Server
                     pair => pair.Value.GetGenericArguments()[0]);
         }
 
-        internal static Type CommandTypeByName(string name) => _commandTypesByCommandTypeName[name];
+        internal static Type CommandTypeByName(string name)
+        {
+            if (!_commandTypesByCommandTypeName.TryGetValue(name, out var commandType))
+            {
+                throw new CommandNotFoundException(name);
+            }
+
+            return commandType;
+        }
 
         private readonly IKernelCommand _command;
 

--- a/src/Microsoft.DotNet.Interactive/Server/Serializer.cs
+++ b/src/Microsoft.DotNet.Interactive/Server/Serializer.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.DotNet.Interactive.Server
 {
-    internal static class Serializer
+    public static class Serializer
     {
         public static readonly JsonSerializerSettings JsonSerializerSettings;
 

--- a/src/Microsoft.DotNet.Interactive/Server/StandardIOKernelServer.cs
+++ b/src/Microsoft.DotNet.Interactive/Server/StandardIOKernelServer.cs
@@ -58,6 +58,11 @@ namespace Microsoft.DotNet.Interactive.Server
             {
                 streamKernelCommand = KernelCommandEnvelope.Deserialize(line);
             }
+            catch (CommandNotFoundException ex)
+            {
+                WriteEventToOutput(new DiagnosticLogEntryProduced($"Command '{ex.CommandName}' not found."));
+                return;
+            }
             catch (JsonReaderException ex)
             {
                 WriteEventToOutput(


### PR DESCRIPTION
While testing I discovered that submitting a command to the kernel that doesn't exist results in a crash which shouldn't happen.  This fixes that behavior by throwing a very specific exception when a command doesn't exist and returns a diagnostic event.

I verified this in VS Code by submitting a command that doesn't exist and verifying that the server remained active and subsequent (valid) commands were honored.