### PR TITLE
properly set range on completion items if avaivlable

### DIFF
--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -80,7 +80,7 @@
         },
         "dotnet-interactive.minimumInteractiveToolVersion": {
           "type": "string",
-          "default": "1.0.131001",
+          "default": "1.0.131103",
           "description": "The minimum required version of the .NET Interactive tool."
         }
       }

--- a/src/dotnet-interactive-vscode/src/languageServices/completion.ts
+++ b/src/dotnet-interactive-vscode/src/languageServices/completion.ts
@@ -2,13 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { ClientMapper } from './../clientMapper';
-import { CompletionItem } from './../contracts';
+import { CompletionRequestCompleted } from './../contracts';
 import { PositionLike } from './interfaces';
 import { Document } from '../interfaces/vscode';
 
-export async function provideCompletion(clientMapper: ClientMapper, language: string, document: Document, position: PositionLike, token?: string | undefined): Promise<Array<CompletionItem>> {
+export async function provideCompletion(clientMapper: ClientMapper, language: string, document: Document, position: PositionLike, token?: string | undefined): Promise<CompletionRequestCompleted> {
     let client = await clientMapper.getOrAddClient(document.uri);
     let completion = await client.completion(language, document.getText(), position.line, position.character, token);
-    let completionItems = completion.completionList;
-    return completionItems;
+    return completion;
 }

--- a/src/dotnet-interactive-vscode/src/tests/unit/languageProvider.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/languageProvider.test.ts
@@ -17,6 +17,7 @@ describe('LanguageProvider tests', () => {
                 {
                     eventType: CompletionRequestCompletedType,
                     event: {
+                        range: null,
                         completionList: [
                             {
                                 displayText: 'Sqrt',
@@ -51,16 +52,19 @@ describe('LanguageProvider tests', () => {
 
         // perform the completion request
         let completion = await provideCompletion(clientMapper, 'csharp', document, position, token);
-        expect(completion).to.deep.equal([
-            {
-                displayText: 'Sqrt',
-                kind: 'Method',
-                filterText: 'Sqrt',
-                sortText: 'Sqrt',
-                insertText: 'Sqrt',
-                documentation: null
-            }
-        ]);
+        expect(completion).to.deep.equal({
+            range: null,
+            completionList: [
+                {
+                    displayText: 'Sqrt',
+                    kind: 'Method',
+                    filterText: 'Sqrt',
+                    sortText: 'Sqrt',
+                    insertText: 'Sqrt',
+                    documentation: null
+                }
+            ]
+        });
     });
 
     it('HoverProvider', async () => {

--- a/src/dotnet-interactive-vscode/src/vscode/languageProvider.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/languageProvider.ts
@@ -32,14 +32,21 @@ export class CompletionItemProvider implements vscode.CompletionItemProvider {
     provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext): vscode.ProviderResult<vscode.CompletionItem[] | vscode.CompletionList> {
         return new Promise<vscode.CompletionList>((resolve, reject) => {
             provideCompletion(this.clientMapper, getSimpleLanguage(document.languageId), document, position).then(result => {
+                let range: vscode.Range | undefined = undefined;
+                if (result.range) {
+                    range = new vscode.Range(
+                        new vscode.Position(result.range.start.line, result.range.start.character),
+                        new vscode.Position(result.range.end.line, result.range.end.character));
+                }
                 let completionItems: Array<vscode.CompletionItem> = [];
-                for (let item of result) {
+                for (let item of result.completionList) {
                     let vscodeItem : vscode.CompletionItem = {
                         label: item.displayText,
                         documentation: item.documentation,
                         filterText: item.filterText,
                         insertText: item.insertText,
                         sortText: item.sortText,
+                        range: range,
                         kind: this.mapCompletionItem(item.kind)
                     };
                     completionItems.push(vscodeItem);


### PR DESCRIPTION
This enables magic command completion to behave since it contains non-identifier characters.

![image](https://user-images.githubusercontent.com/926281/84451142-052ff900-ac07-11ea-9b7a-f4408d0f0e5b.png)
