### PR TITLE
Have VSCode client wait for `KernelReady` event before loading the notebook.

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/contracts.ts
+++ b/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/contracts.ts
@@ -264,4 +264,5 @@ export interface DisposableSubscription extends Disposable {
 export interface KernelTransport extends Disposable {
     subscribeToKernelEvents(observer: KernelEventEnvelopeObserver): DisposableSubscription;
     submitCommand(command: KernelCommand, commandType: KernelCommandType, token: string): Promise<void>;
+    waitForReady(): Promise<void>;
 }

--- a/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/signalr-client.ts
+++ b/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/signalr-client.ts
@@ -62,6 +62,10 @@ export async function signalTransportFactory(rootUrl: string): Promise<KernelTra
             return connection.send("submitCommand", JSON.stringify(envelope));
         },
 
+        waitForReady: (): Promise<void> => {
+            return Promise.resolve();
+        },
+
         dispose: (): void => {
         }
     };

--- a/src/Microsoft.DotNet.Interactive.Js/tests/testSupport.ts
+++ b/src/Microsoft.DotNet.Interactive.Js/tests/testSupport.ts
@@ -40,6 +40,10 @@ export class MockKernelTransport implements KernelTransport {
         return Promise.resolve();
     }
 
+    public waitForReady(): Promise<void> {
+        return Promise.resolve();
+    }
+
     public dispose() {
     }
 }

--- a/src/Microsoft.DotNet.Interactive/Server/KernelClientServerExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/Server/KernelClientServerExtensions.cs
@@ -11,12 +11,12 @@ namespace Microsoft.DotNet.Interactive.Server
 {
     public static class ConnectableKernel
     {
-        public static  KernelServer CreateKernelServer(this Kernel kernel)
+        public static  KernelServer CreateKernelServer(this Kernel kernel, DirectoryInfo workingDir = null)
         {
-            return kernel.CreateKernelServer(Console.In, Console.Out);
+            return kernel.CreateKernelServer(Console.In, Console.Out, workingDir);
         }
 
-        public static KernelServer CreateKernelServer(this Kernel kernel, TextReader inputStream, TextWriter outputStream)
+        public static KernelServer CreateKernelServer(this Kernel kernel, TextReader inputStream, TextWriter outputStream, DirectoryInfo workingDir = null)
         {
             if (kernel == null)
             {
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Interactive.Server
 
             var input = new TextReaderInputStream(inputStream);
             var output = new TextWriterOutputStream(outputStream);
-            var kernelServer = new KernelServer(kernel, input, output);
+            var kernelServer = new KernelServer(kernel, input, output, workingDir);
 
             kernel.RegisterForDisposal(kernelServer);
             return kernelServer;

--- a/src/Microsoft.DotNet.Interactive/Server/KernelServer.cs
+++ b/src/Microsoft.DotNet.Interactive/Server/KernelServer.cs
@@ -19,9 +19,10 @@ namespace Microsoft.DotNet.Interactive.Server
 
 
         public KernelServer(
-            Kernel kernel, 
+            Kernel kernel,
             IInputTextStream input,
-            IOutputTextStream output)
+            IOutputTextStream output,
+            DirectoryInfo workingDir = null)
         {
             _kernel = kernel ?? throw new ArgumentNullException(nameof(kernel));
             _input = input ?? throw new ArgumentNullException(nameof(input));
@@ -36,6 +37,11 @@ namespace Microsoft.DotNet.Interactive.Server
                 _kernel.KernelEvents.Subscribe(WriteEventToOutput),
                 _input
             };
+
+            if (workingDir is { })
+            {
+                Environment.CurrentDirectory = workingDir.FullName;
+            }
 
             WriteEventToOutput(new KernelReady());
         }

--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -59,9 +59,7 @@
             "[vscode]",
             "stdio",
             "--http-port-range",
-            "1000-3000",
-            "--working-dir",
-            "{working_dir}"
+            "1000-3000"
           ],
           "description": "Command and arguments used to start a notebook session."
         },

--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -59,7 +59,9 @@
             "[vscode]",
             "stdio",
             "--http-port-range",
-            "1000-3000"
+            "1000-3000",
+            "--working-dir",
+            "{working_dir}"
           ],
           "description": "Command and arguments used to start a notebook session."
         },
@@ -80,7 +82,7 @@
         },
         "dotnet-interactive.minimumInteractiveToolVersion": {
           "type": "string",
-          "default": "1.0.131505",
+          "default": "1.0.132606",
           "description": "The minimum required version of the .NET Interactive tool."
         }
       }

--- a/src/dotnet-interactive-vscode/src/clientMapper.ts
+++ b/src/dotnet-interactive-vscode/src/clientMapper.ts
@@ -1,14 +1,14 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+import { KernelTransport } from "./contracts";
 import { InteractiveClient } from "./interactiveClient";
 import { Uri } from "./interfaces/vscode";
-import { KernelTransportCreationResult } from "./interfaces";
 
 export class ClientMapper {
     private clientMap: Map<string, InteractiveClient> = new Map();
 
-    constructor(readonly kernelTransportCreator: (notebookPath: string) => KernelTransportCreationResult) {
+    constructor(readonly kernelTransportCreator: (notebookPath: string) => Promise<KernelTransport>) {
     }
 
     static keyFromUri(uri: Uri): string {
@@ -19,10 +19,9 @@ export class ClientMapper {
         let key = ClientMapper.keyFromUri(uri);
         let client = this.clientMap.get(key);
         if (client === undefined) {
-            const creationResult = this.kernelTransportCreator(uri.fsPath);
-            client = new InteractiveClient(creationResult.transport);
+            const transport = await this.kernelTransportCreator(uri.fsPath);
+            client = new InteractiveClient(transport);
             this.clientMap.set(key, client);
-            await creationResult.initialization;
         }
 
         return client;

--- a/src/dotnet-interactive-vscode/src/contracts.ts
+++ b/src/dotnet-interactive-vscode/src/contracts.ts
@@ -264,4 +264,5 @@ export interface DisposableSubscription extends Disposable {
 export interface KernelTransport extends Disposable {
     subscribeToKernelEvents(observer: KernelEventEnvelopeObserver): DisposableSubscription;
     submitCommand(command: KernelCommand, commandType: KernelCommandType, token: string): Promise<void>;
+    waitForReady(): Promise<void>;
 }

--- a/src/dotnet-interactive-vscode/src/interfaces.ts
+++ b/src/dotnet-interactive-vscode/src/interfaces.ts
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { KernelTransport } from "./contracts";
-
 export interface IsValidToolVersion {
     (actualVersion: string, minSupportedVersion: string): boolean;
 }
@@ -53,9 +51,4 @@ export interface InstallInteractiveTool {
 
 export interface ReportInstallationFinished {
     (): void;
-}
-
-export interface KernelTransportCreationResult {
-    transport: KernelTransport;
-    initialization: Promise<void>;
 }

--- a/src/dotnet-interactive-vscode/src/stdioKernelTransport.ts
+++ b/src/dotnet-interactive-vscode/src/stdioKernelTransport.ts
@@ -2,11 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import * as cp from 'child_process';
-import * as path from 'path';
 import {
-    CommandFailed,
-    CommandFailedType,
-    CommandSucceededType,
     DisposableSubscription,
     KernelCommand,
     KernelCommandType,
@@ -14,18 +10,34 @@ import {
     KernelEventEnvelopeObserver,
     DiagnosticLogEntryProducedType,
     DiagnosticLogEntryProduced,
-    ChangeWorkingDirectory
+    KernelReadyType
 } from "./contracts";
-import { ProcessStart, KernelTransportCreationResult } from './interfaces';
+import { ProcessStart } from './interfaces';
 import { ReportChannel } from './interfaces/vscode';
 import { LineReader } from './lineReader';
 
 export class StdioKernelTransport {
     private childProcess: cp.ChildProcessWithoutNullStreams;
     private lineReader: LineReader;
+    private readyPromise: Promise<void>;
     private subscribers: Array<KernelEventEnvelopeObserver> = [];
 
-    private constructor(processStart: ProcessStart, notebookPath: string, private diagnosticChannel: ReportChannel) {
+    constructor(processStart: ProcessStart, private diagnosticChannel: ReportChannel) {
+        // prepare root event handler
+        this.lineReader = new LineReader();
+        this.lineReader.subscribe(line => this.handleLine(line));
+
+        // prepare one-time ready event
+        this.readyPromise = new Promise<void>((resolve, reject) => {
+            const readySubscriber = this.subscribeToKernelEvents(eventEnvelope => {
+                if (eventEnvelope.eventType === KernelReadyType) {
+                    readySubscriber.dispose();
+                    resolve();
+                }
+            });
+        });
+
+        // launch the process
         this.childProcess = cp.spawn(processStart.command, processStart.args, { cwd: processStart.workingDirectory });
         this.diagnosticChannel.appendLine(`Kernel started with pid ${this.childProcess.pid}.`);
         this.childProcess.on('exit', (code: number, _signal: string) => {
@@ -35,8 +47,6 @@ export class StdioKernelTransport {
                 : '';
             this.diagnosticChannel.appendLine(message + messageSuffix);
         });
-        this.lineReader = new LineReader();
-        this.lineReader.subscribe(line => this.handleLine(line));
         this.childProcess.stdout.on('data', data => this.lineReader.onData(data));
     }
 
@@ -52,40 +62,6 @@ export class StdioKernelTransport {
         for (let i = this.subscribers.length - 1; i >= 0; i--) {
             this.subscribers[i](envelope);
         }
-    }
-
-    static create(processStart: ProcessStart, notebookPath: string, diagnosticChannel: ReportChannel): KernelTransportCreationResult {
-        let kernelTransport = new StdioKernelTransport(processStart, notebookPath, diagnosticChannel);
-        // set the working directory to be next to the notebook; this allows relative file access to work as expected
-        // immediately clean up afterwards because we'll never do this again
-        let token = 'change-working-directory-token';
-        let command: ChangeWorkingDirectory = {
-            workingDirectory: path.dirname(notebookPath)
-        };
-        const initialization = new Promise<void>((resolve, reject) => {
-            let disposable = kernelTransport.subscribeToKernelEvents(envelope => {
-                if (envelope.command?.token === token) {
-                    switch (envelope.eventType) {
-                        case CommandFailedType:
-                            let failed = <CommandFailed>envelope.event;
-                            let message = `Unable to set notebook working directory to '${notebookPath}'.\n${failed.message}`;
-                            diagnosticChannel.appendLine(message);
-                            disposable.dispose();
-                            resolve();
-                            break;
-                        case CommandSucceededType:
-                            disposable.dispose();
-                            resolve();
-                            break;
-                    }
-                }
-            });
-            kernelTransport.submitCommand(command, 'ChangeWorkingDirectory', token);
-        });
-        return {
-            transport: kernelTransport,
-            initialization
-        };
     }
 
     subscribeToKernelEvents(observer: KernelEventEnvelopeObserver): DisposableSubscription {
@@ -113,6 +89,10 @@ export class StdioKernelTransport {
             this.childProcess.stdin.write('\n');
             resolve();
         });
+    }
+
+    waitForReady(): Promise<void> {
+        return this.readyPromise;
     }
 
     dispose() {

--- a/src/dotnet-interactive-vscode/src/tests/unit/client.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/client.test.ts
@@ -12,7 +12,7 @@ describe('InteractiveClient tests', () => {
     it('command execution returns deferred events', async () => {
         let token = 'test-token';
         let code = '1 + 1';
-        let clientMapper = new ClientMapper(() => TestKernelTransport.create({
+        let clientMapper = new ClientMapper(async (notebookPath) => new TestKernelTransport({
             'SubmitCode': [
                 {
                     // deferred event; unassociated with the original submission; has its own token
@@ -86,7 +86,7 @@ describe('InteractiveClient tests', () => {
     it('deferred events do not interfere with display update events', async () => {
         let token = 'test-token';
         let code = '1 + 1';
-        let clientMapper = new ClientMapper(() => TestKernelTransport.create({
+        let clientMapper = new ClientMapper(async (notebookPath) => new TestKernelTransport({
             'SubmitCode': [
                 {
                     // deferred event; unassociated with the original submission; has its own token
@@ -160,7 +160,7 @@ describe('InteractiveClient tests', () => {
     it('interleaved deferred events do not interfere with display update events', async () => {
         let token = 'test-token';
         let code = '1 + 1';
-        let clientMapper = new ClientMapper(() => TestKernelTransport.create({
+        let clientMapper = new ClientMapper(async (notebookPath) => new TestKernelTransport({
             'SubmitCode': [
                 {
                     // deferred event; unassociated with the original submission; has its own token
@@ -254,7 +254,7 @@ describe('InteractiveClient tests', () => {
 
     it('display update events from separate submissions trigger the correct observer', async () => {
         let code = '1 + 1';
-        let clientMapper = new ClientMapper(() => TestKernelTransport.create({
+        let clientMapper = new ClientMapper(async (notebookPath) => new TestKernelTransport({
             'SubmitCode#1': [
                 {
                     eventType: DisplayedValueProducedType,

--- a/src/dotnet-interactive-vscode/src/tests/unit/languageProvider.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/languageProvider.test.ts
@@ -12,7 +12,7 @@ import { CommandSucceededType, CompletionsProducedType } from '../../contracts';
 describe('LanguageProvider tests', () => {
     it('CompletionProvider', async () => {
         let token = '123';
-        let clientMapper = new ClientMapper(() => TestKernelTransport.create({
+        let clientMapper = new ClientMapper(async (notebookPath) => new TestKernelTransport({
             'RequestCompletions': [
                 {
                     eventType: CompletionsProducedType,
@@ -69,7 +69,7 @@ describe('LanguageProvider tests', () => {
 
     it('HoverProvider', async () => {
         let token = '123';
-        let clientMapper = new ClientMapper(() => TestKernelTransport.create({
+        let clientMapper = new ClientMapper(async (notebookPath) => new TestKernelTransport({
             'RequestHoverText': [
                 {
                     eventType: 'HoverTextProduced',

--- a/src/dotnet-interactive-vscode/src/tests/unit/misc.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/misc.test.ts
@@ -14,11 +14,13 @@ describe('Miscellaneous tests', () => {
                 'run',
                 'dotnet-interactive',
                 '--',
-                'stdio'
+                'stdio',
+                '--working-dir',
+                '{working_dir}'
             ],
             workingDirectory: '{global_storage_path}'
         };
-        let actual = processArguments(template, 'replacement-dotnet-path', 'replacement-global-storage-path');
+        let actual = processArguments(template, 'replacement-working-dir/notebook-file.dib', 'replacement-dotnet-path', 'replacement-global-storage-path');
         expect(actual).to.deep.equal({
             command: 'replacement-dotnet-path',
             args: [
@@ -26,7 +28,9 @@ describe('Miscellaneous tests', () => {
                 'run',
                 'dotnet-interactive',
                 '--',
-                'stdio'
+                'stdio',
+                '--working-dir',
+                'replacement-working-dir'
             ],
             workingDirectory: 'replacement-global-storage-path'
         });

--- a/src/dotnet-interactive-vscode/src/tests/unit/notebook.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/notebook.test.ts
@@ -19,7 +19,7 @@ describe('Notebook tests', () => {
         it(`executes and returns expected value: ${language}`, async () => {
             let token = '123';
             let code = '1+1';
-            let clientMapper = new ClientMapper(() => TestKernelTransport.create({
+            let clientMapper = new ClientMapper(async (notebookPath) => new TestKernelTransport({
                 'SubmitCode': [
                     {
                         eventType: CodeSubmissionReceivedType,
@@ -76,7 +76,7 @@ Console.WriteLine(1);
 Console.WriteLine(1);
 Console.WriteLine(1);
 `;
-        let clientMapper = new ClientMapper(() => TestKernelTransport.create({
+        let clientMapper = new ClientMapper(async (notebookPath) => new TestKernelTransport({
             'SubmitCode': [
                 {
                     eventType: CodeSubmissionReceivedType,
@@ -166,7 +166,7 @@ Console.WriteLine(1);
     it('updated values are replaced instead of added', async () => {
         let token = '123';
         let code = '#r nuget:Newtonsoft.Json';
-        let clientMapper = new ClientMapper(() => TestKernelTransport.create({
+        let clientMapper = new ClientMapper(async (notebookPath) => new TestKernelTransport({
             'SubmitCode': [
                 {
                     eventType: CodeSubmissionReceivedType,
@@ -245,7 +245,7 @@ Console.WriteLine(1);
     it('returned json is property parsed', async () => {
         let token = '123';
         let code = 'JObject.FromObject(new { a = 1, b = false })';
-        let clientMapper = new ClientMapper(() => TestKernelTransport.create({
+        let clientMapper = new ClientMapper(async (notebookPath) => new TestKernelTransport({
             'SubmitCode': [
                 {
                     eventType: CodeSubmissionReceivedType,

--- a/src/dotnet-interactive-vscode/src/tests/unit/testKernelTransport.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/testKernelTransport.ts
@@ -1,23 +1,14 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { KernelCommand, KernelCommandType, KernelEventType, KernelEventEnvelopeObserver, DisposableSubscription, KernelTransport, KernelEvent } from "../../contracts";
-import { KernelTransportCreationResult } from "../../interfaces";
+import { KernelCommand, KernelCommandType, KernelEventType, KernelEventEnvelopeObserver, DisposableSubscription, KernelEvent } from "../../contracts";
 
 // Replays all events given to it
 export class TestKernelTransport {
     private theObserver: KernelEventEnvelopeObserver | undefined;
     private fakedCommandCounter: Map<string, number> = new Map<string, number>();
 
-    constructor(readonly fakedEventEnvelopes: { [key: string]: {eventType: KernelEventType, event: any, token: string}[] }) {
-    }
-
-    static create(fakedEventEnvelopes: { [key: string]: { eventType: KernelEventType, event: any, token: string}[] }): KernelTransportCreationResult {
-        let transport = new TestKernelTransport(fakedEventEnvelopes);
-        return {
-            transport,
-            initialization: Promise.resolve()
-        };
+    constructor(readonly fakedEventEnvelopes: { [key: string]: {eventType: KernelEventType, event: KernelEvent, token: string}[] }) {
     }
 
     subscribeToKernelEvents(observer: KernelEventEnvelopeObserver): DisposableSubscription {
@@ -61,6 +52,10 @@ export class TestKernelTransport {
                 });
             }
         }
+    }
+
+    waitForReady(): Promise<void> {
+        return Promise.resolve();
     }
 
     dispose() {

--- a/src/dotnet-interactive-vscode/src/utilities.ts
+++ b/src/dotnet-interactive-vscode/src/utilities.ts
@@ -1,12 +1,14 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+import * as path from 'path';
 import { ProcessStart } from "./interfaces";
 
-export function processArguments(template: { args: Array<string>, workingDirectory: string }, dotnetPath: string, globalStoragePath: string): ProcessStart {
+export function processArguments(template: { args: Array<string>, workingDirectory: string }, notebookPath: string, dotnetPath: string, globalStoragePath: string): ProcessStart {
     let map: { [key: string]: string } = {
         'dotnet_path': dotnetPath,
-        'global_storage_path': globalStoragePath
+        'global_storage_path': globalStoragePath,
+        'working_dir': path.dirname(notebookPath)
     };
     let processed = template.args.map(a => performReplacement(a, map));
     return {

--- a/src/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
+++ b/src/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
@@ -14,6 +14,7 @@ using Microsoft.DotNet.Interactive.App.CommandLine;
 using Microsoft.DotNet.Interactive.App.Commands;
 using Microsoft.DotNet.Interactive.Server;
 using Microsoft.DotNet.Interactive.Telemetry;
+using Microsoft.DotNet.Interactive.Utility;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using Xunit.Abstractions;
@@ -314,6 +315,16 @@ namespace Microsoft.DotNet.Interactive.App.Tests.CommandLine
             await _parser.InvokeAsync($"jupyter {expected}", testConsole);
 
             testConsole.Error.ToString().Should().Contain("File does not exist: not_exist.json");
+        }
+
+        [Fact]
+        public async Task stdio_command_supports_working_dir_option()
+        {
+            using var workingDirectory = DisposableDirectory.Create();
+
+            await _parser.InvokeAsync($"stdio --working-dir \"{workingDirectory.Directory.FullName}\"");
+
+            _startOptions.WorkingDir.FullName.Should().Be(workingDirectory.Directory.FullName);
         }
 
         [Theory]

--- a/src/dotnet-interactive/CommandLine/CommandLineParser.cs
+++ b/src/dotnet-interactive/CommandLine/CommandLineParser.cs
@@ -324,12 +324,17 @@ namespace Microsoft.DotNet.Interactive.App.CommandLine
                     parseArgument: result => result.Tokens.Count == 0 ? HttpPortRange.Default : ParsePortRangeOption(result),
                     description: "Specifies the range of ports to use to enable HTTP services");
 
+                var workingDirOption = new Option<DirectoryInfo>(
+                    "--working-dir",
+                    "Working directory to which to change after launching the kernel.");
+
                 var command = new Command(
                     "stdio",
                     "Starts dotnet-interactive with kernel functionality exposed over standard I/O")
                 {
                     defaultKernelOption,
-                    httpPortRangeOption
+                    httpPortRangeOption,
+                    workingDirOption
                 };
 
                 command.Handler = CommandHandler.Create<StartupOptions, StdIOOptions, IConsole, InvocationContext, CancellationToken>(
@@ -348,7 +353,7 @@ namespace Microsoft.DotNet.Interactive.App.CommandLine
                                         c.GetService<HtmlNotebookFrontedEnvironment>());
                                 }, kernel =>
                                 {
-                                    kernel.CreateKernelServer();
+                                    kernel.CreateKernelServer(startupOptions.WorkingDir);
 
                                     kernel.UseQuiCommand(disposeOnQuit, cancellationToken);
                                 });

--- a/src/dotnet-interactive/CommandLine/StartupOptions.cs
+++ b/src/dotnet-interactive/CommandLine/StartupOptions.cs
@@ -25,12 +25,14 @@ namespace Microsoft.DotNet.Interactive.App.CommandLine
             DirectoryInfo logPath = null,
             bool verbose = false,
             HttpPortRange httpPortRange = null,
-            HttpPort httpPort = null)
+            HttpPort httpPort = null,
+            DirectoryInfo workingDir = null)
         {
             LogPath = logPath;
             Verbose = verbose;
             HttpPortRange = httpPortRange;
             HttpPort = httpPort;
+            WorkingDir = workingDir;
         }
 
         public DirectoryInfo LogPath { get; }
@@ -40,6 +42,8 @@ namespace Microsoft.DotNet.Interactive.App.CommandLine
         public HttpPort HttpPort { get; internal set; }
 
         public HttpPortRange HttpPortRange { get; internal set; }
+
+        public DirectoryInfo WorkingDir { get; internal set; }
 
         public bool EnableHttpApi => HttpPort != null || HttpPortRange != null;
     }

--- a/src/dotnet-interactive/CommandLine/StdIOCommand.cs
+++ b/src/dotnet-interactive/CommandLine/StdIOCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CommandLine;
+using System.IO;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.Server;
@@ -13,7 +14,7 @@ namespace Microsoft.DotNet.Interactive.App.CommandLine
         public static async Task<int> Do(StartupOptions startupOptions, Kernel kernel, IConsole console)
         {
             var disposable = Program.StartToolLogging(startupOptions);
-            var server = kernel.CreateKernelServer();
+            var server = kernel.CreateKernelServer(startupOptions.WorkingDir);
             kernel.RegisterForDisposal(disposable);
             await server.Input.LastOrDefaultAsync();
             return 0;

--- a/src/interface-generator/StaticContents.ts
+++ b/src/interface-generator/StaticContents.ts
@@ -24,4 +24,5 @@ export interface DisposableSubscription extends Disposable {
 export interface KernelTransport extends Disposable {
     subscribeToKernelEvents(observer: KernelEventEnvelopeObserver): DisposableSubscription;
     submitCommand(command: KernelCommand, commandType: KernelCommandType, token: string): Promise<void>;
+    waitForReady(): Promise<void>;
 }


### PR DESCRIPTION
**N.b.,** immediately after this PR is in, I'll be submitting another one that passes `--working-dir` to the kernel.  It can't be done in this PR yet due to an off-by-one error in our releases, but that'll be fixed shortly.