### PR TITLE
move jupyter integration to be an explicit conversion step

### DIFF
--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -25,6 +25,7 @@
   "activationEvents": [
     "onNotebookEditor:dotnet-interactive",
     "onCommand:dotnet-interactive.acquire",
+    "onCommand:dotnet-interactive.convertJupyterNotebook",
     "onCommand:dotnet-interactive.reportInteractiveVersion"
   ],
   "main": "./out/extension.js",
@@ -39,9 +40,6 @@
         "selector": [
           {
             "filenamePattern": "*.dotnet-interactive"
-          },
-          {
-            "filenamePattern": "*.ipynb"
           }
         ]
       }
@@ -92,7 +90,11 @@
       },
       {
         "command": "dotnet-interactive.reportInteractiveVersion",
-        "title": "Report installed version for .NET Interactive"
+        "title": ".NET Interactive: Report installed version of .NET Interactive"
+      },
+      {
+        "command": "dotnet-interactive.convertJupyterNotebook",
+        "title": ".NET Interactive: Convert Jupyter notebook (.ipynb) to .NET Interactive notebook"
       },
       {
         "command": "dotnet-interactive.exportAsJupyterNotebook",


### PR DESCRIPTION
Removes the `.ipynb` file association.  This is good because we don't want to accidentally stomp on an existing Jupyter notebook.  Instead, the user explicitly invokes the convert command that will write out a new `.dotnet-interactive` file which then can then use as normal.  There is an existing command to export as a Jupyter notebook to complete the cycle.