### PR TITLE
Fixed how PSCustomObject instances are displayed with OutDisplay

### DIFF
--- a/src/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
@@ -249,7 +249,7 @@ for ($j = 0; $j -le 4; $j += 4 ) {
                 e => e.Should().BeOfType<CodeSubmissionReceived>(),
                 e => e.Should().BeOfType<CompleteCodeSubmissionReceived>(),
                 e => e.Should().BeOfType<DisplayedValueProduced>().Which.Value.Should().BeEquivalentTo(props),
-                e => e.Should().BeOfType<CommandHandled>()
+                e => e.Should().BeOfType<CommandSucceeded>()
             );
         }
     }

--- a/src/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
@@ -245,10 +245,10 @@ for ($j = 0; $j -le 4; $j += 4 ) {
             var result = await kernel.SendAsync(new SubmitCode("[pscustomobject]@{ prop1 = 'value1'; prop2 = 'value2'; prop3 = 'value3' } | Out-Display"));
             var outputs = result.KernelEvents.ToSubscribedList();
 
-            Assert.Collection(outputs,
+            outputs.Should().SatisfyRespectively(
                               e => e.Should().BeOfType<CodeSubmissionReceived>(),
                               e => e.Should().BeOfType<CompleteCodeSubmissionReceived>(),
-                              e => e.Should().BeOfType<DisplayedValueProduced>().Which.FormattedValues.Should().Equals(props),
+                              e => e.Should().BeOfType<DisplayedValueProduced>().Which.Value.Should().BeEquivalentTo(props),
                               e => e.Should().BeOfType<CommandHandled>()
                              );
         }

--- a/src/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
@@ -55,7 +55,6 @@ for ($j = 0; $j -le 4; $j += 4 ) {
 
             var events = result.KernelEvents.ToSubscribedList();
 
-            var formattedValues = ((DisplayEventBase)(result.KernelEvents.ToSubscribedList()[2])).FormattedValues;
             Assert.Collection(events,
                                        e => e.Should().BeOfType<CodeSubmissionReceived>(),
                                        e => e.Should().BeOfType<CompleteCodeSubmissionReceived>(),

--- a/src/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
@@ -232,25 +232,24 @@ for ($j = 0; $j -le 4; $j += 4 ) {
         }
 
         [Fact]
-        public async Task Powershell_customobject_is_formatted_for_outdisplay()
+        public async Task PowerShell_Custom_Object_OutDisplay_Passed()
         {
-            var obj = new PSObject();
-            obj.Properties.Add(new PSNoteProperty("prop1", "value1"));
-            obj.Properties.Add(new PSNoteProperty("prop2", "value2"));
-            obj.Properties.Add(new PSNoteProperty("prop3", "value3"));
-            var propDict = obj.Properties.ToDictionary(x => x.Name, x => x.Value);
+            var props = (new Dictionary<string, object>
+                {
+                    { "prop1", "value1" },
+                    { "prop2", "value2" },
+                    { "prop3", "value3" }
+                });
 
             var kernel = CreateKernel(Language.PowerShell);
             var result = await kernel.SendAsync(new SubmitCode("[pscustomobject]@{ prop1 = 'value1'; prop2 = 'value2'; prop3 = 'value3' } | Out-Display"));
             var outputs = result.KernelEvents.ToSubscribedList();
 
             outputs.Should().SatisfyRespectively(
-                                  e => e.Should().BeOfType<CodeSubmissionReceived>(),
-                                  e => e.Should().BeOfType<CompleteCodeSubmissionReceived>(),
-                                  e => e.Should().BeOfType<DisplayedValueProduced>().
-                                        Which.Value.Should().BeOfType<PSObject>().
-                                        Which.Properties.ToDictionary(x => x.Name, x => x.Value).Should().BeEquivalentTo(propDict),
-                                  e => e.Should().BeOfType<CommandHandled>()
+                              e => e.Should().BeOfType<CodeSubmissionReceived>(),
+                              e => e.Should().BeOfType<CompleteCodeSubmissionReceived>(),
+                              e => e.Should().BeOfType<DisplayedValueProduced>().Which.Value.Should().BeEquivalentTo(props),
+                              e => e.Should().BeOfType<CommandHandled>()
                              );
         }
     }

--- a/src/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
@@ -232,23 +232,20 @@ for ($j = 0; $j -le 4; $j += 4 ) {
         }
 
         [Fact]
-        public async Task Powershell_customobject_is_parsed_for_outdisplay()
+        public async Task Powershell_customobject_is_formatted_for_outdisplay()
         {
-            var props = (new Dictionary<string, object>
-            {
-                { "prop1", "value1" },
-                { "prop2", "value2" },
-                { "prop3", "value3" }
-            });
-
             var kernel = CreateKernel(Language.PowerShell);
             var result = await kernel.SendAsync(new SubmitCode("[pscustomobject]@{ prop1 = 'value1'; prop2 = 'value2'; prop3 = 'value3' } | Out-Display"));
             var outputs = result.KernelEvents.ToSubscribedList();
 
+            string mimeType = "text/html";
+            string formattedHtml = "<table><thead><tr><th><i>key</i></th><th>value</th></tr></thead><tbody><tr><td>prop1</td><td>value1</td></tr><tr><td>prop2</td><td>value2</td></tr><tr><td>prop3</td><td>value3</td></tr></tbody></table>";
+            FormattedValue fv = new FormattedValue(mimeType, formattedHtml);
+
             outputs.Should().SatisfyRespectively(
                 e => e.Should().BeOfType<CodeSubmissionReceived>(),
                 e => e.Should().BeOfType<CompleteCodeSubmissionReceived>(),
-                e => e.Should().BeOfType<DisplayedValueProduced>().Which.Value.Should().BeEquivalentTo(props),
+                e => e.Should().BeOfType<DisplayedValueProduced>().Which.FormattedValues.ElementAt(0).Should().BeEquivalentTo(fv),
                 e => e.Should().BeOfType<CommandSucceeded>()
             );
         }

--- a/src/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
@@ -232,24 +232,25 @@ for ($j = 0; $j -le 4; $j += 4 ) {
         }
 
         [Fact]
-        public async Task PowerShell_Custom_Object_OutDisplay_Passed()
+        public async Task Powershell_customobject_is_formatted_for_outdisplay()
         {
-            var props = (new Dictionary<string, object>
-                {
-                    { "prop1", "value1" },
-                    { "prop2", "value2" },
-                    { "prop3", "value3" }
-                });
+            var obj = new PSObject();
+            obj.Properties.Add(new PSNoteProperty("prop1", "value1"));
+            obj.Properties.Add(new PSNoteProperty("prop2", "value2"));
+            obj.Properties.Add(new PSNoteProperty("prop3", "value3"));
+            var propDict = obj.Properties.ToDictionary(x => x.Name, x => x.Value);
 
             var kernel = CreateKernel(Language.PowerShell);
             var result = await kernel.SendAsync(new SubmitCode("[pscustomobject]@{ prop1 = 'value1'; prop2 = 'value2'; prop3 = 'value3' } | Out-Display"));
             var outputs = result.KernelEvents.ToSubscribedList();
 
             outputs.Should().SatisfyRespectively(
-                              e => e.Should().BeOfType<CodeSubmissionReceived>(),
-                              e => e.Should().BeOfType<CompleteCodeSubmissionReceived>(),
-                              e => e.Should().BeOfType<DisplayedValueProduced>().Which.Value.Should().BeEquivalentTo(props),
-                              e => e.Should().BeOfType<CommandHandled>()
+                                  e => e.Should().BeOfType<CodeSubmissionReceived>(),
+                                  e => e.Should().BeOfType<CompleteCodeSubmissionReceived>(),
+                                  e => e.Should().BeOfType<DisplayedValueProduced>().
+                                        Which.Value.Should().BeOfType<PSObject>().
+                                        Which.Properties.ToDictionary(x => x.Name, x => x.Value).Should().BeEquivalentTo(propDict),
+                                  e => e.Should().BeOfType<CommandHandled>()
                              );
         }
     }

--- a/src/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
@@ -235,11 +235,11 @@ for ($j = 0; $j -le 4; $j += 4 ) {
         public async Task Powershell_customobject_is_parsed_for_outdisplay()
         {
             var props = (new Dictionary<string, object>
-                {
-                    { "prop1", "value1" },
-                    { "prop2", "value2" },
-                    { "prop3", "value3" }
-                });
+            {
+                { "prop1", "value1" },
+                { "prop2", "value2" },
+                { "prop3", "value3" }
+            });
 
             var kernel = CreateKernel(Language.PowerShell);
             var result = await kernel.SendAsync(new SubmitCode("[pscustomobject]@{ prop1 = 'value1'; prop2 = 'value2'; prop3 = 'value3' } | Out-Display"));

--- a/src/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
@@ -232,7 +232,7 @@ for ($j = 0; $j -le 4; $j += 4 ) {
         }
 
         [Fact]
-        public async Task PowerShell_Custom_Object_OutDisplay_Passed()
+        public async Task Powershell_customobject_is_parsed_for_outdisplay()
         {
             var props = (new Dictionary<string, object>
                 {

--- a/src/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
@@ -246,11 +246,11 @@ for ($j = 0; $j -le 4; $j += 4 ) {
             var outputs = result.KernelEvents.ToSubscribedList();
 
             outputs.Should().SatisfyRespectively(
-                              e => e.Should().BeOfType<CodeSubmissionReceived>(),
-                              e => e.Should().BeOfType<CompleteCodeSubmissionReceived>(),
-                              e => e.Should().BeOfType<DisplayedValueProduced>().Which.Value.Should().BeEquivalentTo(props),
-                              e => e.Should().BeOfType<CommandHandled>()
-                             );
+                e => e.Should().BeOfType<CodeSubmissionReceived>(),
+                e => e.Should().BeOfType<CompleteCodeSubmissionReceived>(),
+                e => e.Should().BeOfType<DisplayedValueProduced>().Which.Value.Should().BeEquivalentTo(props),
+                e => e.Should().BeOfType<CommandHandled>()
+            );
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
@@ -1,12 +1,12 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using static Microsoft.DotNet.Interactive.Kernel;
+using Microsoft.DotNet.Interactive.Events;
+using System.Management.Automation;
 using System.Collections.Generic;
+using static Microsoft.DotNet.Interactive.Kernel;
 
 namespace Microsoft.DotNet.Interactive.PowerShell.Commands
 {
-    using System.Management.Automation;
-    using Microsoft.DotNet.Interactive.Events;
 
     /// <summary>
     /// Takes the the input and displays it on the client using .NET Interactive's formatters.

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Commands
         /// </summary>
         protected override void ProcessRecord()
         {
-            object obj = InputObject is PSObject psObject ? psObject.BaseObject : InputObject;
+            object obj;
 
             // If object is PSCustomObject, convert to PSObject to find the properties to display
             if (InputObject is PSObject psObj)

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Commands
             object obj = InputObject is PSObject psObject ? psObject.BaseObject : InputObject;
 
             // If object is PSCustomObject, find convert to PSObject to find the properties to display
-            if(((PSObject)InputObject).BaseObject is PSCustomObject)
+            if (((PSObject)InputObject).BaseObject is PSCustomObject)
             {
                 Dictionary<string, object> table = new Dictionary<string, object>();
                 var props = ((PSObject)InputObject).Properties;

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
@@ -58,8 +58,8 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Commands
             
             object obj = InputObject is PSObject psObject ? psObject.BaseObject : InputObject;
 
-            // If object is PSCustomObject, find convert to PSObject to find the properties to display
-            if (((PSObject)InputObject).BaseObject is PSCustomObject)
+            // If object is PSCustomObject, convert to PSObject to find the properties to display
+            if (InputObject is PSObject && ((PSObject)InputObject).BaseObject is PSCustomObject)
             {
                 Dictionary<string, object> table = new Dictionary<string, object>();
                 var props = ((PSObject)InputObject).Properties;

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
@@ -55,7 +55,32 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Commands
         /// </summary>
         protected override void ProcessRecord()
         {
-            DisplayedValue displayedValue = display(InputObject, MimeType);
+            object obj = InputObject is PSObject psObject ? psObject.BaseObject : InputObject;
+
+            // If object is PSCustomObject, convert to PSObject to find the properties to display
+            if (InputObject is PSObject psObj)
+            {
+                if (psObj.BaseObject is PSCustomObject)
+                {
+                    Dictionary<string, object> table = new Dictionary<string, object>();
+                    var props = psObj.Properties;
+                    foreach (var p in props)
+                    {
+                        table.Add(p.Name, p.Value);
+                    }
+                    obj = table;
+                }
+                else
+                {
+                    obj = psObj.BaseObject;
+                }
+            }
+            else
+            {
+                obj = InputObject;
+            }
+
+            DisplayedValue displayedValue = display(obj, MimeType);
             
             if (PassThru.IsPresent)
             {

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
@@ -1,10 +1,10 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using static Microsoft.DotNet.Interactive.Kernel;
+using System.Collections.Generic;
 
 namespace Microsoft.DotNet.Interactive.PowerShell.Commands
 {
-    using System.Collections.Generic;
     using System.Management.Automation;
     using Microsoft.DotNet.Interactive.Events;
 

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
@@ -55,32 +55,7 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Commands
         /// </summary>
         protected override void ProcessRecord()
         {
-            object obj = InputObject is PSObject psObject ? psObject.BaseObject : InputObject;
-
-            // If object is PSCustomObject, convert to PSObject to find the properties to display
-            if (InputObject is PSObject psObj)
-            {
-                if (psObj.BaseObject is PSCustomObject)
-                {
-                    Dictionary<string, object> table = new Dictionary<string, object>();
-                    var props = psObj.Properties;
-                    foreach (var p in props)
-                    {
-                        table.Add(p.Name, p.Value);
-                    }
-                    obj = table;
-                }
-                else
-                {
-                    obj = psObj.BaseObject;
-                }
-            }
-            else
-            {
-                obj = InputObject;
-            }
-
-            DisplayedValue displayedValue = display(obj, MimeType);
+            DisplayedValue displayedValue = display(InputObject, MimeType);
             
             if (PassThru.IsPresent)
             {

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.DotNet.Interactive.Events;
 using System.Management.Automation;
-using System.Collections.Generic;
 using static Microsoft.DotNet.Interactive.Kernel;
 
 namespace Microsoft.DotNet.Interactive.PowerShell.Commands

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
@@ -55,7 +55,6 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Commands
         /// </summary>
         protected override void ProcessRecord()
         {
-            
             object obj = InputObject is PSObject psObject ? psObject.BaseObject : InputObject;
 
             // If object is PSCustomObject, convert to PSObject to find the properties to display

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
@@ -62,13 +62,7 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Commands
             {
                 if (psObj.BaseObject is PSCustomObject)
                 {
-                    Dictionary<string, object> table = new Dictionary<string, object>();
-                    var props = psObj.Properties;
-                    foreach (var p in props)
-                    {
-                        table.Add(p.Name, p.Value);
-                    }
-                    obj = table;
+                    obj = PowerShellKernel.GetPSObjectProperties(psObj);
                 }
                 else
                 {

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
@@ -55,25 +55,7 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Commands
         /// </summary>
         protected override void ProcessRecord()
         {
-            object obj;
-
-            // If object is PSCustomObject, convert to PSObject to find the properties to display
-            if (InputObject is PSObject psObj)
-            {
-                if (psObj.BaseObject is PSCustomObject)
-                {
-                    obj = PowerShellKernel.GetPSObjectProperties(psObj);
-                }
-                else
-                {
-                    obj = psObj.BaseObject;
-                }
-            }
-            else
-            {
-                obj = InputObject;
-            }
-
+            object obj = InputObject is PSObject psObj ? psObj.Unwrap() : InputObject;
             DisplayedValue displayedValue = display(obj, MimeType);
             
             if (PassThru.IsPresent)

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
@@ -59,15 +59,26 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Commands
             object obj = InputObject is PSObject psObject ? psObject.BaseObject : InputObject;
 
             // If object is PSCustomObject, convert to PSObject to find the properties to display
-            if (InputObject is PSObject && ((PSObject)InputObject).BaseObject is PSCustomObject)
+            if (InputObject is PSObject psObj)
             {
-                Dictionary<string, object> table = new Dictionary<string, object>();
-                var props = ((PSObject)InputObject).Properties;
-                foreach (var p in props)
+                if (psObj.BaseObject is PSCustomObject)
                 {
-                    table.Add(p.Name, p.Value);
+                    Dictionary<string, object> table = new Dictionary<string, object>();
+                    var props = psObj.Properties;
+                    foreach (var p in props)
+                    {
+                        table.Add(p.Name, p.Value);
+                    }
+                    obj = table;
                 }
-                obj = table;
+                else
+                {
+                    obj = psObj.BaseObject;
+                }
+            }
+            else
+            {
+                obj = InputObject;
             }
 
             DisplayedValue displayedValue = display(obj, MimeType);

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
@@ -4,6 +4,7 @@ using static Microsoft.DotNet.Interactive.Kernel;
 
 namespace Microsoft.DotNet.Interactive.PowerShell.Commands
 {
+    using System.Collections.Generic;
     using System.Management.Automation;
     using Microsoft.DotNet.Interactive.Events;
 
@@ -54,7 +55,21 @@ namespace Microsoft.DotNet.Interactive.PowerShell.Commands
         /// </summary>
         protected override void ProcessRecord()
         {
+            
             object obj = InputObject is PSObject psObject ? psObject.BaseObject : InputObject;
+
+            // If object is PSCustomObject, find convert to PSObject to find the properties to display
+            if(((PSObject)InputObject).BaseObject is PSCustomObject)
+            {
+                Dictionary<string, object> table = new Dictionary<string, object>();
+                var props = ((PSObject)InputObject).Properties;
+                foreach (var p in props)
+                {
+                    table.Add(p.Name, p.Value);
+                }
+                obj = table;
+            }
+
             DisplayedValue displayedValue = display(obj, MimeType);
             
             if (PassThru.IsPresent)

--- a/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Security;
 using System.Threading.Tasks;
@@ -95,6 +96,33 @@ namespace Microsoft.DotNet.Interactive.PowerShell
             }
 
             return secure;
+        }
+
+        internal static object Unwrap(this PSObject inputObject)
+        {
+            object obj;
+            if (inputObject is PSObject psObj)
+            {
+                if (psObj.BaseObject is PSCustomObject)
+                {
+                    Dictionary<string, object> table = new Dictionary<string, object>();
+                    foreach (var p in psObj.Properties)
+                    {
+                        table.Add(p.Name, p.Value);
+                    }
+                    obj = table;
+                }
+                else
+                {
+                    obj = psObj.BaseObject;
+                }
+            }
+            else
+            {
+                obj = inputObject;
+            }
+            
+            return obj;
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellExtensions.cs
@@ -98,30 +98,19 @@ namespace Microsoft.DotNet.Interactive.PowerShell
             return secure;
         }
 
-        internal static object Unwrap(this PSObject inputObject)
+        internal static object Unwrap(this PSObject psObj)
         {
-            object obj;
-            if (inputObject is PSObject psObj)
+            object obj = psObj.BaseObject;
+            if (psObj.BaseObject is PSCustomObject)
             {
-                if (psObj.BaseObject is PSCustomObject)
+                Dictionary<string, object> table = new Dictionary<string, object>();
+                foreach (var p in psObj.Properties)
                 {
-                    Dictionary<string, object> table = new Dictionary<string, object>();
-                    foreach (var p in psObj.Properties)
-                    {
-                        table.Add(p.Name, p.Value);
-                    }
-                    obj = table;
+                    table.Add(p.Name, p.Value);
                 }
-                else
-                {
-                    obj = psObj.BaseObject;
-                }
+                obj = table;
             }
-            else
-            {
-                obj = inputObject;
-            }
-            
+
             return obj;
         }
     }

--- a/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellExtensions.cs
@@ -101,7 +101,7 @@ namespace Microsoft.DotNet.Interactive.PowerShell
         internal static object Unwrap(this PSObject psObj)
         {
             object obj = psObj.BaseObject;
-            if (psObj.BaseObject is PSCustomObject)
+            if (obj is PSCustomObject)
             {
                 Dictionary<string, object> table = new Dictionary<string, object>();
                 foreach (var p in psObj.Properties)

--- a/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Management.Automation.Language;

--- a/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -126,14 +126,7 @@ namespace Microsoft.DotNet.Interactive.PowerShell
                 object outVal;
                 if(variable.Value is PSObject psobject)
                 {
-                    if (psobject.BaseObject is PSCustomObject)
-                    {
-                        outVal = GetPSObjectProperties(psobject);
-                    }
-                    else
-                    {
-                        outVal = psobject.BaseObject;
-                    }
+                    outVal = psobject.Unwrap();
                 }
                 else
                 {
@@ -241,15 +234,6 @@ namespace Microsoft.DotNet.Interactive.PowerShell
 
             context.Publish(completion);
             return Task.CompletedTask;
-        }
-
-        public static Dictionary<String, Object> GetPSObjectProperties(PSObject psObject){
-            Dictionary<string, object> table = new Dictionary<string, object>();
-            foreach (var p in psObject.Properties)
-            {
-                table.Add(p.Name, p.Value);
-            }
-            return table;
         }
 
         private async Task RunSubmitCodeInAzShell(string code)

--- a/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -124,26 +124,25 @@ namespace Microsoft.DotNet.Interactive.PowerShell
             if (variable != null)
             {
                 object outVal;
-                switch (variable.Value)
+                if(variable.Value is PSObject psobject)
                 {
-                    case PSObject psobject:
-                        if (psobject.BaseObject is PSCustomObject)
+                    if (psobject.BaseObject is PSCustomObject)
+                    {
+                        Dictionary<string, object> table = new Dictionary<string, object>();
+                        foreach (var p in psobject.Properties)
                         {
-                            Dictionary<string, object> table = new Dictionary<string, object>();
-                            foreach (var p in psobject.Properties)
-                            {
-                                table.Add(p.Name, p.Value);
-                            }
-                            outVal = table;
+                            table.Add(p.Name, p.Value);
                         }
-                        else
-                        {
-                            outVal = psobject.BaseObject;
-                        }
-                        break;
-                    default:
-                        outVal = variable.Value;
-                        break;
+                        outVal = table;
+                    }
+                    else
+                    {
+                        outVal = psobject.BaseObject;
+                    }
+                }
+                else
+                {
+                    outVal = variable.Value;
                 }
 
                 if(outVal is T tObj)

--- a/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Management.Automation.Language;
@@ -125,7 +126,19 @@ namespace Microsoft.DotNet.Interactive.PowerShell
                 switch (variable.Value)
                 {
                     case PSObject psobject:
-                        value = (T) psobject.BaseObject;
+                        if (psobject.BaseObject is PSCustomObject)
+                        {
+                            Dictionary<string, object> table = new Dictionary<string, object>();
+                            foreach (var p in psobject.Properties)
+                            {
+                                table.Add(p.Name, p.Value);
+                            }
+                            value = (T) ((Object)table);
+                        }
+                        else
+                        {
+                            value = (T) psobject.BaseObject;
+                        }
                         break;
                     default:
                         value = (T) variable.Value;

--- a/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Management.Automation.Language;
@@ -10,6 +11,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
+using Microsoft.DotNet.Interactive.Formatting;
 using Microsoft.DotNet.Interactive.PowerShell.Host;
 using Microsoft.PowerShell;
 using Microsoft.PowerShell.Commands;
@@ -113,6 +115,32 @@ namespace Microsoft.DotNet.Interactive.PowerShell
                 $"{psJupyterModulePath}{Path.PathSeparator}{psModulePath}");
 
             RegisterForDisposal(pwsh);
+
+            //TODO: Is this declared anywhere else?
+            string[] mimeTypes = new string[] {HtmlFormatter.MimeType, JsonFormatter.MimeType, PlainTextFormatter.MimeType};
+
+            foreach (string mt in mimeTypes)
+            {
+                Formatter<PSObject>.Register((psObj, writer) => 
+                {
+                    object obj;
+                    if (psObj.BaseObject is PSCustomObject)
+                    {
+                        Dictionary<string, object> table = new Dictionary<string, object>();
+                        var props = psObj.Properties;
+                        foreach (var p in props)
+                        {
+                            table.Add(p.Name, p.Value);
+                        }
+                        obj = table;
+                    }
+                    else
+                    {
+                        obj = psObj.BaseObject;
+                    }
+                    obj.FormatTo(writer, mt);
+                }, mimeType: mt);
+            }
             return pwsh;
         }
 

--- a/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -123,6 +123,7 @@ namespace Microsoft.DotNet.Interactive.PowerShell
 
             if (variable != null)
             {
+                object outVal;
                 switch (variable.Value)
                 {
                     case PSObject psobject:
@@ -133,19 +134,23 @@ namespace Microsoft.DotNet.Interactive.PowerShell
                             {
                                 table.Add(p.Name, p.Value);
                             }
-                            value = (T) ((Object)table);
+                            outVal = table;
                         }
                         else
                         {
-                            value = (T) psobject.BaseObject;
+                            outVal = psobject.BaseObject;
                         }
                         break;
                     default:
-                        value = (T) variable.Value;
+                        outVal = variable.Value;
                         break;
                 }
 
-                return true;
+                if(outVal is T tObj)
+                {
+                    value = tObj;
+                    return true;
+                }
             }
 
             value = default;

--- a/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Management.Automation.Language;
@@ -11,7 +10,6 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
-using Microsoft.DotNet.Interactive.Formatting;
 using Microsoft.DotNet.Interactive.PowerShell.Host;
 using Microsoft.PowerShell;
 using Microsoft.PowerShell.Commands;
@@ -71,32 +69,6 @@ namespace Microsoft.DotNet.Interactive.PowerShell
             // Add accelerators that exist in other namespaces.
             addAccelerator.Invoke(null, new object[] { "Layout", typeof(Layout.Layout) });
             addAccelerator.Invoke(null, new object[] { "Chart", typeof(Chart) });
-
-            //TODO: Is this declared anywhere else?
-            string[] mimeTypes = new string[] { HtmlFormatter.MimeType, JsonFormatter.MimeType, PlainTextFormatter.MimeType };
-
-            foreach (string mt in mimeTypes)
-            {
-                Formatter<PSObject>.Register((psObj, writer) =>
-                {
-                    object obj;
-                    if (psObj.BaseObject is PSCustomObject)
-                    {
-                        Dictionary<string, object> table = new Dictionary<string, object>();
-                        var props = psObj.Properties;
-                        foreach (var p in props)
-                        {
-                            table.Add(p.Name, p.Value);
-                        }
-                        obj = table;
-                    }
-                    else
-                    {
-                        obj = psObj.BaseObject;
-                    }
-                    obj.FormatTo(writer, mt);
-                }, mimeType: mt);
-            }
         }
 
         public PowerShellKernel() : base(DefaultKernelName)

--- a/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -128,12 +128,7 @@ namespace Microsoft.DotNet.Interactive.PowerShell
                 {
                     if (psobject.BaseObject is PSCustomObject)
                     {
-                        Dictionary<string, object> table = new Dictionary<string, object>();
-                        foreach (var p in psobject.Properties)
-                        {
-                            table.Add(p.Name, p.Value);
-                        }
-                        outVal = table;
+                        outVal = GetPSObjectProperties(psobject);
                     }
                     else
                     {
@@ -246,6 +241,15 @@ namespace Microsoft.DotNet.Interactive.PowerShell
 
             context.Publish(completion);
             return Task.CompletedTask;
+        }
+
+        public static Dictionary<String, Object> GetPSObjectProperties(PSObject psObject){
+            Dictionary<string, object> table = new Dictionary<string, object>();
+            foreach (var p in psObject.Properties)
+            {
+                table.Add(p.Name, p.Value);
+            }
+            return table;
         }
 
         private async Task RunSubmitCodeInAzShell(string code)

--- a/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -71,6 +71,32 @@ namespace Microsoft.DotNet.Interactive.PowerShell
             // Add accelerators that exist in other namespaces.
             addAccelerator.Invoke(null, new object[] { "Layout", typeof(Layout.Layout) });
             addAccelerator.Invoke(null, new object[] { "Chart", typeof(Chart) });
+
+            //TODO: Is this declared anywhere else?
+            string[] mimeTypes = new string[] { HtmlFormatter.MimeType, JsonFormatter.MimeType, PlainTextFormatter.MimeType };
+
+            foreach (string mt in mimeTypes)
+            {
+                Formatter<PSObject>.Register((psObj, writer) =>
+                {
+                    object obj;
+                    if (psObj.BaseObject is PSCustomObject)
+                    {
+                        Dictionary<string, object> table = new Dictionary<string, object>();
+                        var props = psObj.Properties;
+                        foreach (var p in props)
+                        {
+                            table.Add(p.Name, p.Value);
+                        }
+                        obj = table;
+                    }
+                    else
+                    {
+                        obj = psObj.BaseObject;
+                    }
+                    obj.FormatTo(writer, mt);
+                }, mimeType: mt);
+            }
         }
 
         public PowerShellKernel() : base(DefaultKernelName)
@@ -115,32 +141,6 @@ namespace Microsoft.DotNet.Interactive.PowerShell
                 $"{psJupyterModulePath}{Path.PathSeparator}{psModulePath}");
 
             RegisterForDisposal(pwsh);
-
-            //TODO: Is this declared anywhere else?
-            string[] mimeTypes = new string[] {HtmlFormatter.MimeType, JsonFormatter.MimeType, PlainTextFormatter.MimeType};
-
-            foreach (string mt in mimeTypes)
-            {
-                Formatter<PSObject>.Register((psObj, writer) => 
-                {
-                    object obj;
-                    if (psObj.BaseObject is PSCustomObject)
-                    {
-                        Dictionary<string, object> table = new Dictionary<string, object>();
-                        var props = psObj.Properties;
-                        foreach (var p in props)
-                        {
-                            table.Add(p.Name, p.Value);
-                        }
-                        obj = table;
-                    }
-                    else
-                    {
-                        obj = psObj.BaseObject;
-                    }
-                    obj.FormatTo(writer, mt);
-                }, mimeType: mt);
-            }
             return pwsh;
         }
 

--- a/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -123,15 +123,7 @@ namespace Microsoft.DotNet.Interactive.PowerShell
 
             if (variable != null)
             {
-                object outVal;
-                if(variable.Value is PSObject psobject)
-                {
-                    outVal = psobject.Unwrap();
-                }
-                else
-                {
-                    outVal = variable.Value;
-                }
+                object outVal = (variable.Value is PSObject psobject) ? psobject.Unwrap() : variable.Value;
 
                 if(outVal is T tObj)
                 {


### PR DESCRIPTION
When running something like `[pscustomobject]@{
    a = 'b';
    c = 'd'
  } | Out-Display` nothing is shown because of how the InputObject is used in OutDisplayCommand.

Created fix by checking for the case that the InputObject is a PSCustomObject and converting it to a PSObject to find the properties.