### PR TITLE
properly fail publish if verification doesn't work

### DIFF
--- a/eng/publish/PublishVSCodeExtension.ps1
+++ b/eng/publish/PublishVSCodeExtension.ps1
@@ -13,6 +13,9 @@ try {
 
     # verify
     . "$PSScriptRoot\VerifyVSCodeExtension.ps1" -extensionPath $extension
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
 
     # publish
     npm install -g vsce


### PR DESCRIPTION
If a script fails in a release definition and nobody is watching it, does it return an error code?

Yes, it does, but we have to explicitly look for it.
