### PR TITLE
allow DisplayedValueUpdated to update across submissions

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelFormattingTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelFormattingTests.cs
@@ -139,7 +139,7 @@ namespace Microsoft.DotNet.Interactive.Tests
                     v.Value.ToString().Contains("<b>world</b>"));
         }
 
-        [Theory(Timeout = 45000)]
+        [Theory]
         [InlineData(Language.CSharp)]
         [InlineData(Language.FSharp)]
         public async Task Displayed_value_can_be_updated_from_later_submissions(Language language)
@@ -153,19 +153,16 @@ namespace Microsoft.DotNet.Interactive.Tests
             };
 
             await kernel.SubmitCodeAsync(submissions[0]);
-            await kernel.SubmitCodeAsync(submissions[1]);
 
-            KernelEvents
-                .OfType<DisplayedValueProduced>()
-                .SelectMany(v => v.FormattedValues)
+            var updateCommandResult = await kernel.SubmitCodeAsync(submissions[1]);
+
+            updateCommandResult
+                .KernelEvents
+                .ToSubscribedList()
                 .Should()
-                .ContainSingle(v =>
-                    v.MimeType == "text/html" &&
-                    v.Value.ToString().Contains("<b>hello</b>"));
-
-            KernelEvents
-                .OfType<DisplayedValueUpdated>()
-                .SelectMany(v => v.FormattedValues)
+                .ContainSingle<DisplayedValueUpdated>()
+                .Which
+                .FormattedValues
                 .Should()
                 .ContainSingle(v =>
                     v.MimeType == "text/html" &&

--- a/src/Microsoft.DotNet.Interactive/Events/DisplayedValue.cs
+++ b/src/Microsoft.DotNet.Interactive/Events/DisplayedValue.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Formatting;
 
 namespace Microsoft.DotNet.Interactive.Events
@@ -10,7 +11,7 @@ namespace Microsoft.DotNet.Interactive.Events
     {
         private readonly string _displayId;
         private readonly string _mimeType;
-        private readonly KernelInvocationContext _context;
+        private KernelInvocationContext _context;
 
         public DisplayedValue(string displayId, string mimeType, KernelInvocationContext context)
         {
@@ -34,6 +35,11 @@ namespace Microsoft.DotNet.Interactive.Events
             var formatted = new FormattedValue(
                 _mimeType,
                 updatedValue.ToDisplayString(_mimeType));
+
+            if (KernelInvocationContext.Current?.Command is SubmitCode)
+            {
+                _context = KernelInvocationContext.Current;
+            }
 
             _context.Publish(new DisplayedValueUpdated(updatedValue, _displayId, _context.Command, new[] { formatted }));
         }


### PR DESCRIPTION
Fixes #480.

Allows a display updater to be used across submissions.  Once this is merged and the signed build is complete, there will be another PR to update the VS Code tool version so that it contains the kernel updates.

Thanks to @colombod for doing the kernel work/tests.