### PR TITLE
temporarily turn off git sha appending

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -136,7 +136,7 @@ stages:
             filePath: $(Build.SourcesDirectory)/eng/package/PackVSCodeExtension.ps1
             arguments: -stableToolVersionNumber $(StableToolVersionNumber) -gitSha $(Build.SourceVersion) -outDir "$(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)"
             workingDirectory: "$(Build.SourcesDirectory)/src/dotnet-interactive-vscode"
-            pwsh: true
+            #pwsh: true # temporarily turned off due to https://github.com/dotnet/core-eng/issues/9913
 
         # Prevent symbols packages from being saved in the following `packages` artifact because they're incomplete.
         # See `eng/AfterSolutionBuild.targets:StripFilesFromSymbolPackages` for details.

--- a/eng/package/PackVSCodeExtension.ps1
+++ b/eng/package/PackVSCodeExtension.ps1
@@ -18,7 +18,9 @@ try {
     Write-Host "Appending git sha to description in $packageJsonPath"
     $packageJsonContents = (Get-Content $packageJsonPath | Out-String | ConvertFrom-Json)
     $packageJsonContents.description += "  Git SHA $gitSha"
-    $packageJsonContents | ConvertTo-Json -depth 100 | Out-File $packageJsonPath
+    # writing back changes temporarily disabled until internal machines have access to pwsh.exe
+    # see https://github.com/dotnet/core-eng/issues/9913
+    #$packageJsonContents | ConvertTo-Json -depth 100 | Out-File $packageJsonPath
 
     # pack
     Write-Host "Packing extension"


### PR DESCRIPTION
The build step to append the git SHA on the VS Code package depends on PowerShell Core (`pwsh.exe`) but that's currently unavailable on the official build machines.  This PR temporarily removes that functionality until the machine image is updated, or we have guidance on what to do next.