### PR TITLE
bring in extension publishing steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,9 +171,6 @@ DocProject/Help/*.hhp
 DocProject/Help/Html2
 DocProject/Help/html
 
-# Click-Once directory
-publish/
-
 # Publish Web Output
 *.[Pp]ublish.xml
 *.azurePubxml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -134,9 +134,16 @@ stages:
           displayName: Pack VS Code Extension
           inputs:
             filePath: $(Build.SourcesDirectory)/eng/package/PackVSCodeExtension.ps1
-            arguments: -stableToolVersionNumber $(StableToolVersionNumber) -gitSha $(Build.SourceVersion) -outDir "$(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)"
+            arguments: -stableToolVersionNumber $(StableToolVersionNumber) -gitSha $(Build.SourceVersion) -outDir "$(Build.ArtifactStagingDirectory)\vscode"
             workingDirectory: "$(Build.SourcesDirectory)/src/dotnet-interactive-vscode"
             #pwsh: true # temporarily turned off due to https://github.com/dotnet/core-eng/issues/9913
+
+        - task: PublishBuildArtifacts@1
+          displayName: Publish VSCode extension artifacts
+          inputs:
+            pathToPublish: $(Build.ArtifactStagingDirectory)\vscode
+            artifactName: vscode
+            artifactType: container
 
         # Prevent symbols packages from being saved in the following `packages` artifact because they're incomplete.
         # See `eng/AfterSolutionBuild.targets:StripFilesFromSymbolPackages` for details.

--- a/eng/package/PackVSCodeExtension.ps1
+++ b/eng/package/PackVSCodeExtension.ps1
@@ -22,6 +22,12 @@ try {
     # see https://github.com/dotnet/core-eng/issues/9913
     #$packageJsonContents | ConvertTo-Json -depth 100 | Out-File $packageJsonPath
 
+    # create destination
+    New-Item -Path $outDir -ItemType Directory
+
+    # copy publish scripts
+    Copy-Item -Path $PSScriptRoot\..\publish\* -Destination $outDir -Recurse
+
     # pack
     Write-Host "Packing extension"
     npx vsce package --out "$outDir\dotnet-interactive-vscode-$stableToolVersionNumber.vsix"

--- a/eng/publish/PublishVSCodeExtension.ps1
+++ b/eng/publish/PublishVSCodeExtension.ps1
@@ -1,0 +1,23 @@
+[CmdletBinding(PositionalBinding=$false)]
+param (
+    [string]$artifactsPath,
+    [string]$publishToken
+)
+
+Set-StrictMode -version 2.0
+$ErrorActionPreference = "Stop"
+
+try {
+    # find extension vsix
+    $extension = Get-ChildItem "$artifactsPath\dotnet-interactive-vscode-*.vsix" | Select-Object -First 1
+
+    # publish
+    npm install -g vsce
+    vsce publish --packagePath $extension --pat $publishToken --noVerify
+}
+catch {
+    Write-Host $_
+    Write-Host $_.Exception
+    Write-Host $_.ScriptStackTrace
+    exit 1
+}


### PR DESCRIPTION
Create separate build artifact container for VSCode extension containing the VSIX itself and all associated publishing scripts.  The publish script is what we're currently using to publish the extension, I just copy/pasted it from the internal definition, but I'd rather it be in source control so it's easier to reason about.  Once this is all done I'll update the actual internal publish definition to simply download the `vscode` artifact and call the script.

Once this is in we can start modifying the publish script to do things like ensure the required tool version is actually available on the specified package feed, else fail the publish.