### PR TITLE
don't return the notebook data until it's ready for execution

### DIFF
--- a/src/dotnet-interactive-vscode/src/clientMapper.ts
+++ b/src/dotnet-interactive-vscode/src/clientMapper.ts
@@ -8,18 +8,19 @@ import { Uri } from "./interfaces/vscode";
 export class ClientMapper {
     private clientMap: Map<string, InteractiveClient> = new Map();
 
-    constructor(readonly kernelTransportCreator: {(notebookPath: string): KernelTransport}) {
+    constructor(readonly kernelTransportCreator: {(notebookPath: string): Promise<KernelTransport>}) {
     }
 
     static keyFromUri(uri: Uri): string {
         return uri.fsPath;
     }
 
-    getOrAddClient(uri: Uri): InteractiveClient {
+    async getOrAddClient(uri: Uri): Promise<InteractiveClient> {
         let key = ClientMapper.keyFromUri(uri);
         let client = this.clientMap.get(key);
         if (client === undefined) {
-            client = new InteractiveClient(this.kernelTransportCreator(uri.fsPath));
+            let kernelTransport = await this.kernelTransportCreator(uri.fsPath);
+            client = new InteractiveClient(kernelTransport);
             this.clientMap.set(key, client);
         }
 

--- a/src/dotnet-interactive-vscode/src/extension.ts
+++ b/src/dotnet-interactive-vscode/src/extension.ts
@@ -51,7 +51,7 @@ export async function activate(context: vscode.ExtensionContext) {
     let processStart = processArguments(argsTemplate, dotnetPath, launchOptions!.workingDirectory);
 
     // register with VS Code
-    const clientMapper = new ClientMapper(notebookPath => new StdioKernelTransport(processStart, notebookPath, diagnosticsChannel));
+    const clientMapper = new ClientMapper(notebookPath => StdioKernelTransport.create(processStart, notebookPath, diagnosticsChannel));
 
     registerKernelCommands(context, clientMapper);
     registerInteropCommands(context);

--- a/src/dotnet-interactive-vscode/src/languageServices/completion.ts
+++ b/src/dotnet-interactive-vscode/src/languageServices/completion.ts
@@ -7,7 +7,7 @@ import { PositionLike } from './interfaces';
 import { Document } from '../interfaces/vscode';
 
 export async function provideCompletion(clientMapper: ClientMapper, language: string, document: Document, position: PositionLike, token?: string | undefined): Promise<Array<CompletionItem>> {
-    let client = clientMapper.getOrAddClient(document.uri);
+    let client = await clientMapper.getOrAddClient(document.uri);
     let completion = await client.completion(language, document.getText(), position.line, position.character, token);
     let completionItems = completion.completionList;
     return completionItems;

--- a/src/dotnet-interactive-vscode/src/languageServices/hover.ts
+++ b/src/dotnet-interactive-vscode/src/languageServices/hover.ts
@@ -6,7 +6,7 @@ import { HoverResult, PositionLike } from './interfaces';
 import { Document } from '../interfaces/vscode';
 
 export async function provideHover(clientMapper: ClientMapper, language: string, document: Document, position: PositionLike, token?: string | undefined): Promise<HoverResult> {
-    let client = clientMapper.getOrAddClient(document.uri);
+    let client = await clientMapper.getOrAddClient(document.uri);
     let hoverText = await client.hover(language, document.getText(), position.line, position.character, token);
     let content = hoverText.content.sort((a, b) => mimeTypeToPriority(a.mimeType) - mimeTypeToPriority(b.mimeType))[0];
     let hoverResult = {

--- a/src/dotnet-interactive-vscode/src/stdioKernelTransport.ts
+++ b/src/dotnet-interactive-vscode/src/stdioKernelTransport.ts
@@ -73,7 +73,7 @@ export class StdioKernelTransport {
                             let failed = <CommandFailed>envelope.event;
                             let message = `Unable to set notebook working directory to '${notebookPath}'.\n${failed.message}`;
                             diagnosticChannel.appendLine(message);
-                            reject();
+                            resolve(kernelTransport);
                             disposable.dispose();
                             break;
                         case CommandHandledType:

--- a/src/dotnet-interactive-vscode/src/stdioKernelTransport.ts
+++ b/src/dotnet-interactive-vscode/src/stdioKernelTransport.ts
@@ -24,7 +24,7 @@ export class StdioKernelTransport {
     private childProcess: cp.ChildProcessWithoutNullStreams;
     private subscribers: Array<KernelEventEnvelopeObserver> = [];
 
-    constructor(processStart: ProcessStart, notebookPath: string, private diagnosticChannel: ReportChannel) {
+    private constructor(processStart: ProcessStart, notebookPath: string, private diagnosticChannel: ReportChannel) {
         this.childProcess = cp.spawn(processStart.command, processStart.args, { cwd: processStart.workingDirectory });
         this.diagnosticChannel.appendLine(`Kernel started with pid ${this.childProcess.pid}.`);
         this.childProcess.on('exit', (code: number, _signal: string) => {
@@ -58,29 +58,36 @@ export class StdioKernelTransport {
                 }
             }
         });
+    }
 
-        // set the working directory to be next to the notebook; this allows relative file access to work as expected
-        // immediately clean up afterwards because we'll never do this again
-        let token = 'change-working-directory-token';
-        let disposable = this.subscribeToKernelEvents(envelope => {
-            if (envelope.command?.token === token) {
-                switch (envelope.eventType) {
-                    case CommandFailedType:
-                        let failed = <CommandFailed>envelope.event;
-                        let message = `Unable to set notebook working directory to '${notebookPath}'.\n${failed.message}`;
-                        diagnosticChannel.appendLine(message);
-                        disposable.dispose();
-                        break;
-                    case CommandHandledType:
-                        disposable.dispose();
-                        break;
+    static create(processStart: ProcessStart, notebookPath: string, diagnosticChannel: ReportChannel): Promise<StdioKernelTransport> {
+        return new Promise<StdioKernelTransport>((resolve, reject) => {
+            let kernelTransport = new StdioKernelTransport(processStart, notebookPath, diagnosticChannel);
+            // set the working directory to be next to the notebook; this allows relative file access to work as expected
+            // immediately clean up afterwards because we'll never do this again
+            let token = 'change-working-directory-token';
+            let disposable = kernelTransport.subscribeToKernelEvents(envelope => {
+                if (envelope.command?.token === token) {
+                    switch (envelope.eventType) {
+                        case CommandFailedType:
+                            let failed = <CommandFailed>envelope.event;
+                            let message = `Unable to set notebook working directory to '${notebookPath}'.\n${failed.message}`;
+                            diagnosticChannel.appendLine(message);
+                            reject();
+                            disposable.dispose();
+                            break;
+                        case CommandHandledType:
+                            resolve(kernelTransport);
+                            disposable.dispose();
+                            break;
+                    }
                 }
-            }
+            });
+            let command: ChangeWorkingDirectory = {
+                workingDirectory: path.dirname(notebookPath)
+            };
+            kernelTransport.submitCommand(command, 'ChangeWorkingDirectory', token);
         });
-        let command: ChangeWorkingDirectory = {
-            workingDirectory: path.dirname(notebookPath)
-        };
-        this.submitCommand(command, 'ChangeWorkingDirectory', token);
     }
 
     subscribeToKernelEvents(observer: KernelEventEnvelopeObserver): DisposableSubscription {

--- a/src/dotnet-interactive-vscode/src/tests/unit/client.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/client.test.ts
@@ -12,7 +12,7 @@ describe('InteractiveClient tests', () => {
     it('command execution returns deferred events', async () => {
         let token = 'test-token';
         let code = '1 + 1';
-        let clientMapper = new ClientMapper(() => new TestKernelTransport({
+        let clientMapper = new ClientMapper(() => TestKernelTransport.create({
             'SubmitCode': [
                 {
                     // deferred event; unassociated with the original submission; has its own token
@@ -64,7 +64,7 @@ describe('InteractiveClient tests', () => {
                 }
             ]
         }));
-        let client = clientMapper.getOrAddClient({ fsPath: 'test/path' });
+        let client = await clientMapper.getOrAddClient({ fsPath: 'test/path' });
         let result: Array<CellOutput> = [];
         await client.execute(code, 'csharp', outputs => result = outputs, token);
         expect(result).to.deep.equal([
@@ -86,7 +86,7 @@ describe('InteractiveClient tests', () => {
     it('deferred events do not interfere with display update events', async () => {
         let token = 'test-token';
         let code = '1 + 1';
-        let clientMapper = new ClientMapper(() => new TestKernelTransport({
+        let clientMapper = new ClientMapper(() => TestKernelTransport.create({
             'SubmitCode': [
                 {
                     // deferred event; unassociated with the original submission; has its own token
@@ -138,7 +138,7 @@ describe('InteractiveClient tests', () => {
                 }
             ]
         }));
-        let client = clientMapper.getOrAddClient({ fsPath: 'test/path' });
+        let client = await clientMapper.getOrAddClient({ fsPath: 'test/path' });
         let result: Array<CellOutput> = [];
         await client.execute(code, 'csharp', outputs => result = outputs, token);
         expect(result).to.deep.equal([
@@ -160,7 +160,7 @@ describe('InteractiveClient tests', () => {
     it('interleaved deferred events do not interfere with display update events', async () => {
         let token = 'test-token';
         let code = '1 + 1';
-        let clientMapper = new ClientMapper(() => new TestKernelTransport({
+        let clientMapper = new ClientMapper(() => TestKernelTransport.create({
             'SubmitCode': [
                 {
                     // deferred event; unassociated with the original submission; has its own token
@@ -227,7 +227,7 @@ describe('InteractiveClient tests', () => {
                 }
             ]
         }));
-        let client = clientMapper.getOrAddClient({ fsPath: 'test/path' });
+        let client = await clientMapper.getOrAddClient({ fsPath: 'test/path' });
         let result: Array<CellOutput> = [];
         await client.execute(code, 'csharp', outputs => result = outputs, token);
         expect(result).to.deep.equal([

--- a/src/dotnet-interactive-vscode/src/tests/unit/languageProvider.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/languageProvider.test.ts
@@ -12,7 +12,7 @@ import { CommandHandledType, CompletionRequestCompletedType } from '../../contra
 describe('LanguageProvider tests', () => {
     it('CompletionProvider', async () => {
         let token = '123';
-        let clientMapper = new ClientMapper(() => new TestKernelTransport({
+        let clientMapper = new ClientMapper(() => TestKernelTransport.create({
             'RequestCompletion': [
                 {
                     eventType: CompletionRequestCompletedType,
@@ -65,7 +65,7 @@ describe('LanguageProvider tests', () => {
 
     it('HoverProvider', async () => {
         let token = '123';
-        let clientMapper = new ClientMapper(() => new TestKernelTransport({
+        let clientMapper = new ClientMapper(() => TestKernelTransport.create({
             'RequestHoverText': [
                 {
                     eventType: 'HoverTextProduced',

--- a/src/dotnet-interactive-vscode/src/tests/unit/notebook.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/notebook.test.ts
@@ -13,7 +13,7 @@ describe('Notebook tests', () => {
         it(`executes and returns expected value: ${language}`, async () => {
             let token = '123';
             let code = '1+1';
-            let clientMapper = new ClientMapper(() => new TestKernelTransport({
+            let clientMapper = new ClientMapper(() => TestKernelTransport.create({
                 'SubmitCode': [
                     {
                         eventType: CodeSubmissionReceivedType,
@@ -50,7 +50,7 @@ describe('Notebook tests', () => {
                     }
                 ]
             }));
-            let client = clientMapper.getOrAddClient({ fsPath: 'test/path' });
+            let client = await clientMapper.getOrAddClient({ fsPath: 'test/path' });
             let result: Array<CellOutput> = [];
             await client.execute(code, language, outputs => result = outputs, token);
             expect(result).to.deep.equal([
@@ -71,7 +71,7 @@ Console.WriteLine(1);
 Console.WriteLine(1);
 Console.WriteLine(1);
 `;
-        let clientMapper = new ClientMapper(() => new TestKernelTransport({
+        let clientMapper = new ClientMapper(() => TestKernelTransport.create({
             'SubmitCode': [
                 {
                     eventType: CodeSubmissionReceivedType,
@@ -136,7 +136,7 @@ Console.WriteLine(1);
                 }
             ]
         }));
-        let client = clientMapper.getOrAddClient({ fsPath: 'test/path' });
+        let client = await clientMapper.getOrAddClient({ fsPath: 'test/path' });
         let result: Array<CellOutput> = [];
         await client.execute(code, 'csharp', outputs => result = outputs, token);
         expect(result).to.deep.equal([
@@ -158,7 +158,7 @@ Console.WriteLine(1);
     it('updated values are replaced instead of added', async () => {
         let token = '123';
         let code = '#r nuget:Newtonsoft.Json';
-        let clientMapper = new ClientMapper(() => new TestKernelTransport({
+        let clientMapper = new ClientMapper(() => TestKernelTransport.create({
             'SubmitCode': [
                 {
                     eventType: CodeSubmissionReceivedType,
@@ -208,7 +208,7 @@ Console.WriteLine(1);
                 }
             ]
         }));
-        let client = clientMapper.getOrAddClient({ fsPath: 'test/path' });
+        let client = await clientMapper.getOrAddClient({ fsPath: 'test/path' });
         let result: Array<CellOutput> = [];
         await client.execute(code, 'csharp', outputs => result = outputs, token);
         expect(result).to.deep.equal([
@@ -230,7 +230,7 @@ Console.WriteLine(1);
     it('returned json is property parsed', async () => {
         let token = '123';
         let code = 'JObject.FromObject(new { a = 1, b = false })';
-        let clientMapper = new ClientMapper(() => new TestKernelTransport({
+        let clientMapper = new ClientMapper(() => TestKernelTransport.create({
             'SubmitCode': [
                 {
                     eventType: CodeSubmissionReceivedType,
@@ -267,7 +267,7 @@ Console.WriteLine(1);
                 }
             ]
         }));
-        let client = clientMapper.getOrAddClient({ fsPath: 'test/path' });
+        let client = await clientMapper.getOrAddClient({ fsPath: 'test/path' });
         let result: Array<CellOutput> = [];
         await client.execute(code, 'csharp', outputs => result = outputs, token);
         expect(result).to.deep.equal([

--- a/src/dotnet-interactive-vscode/src/tests/unit/testKernelTransport.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/testKernelTransport.ts
@@ -10,6 +10,13 @@ export class TestKernelTransport {
     constructor(readonly fakedEventEnvelopes: { [key: string]: {eventType: KernelEventType, event: any, token: string}[] }) {
     }
 
+    static create(fakedEventEnvelopes: { [key: string]: {eventType: KernelEventType, event: any, token: string}[] }): Promise<TestKernelTransport> {
+        return new Promise<TestKernelTransport>((resolve, reject) => {
+            let testTransport = new TestKernelTransport(fakedEventEnvelopes);
+            resolve(testTransport);
+        });
+    }
+
     subscribeToKernelEvents(observer: KernelEventEnvelopeObserver): DisposableSubscription {
         this.theObserver = observer;
         return {

--- a/src/dotnet-interactive-vscode/src/vscode/notebookProvider.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/notebookProvider.ts
@@ -32,7 +32,7 @@ export class DotNetInteractiveNotebookContentProvider implements vscode.Notebook
         }
 
         let notebook = parseNotebook(contents);
-        this.clientMapper.getOrAddClient(uri);
+        await this.clientMapper.getOrAddClient(uri);
 
         let notebookData: vscode.NotebookData = {
             languages: notebookCellLanguages,
@@ -55,14 +55,14 @@ export class DotNetInteractiveNotebookContentProvider implements vscode.Notebook
 
     onDidChangeNotebook: vscode.Event<vscode.NotebookDocumentEditEvent> = this.onDidChangeNotebookEventEmitter.event;
 
-    executeCell(document: vscode.NotebookDocument, cell: vscode.NotebookCell | undefined, token: vscode.CancellationToken): Promise<void> {
+    async executeCell(document: vscode.NotebookDocument, cell: vscode.NotebookCell | undefined, token: vscode.CancellationToken): Promise<void> {
         if (!cell) {
             // TODO: run everything
-            return new Promise((resolve, reject) => resolve());
+            return;
         }
 
         cell.outputs = [];
-        let client = this.clientMapper.getOrAddClient(document.uri);
+        let client = await this.clientMapper.getOrAddClient(document.uri);
         let source = cell.source.toString();
         return client.execute(source, getSimpleLanguage(cell.language), outputs => {
             // to properly trigger the UI update, `cell.outputs` needs to be uniquely assigned; simply setting it to the local variable has no effect


### PR DESCRIPTION
Previously, if notebook cells were executed too quickly they would fail because the deferred commands had not yet run which meant helper functions we inject, like `display()`, would fail to bind and all subsequent calls to those would fail.  The workaround was to restart the kernel and wait for a bit and hope you weren't too fast.

Since the stdio kernel transport always executes a ChangeWorkingDirectory command, that's enough to ensure the kernel is in a ready state, so the change was to turn `ClientMapper.getOrAddClient` to instead return a Promise; that way we can properly `await` the CWD.  Only on client creation is the `await` actually awaiting anything; all subsequent calls return immediately.

Since a constructor can't be async/Promise I made the .ctor private and added a static `create` method with the appropriate signature and moved the CWD invocation there.  The rest of the changes on this PR were simply to add `await` where necessary when calling `getOrAddClient`.