### PR TITLE
expand grammar for magic commands

### DIFF
--- a/src/dotnet-interactive-vscode/src/tests/unit/grammar.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/grammar.test.ts
@@ -161,7 +161,7 @@ describe('TextMate grammar tests', async () => {
         ]);
     });
 
-    it('magic command doesnt invalidate language', async () => {
+    it("magic command doesn't invalidate language", async () => {
         const text = [
             '#!fsharp',
             '// this is fsharp',
@@ -185,11 +185,11 @@ describe('TextMate grammar tests', async () => {
             [
                 {
                     tokenText: '#!',
-                    scopes: ['source.dotnet-interactive', 'language.switch.fsharp', 'comment.line.magic-commands']
+                    scopes: ['source.dotnet-interactive', 'language.switch.fsharp', 'comment.line.magic-commands', 'comment.line.magic-commands.hash-bang']
                 },
                 {
                     tokenText: 'some-magic-command',
-                    scopes: ['source.dotnet-interactive', 'language.switch.fsharp', 'keyword.control.magic-commands']
+                    scopes: ['source.dotnet-interactive', 'language.switch.fsharp', 'comment.line.magic-commands', 'keyword.control.magic-commands']
                 }
             ],
             [
@@ -237,57 +237,73 @@ describe('TextMate grammar tests', async () => {
     }
 
     it('sub-parsing within magic commands', async () => {
-        const text = ['#!share --from csharp x "some string"'];
+        const text = ['#!share --from csharp x "some string" /a b'];
         const tokens = await getTokens(text, 'source.dotnet-interactive.magic-commands');
         expect(tokens).to.deep.equal([
             [
                 {
                     tokenText: '#!',
-                    scopes: ['source.dotnet-interactive.magic-commands', 'comment.line.magic-commands']
+                    scopes: ['source.dotnet-interactive.magic-commands', 'comment.line.magic-commands', 'comment.line.magic-commands.hash-bang']
                 },
                 {
                     tokenText: 'share',
-                    scopes: ['source.dotnet-interactive.magic-commands', 'keyword.control.magic-commands']
+                    scopes: ['source.dotnet-interactive.magic-commands', 'comment.line.magic-commands', 'keyword.control.magic-commands']
                 },
                 {
                     tokenText: ' ',
-                    scopes: ['source.dotnet-interactive.magic-commands']
+                    scopes: ['source.dotnet-interactive.magic-commands', 'comment.line.magic-commands']
                 },
                 {
                     tokenText: '--from',
-                    scopes: ['source.dotnet-interactive.magic-commands', 'constant.language.magic-commands']
+                    scopes: ['source.dotnet-interactive.magic-commands', 'comment.line.magic-commands', 'constant.language.magic-commands']
                 },
                 {
                     tokenText: ' ',
-                    scopes: ['source.dotnet-interactive.magic-commands']
+                    scopes: ['source.dotnet-interactive.magic-commands', 'comment.line.magic-commands']
                 },
                 {
                     tokenText: 'csharp',
-                    scopes: ['source.dotnet-interactive.magic-commands', 'variable.parameter.magic-commands']
+                    scopes: ['source.dotnet-interactive.magic-commands', 'comment.line.magic-commands', 'variable.parameter.magic-commands']
                 },
                 {
                     tokenText: ' ',
-                    scopes: ['source.dotnet-interactive.magic-commands']
+                    scopes: ['source.dotnet-interactive.magic-commands', 'comment.line.magic-commands']
                 },
                 {
                     tokenText: 'x',
-                    scopes: ['source.dotnet-interactive.magic-commands', 'variable.parameter.magic-commands']
+                    scopes: ['source.dotnet-interactive.magic-commands', 'comment.line.magic-commands', 'variable.parameter.magic-commands']
                 },
                 {
                     tokenText: ' ',
-                    scopes: ['source.dotnet-interactive.magic-commands']
+                    scopes: ['source.dotnet-interactive.magic-commands', 'comment.line.magic-commands']
                 },
                 {
                     tokenText: '"',
-                    scopes: ['source.dotnet-interactive.magic-commands', 'string.quoted.double.magic-commands']
+                    scopes: ['source.dotnet-interactive.magic-commands', 'comment.line.magic-commands', 'string.quoted.double.magic-commands']
                 },
                 {
                     tokenText: 'some string',
-                    scopes: ['source.dotnet-interactive.magic-commands', 'string.quoted.double.magic-commands']
+                    scopes: ['source.dotnet-interactive.magic-commands', 'comment.line.magic-commands', 'string.quoted.double.magic-commands']
                 },
                 {
                     tokenText: '"',
-                    scopes: ['source.dotnet-interactive.magic-commands', 'string.quoted.double.magic-commands']
+                    scopes: ['source.dotnet-interactive.magic-commands', 'comment.line.magic-commands', 'string.quoted.double.magic-commands']
+                },
+                {
+                    tokenText: ' ',
+                    scopes: ['source.dotnet-interactive.magic-commands', 'comment.line.magic-commands']
+                },
+                {
+                    tokenText: '/a',
+                    scopes: ['source.dotnet-interactive.magic-commands', 'comment.line.magic-commands', 'constant.language.magic-commands']
+                },
+                {
+                    tokenText: ' ',
+                    scopes: ['source.dotnet-interactive.magic-commands', 'comment.line.magic-commands']
+                },
+                {
+                    tokenText: 'b',
+                    scopes: ['source.dotnet-interactive.magic-commands', 'comment.line.magic-commands', 'variable.parameter.magic-commands']
                 }
             ]
         ]);

--- a/src/dotnet-interactive-vscode/src/tests/unit/grammar.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/grammar.test.ts
@@ -28,23 +28,32 @@ describe('TextMate grammar tests', async () => {
             return new Promise<vsctm.IRawGrammar | null>((resolve, reject) => {
                 const grammarFileName = `${scopeName}.tmGrammar.json`;
                 const grammarFilePath = path.join(grammarDir, grammarFileName);
+                let contents: string;
                 if (!fs.existsSync(grammarFilePath)) {
-                    resolve(null);
-                    return;
+                    // tests can't delegate to well-known languages because those grammars aren't in this repo, so we create a catch-all
+                    const emptyGrammar = {
+                        scopeName,
+                        patterns: [
+                            {
+                                name: `language.line.${scopeName}`,
+                                match: '^.*$'
+                            }
+                        ]
+                    };
+                    contents = JSON.stringify(emptyGrammar);
+                } else {
+                    const buffer = fs.readFileSync(grammarFilePath);
+                    contents = buffer.toString('utf-8');
                 }
 
-                fs.readFile(grammarFilePath, (_err, data) => {
-                    const contents = data.toString('utf-8');
-                    const grammar = vsctm.parseRawGrammar(contents, grammarFilePath);
-                    resolve(grammar);
-                });
-                
+                const grammar = vsctm.parseRawGrammar(contents, grammarFilePath);
+                resolve(grammar);
             });
         }
     });
 
-    async function getTokens(text: Array<string>): Promise<Array<Array<any>>> {
-        const grammar = await registry.loadGrammar('source.dotnet-interactive');
+    async function getTokens(text: Array<string>, initialScope?: string): Promise<Array<Array<any>>> {
+        const grammar = await registry.loadGrammar(initialScope ?? 'source.dotnet-interactive');
         let ruleStack = vsctm.INITIAL;
         let allTokens = [];
         for (let i = 0; i < text.length; i++) {
@@ -86,67 +95,67 @@ describe('TextMate grammar tests', async () => {
             [
                 {
                     tokenText: '#!csharp',
-                    scopes: ['source.dotnet-interactive', 'language.csharp']
+                    scopes: ['source.dotnet-interactive', 'language.switch.csharp']
                 }
             ],
             [
                 {
                     tokenText: '#!cs',
-                    scopes: ['source.dotnet-interactive', 'language.csharp']
+                    scopes: ['source.dotnet-interactive', 'language.switch.csharp']
                 }
             ],
             [
                 {
                     tokenText: '#!fsharp',
-                    scopes: ['source.dotnet-interactive', 'language.fsharp']
+                    scopes: ['source.dotnet-interactive', 'language.switch.fsharp']
                 }
             ],
             [
                 {
                     tokenText: '#!fs',
-                    scopes: ['source.dotnet-interactive', 'language.fsharp']
+                    scopes: ['source.dotnet-interactive', 'language.switch.fsharp']
                 }
             ],
             [
                 {
                     tokenText: '#!html',
-                    scopes: ['source.dotnet-interactive', 'language.html']
+                    scopes: ['source.dotnet-interactive', 'language.switch.html']
                 }
             ],
             [
                 {
                     tokenText: '#!javascript',
-                    scopes: ['source.dotnet-interactive', 'language.javascript']
+                    scopes: ['source.dotnet-interactive', 'language.switch.javascript']
                 }
             ],
             [
                 {
                     tokenText: '#!js',
-                    scopes: ['source.dotnet-interactive', 'language.javascript']
+                    scopes: ['source.dotnet-interactive', 'language.switch.javascript']
                 }
             ],
             [
                 {
                     tokenText: '#!markdown',
-                    scopes: ['source.dotnet-interactive', 'language.markdown']
+                    scopes: ['source.dotnet-interactive', 'language.switch.markdown']
                 }
             ],
             [
                 {
                     tokenText: '#!md',
-                    scopes: ['source.dotnet-interactive', 'language.markdown']
+                    scopes: ['source.dotnet-interactive', 'language.switch.markdown']
                 }
             ],
             [
                 {
                     tokenText: '#!powershell',
-                    scopes: ['source.dotnet-interactive', 'language.powershell']
+                    scopes: ['source.dotnet-interactive', 'language.switch.powershell']
                 }
             ],
             [
                 {
                     tokenText: '#!pwsh',
-                    scopes: ['source.dotnet-interactive', 'language.powershell']
+                    scopes: ['source.dotnet-interactive', 'language.switch.powershell']
                 }
             ]
         ]);
@@ -164,25 +173,29 @@ describe('TextMate grammar tests', async () => {
             [
                 {
                     tokenText: '#!fsharp',
-                    scopes: ['source.dotnet-interactive', 'language.fsharp']
+                    scopes: ['source.dotnet-interactive', 'language.switch.fsharp']
                 }
             ],
             [
                 {
                     tokenText: '// this is fsharp',
-                    scopes: ['source.dotnet-interactive', 'language.fsharp']
+                    scopes: ['source.dotnet-interactive', 'language.switch.fsharp', 'language.line.source.fsharp']
                 }
             ],
             [
                 {
-                    tokenText: '#!some-magic-command',
-                    scopes: ['source.dotnet-interactive', 'language.fsharp', 'comment.magic-command']
+                    tokenText: '#!',
+                    scopes: ['source.dotnet-interactive', 'language.switch.fsharp', 'comment.line.magic-commands']
+                },
+                {
+                    tokenText: 'some-magic-command',
+                    scopes: ['source.dotnet-interactive', 'language.switch.fsharp', 'keyword.control.magic-commands']
                 }
             ],
             [
                 {
                     tokenText: '// this is still fsharp',
-                    scopes: ['source.dotnet-interactive', 'language.fsharp']
+                    scopes: ['source.dotnet-interactive', 'language.switch.fsharp', 'language.line.source.fsharp']
                 }
             ]
         ]);
@@ -204,7 +217,7 @@ describe('TextMate grammar tests', async () => {
                 [
                     {
                         tokenText: `#!${language}`,
-                        scopes: ['source.dotnet-interactive', `language.${language}`]
+                        scopes: ['source.dotnet-interactive', `language.switch.${language}`]
                     }
                 ]
             ];
@@ -213,7 +226,7 @@ describe('TextMate grammar tests', async () => {
                 expected.push([
                     {
                         tokenText: `#!${otherLanguage}`,
-                        scopes: ['source.dotnet-interactive', `language.${otherLanguage}`]
+                        scopes: ['source.dotnet-interactive', `language.switch.${otherLanguage}`]
                     }
                 ]);
             }
@@ -222,4 +235,61 @@ describe('TextMate grammar tests', async () => {
             expect(tokens).to.deep.equal(expected);
         });
     }
+
+    it('sub-parsing within magic commands', async () => {
+        const text = ['#!share --from csharp x "some string"'];
+        const tokens = await getTokens(text, 'source.dotnet-interactive.magic-commands');
+        expect(tokens).to.deep.equal([
+            [
+                {
+                    tokenText: '#!',
+                    scopes: ['source.dotnet-interactive.magic-commands', 'comment.line.magic-commands']
+                },
+                {
+                    tokenText: 'share',
+                    scopes: ['source.dotnet-interactive.magic-commands', 'keyword.control.magic-commands']
+                },
+                {
+                    tokenText: ' ',
+                    scopes: ['source.dotnet-interactive.magic-commands']
+                },
+                {
+                    tokenText: '--from',
+                    scopes: ['source.dotnet-interactive.magic-commands', 'constant.language.magic-commands']
+                },
+                {
+                    tokenText: ' ',
+                    scopes: ['source.dotnet-interactive.magic-commands']
+                },
+                {
+                    tokenText: 'csharp',
+                    scopes: ['source.dotnet-interactive.magic-commands', 'variable.parameter.magic-commands']
+                },
+                {
+                    tokenText: ' ',
+                    scopes: ['source.dotnet-interactive.magic-commands']
+                },
+                {
+                    tokenText: 'x',
+                    scopes: ['source.dotnet-interactive.magic-commands', 'variable.parameter.magic-commands']
+                },
+                {
+                    tokenText: ' ',
+                    scopes: ['source.dotnet-interactive.magic-commands']
+                },
+                {
+                    tokenText: '"',
+                    scopes: ['source.dotnet-interactive.magic-commands', 'string.quoted.double.magic-commands']
+                },
+                {
+                    tokenText: 'some string',
+                    scopes: ['source.dotnet-interactive.magic-commands', 'string.quoted.double.magic-commands']
+                },
+                {
+                    tokenText: '"',
+                    scopes: ['source.dotnet-interactive.magic-commands', 'string.quoted.double.magic-commands']
+                }
+            ]
+        ]);
+    });
 });

--- a/src/dotnet-interactive-vscode/syntaxes/source.dotnet-interactive.magic-commands.tmGrammar.json
+++ b/src/dotnet-interactive-vscode/syntaxes/source.dotnet-interactive.magic-commands.tmGrammar.json
@@ -4,19 +4,27 @@
     "patterns": [
         {
             "name": "comment.line.magic-commands",
-            "match": "^#!(?!([cf](#|s(harp)?)|powershell|pwsh|html|javascript|js|markdown|md).*$)"
-        },
-        {
-            "include": "#magic-command-name"
-        },
-        {
-            "include": "#flag-argument"
-        },
-        {
-            "include": "#parameter"
-        },
-        {
-            "include": "#strings"
+            "begin": "^(#!)(?!([cf](#|s(harp)?)|powershell|pwsh|html|javascript|js|markdown|md))",
+            "end": "(?<=$)",
+            "beginCaptures": {
+                "1": {
+                    "name": "comment.line.magic-commands.hash-bang"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#magic-command-name"
+                },
+                {
+                    "include": "#strings"
+                },
+                {
+                    "include": "#option"
+                },
+                {
+                    "include": "#argument"
+                }
+            ]
         }
     ],
     "repository": {
@@ -28,19 +36,19 @@
                 }
             ]
         },
-        "flag-argument": {
+        "option": {
             "patterns": [
                 {
                     "name": "constant.language.magic-commands",
-                    "match": "--?[^\\s-]+"
+                    "match": "(--?|/)[^\\s\\\"]+"
                 }
             ]
         },
-        "parameter": {
+        "argument": {
             "patterns": [
                 {
                     "name": "variable.parameter.magic-commands",
-                    "match": "[_a-zA-Z0-9]+"
+                    "match": "[^\\s\\\"]+"
                 }
             ]
         },

--- a/src/dotnet-interactive-vscode/syntaxes/source.dotnet-interactive.magic-commands.tmGrammar.json
+++ b/src/dotnet-interactive-vscode/syntaxes/source.dotnet-interactive.magic-commands.tmGrammar.json
@@ -1,9 +1,63 @@
 {
+    "name": ".NET Interactive Magic Commands",
     "scopeName": "source.dotnet-interactive.magic-commands",
     "patterns": [
         {
-            "name": "comment.magic-command",
-            "match": "^#!(?!([cf](#|s(harp)?)|powershell|pwsh|html|javascript|js|markdown|md)).*$"
+            "name": "comment.line.magic-commands",
+            "match": "^#!(?!([cf](#|s(harp)?)|powershell|pwsh|html|javascript|js|markdown|md).*$)"
+        },
+        {
+            "include": "#magic-command-name"
+        },
+        {
+            "include": "#flag-argument"
+        },
+        {
+            "include": "#parameter"
+        },
+        {
+            "include": "#strings"
         }
-    ]
+    ],
+    "repository": {
+        "magic-command-name": {
+            "patterns": [
+                {
+                    "name": "keyword.control.magic-commands",
+                    "match": "(?<=^#!)[a-zA-Z0-9_-]+"
+                }
+            ]
+        },
+        "flag-argument": {
+            "patterns": [
+                {
+                    "name": "constant.language.magic-commands",
+                    "match": "--?[^\\s-]+"
+                }
+            ]
+        },
+        "parameter": {
+            "patterns": [
+                {
+                    "name": "variable.parameter.magic-commands",
+                    "match": "[_a-zA-Z0-9]+"
+                }
+            ]
+        },
+        "strings": {
+            "patterns": [
+                {
+                    "name": "string.quoted.double.magic-commands",
+                    "begin": "\"",
+                    "end": "\"",
+                    "patterns": [
+                        {
+                            "name": "constant.character.escape.magic-commands",
+                            "match": "\\."
+                        }
+                    ]
+                }
+            ]
+        }
+    }
 }

--- a/src/dotnet-interactive-vscode/syntaxes/source.dotnet-interactive.tmGrammar.json
+++ b/src/dotnet-interactive-vscode/syntaxes/source.dotnet-interactive.tmGrammar.json
@@ -4,7 +4,7 @@
         {
             "begin": "^#!cs(harp)?\\s+$",
             "end": "(?=^#!(cs(harp)?|fs(harp)?|html|javascript|js|markdown|md|powershell|pwsh)\\s+$)",
-            "name": "language.csharp",
+            "name": "language.switch.csharp",
             "patterns": [
                 {
                     "include": "source.dotnet-interactive.csharp"
@@ -14,7 +14,7 @@
         {
             "begin": "^#!fs(harp)?\\s+$",
             "end": "(?=^#!(cs(harp)?|fs(harp)?|html|javascript|js|markdown|md|powershell|pwsh)\\s+$)",
-            "name": "language.fsharp",
+            "name": "language.switch.fsharp",
             "patterns": [
                 {
                     "include": "source.dotnet-interactive.fsharp"
@@ -24,7 +24,7 @@
         {
             "begin": "^#!html\\s+$",
             "end": "(?=^#!(cs(harp)?|fs(harp)?|html|javascript|js|markdown|md|powershell|pwsh)\\s+$)",
-            "name": "language.html",
+            "name": "language.switch.html",
             "patterns": [
                 {
                     "include": "source.dotnet-interactive.html"
@@ -34,7 +34,7 @@
         {
             "begin": "^#!(javascript|js)\\s+$",
             "end": "(?=^#!(cs(harp)?|fs(harp)?|html|javascript|js|markdown|md|powershell|pwsh)\\s+$)",
-            "name": "language.javascript",
+            "name": "language.switch.javascript",
             "patterns": [
                 {
                     "include": "source.dotnet-interactive.javascript"
@@ -44,7 +44,7 @@
         {
             "begin": "^#!(markdown|md)\\s+$",
             "end": "(?=^#!(cs(harp)?|fs(harp)?|html|javascript|js|markdown|md|powershell|pwsh)\\s+$)",
-            "name": "language.markdown",
+            "name": "language.switch.markdown",
             "patterns": [
                 {
                     "include": "source.dotnet-interactive.markdown"
@@ -54,7 +54,7 @@
         {
             "begin": "^#!(powershell|pwsh)\\s+$",
             "end": "(?=^#!(cs(harp)?|fs(harp)?|html|javascript|js|markdown|md|powershell|pwsh)\\s+$)",
-            "name": "language.powershell",
+            "name": "language.switch.powershell",
             "patterns": [
                 {
                     "include": "source.dotnet-interactive.powershell"


### PR DESCRIPTION
Instead of classifying the whole line `#!share --from csharp x` as a comment, we can now mark the magic command itself as different from arguments that get passed to it, etc.

![image](https://user-images.githubusercontent.com/926281/84555474-0aa64580-acd2-11ea-9eec-8f0617fa58cd.png)

No functional change, purely display only.
