### PR TITLE
fall back to myget feed

### DIFF
--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -68,7 +68,7 @@
         },
         "dotnet-interactive.interactiveToolSource": {
           "type": "string",
-          "default": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json",
+          "default": "https://dotnet.myget.org/F/dotnet-try/api/v3/index.json",
           "description": "The NuGet source to use when acquiring the .NET Interactive tool."
         },
         "dotnet-interactive.minimumDotNetSdkVersion": {
@@ -78,7 +78,7 @@
         },
         "dotnet-interactive.minimumInteractiveToolVersion": {
           "type": "string",
-          "default": "1.0.126201",
+          "default": "1.0.126504",
           "description": "The minimum required version of the .NET Interactive tool."
         }
       }


### PR DESCRIPTION
The internal package feed is currently having issues so we're falling back to the myget tool feed.  Also updating the tool to one that doesn't crash when you try to change the working directory.