### PR TITLE
re-enable adding git SHA to package description

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -136,7 +136,7 @@ stages:
             filePath: $(Build.SourcesDirectory)/eng/package/PackVSCodeExtension.ps1
             arguments: -stableToolVersionNumber $(StableToolVersionNumber) -gitSha $(Build.SourceVersion) -outDir "$(Build.ArtifactStagingDirectory)\vscode"
             workingDirectory: "$(Build.SourcesDirectory)/src/dotnet-interactive-vscode"
-            #pwsh: true # temporarily turned off due to https://github.com/dotnet/core-eng/issues/9913
+            pwsh: true
 
         - task: PublishBuildArtifacts@1
           displayName: Publish VSCode extension artifacts

--- a/eng/package/PackVSCodeExtension.ps1
+++ b/eng/package/PackVSCodeExtension.ps1
@@ -18,9 +18,7 @@ try {
     Write-Host "Appending git sha to description in $packageJsonPath"
     $packageJsonContents = (Get-Content $packageJsonPath | Out-String | ConvertFrom-Json)
     $packageJsonContents.description += "  Git SHA $gitSha"
-    # writing back changes temporarily disabled until internal machines have access to pwsh.exe
-    # see https://github.com/dotnet/core-eng/issues/9913
-    #$packageJsonContents | ConvertTo-Json -depth 100 | Out-File $packageJsonPath
+    $packageJsonContents | ConvertTo-Json -depth 100 | Out-File $packageJsonPath
 
     # create destination
     New-Item -Path $outDir -ItemType Directory


### PR DESCRIPTION
The internal build machines now have `pwsh.exe` on the path so we can re-enable this.  Verified via [internal build](https://dev.azure.com/dnceng/internal/_build/results?buildId=679268&view=results).