### PR TITLE
refactor `SubmitCode` handling to use IKernelCommandHandler<> interface

### DIFF
--- a/dotnet-interactive.sln
+++ b/dotnet-interactive.sln
@@ -53,6 +53,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "integration-tests", "integr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "interface-generator", "src\interface-generator\interface-generator.csproj", "{9A091E80-D5EB-4DEF-8E38-B24B128393DF}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Interactive.FSharp.Wrapper", "src\Microsoft.DotNet.Interactive.FSharp.Wrapper\Microsoft.DotNet.Interactive.FSharp.Wrapper.csproj", "{89672116-94E4-4F17-A64A-AA049410F595}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -327,6 +329,18 @@ Global
 		{9A091E80-D5EB-4DEF-8E38-B24B128393DF}.Release|x64.Build.0 = Release|Any CPU
 		{9A091E80-D5EB-4DEF-8E38-B24B128393DF}.Release|x86.ActiveCfg = Release|Any CPU
 		{9A091E80-D5EB-4DEF-8E38-B24B128393DF}.Release|x86.Build.0 = Release|Any CPU
+		{89672116-94E4-4F17-A64A-AA049410F595}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{89672116-94E4-4F17-A64A-AA049410F595}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{89672116-94E4-4F17-A64A-AA049410F595}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{89672116-94E4-4F17-A64A-AA049410F595}.Debug|x64.Build.0 = Debug|Any CPU
+		{89672116-94E4-4F17-A64A-AA049410F595}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{89672116-94E4-4F17-A64A-AA049410F595}.Debug|x86.Build.0 = Debug|Any CPU
+		{89672116-94E4-4F17-A64A-AA049410F595}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{89672116-94E4-4F17-A64A-AA049410F595}.Release|Any CPU.Build.0 = Release|Any CPU
+		{89672116-94E4-4F17-A64A-AA049410F595}.Release|x64.ActiveCfg = Release|Any CPU
+		{89672116-94E4-4F17-A64A-AA049410F595}.Release|x64.Build.0 = Release|Any CPU
+		{89672116-94E4-4F17-A64A-AA049410F595}.Release|x86.ActiveCfg = Release|Any CPU
+		{89672116-94E4-4F17-A64A-AA049410F595}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -354,6 +368,7 @@ Global
 		{30DE6920-EA82-4E4F-BFCA-1FF179FAA2DA} = {11BA3480-4584-435C-BA9A-8C554DB60E9F}
 		{8017943B-B591-49C8-B957-40141B427AD9} = {979A5022-09CA-4258-B76D-CFDC31DA71E0}
 		{9A091E80-D5EB-4DEF-8E38-B24B128393DF} = {B95A8485-8C53-4F56-B0CE-19C0726B5805}
+		{89672116-94E4-4F17-A64A-AA049410F595} = {B95A8485-8C53-4F56-B0CE-19C0726B5805}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6D05A9AF-CFFB-4187-8599-574387B76727}

--- a/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
@@ -31,7 +31,8 @@ namespace Microsoft.DotNet.Interactive.CSharp
         IExtensibleKernel,
         ISupportNuget,
         IKernelCommandHandler<RequestCompletion>,
-        IKernelCommandHandler<RequestHoverText>
+        IKernelCommandHandler<RequestHoverText>,
+        IKernelCommandHandler<SubmitCode>
     {
         internal const string DefaultKernelName = "csharp";
 
@@ -147,9 +148,7 @@ namespace Microsoft.DotNet.Interactive.CSharp
             context.PublishHoverTextMarkdownResponse(command, info.ToMarkdownString(), correctedLinePosSpan);
         }
 
-        protected override async Task HandleSubmitCode(
-            SubmitCode submitCode,
-            KernelInvocationContext context)
+        public async Task HandleAsync(SubmitCode submitCode, KernelInvocationContext context)
         {
             var codeSubmissionReceived = new CodeSubmissionReceived(submitCode);
 

--- a/src/Microsoft.DotNet.Interactive.FSharp.Wrapper/FSharpKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.FSharp.Wrapper/FSharpKernel.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using Microsoft.DotNet.Interactive.Commands;
+
+namespace Microsoft.DotNet.Interactive.FSharp
+{
+    // The purpose of this class is to enable interface implementation with different generic instantiations; can be removed
+    // once https://github.com/dotnet/fsharp/pull/2867 is complete.
+    public class FSharpKernel :
+        FSharpKernelBase,
+        IKernelCommandHandler<RequestCompletion>,
+        IKernelCommandHandler<SubmitCode>
+    {
+        public Task HandleAsync(RequestCompletion command, KernelInvocationContext context) => HandleRequestCompletionAsync(command, context);
+
+        public Task HandleAsync(SubmitCode command, KernelInvocationContext context) => HandleSubmitCodeAsync(command, context);
+    }
+}

--- a/src/Microsoft.DotNet.Interactive.FSharp.Wrapper/Microsoft.DotNet.Interactive.FSharp.Wrapper.csproj
+++ b/src/Microsoft.DotNet.Interactive.FSharp.Wrapper/Microsoft.DotNet.Interactive.FSharp.Wrapper.csproj
@@ -9,7 +9,8 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <PackageDescription>Microsoft.DotNet.Interactive.IKernel implementation for F# (Wrapper)</PackageDescription>
+    <PackageId>Microsoft.DotNet.Interactive.FSharp</PackageId>
+    <PackageDescription>Microsoft.DotNet.Interactive.IKernel implementation for F#</PackageDescription>
     <PackageTags>interactive fsharp</PackageTags>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Interactive.FSharp.Wrapper/Microsoft.DotNet.Interactive.FSharp.Wrapper.csproj
+++ b/src/Microsoft.DotNet.Interactive.FSharp.Wrapper/Microsoft.DotNet.Interactive.FSharp.Wrapper.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <NoWarn>$(NoWarn);2003;CS8002</NoWarn> <!-- AssemblyInformationalVersionAttribute contains a non-standard value -->
+    <Deterministic Condition="'$(NCrunch)' == '1'">false</Deterministic>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <IsPackable>true</IsPackable>
+    <PackageDescription>Microsoft.DotNet.Interactive.IKernel implementation for F# (Wrapper)</PackageDescription>
+    <PackageTags>interactive fsharp</PackageTags>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>;NU5104;2003;8002</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.DotNet.Interactive.FSharp\Microsoft.DotNet.Interactive.FSharp.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernelExtensions.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernelExtensions.fs
@@ -21,7 +21,7 @@ type FSharpKernelExtensions private () =
     static let openNamespaceOrType = fun (whatToOpen: String) -> sprintf "open %s" whatToOpen
 
     [<Extension>]
-    static member UseDefaultFormatting(kernel: FSharpKernel) = 
+    static member UseDefaultFormatting(kernel: FSharpKernelBase) =
         let code = 
             [
                 referenceFromType typeof<IHtmlContent>
@@ -36,32 +36,32 @@ type FSharpKernelExtensions private () =
                 openNamespaceOrType typeof<Formatter>.Namespace
             ] |> List.reduce(fun x y -> x + Environment.NewLine + y)
 
-        kernel.DeferCommand(SubmitCode code) 
+        kernel.DeferCommand(SubmitCode code)
         kernel
 
     [<Extension>]
-    static member UseDefaultNamespaces(kernel: FSharpKernel) =
+    static member UseDefaultNamespaces(kernel: FSharpKernelBase) =
         let code = @"
 open System
 open System.Text
 open System.Threading.Tasks
 open System.Linq"
-        kernel.DeferCommand(SubmitCode code) 
+        kernel.DeferCommand(SubmitCode code)
         kernel
 
     [<Extension>]
-    static member UseKernelHelpers(kernel: FSharpKernel) =
+    static member UseKernelHelpers(kernel: FSharpKernelBase) =
         let code = 
             [
                 referenceFromType typeof<FSharpKernelHelpers.IMarker>
                 openNamespaceOrType (typeof<FSharpKernelHelpers.IMarker>.DeclaringType.Namespace + "." + nameof(FSharpKernelHelpers))
             ] |> List.reduce(fun x y -> x + Environment.NewLine + y)
 
-        kernel.DeferCommand(SubmitCode code) 
+        kernel.DeferCommand(SubmitCode code)
         kernel
 
     [<Extension>]
-    static member UseWho(kernel: FSharpKernel) =
+    static member UseWho(kernel: FSharpKernelBase) =
         let detailedName = "#!whos"
         let command = Command(detailedName, "Display the names of the current top-level variables and their values.")
         command.Handler <- CommandHandler.Create(
@@ -70,7 +70,7 @@ open System.Linq"
                 match context.Command with
                 | :? SubmitCode ->
                     match context.HandlingKernel with
-                    | :? FSharpKernel as kernel ->
+                    | :? FSharpKernelBase as kernel ->
                         let kernelVariables = kernel.GetCurrentVariables()
                         let currentVariables = CurrentVariables(kernelVariables, detailed)
                         let html = currentVariables.ToDisplayString(HtmlFormatter.MimeType)

--- a/src/Microsoft.DotNet.Interactive.FSharp/Microsoft.DotNet.Interactive.FSharp.fsproj
+++ b/src/Microsoft.DotNet.Interactive.FSharp/Microsoft.DotNet.Interactive.FSharp.fsproj
@@ -8,7 +8,10 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <IsPackable>true</IsPackable>
+    <!-- The Microsoft.DotNet.Interactive.FSharp.Wrapper project is the package entry point. -->
+    <IsPackable>false</IsPackable>
+    <PackageId>Microsoft.DotNet.Interactive.FSharp.Internal</PackageId>
+    <!-- -->
     <PackageDescription>Microsoft.DotNet.Interactive.IKernel implementation for F#</PackageDescription>
     <PackageTags>interactive fsharp</PackageTags>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterRequestHandlerTestBase{T}.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterRequestHandlerTestBase{T}.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
     {
         private readonly CompositeDisposable _disposables = new CompositeDisposable();
         private readonly CSharpKernel _cSharpKernel;
-        private readonly FSharpKernel _fSharpKernel;
+        private readonly FSharpKernelBase _fSharpKernel;
         private readonly PowerShellKernel _psKernel;
         private readonly CompositeKernel _compositeKernel;
 

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/MagicCommandTests.lsmagic.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/MagicCommandTests.lsmagic.cs
@@ -11,7 +11,6 @@ using Microsoft.DotNet.Interactive.CSharp;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Formatting;
 using Microsoft.DotNet.Interactive.FSharp;
-using Microsoft.DotNet.Interactive.Tests;
 using Microsoft.DotNet.Interactive.Tests.Utility;
 using Xunit;
 

--- a/src/Microsoft.DotNet.Interactive.Jupyter/JupyterFormattingKernelExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/JupyterFormattingKernelExtensions.cs
@@ -27,7 +27,7 @@ using {typeof(LaTeXString).Namespace};
             return kernel;
         }
 
-        public static FSharpKernel UseMathAndLaTeX(this FSharpKernel kernel)
+        public static FSharpKernelBase UseMathAndLaTeX(this FSharpKernelBase kernel)
         {
             if (kernel == null)
             {

--- a/src/Microsoft.DotNet.Interactive.Jupyter/Microsoft.DotNet.Interactive.Jupyter.csproj
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/Microsoft.DotNet.Interactive.Jupyter.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.Interactive.CSharp\Microsoft.DotNet.Interactive.CSharp.csproj" />
+    <ProjectReference Include="..\Microsoft.DotNet.Interactive.FSharp.Wrapper\Microsoft.DotNet.Interactive.FSharp.Wrapper.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Interactive.FSharp\Microsoft.DotNet.Interactive.FSharp.fsproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Interactive.PowerShell\Microsoft.DotNet.Interactive.PowerShell.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Interactive\Microsoft.DotNet.Interactive.csproj" />

--- a/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -23,7 +23,8 @@ namespace Microsoft.DotNet.Interactive.PowerShell
 
     public class PowerShellKernel : 
         DotNetLanguageKernel,
-        IKernelCommandHandler<RequestCompletion>
+        IKernelCommandHandler<RequestCompletion>,
+        IKernelCommandHandler<SubmitCode>
     {
         internal const string DefaultKernelName = "pwsh";
 
@@ -145,7 +146,7 @@ namespace Microsoft.DotNet.Interactive.PowerShell
             return Task.CompletedTask;
         }
 
-        protected override async Task HandleSubmitCode(
+        public async Task HandleAsync(
             SubmitCode submitCode,
             KernelInvocationContext context)
         {

--- a/src/Microsoft.DotNet.Interactive.Tests/Microsoft.DotNet.Interactive.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.Tests/Microsoft.DotNet.Interactive.Tests.csproj
@@ -44,6 +44,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.Interactive.CSharp\Microsoft.DotNet.Interactive.CSharp.csproj" />
+    <ProjectReference Include="..\Microsoft.DotNet.Interactive.FSharp.Wrapper\Microsoft.DotNet.Interactive.FSharp.Wrapper.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Interactive.FSharp\Microsoft.DotNet.Interactive.FSharp.fsproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Interactive.PowerShell\Microsoft.DotNet.Interactive.PowerShell.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Interactive.Jupyter\Microsoft.DotNet.Interactive.Jupyter.csproj" />

--- a/src/Microsoft.DotNet.Interactive.Tests/Parsing/SubmissionParserTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Parsing/SubmissionParserTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Linq;
 using FluentAssertions;
 using FluentAssertions.Execution;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.DotNet.Interactive.CSharp;
 using Microsoft.DotNet.Interactive.FSharp;
 using Microsoft.DotNet.Interactive.Jupyter;

--- a/src/Microsoft.DotNet.Interactive.Tests/Utility/FakeKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Utility/FakeKernel.cs
@@ -1,14 +1,15 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.Commands;
 
 namespace Microsoft.DotNet.Interactive.Tests.Utility
 {
-    public class FakeKernel : KernelBase
+    public class FakeKernel :
+        KernelBase,
+        IKernelCommandHandler<SubmitCode>
     {
         public FakeKernel([CallerMemberName] string name = null) : base(name)
         {
@@ -16,7 +17,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Utility
 
         public KernelCommandInvocation Handle { get; set; }
 
-        protected override Task HandleSubmitCode(SubmitCode command, KernelInvocationContext context)
+        public Task HandleAsync(SubmitCode command, KernelInvocationContext context)
         {
             Handle(command, context);
             return Task.CompletedTask;

--- a/src/Microsoft.DotNet.Interactive/CompositeKernel.cs
+++ b/src/Microsoft.DotNet.Interactive/CompositeKernel.cs
@@ -196,13 +196,6 @@ namespace Microsoft.DotNet.Interactive
             throw new NoSuitableKernelException(command);
         }
 
-        protected override Task HandleSubmitCode(
-            SubmitCode command, 
-            KernelInvocationContext context)
-        {
-            throw new NotSupportedException();
-        }
-
         public IEnumerator<IKernel> GetEnumerator() => _childKernels.GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/src/Microsoft.DotNet.Interactive/HtmlKernel.cs
+++ b/src/Microsoft.DotNet.Interactive/HtmlKernel.cs
@@ -1,14 +1,15 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Formatting;
 
 namespace Microsoft.DotNet.Interactive
 {
-    public class HtmlKernel : KernelBase
+    public class HtmlKernel :
+        KernelBase,
+        IKernelCommandHandler<SubmitCode>
     {
         public const string DefaultKernelName = "html";
 
@@ -16,7 +17,7 @@ namespace Microsoft.DotNet.Interactive
         {
         }
 
-        protected override async Task HandleSubmitCode(SubmitCode command, KernelInvocationContext context)
+        public async Task HandleAsync(SubmitCode command, KernelInvocationContext context)
         {
             await context.DisplayAsync(
                 command.Code,

--- a/src/Microsoft.DotNet.Interactive/JavaScriptKernel.cs
+++ b/src/Microsoft.DotNet.Interactive/JavaScriptKernel.cs
@@ -6,14 +6,16 @@ using Microsoft.DotNet.Interactive.Commands;
 
 namespace Microsoft.DotNet.Interactive
 {
-    public class JavaScriptKernel : KernelBase
+    public class JavaScriptKernel :
+        KernelBase,
+        IKernelCommandHandler<SubmitCode>
     {
         public const string DefaultKernelName = "javascript";
 
         public JavaScriptKernel() : base(DefaultKernelName)
         {
         }
-        protected override async Task HandleSubmitCode(
+        public async Task HandleAsync(
             SubmitCode command,
             KernelInvocationContext context)
         {

--- a/src/Microsoft.DotNet.Interactive/KernelBase.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelBase.cs
@@ -348,10 +348,6 @@ namespace Microsoft.DotNet.Interactive
             _disposables.Add(disposable);
         }
 
-        protected abstract Task HandleSubmitCode(
-            SubmitCode command, 
-            KernelInvocationContext context);
-
         private protected void SetHandler(
             IKernelCommand command,
             KernelInvocationContext context)
@@ -363,10 +359,10 @@ namespace Microsoft.DotNet.Interactive
                     switch (command)
                     {
                         case SubmitCode submitCode:
-                            submitCode.Handler = (_, invocationContext) =>
+                            if (this is IKernelCommandHandler<SubmitCode> submitHandler)
                             {
-                                return HandleSubmitCode(submitCode, context);
-                            };
+                                SetHandler(submitHandler, submitCode);
+                            }
                             break;
 
                         case RequestCompletion requestCompletion:

--- a/src/dotnet-interactive.Profiler/dotnet-interactive.Profiler.csproj
+++ b/src/dotnet-interactive.Profiler/dotnet-interactive.Profiler.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\dotnet-interactive\dotnet-interactive.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Interactive.Formatting\Microsoft.DotNet.Interactive.Formatting.csproj" />
+    <ProjectReference Include="..\Microsoft.DotNet.Interactive.FSharp.Wrapper\Microsoft.DotNet.Interactive.FSharp.Wrapper.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Interactive.FSharp\Microsoft.DotNet.Interactive.FSharp.fsproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Interactive.Jupyter\Microsoft.DotNet.Interactive.Jupyter.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Interactive\Microsoft.DotNet.Interactive.csproj" />

--- a/src/dotnet-interactive/CommandLine/CommandLineParser.cs
+++ b/src/dotnet-interactive/CommandLine/CommandLineParser.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;

--- a/src/dotnet-interactive/dotnet-interactive.csproj
+++ b/src/dotnet-interactive/dotnet-interactive.csproj
@@ -90,6 +90,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.Interactive.CSharp\Microsoft.DotNet.Interactive.CSharp.csproj" />
+    <ProjectReference Include="..\Microsoft.DotNet.Interactive.FSharp.Wrapper\Microsoft.DotNet.Interactive.FSharp.Wrapper.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Interactive.FSharp\Microsoft.DotNet.Interactive.FSharp.fsproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Interactive.PowerShell\Microsoft.DotNet.Interactive.PowerShell.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Interactive.Jupyter\Microsoft.DotNet.Interactive.Jupyter.csproj" />


### PR DESCRIPTION
Required a refactor of the F# kernel to allow interface implementations with different generic instantiations.  See dotnet/fsharp#2867 for details.

In doing this I wanted to prevent the old F# kernel from being instantiated so that we don't get into a situation where we call `new FSharpKernel()` and it doesn't properly handle commands.  To do this I (1) changed the name to `FSharpKernelInternal`, (2) set the constructor to private, and (3) forced creation through a `CreateKernelForWrapper()` method.  This way it's very explicit when and where we instantiate this.  Spoiler alert, it only happens in the C# wrapper class, now.

Second, I created a wrapper in C# that simply forwards everything to the underlying kernel as appropriate and rewrites the `HandleAsync` methods to `Handle{specific-thing}Async`.

Third, I wanted to keep the contents of the F# kernel extensions, but allow them to be applied to the new C# wrapper.  To accomplish this I made the method generic with the constraint `IFSharpKernel and KernelBase`.  This keeps the extension methods strongly typed to F# and will prevent the C#/PowerShell kernels from accidentally injecting F#-specific helper code.

Finally, it was done this way so that when the time comes for us to remove the C# wrapper, the steps will be:
1. Remove C# wrapper `FSharpKernel`.
2. Rename `FSharpKernelInternal` -> `FSharpKernel` and make the constructor public again.
3. Remove/replace all instances of the `Microsoft.DotNet.Interactive.FSharp.Wrapper` namespace.

Otherwise everything is basically unchanged.