### PR TITLE
account for submission splitting when requesting language services

### DIFF
--- a/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
@@ -132,7 +132,7 @@ namespace Microsoft.DotNet.Interactive.CSharp
         {
             var document = _workspace.ForkDocument(command.Code);
             var text = await document.GetTextAsync();
-            var cursorPosition = text.Lines.GetPosition(new LinePosition(command.Position.Line, command.Position.Character));
+            var cursorPosition = text.Lines.GetPosition(command.Position);
             var service = QuickInfoService.GetService(document);
             var info = await service.GetQuickInfoAsync(document, cursorPosition);
 

--- a/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/contracts.ts
+++ b/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/contracts.ts
@@ -48,7 +48,10 @@ export interface DisplayValue extends KernelCommand {
     valueId: string;
 }
 
-export interface RequestCompletion extends KernelCommand {
+export interface RequestCompletion extends LanguageServiceCommandBase {
+}
+
+export interface LanguageServiceCommandBase extends KernelCommand {
     code: string;
     position: LinePosition;
 }
@@ -56,9 +59,7 @@ export interface RequestCompletion extends KernelCommand {
 export interface RequestDiagnostics extends KernelCommand {
 }
 
-export interface RequestHoverText extends KernelCommand {
-    code: string;
-    position: LinePosition;
+export interface RequestHoverText extends LanguageServiceCommandBase {
 }
 
 export interface SubmitCode extends KernelCommand {

--- a/src/Microsoft.DotNet.Interactive/Commands/LanguageServiceCommandBase.cs
+++ b/src/Microsoft.DotNet.Interactive/Commands/LanguageServiceCommandBase.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.DotNet.Interactive.Commands
+{
+    public abstract class LanguageServiceCommandBase : KernelCommandBase
+    {
+        public string Code { get; protected set; }
+        public LinePosition Position { get; protected set; }
+
+        protected LanguageServiceCommandBase(string code, LinePosition position, string targetKernelName = null, IKernelCommand parent = null)
+            : base(targetKernelName, parent)
+        {
+            Code = code;
+            Position = position;
+        }
+
+        internal abstract LanguageServiceCommandBase WithCodeAndPosition(string code, LinePosition position);
+    }
+}

--- a/src/Microsoft.DotNet.Interactive/Commands/RequestCompletion.cs
+++ b/src/Microsoft.DotNet.Interactive/Commands/RequestCompletion.cs
@@ -1,21 +1,20 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.DotNet.Interactive.Commands
 {
-    public class RequestCompletion : KernelCommandBase
+    public class RequestCompletion : LanguageServiceCommandBase
     {
-        public RequestCompletion(string code, LinePosition position, string targetKernelName = null):base(targetKernelName)
+        public RequestCompletion(string code, LinePosition position, string targetKernelName = null)
+            : base(code, position, targetKernelName)
         {
-            Code = code ?? throw new ArgumentNullException(nameof(code));
-            Position = position;
         }
 
-        public string Code { get;  }
-
-        public LinePosition Position { get; }
+        internal override LanguageServiceCommandBase WithCodeAndPosition(string code, LinePosition position)
+        {
+            return new RequestCompletion(code, position);
+        }
     }
 }

--- a/src/Microsoft.DotNet.Interactive/Commands/RequestHoverText.cs
+++ b/src/Microsoft.DotNet.Interactive/Commands/RequestHoverText.cs
@@ -1,27 +1,25 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.DotNet.Interactive.Commands
 {
-    public class RequestHoverText : KernelCommandBase
+    public class RequestHoverText : LanguageServiceCommandBase
     {
-        public string Code { get; }
-        public LinePosition Position { get; }
-
         public RequestHoverText(string code, LinePosition position)
+            : base(code, position)
         {
-            Code = code;
-            Position = position;
         }
 
-        public static string MakeDataUriFromContents(string code)
+        internal RequestHoverText(string code, LinePosition position, IKernelCommand parent)
+            : base(code, position, targetKernelName: null, parent: parent)
         {
-            var encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(code));
-            return "data:text/plain;base64," + encoded;
+        }
+
+        internal override LanguageServiceCommandBase WithCodeAndPosition(string code, LinePosition position)
+        {
+            return new RequestHoverText(code, position);
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive/CompositeKernel.cs
+++ b/src/Microsoft.DotNet.Interactive/CompositeKernel.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.Interactive
             set
             {
                 _defaultKernelName = value;
-                SubmissionParser.DefaultLanguage = value;
+                SubmissionParser.KernelLanguage = value;
             }
         }
 
@@ -138,7 +138,7 @@ namespace Microsoft.DotNet.Interactive
         {
             var kernel = GetHandlingKernel(command, context);
 
-            context.HandlingKernel ??= kernel;
+            context.HandlingKernel = kernel;
         }
 
         private IKernel GetHandlingKernel(

--- a/src/Microsoft.DotNet.Interactive/Events/CompletionRequestCompleted.cs
+++ b/src/Microsoft.DotNet.Interactive/Events/CompletionRequestCompleted.cs
@@ -5,24 +5,27 @@ using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.DotNet.Interactive.Commands;
+using Microsoft.DotNet.Interactive.Extensions;
 
 namespace Microsoft.DotNet.Interactive.Events
 {
     public class CompletionRequestCompleted : KernelEventBase
     {
+        private LinePositionSpan? _range;
+
         public CompletionRequestCompleted(
             IEnumerable<CompletionItem> completionList,
             RequestCompletion command,
             LinePositionSpan? range = null) : base(command)
         {
             CompletionList = completionList ?? throw new ArgumentNullException(nameof(completionList));
-            Range = range;
+            _range = range;
         }
 
         /// <summary>
         /// The range of where to replace in a completion request.
         /// </summary>
-        public LinePositionSpan? Range { get; set; }
+        public LinePositionSpan? Range => this.CalculateLineOffsetFromParentCommand(_range);
 
         /// <summary>
         /// The list of completion options.

--- a/src/Microsoft.DotNet.Interactive/Events/HoverTextProduced.cs
+++ b/src/Microsoft.DotNet.Interactive/Events/HoverTextProduced.cs
@@ -5,15 +5,18 @@ using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.DotNet.Interactive.Commands;
+using Microsoft.DotNet.Interactive.Extensions;
 
 namespace Microsoft.DotNet.Interactive.Events
 {
     public class HoverTextProduced : KernelEventBase
     {
-        public IReadOnlyCollection<FormattedValue> Content { get; }
-        public LinePositionSpan? Range { get; set; }
+        private LinePositionSpan? _range;
 
-        public HoverTextProduced(IKernelCommand command, IReadOnlyCollection<FormattedValue> content, LinePositionSpan? range = null)
+        public IReadOnlyCollection<FormattedValue> Content { get; }
+        public LinePositionSpan? Range => this.CalculateLineOffsetFromParentCommand(_range);
+
+        public HoverTextProduced(RequestHoverText command, IReadOnlyCollection<FormattedValue> content, LinePositionSpan? range = null)
             : base(command)
         {
             if (content.Count == 0)
@@ -22,7 +25,7 @@ namespace Microsoft.DotNet.Interactive.Events
             }
 
             Content = content;
-            Range = range;
+            _range = range;
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive/Extensions/EventExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/Extensions/EventExtensions.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.DotNet.Interactive.Commands;
+using Microsoft.DotNet.Interactive.Events;
+
+namespace Microsoft.DotNet.Interactive.Extensions
+{
+    internal static class EventExtensions
+    {
+        public static LinePositionSpan? CalculateLineOffsetFromParentCommand(this KernelEventBase @event, LinePositionSpan? initialRange)
+        {
+            if (!initialRange.HasValue)
+            {
+                return null;
+            }
+
+            var range = initialRange.GetValueOrDefault();
+            var requestCommand = @event.Command as LanguageServiceCommandBase;
+            if (requestCommand?.Parent is LanguageServiceCommandBase parentRequest)
+            {
+                var requestPosition = requestCommand.Position;
+                var lineOffset = parentRequest.Position.Line - requestPosition.Line;
+                return new LinePositionSpan(
+                    new LinePosition(range.Start.Line + lineOffset, range.Start.Character),
+                    new LinePosition(range.End.Line + lineOffset, range.End.Character));
+            }
+
+            return range;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Interactive/KernelBase.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelBase.cs
@@ -103,19 +103,121 @@ namespace Microsoft.DotNet.Interactive
         private void AddDirectiveMiddlewareAndCommonCommandHandlers()
         {
             AddMiddleware(
-                (command, context, next) =>
+                async (originalCommand, context, next) =>
                 {
-                    return command switch
+                    var commands = PreprocessCommands(originalCommand, context).ToList();
+                    if (!commands.Contains(originalCommand) && commands.Any())
                     {
-                        SubmitCode submitCode =>
-                        HandleDirectivesAndSubmitCode(
-                            submitCode,
-                            context,
-                            next),
+                        context.CommandToSignalCompletion = commands.Last();
+                    }
 
-                        _ => next(command, context)
-                    };
+                    foreach (var command in commands)
+                    {
+                        if (context.IsComplete)
+                        {
+                            break;
+                        }
+
+                        if (command == originalCommand)
+                        {
+                            // no new context is needed
+                            await next(originalCommand, context);
+                        }
+                        else
+                        {
+                            switch (command)
+                            {
+                                case AnonymousKernelCommand _:
+                                case DirectiveCommand _:
+                                    await command.InvokeAsync(context);
+                                    break;
+                                default:
+                                    SetHandlingKernel(command, context);
+                                    var kernel = context.HandlingKernel;
+                                    if (kernel == this)
+                                    {
+                                        var c = KernelInvocationContext.Establish(command);
+                                        await next(command, c);
+                                    }
+                                    else
+                                    {
+                                        // forward to appropriate kernel
+                                        await kernel.SendAsync(command);
+                                    }
+                                    break;
+                            }
+                        }
+                    }
                 });
+        }
+
+        private IEnumerable<IKernelCommand> PreprocessCommands(IKernelCommand command, KernelInvocationContext context)
+        {
+            return command switch
+            {
+                SubmitCode submitCode => SubmissionParser.SplitSubmission(submitCode),
+                LanguageServiceCommandBase languageServiceCommand => PreprocessLanguageServiceCommand(languageServiceCommand, context),
+                _ => new[] { command }
+            };
+        }
+
+        private IEnumerable<IKernelCommand> PreprocessLanguageServiceCommand(LanguageServiceCommandBase languageServiceCommand, KernelInvocationContext context)
+        {
+            var commands = new List<IKernelCommand>();
+            var tree = SubmissionParser.Parse(languageServiceCommand.Code, languageServiceCommand.TargetKernelName);
+            var nodes = tree.GetRoot().ChildNodes.ToArray();
+            var sourceText = SourceText.From(languageServiceCommand.Code);
+            var requestPosition = sourceText.Lines.GetPosition(languageServiceCommand.Position);
+
+            foreach (var node in nodes)
+            {
+                // TextSpan.Contains only checks `[start, end)`, but we need to allow for `[start, end]`
+                if (node.Span.Contains(requestPosition) || node.Span.End == requestPosition)
+                {
+                    switch (node)
+                    {
+                        case DirectiveNode directiveNode:
+                            HandleDirectiveNodeLanguageServiceRequest(directiveNode, requestPosition, languageServiceCommand, context);
+                            break;
+                        case LanguageNode languageNode:
+                            // calculate new position
+                            var nodeStartLine = sourceText.Lines.GetLinePosition(node.Span.Start).Line;
+                            var offsetNodeLine = languageServiceCommand.Position.Line - nodeStartLine;
+                            var position = new LinePosition(offsetNodeLine, languageServiceCommand.Position.Character);
+
+                            // create new command
+                            var offsetLanguageServiceCommand = languageServiceCommand.WithCodeAndPosition(node.Text, position);
+                            offsetLanguageServiceCommand.TargetKernelName = languageNode.Language;
+                            commands.Add(offsetLanguageServiceCommand);
+                            break;
+                    }
+                }
+            }
+
+            return commands;
+        }
+
+        private void HandleDirectiveNodeLanguageServiceRequest(DirectiveNode directiveNode, int requestPosition, LanguageServiceCommandBase languageServiceCommand, KernelInvocationContext context)
+        {
+            var directiveParseResult = directiveNode.GetDirectiveParseResult();
+            var resultRange = new LinePositionSpan(
+                new LinePosition(languageServiceCommand.Position.Line, 0),
+                languageServiceCommand.Position);
+            switch (languageServiceCommand)
+            {
+                case RequestCompletion requestCompletion:
+                    var completions = directiveParseResult
+                        .GetSuggestions(requestPosition)
+                        .Select(s => SubmissionParser.CompletionItemFor(s, directiveNode.DirectiveParser))
+                        .ToArray();
+
+                    context.Publish(new CompletionRequestCompleted(
+                        completions, requestCompletion, resultRange));
+                    break;
+                case RequestHoverText _requestHover:
+                    // NYI
+                    break;
+            }
         }
 
         private async Task SetKernel(IKernelCommand command, KernelInvocationContext context, KernelPipelineContinuation next)
@@ -129,59 +231,6 @@ namespace Microsoft.DotNet.Interactive
             await next(command, context);
 
             context.CurrentKernel = previousKernel;
-        }
-
-        private async Task HandleDirectivesAndSubmitCode(
-            SubmitCode submitCode,
-            KernelInvocationContext context,
-            KernelPipelineContinuation continueOnCurrentPipeline)
-        {
-            var commands = SubmissionParser.SplitSubmission(submitCode);
-
-            if (!commands.Contains(submitCode))
-            {
-                context.CommandToSignalCompletion = commands.Last();
-            }
-
-            foreach (var command in commands)
-            {
-                if (context.IsComplete)
-                {
-                    break;
-                }
-
-                if (command == submitCode)
-                {
-                    // no new context is needed
-                    await continueOnCurrentPipeline(submitCode, context);
-                }
-                else
-                {
-                    switch (command)
-                    {
-                        case AnonymousKernelCommand _:
-                        case DirectiveCommand _:
-                            await command.InvokeAsync(context);
-                            break;
-                        default:
-                            var kernel = context.HandlingKernel;
-
-                            if (kernel == this)
-                            {
-                                var c = KernelInvocationContext.Establish(command);
-
-                                await continueOnCurrentPipeline(command, c);
-                            }
-                            else
-                            {
-                                // forward to next kernel
-                                await kernel.SendAsync(command);
-                            }
-
-                            break;
-                    }
-                }
-            }
         }
 
         public FrontendEnvironment FrontendEnvironment
@@ -368,7 +417,7 @@ namespace Microsoft.DotNet.Interactive
                         case RequestCompletion requestCompletion:
                             if (this is IKernelCommandHandler<RequestCompletion> completionHandler)
                             {
-                                SetCompletionHandler(requestCompletion, completionHandler);
+                                SetHandler(completionHandler, requestCompletion);
                             }
 
                             break;
@@ -390,57 +439,6 @@ namespace Microsoft.DotNet.Interactive
                             break;
                     }
                 }
-            }
-        }
-
-        private void SetCompletionHandler(RequestCompletion requestCompletion, IKernelCommandHandler<RequestCompletion> completionHandler)
-        {
-            var tree = SubmissionParser.Parse(requestCompletion.Code);
-
-            var linePosition = requestCompletion.Position;
-
-            var rootNode = tree.GetRoot();
-
-            var absolutePosition = tree.GetAbsolutePosition(linePosition);
-            if (absolutePosition >= tree.Length)
-            {
-                absolutePosition--;
-            }
-            else if (char.IsWhiteSpace(tree.GetRoot().Text[absolutePosition]))
-            {
-                absolutePosition--;
-            }
-
-            var nodeToComplete =
-                rootNode.FindNode(absolutePosition);
-
-            var charPosition = linePosition.Character;
-
-            if (nodeToComplete is DirectiveNode directiveNode)
-            {
-                requestCompletion.Handler = (_, c) =>
-                {
-                    var directiveParseResult = directiveNode
-                        .GetDirectiveParseResult();
-
-                    var completions = directiveParseResult
-                                      .GetSuggestions(charPosition)
-                                      .Select(s => SubmissionParser.CompletionItemFor(s, directiveNode.DirectiveParser))
-                                      .ToArray();
-
-                    var lps = new LinePositionSpan(
-                        new LinePosition(linePosition.Line, 0),
-                        linePosition);
-
-                    c.Publish(new CompletionRequestCompleted(
-                                  completions, requestCompletion, lps));
-
-                    return Task.CompletedTask;
-                };
-            }
-            else
-            {
-                SetHandler(completionHandler, requestCompletion);
             }
         }
 

--- a/src/dotnet-interactive-vscode/src/contracts.ts
+++ b/src/dotnet-interactive-vscode/src/contracts.ts
@@ -48,7 +48,10 @@ export interface DisplayValue extends KernelCommand {
     valueId: string;
 }
 
-export interface RequestCompletion extends KernelCommand {
+export interface RequestCompletion extends LanguageServiceCommandBase {
+}
+
+export interface LanguageServiceCommandBase extends KernelCommand {
     code: string;
     position: LinePosition;
 }
@@ -56,9 +59,7 @@ export interface RequestCompletion extends KernelCommand {
 export interface RequestDiagnostics extends KernelCommand {
 }
 
-export interface RequestHoverText extends KernelCommand {
-    code: string;
-    position: LinePosition;
+export interface RequestHoverText extends LanguageServiceCommandBase {
 }
 
 export interface SubmitCode extends KernelCommand {

--- a/src/dotnet-interactive-vscode/src/vscode/notebookProvider.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/notebookProvider.ts
@@ -65,7 +65,7 @@ export class DotNetInteractiveNotebookContentProvider implements vscode.Notebook
         cell.metadata.runState = vscode.NotebookCellRunState.Running;
         cell.outputs = [];
         let client = await this.clientMapper.getOrAddClient(document.uri);
-        let source = cell.source.toString();
+        let source = cell.document.getText();
         return client.execute(source, getSimpleLanguage(cell.language), outputs => {
             // to properly trigger the UI update, `cell.outputs` needs to be uniquely assigned; simply setting it to the local variable has no effect
             cell.outputs = [];


### PR DESCRIPTION
When language service requests are received, parse/split the submission and re-create with appropriate line offsets.  In the example screenshot below, the F# kernel is told to compute completion items on line 2.  It has no idea that the actual incoming request was for line 5.

The resultant events are also massaged; F# can specify that the computed result is on line 2, but when an event listener (e.g., VS Code) gets the result, they only see line 5.

![image](https://user-images.githubusercontent.com/926281/84092320-db2eca80-a9ab-11ea-8289-ea7781ec2c7c.png)

Note to @jonsequitur and @colombod: We talked about making the incoming commands mutable, but that prevents us from using the handy trick of checking the parent command on the resulting events, so we have to stick with re-creating new commands so we have an original to compare against when computing the line offsets on the way back out.