### PR TITLE
#!connect with remote composite kernels

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Formatting/Microsoft.DotNet.Interactive.Formatting.csproj
+++ b/src/Microsoft.DotNet.Interactive.Formatting/Microsoft.DotNet.Interactive.Formatting.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="2.2.0" />
-    <PackageReference Include="microsoft.csharp" Version="4.5.0" />
+    <PackageReference Include="microsoft.csharp" Version="4.7.0" />
     <PackageReference Include="System.CommandLine.Rendering" Version="0.3.0-alpha.20309.1" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -76,7 +76,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IO.Pipelines" Version="4.7.0" />
+    <PackageReference Include="System.IO.Pipelines" Version="4.7.1" />
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.0" />
     <PackageReference Include="XPlot.Plotly" Version="3.0.1" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
@@ -156,9 +156,8 @@ namespace Microsoft.DotNet.Interactive
             var connectionCommand = new Command("named-pipe", "Connects to a kernel using named pipes");
             connectionCommand.AddArgument(new Argument<string>("kernel-name"));
             connectionCommand.AddArgument(new Argument<string>("pipe-name"));
-            connectionCommand.AddOption(new Option<string>("--remote-kernel-name"));
 
-            connectionCommand.Handler = CommandHandler.Create<string, string, string, KernelInvocationContext>(async (kernelName, pipeName, remoteKernelName, context) =>
+            connectionCommand.Handler = CommandHandler.Create<string, string, KernelInvocationContext>(async (kernelName, pipeName,  context) =>
             {
                 var existingProxyKernel = kernel.FindKernel(kernelName);
                 if (existingProxyKernel == null)
@@ -169,7 +168,7 @@ namespace Microsoft.DotNet.Interactive
                     await clientStream.ConnectAsync();
                     clientStream.ReadMode = PipeTransmissionMode.Message;
                     var client = clientStream.CreateKernelClient();
-                    var proxyKernel = new ProxyKernel(kernelName, client, remoteKernelName);
+                    var proxyKernel = new ProxyKernel(kernelName, client);
 
                     proxyKernel.RegisterForDisposal(client);
                     kernel.Add(proxyKernel);
@@ -185,9 +184,8 @@ namespace Microsoft.DotNet.Interactive
             var connectionCommand = new Command("signalr", "Connects to a kernel using signal R");
             connectionCommand.AddArgument(new Argument<string>("kernel-name"));
             connectionCommand.AddArgument(new Argument<string>("hub-url"));
-            connectionCommand.AddOption(new Option<string>("--remote-kernel-name"));
 
-            connectionCommand.Handler = CommandHandler.Create<string, string, string, KernelInvocationContext>(async (kernelName, hubUrl, remoteKernelName, context) =>
+            connectionCommand.Handler = CommandHandler.Create<string, string, KernelInvocationContext>(async (kernelName, hubUrl, context) =>
             {
                 var existingProxyKernel = kernel.FindKernel(kernelName);
                 if (existingProxyKernel == null)
@@ -200,7 +198,7 @@ namespace Microsoft.DotNet.Interactive
                     await connection.StartAsync();
 
                     var client = connection.CreateKernelClient();
-                    var proxyKernel = new ProxyKernel(kernelName, client, remoteKernelName);
+                    var proxyKernel = new ProxyKernel(kernelName, client);
                     await connection.SendAsync("connect");
 
                     proxyKernel.RegisterForDisposal(client);

--- a/src/Microsoft.DotNet.Interactive/Microsoft.DotNet.Interactive.csproj
+++ b/src/Microsoft.DotNet.Interactive/Microsoft.DotNet.Interactive.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="1.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.5" />
     <PackageReference Include="System.Runtime.Loader" Version="$(SystemRuntimeLoaderVersion)" />
     <PackageReference Include="System.Reactive" Version="$(SystemReactiveVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />

--- a/src/Microsoft.DotNet.Interactive/ProxyKernel.cs
+++ b/src/Microsoft.DotNet.Interactive/ProxyKernel.cs
@@ -16,12 +16,11 @@ namespace Microsoft.DotNet.Interactive
         IKernelCommandHandler<RequestHoverText>
     {
         private readonly KernelClient _client;
-        private readonly string _remoteTargetKernelName;
 
-        public ProxyKernel(string name, KernelClient client, string remoteTargetKernelName = null) : base(name)
+        public ProxyKernel(string name, KernelClient client) : base(name)
         {
             _client = client ?? throw new ArgumentNullException(nameof(client));
-            _remoteTargetKernelName = remoteTargetKernelName;
+        
             RegisterForDisposal(client.KernelEvents.Subscribe(OnKernelEvents));
         }
 
@@ -48,7 +47,7 @@ namespace Microsoft.DotNet.Interactive
         private async Task SendCommandToRemoteKernel(KernelCommand command)
         {
             var targetKernelName = command.TargetKernelName;
-            command.TargetKernelName = _remoteTargetKernelName;
+            command.TargetKernelName = null;
             await _client.SendAsync(command);
             command.TargetKernelName = targetKernelName;
         }

--- a/src/dotnet-interactive.Tests/dotnet-interactive.Tests.csproj
+++ b/src/dotnet-interactive.Tests/dotnet-interactive.Tests.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.17" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.5" />
     <PackageReference Include="pocketlogger.subscribe" Version="0.6.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
when remotign a command the targetKernelName is serialisedacross the boundaries causing the remote compositeKernel to fail routing