### PR TITLE
update to current notebook APIs

### DIFF
--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -80,7 +80,7 @@
         },
         "dotnet-interactive.minimumInteractiveToolVersion": {
           "type": "string",
-          "default": "1.0.131103",
+          "default": "1.0.131105",
           "description": "The minimum required version of the .NET Interactive tool."
         }
       }

--- a/src/dotnet-interactive-vscode/src/acquisition.ts
+++ b/src/dotnet-interactive-vscode/src/acquisition.ts
@@ -47,7 +47,7 @@ export async function acquireDotnetInteractive(
 
     // no current version installed or it's out of date
     reportInstallationStarted(requiredVersion);
-    reportingChannel.appendLine(`Acquiring `);
+    reportingChannel.appendLine(`Acquiring`);
     await installInteractive({
             dotnetPath: args.dotnetPath,
             toolVersion: requiredVersion

--- a/src/dotnet-interactive-vscode/src/interfaces/vscode.ts
+++ b/src/dotnet-interactive-vscode/src/interfaces/vscode.ts
@@ -44,7 +44,7 @@ export interface Document {
 
 export interface NotebookCell {
     cellKind: CellKind;
-    source: string;
+    document: Document;
     language: string;
     outputs: CellOutput[];
 }

--- a/src/dotnet-interactive-vscode/src/interop/jupyter.ts
+++ b/src/dotnet-interactive-vscode/src/interop/jupyter.ts
@@ -17,11 +17,11 @@ export function convertToJupyter(document: NotebookDocument): JupyterNotebook {
                 jcell = {
                     cell_type: 'markdown',
                     metadata: {},
-                    source: cell.source
+                    source: cell.document.getText()
                 };
                 break;
             case CellKind.Code:
-                let cellSource = splitAndEnsureNewlineTerminators(cell.source);
+                let cellSource = splitAndEnsureNewlineTerminators(cell.document.getText());
                 if (cell.language !== notebookLanguage) {
                     cellSource.unshift(`#!${getSimpleLanguage(cell.language)}\r\n`);
                 }

--- a/src/dotnet-interactive-vscode/src/tests/unit/importExport.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/importExport.test.ts
@@ -15,7 +15,10 @@ describe('File export tests', () => {
             cells: [
                 {
                     cellKind: CellKind.Code,
-                    source: '[1;2;3;4]\r\n|> List.sum',
+                    document: {
+                        uri: { fsPath: 'test-notebook' },
+                        getText: () => '[1;2;3;4]\r\n|> List.sum'
+                    },
                     language: 'dotnet-interactive.fsharp',
                     outputs: [
                         {
@@ -28,7 +31,10 @@ describe('File export tests', () => {
                 },
                 {
                     cellKind: CellKind.Code,
-                    source: '1 + 1',
+                    document: {
+                        uri: { fsPath: 'test-notebook' },
+                        getText: () => '1 + 1'
+                    },
                     language: 'dotnet-interactive.csharp',
                     outputs: [
                         {
@@ -41,7 +47,10 @@ describe('File export tests', () => {
                 },
                 {
                     cellKind: CellKind.Markdown,
-                    source: 'This is `markdown`.',
+                    document: {
+                        uri: { fsPath: 'test-notebook' },
+                        getText: () => 'This is `markdown`.'
+                    },
                     language: 'dotnet-interactive.markdown',
                     outputs: []
                 },

--- a/src/dotnet-interactive-vscode/src/vscode/notebookProvider.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/notebookProvider.ts
@@ -61,7 +61,8 @@ export class DotNetInteractiveNotebookContentProvider implements vscode.Notebook
             return;
         }
 
-        cell.metadata.runStartTime = Date.now();
+        const startTime = Date.now();
+        cell.metadata.runStartTime = startTime;
         cell.metadata.runState = vscode.NotebookCellRunState.Running;
         cell.outputs = [];
         let client = await this.clientMapper.getOrAddClient(document.uri);
@@ -72,8 +73,10 @@ export class DotNetInteractiveNotebookContentProvider implements vscode.Notebook
             cell.outputs = outputs;
         }).then(() => {
             cell.metadata.runState = vscode.NotebookCellRunState.Success;
+            cell.metadata.lastRunDuration = Date.now() - startTime;
         }).catch(() => {
             cell.metadata.runState = vscode.NotebookCellRunState.Error;
+            cell.metadata.lastRunDuration = Date.now() - startTime;
         });
     }
 

--- a/src/dotnet-interactive-vscode/src/vscode/notebookProvider.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/notebookProvider.ts
@@ -18,10 +18,13 @@ export class DotNetInteractiveNotebookContentProvider implements vscode.Notebook
         this.kernel = this;
         this.label = ".NET Interactive";
     }
-    
+
     preloads?: vscode.Uri[] | undefined;
-    executeAllCells(document: vscode.NotebookDocument, token: vscode.CancellationToken): Promise<void> {
-        throw new Error("Method not implemented.");
+
+    async executeAllCells(document: vscode.NotebookDocument, token: vscode.CancellationToken): Promise<void> {
+        for (let cell of document.cells) {
+            await this.executeCell(document, cell, token);
+        }
     }
 
     async openNotebook(uri: vscode.Uri): Promise<vscode.NotebookData> {
@@ -55,12 +58,7 @@ export class DotNetInteractiveNotebookContentProvider implements vscode.Notebook
 
     onDidChangeNotebook: vscode.Event<vscode.NotebookDocumentEditEvent> = this.onDidChangeNotebookEventEmitter.event;
 
-    async executeCell(document: vscode.NotebookDocument, cell: vscode.NotebookCell | undefined, token: vscode.CancellationToken): Promise<void> {
-        if (!cell) {
-            // TODO: run everything
-            return;
-        }
-
+    async executeCell(document: vscode.NotebookDocument, cell: vscode.NotebookCell, token: vscode.CancellationToken): Promise<void> {
         const startTime = Date.now();
         cell.metadata.runStartTime = startTime;
         cell.metadata.runState = vscode.NotebookCellRunState.Running;

--- a/src/dotnet-interactive-vscode/src/vscode/notebookProvider.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/notebookProvider.ts
@@ -65,7 +65,7 @@ export class DotNetInteractiveNotebookContentProvider implements vscode.Notebook
         cell.metadata.runState = vscode.NotebookCellRunState.Running;
         cell.outputs = [];
         let client = await this.clientMapper.getOrAddClient(document.uri);
-        let source = cell.source.toString();
+        let source = cell.document.getText();
         return client.execute(source, getSimpleLanguage(cell.language), outputs => {
             // to properly trigger the UI update, `cell.outputs` needs to be uniquely assigned; simply setting it to the local variable has no effect
             cell.outputs = [];


### PR DESCRIPTION
The property `cell.source` has been removed; `cell.document.getText()` is to be used instead.