### PR TITLE
get fresh kernel transport args on each notebook open

### DIFF
--- a/src/dotnet-interactive-vscode/DEVGUIDE.md
+++ b/src/dotnet-interactive-vscode/DEVGUIDE.md
@@ -41,13 +41,14 @@ Developer Instructions
       -  "dotnet-interactive",
       -  "--",
       +  "E:/dotnet/interactive/artifacts/bin/dotnet-interactive/Debug/netcoreapp3.1/Microsoft.DotNet.Interactive.App.dll",
+         "[vscode]",
          "stdio",
          "--http-port-range",
          "1000-3000"
        ]
       ```
 
-3. Save `settings.json` and close and re-open VS Code Insiders.
+3. Save `settings.json`.
 
 4. Any subsequently opened notebooks will use your local changes.
 

--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -54,7 +54,7 @@
             "{dotnet_path}",
             "tool",
             "run",
-            "dotnet-interactive",            
+            "dotnet-interactive",
             "--",
             "[vscode]",
             "stdio",


### PR DESCRIPTION
This makes the scenario of changing your kernel transport args easier by always fetching a fresh value so you don't have to close/reopen VS Code after changing this.