### PR TITLE
Fix #569

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/AssertionExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/AssertionExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 {
     public static class AssertionExtensions
     {
-        public static AndWhichConstraint<StringAssertions, string> BeEquivalentHtml(
+        public static AndWhichConstraint<StringAssertions, string> BeEquivalentHtmlTo(
             this StringAssertions assertions,
             string expected)
         {

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/AssertionExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/AssertionExtensions.cs
@@ -15,14 +15,21 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
         {
             var subject = assertions.Subject;
 
-            var compareResult = new DefaultStringComparer(true).Compare(
-                subject.IndentHtml(), 
-                expected.IndentHtml());
+            var actual = subject.IndentHtml();
 
-            compareResult.Error.Should().BeNullOrEmpty();
+            var diff = new DefaultStringComparer(true).Compare(
+                actual,
+                expected.IndentHtml()).Error;
+
+            (diff ?? "")
+                .Replace("Received:", "\nActual:\n")
+                .Replace("Approved:", "\nExpected:\n")
+                .Should()
+                .BeNullOrEmpty(because: "HTML doesn't match. Unexpected output was: \n\n" + actual);
 
             return new AndWhichConstraint<StringAssertions, string>(
-                subject.Should(), subject);
+                subject.Should(),
+                subject);
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/AssertionExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/AssertionExtensions.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Assent;
+using FluentAssertions;
+using FluentAssertions.Primitives;
+
+namespace Microsoft.DotNet.Interactive.Formatting.Tests
+{
+    public static class AssertionExtensions
+    {
+        public static AndWhichConstraint<StringAssertions, string> BeEquivalentHtml(
+            this StringAssertions assertions,
+            string expected)
+        {
+            var subject = assertions.Subject;
+
+            var compareResult = new DefaultStringComparer(true).Compare(
+                subject.IndentHtml(), 
+                expected.IndentHtml());
+
+            compareResult.Error.Should().BeNullOrEmpty();
+
+            return new AndWhichConstraint<StringAssertions, string>(
+                subject.Should(), subject);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
@@ -256,7 +256,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
                 writer.ToString()
                       .Should()
-                      .Be(
+                      .BeEquivalentHtml(
                           "<table><thead><tr><th><i>index</i></th><th>TypeName</th><th>Id</th></tr></thead><tbody><tr><td>0</td><td>entity one</td><td>123</td></tr><tr><td>1</td><td>entity two</td><td>456</td></tr></tbody></table>");
             }
 
@@ -301,7 +301,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
                 writer.ToString()
                       .Should()
-                      .Be(
+                      .BeEquivalentHtml(
                           "<table><thead><tr><th><i>key</i></th><th>TypeName</th><th>Id</th></tr></thead><tbody><tr><td>first</td><td>entity one</td><td>123</td></tr><tr><td>second</td><td>entity two</td><td>456</td></tr></tbody></table>");
             }
 
@@ -322,7 +322,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
                 writer.ToString()
                       .Should()
-                      .Be(
+                      .BeEquivalentHtml(
                           "<table><thead><tr><th><i>key</i></th><th>TypeName</th><th>Id</th></tr></thead><tbody><tr><td>first</td><td>entity one</td><td>123</td></tr><tr><td>second</td><td>entity two</td><td>456</td></tr></tbody></table>");
             }
 
@@ -333,7 +333,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
                 strings.ToDisplayString("text/html")
                        .Should()
-                       .Be(
+                       .BeEquivalentHtml(
                            "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td>apple</td></tr><tr><td>1</td><td>banana</td></tr><tr><td>2</td><td>cherry</td></tr></tbody></table>");
             }
 
@@ -347,7 +347,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
                 var html = sorted.ToDisplayString("text/html");
 
                 html.Should()
-                    .Be(
+                    .BeEquivalentHtml(
                         "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td>kiwi</td></tr><tr><td>1</td><td>apple</td></tr><tr><td>2</td><td>plantain</td></tr></tbody></table>");
             }
 
@@ -359,7 +359,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
                 var html = list.ToDisplayString("text/html");
 
                 html.Should()
-                    .Be(
+                    .BeEquivalentHtml(
                         "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody></tbody></table>");
             }
 
@@ -371,7 +371,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
                 var html = list.ToDisplayString("text/html");
 
                 html.Should()
-                    .Be(
+                    .BeEquivalentHtml(
                         "<table><thead><tr><th><i>key</i></th><th>value</th></tr></thead><tbody></tbody></table>");
             }
 
@@ -428,10 +428,6 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
                     Enumerable.Range(1, 3),
                     new { name = "apple", color = "green" },
                 };
-
-                var obj0 = objects[0].ToDisplayString();
-                var obj1 = objects[1].ToDisplayString();
-                var obj2 = objects[2].ToDisplayString();
 
                 objects.ToDisplayString("text/html")
                        .Should()
@@ -500,7 +496,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
                 var html = objects.ToDisplayString("text/html");
 
-                html.Should().Be(
+                html.Should().BeEquivalentHtml(
                     $"<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td>{date1.ToDisplayString("text/plain")}</td></tr><tr><td>1</td><td>{date2.ToDisplayString("text/plain")}</td></tr></tbody></table>");
             }
 
@@ -511,7 +507,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
                 var html = objects.ToDisplayString("text/html");
 
-                html.Should().Be(
+                html.Should().BeEquivalentHtml(
                     "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td>System.String</td></tr><tr><td>1</td><td>System.Int32</td></tr></tbody></table>");
             }
 
@@ -528,7 +524,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
                 writer.ToString()
                       .Should()
-                      .Be("<span>Hi!</span>");
+                      .BeEquivalentHtml("<span>Hi!</span>");
             }
 
             [Fact]
@@ -544,7 +540,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
                 writer.ToString()
                       .Should()
-                      .Be(
+                      .BeEquivalentHtml(
                           "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td>7</td></tr><tr><td>1</td><td>8</td></tr><tr><td>2</td><td>9</td></tr></tbody></table>");
             }
 
@@ -558,7 +554,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
                 formatter.Format(new object[] { 8, null, 9 }, writer);
 
                 writer.ToString().Should()
-                      .Be(
+                      .BeEquivalentHtml(
                           "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td>8</td></tr><tr><td>1</td><td>&lt;null&gt;</td></tr><tr><td>2</td><td>9</td></tr></tbody></table>");
             }
 
@@ -579,7 +575,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
                 formatter.Format(GetCollection(), writer);
 
                 writer.ToString().Should()
-                      .Be(
+                      .BeEquivalentHtml(
                           "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td>True</td></tr><tr><td>1</td><td>99</td></tr><tr><td>2</td><td>Hello, World</td></tr></tbody></table>");
             }
         }

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
@@ -358,9 +358,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
                 var html = list.ToDisplayString("text/html");
 
-                html.Should()
-                    .BeEquivalentHtml(
-                        "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody></tbody></table>");
+                html.Should().BeEquivalentHtml("<i>(empty)</i>");
             }
 
             [Fact]
@@ -370,9 +368,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
                 var html = list.ToDisplayString("text/html");
 
-                html.Should()
-                    .BeEquivalentHtml(
-                        "<table><thead><tr><th><i>key</i></th><th>value</th></tr></thead><tbody></tbody></table>");
+                html.Should().BeEquivalentHtml("<i>(empty)</i>");
             }
 
             [Fact]

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
@@ -256,7 +256,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
                 writer.ToString()
                       .Should()
-                      .BeEquivalentHtml(
+                      .BeEquivalentHtmlTo(
                           "<table><thead><tr><th><i>index</i></th><th>TypeName</th><th>Id</th></tr></thead><tbody><tr><td>0</td><td>entity one</td><td>123</td></tr><tr><td>1</td><td>entity two</td><td>456</td></tr></tbody></table>");
             }
 
@@ -301,7 +301,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
                 writer.ToString()
                       .Should()
-                      .BeEquivalentHtml(
+                      .BeEquivalentHtmlTo(
                           "<table><thead><tr><th><i>key</i></th><th>TypeName</th><th>Id</th></tr></thead><tbody><tr><td>first</td><td>entity one</td><td>123</td></tr><tr><td>second</td><td>entity two</td><td>456</td></tr></tbody></table>");
             }
 
@@ -322,7 +322,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
                 writer.ToString()
                       .Should()
-                      .BeEquivalentHtml(
+                      .BeEquivalentHtmlTo(
                           "<table><thead><tr><th><i>key</i></th><th>TypeName</th><th>Id</th></tr></thead><tbody><tr><td>first</td><td>entity one</td><td>123</td></tr><tr><td>second</td><td>entity two</td><td>456</td></tr></tbody></table>");
             }
 
@@ -333,7 +333,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
                 strings.ToDisplayString("text/html")
                        .Should()
-                       .BeEquivalentHtml(
+                       .BeEquivalentHtmlTo(
                            "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td>apple</td></tr><tr><td>1</td><td>banana</td></tr><tr><td>2</td><td>cherry</td></tr></tbody></table>");
             }
 
@@ -347,7 +347,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
                 var html = sorted.ToDisplayString("text/html");
 
                 html.Should()
-                    .BeEquivalentHtml(
+                    .BeEquivalentHtmlTo(
                         "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td>kiwi</td></tr><tr><td>1</td><td>apple</td></tr><tr><td>2</td><td>plantain</td></tr></tbody></table>");
             }
 
@@ -358,7 +358,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
                 var html = list.ToDisplayString("text/html");
 
-                html.Should().BeEquivalentHtml("<i>(empty)</i>");
+                html.Should().BeEquivalentHtmlTo("<i>(empty)</i>");
             }
 
             [Fact]
@@ -368,7 +368,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
                 var html = list.ToDisplayString("text/html");
 
-                html.Should().BeEquivalentHtml("<i>(empty)</i>");
+                html.Should().BeEquivalentHtmlTo("<i>(empty)</i>");
             }
 
             [Fact]
@@ -427,7 +427,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
                 objects.ToDisplayString("text/html")
                        .Should()
-                       .BeEquivalentHtml(
+                       .BeEquivalentHtmlTo(
 @"<table>
   <thead>
     <tr>
@@ -492,7 +492,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
                 var html = objects.ToDisplayString("text/html");
 
-                html.Should().BeEquivalentHtml(
+                html.Should().BeEquivalentHtmlTo(
                     $"<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td>{date1.ToDisplayString("text/plain")}</td></tr><tr><td>1</td><td>{date2.ToDisplayString("text/plain")}</td></tr></tbody></table>");
             }
 
@@ -503,7 +503,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
                 var html = objects.ToDisplayString("text/html");
 
-                html.Should().BeEquivalentHtml(
+                html.Should().BeEquivalentHtmlTo(
                     "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td>System.String</td></tr><tr><td>1</td><td>System.Int32</td></tr></tbody></table>");
             }
 
@@ -520,7 +520,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
                 writer.ToString()
                       .Should()
-                      .BeEquivalentHtml("<span>Hi!</span>");
+                      .BeEquivalentHtmlTo("<span>Hi!</span>");
             }
 
             [Fact]
@@ -536,7 +536,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
                 writer.ToString()
                       .Should()
-                      .BeEquivalentHtml(
+                      .BeEquivalentHtmlTo(
                           "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td>7</td></tr><tr><td>1</td><td>8</td></tr><tr><td>2</td><td>9</td></tr></tbody></table>");
             }
 
@@ -550,7 +550,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
                 formatter.Format(new object[] { 8, null, 9 }, writer);
 
                 writer.ToString().Should()
-                      .BeEquivalentHtml(
+                      .BeEquivalentHtmlTo(
                           "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td>8</td></tr><tr><td>1</td><td>&lt;null&gt;</td></tr><tr><td>2</td><td>9</td></tr></tbody></table>");
             }
 
@@ -571,7 +571,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
                 formatter.Format(GetCollection(), writer);
 
                 writer.ToString().Should()
-                      .BeEquivalentHtml(
+                      .BeEquivalentHtmlTo(
                           "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td>True</td></tr><tr><td>1</td><td>99</td></tr><tr><td>2</td><td>Hello, World</td></tr></tbody></table>");
             }
         }

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
@@ -535,7 +535,6 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
   </tbody>
 </table>");
             }
-
             
             [Fact]
             public void All_properties_are_shown_when_sequences_contain_different_types()

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
@@ -418,10 +418,16 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
                 formatted.Contains("6 more").Should().BeTrue();
             }
 
-            [Fact(Skip = "wip")]
+            [Fact]
             public void It_formats_arrays_of_disparate_types_correctly()
             {
-                var objects = new object[] { 1, (2, "two"), Enumerable.Range(1, 3) };
+                var objects = new object[]
+                {
+                    1, 
+                    (2, "two"), 
+                    Enumerable.Range(1, 3),
+                    new { name = "apple", color = "green" },
+                };
 
                 var obj0 = objects[0].ToDisplayString();
                 var obj1 = objects[1].ToDisplayString();
@@ -429,8 +435,84 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
                 objects.ToDisplayString("text/html")
                        .Should()
-                       .Be(
-                           $"<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td>{obj0}</td></tr><tr><td>1</td><td>{obj1}</td></tr><tr><td>2</td><td>{obj2}</td></tr></tbody></table>");
+                       .BeEquivalentHtml(
+@"<table>
+  <thead>
+    <tr>
+      <th><i>index</i></th>
+      <th><i>type</i></th>
+      <th>value</th>
+      <th>Item1</th>
+      <th>Item2</th>
+      <th>name</th>
+      <th>color</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>0</td>
+      <td>System.Int32</td>
+      <td>1</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>1</td>
+      <td>System.ValueTuple&lt;System.Int32,System.String&gt;</td>
+      <td></td>
+      <td>2</td>
+      <td>two</td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>2</td>
+      <td>System.Linq.Enumerable+RangeIterator</td>
+      <td>[ 1, 2, 3 ]</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>3</td>
+      <td>(anonymous)</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>apple</td>
+      <td>green</td>
+    </tr>
+  </tbody>
+</table>");
+            }
+
+            [Fact]
+            public void DateTime_is_not_destructured()
+            {
+                var date1 = DateTime.Now;
+                var date2 = DateTime.Now.AddHours(1.23);
+
+                var objects = new object[] { date1, date2 };
+
+                var html = objects.ToDisplayString("text/html");
+
+                html.Should().Be(
+                    $"<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td>{date1.ToDisplayString("text/plain")}</td></tr><tr><td>1</td><td>{date2.ToDisplayString("text/plain")}</td></tr></tbody></table>");
+            }
+
+            [Fact]
+            public void System_Type_is_not_destructured()
+            {
+                var objects = new object[] { typeof(string), typeof(int) };
+
+                var html = objects.ToDisplayString("text/html");
+
+                html.Should().Be(
+                    "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td>System.String</td></tr><tr><td>1</td><td>System.Int32</td></tr></tbody></table>");
             }
 
             [Fact]

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
@@ -415,74 +415,6 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
             }
 
             [Fact]
-            public void It_formats_arrays_of_disparate_types_correctly()
-            {
-                var objects = new object[]
-                {
-                    1, 
-                    (2, "two"), 
-                    Enumerable.Range(1, 3),
-                    new { name = "apple", color = "green" },
-                };
-
-                objects.ToDisplayString("text/html")
-                       .Should()
-                       .BeEquivalentHtmlTo(
-@"<table>
-  <thead>
-    <tr>
-      <th><i>index</i></th>
-      <th><i>type</i></th>
-      <th>value</th>
-      <th>Item1</th>
-      <th>Item2</th>
-      <th>name</th>
-      <th>color</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>0</td>
-      <td>System.Int32</td>
-      <td>1</td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>1</td>
-      <td>System.ValueTuple&lt;System.Int32,System.String&gt;</td>
-      <td></td>
-      <td>2</td>
-      <td>two</td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>2</td>
-      <td>System.Linq.Enumerable+RangeIterator</td>
-      <td>[ 1, 2, 3 ]</td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>3</td>
-      <td>(anonymous)</td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td>apple</td>
-      <td>green</td>
-    </tr>
-  </tbody>
-</table>");
-            }
-
-            [Fact]
             public void DateTime_is_not_destructured()
             {
                 var date1 = DateTime.Now;
@@ -555,7 +487,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
             }
 
             [Fact]
-            public void Sequences_contain_different_types_of_elements()
+            public void Sequences_can_contain_different_types_of_elements()
             {
                 IEnumerable<object> GetCollection()
                 {
@@ -572,7 +504,104 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
                 writer.ToString().Should()
                       .BeEquivalentHtmlTo(
-                          "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td>True</td></tr><tr><td>1</td><td>99</td></tr><tr><td>2</td><td>Hello, World</td></tr></tbody></table>");
+@"<table>
+  <thead>
+    <tr>
+      <th>
+        <i>index</i>
+      </th>
+      <th>
+        <i>type</i>
+      </th>
+      <th>value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>0</td>
+      <td>System.Boolean</td>
+      <td>True</td>
+    </tr>
+    <tr>
+      <td>1</td>
+      <td>System.Int32</td>
+      <td>99</td>
+    </tr>
+    <tr>
+      <td>2</td>
+      <td>System.String</td>
+      <td>Hello, World</td>
+    </tr>
+  </tbody>
+</table>");
+            }
+
+            
+            [Fact]
+            public void All_properties_are_shown_when_sequences_contain_different_types()
+            {
+                var objects = new object[]
+                {
+                    1, 
+                    (2, "two"), 
+                    Enumerable.Range(1, 3),
+                    new { name = "apple", color = "green" },
+                };
+
+                objects.ToDisplayString("text/html")
+                       .Should()
+                       .BeEquivalentHtmlTo(
+                           @"<table>
+  <thead>
+    <tr>
+      <th><i>index</i></th>
+      <th><i>type</i></th>
+      <th>value</th>
+      <th>Item1</th>
+      <th>Item2</th>
+      <th>name</th>
+      <th>color</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>0</td>
+      <td>System.Int32</td>
+      <td>1</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>1</td>
+      <td>System.ValueTuple&lt;System.Int32,System.String&gt;</td>
+      <td></td>
+      <td>2</td>
+      <td>two</td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>2</td>
+      <td>System.Linq.Enumerable+RangeIterator</td>
+      <td>[ 1, 2, 3 ]</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>3</td>
+      <td>(anonymous)</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>apple</td>
+      <td>green</td>
+    </tr>
+  </tbody>
+</table>");
             }
         }
     }

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/Microsoft.DotNet.Interactive.Formatting.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/Microsoft.DotNet.Interactive.Formatting.Tests.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-
     <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);8002</NoWarn><!-- Assent isn't strongly signed -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/Microsoft.DotNet.Interactive.Formatting.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/Microsoft.DotNet.Interactive.Formatting.Tests.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.0" />
+    <PackageReference Include="Assent" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/PlainTextFormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/PlainTextFormatterTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
                               .Should()
                               .BeOfType<PlainTextFormatter<Widget>>();
         }
-   
+
         public class Objects : FormatterTestBase
         {
             [Fact]

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/StringExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/StringExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text.RegularExpressions;
+using System.Xml.Linq;
 using Microsoft.AspNetCore.Html;
 
 namespace Microsoft.DotNet.Interactive.Formatting.Tests
@@ -27,6 +28,11 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
         public static string Crunch(this IHtmlContent s)
         {
             return s.ToString().Crunch();
+        }
+
+        public static string IndentHtml(this string html)
+        {
+            return XElement.Parse(html).ToString();
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Formatting/DefaultPlainTextFormatterSet.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/DefaultPlainTextFormatterSet.cs
@@ -110,6 +110,15 @@ namespace Microsoft.DotNet.Interactive.Formatting
         }
 
         private static readonly PlainTextFormatter<Type> _formatterForSystemType =
-            new PlainTextFormatter<Type>((type, writer) => type.WriteCSharpDeclarationTo(writer));
+            new PlainTextFormatter<Type>((type, writer) =>
+            {
+                if (type.IsAnonymous())
+                {
+                    writer.Write("(anonymous)");
+                    return;
+                }
+
+                type.WriteCSharpDeclarationTo(writer);
+            });
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Formatting/DefaultPlainTextFormatterSet.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/DefaultPlainTextFormatterSet.cs
@@ -61,6 +61,7 @@ namespace Microsoft.DotNet.Interactive.Formatting
         {
             var singleLineFormatter = new SingleLinePlainTextFormatter();
 
+           
             return new ConcurrentDictionary<Type, ITypeFormatter>
             {
                 [typeof(ExpandoObject)] =
@@ -94,25 +95,21 @@ namespace Microsoft.DotNet.Interactive.Formatting
                     pair.Value.FormatTo(writer);
                 }),
 
-                [typeof(ReadOnlyMemory<char>)] = new PlainTextFormatter<ReadOnlyMemory<char>>((memory, writer) =>
-                {
-                    writer.Write(memory.Span.ToString());
-                }),
+                [typeof(ReadOnlyMemory<char>)] = new PlainTextFormatter<ReadOnlyMemory<char>>((memory, writer) => { writer.Write(memory.Span.ToString()); }),
 
-                [typeof(TimeSpan)] = new PlainTextFormatter<TimeSpan>((timespan, writer) =>
-                {
-                    writer.Write(timespan.ToString());
-                }),
+                [typeof(TimeSpan)] = new PlainTextFormatter<TimeSpan>((timespan, writer) => { writer.Write(timespan.ToString()); }),
 
-                [typeof(Type)] = new PlainTextFormatter<Type>((type, writer) =>
-                {
-                   type.WriteCSharpDeclarationTo(writer);
-                }),
+                [typeof(Type)] = _formatterForSystemType,
+
+                [typeof(Type).GetType()] = _formatterForSystemType,
 
                 [typeof(DateTime)] = new PlainTextFormatter<DateTime>((value, writer) => writer.Write(value.ToString("u"))),
 
                 [typeof(DateTimeOffset)] = new PlainTextFormatter<DateTimeOffset>((value, writer) => writer.Write(value.ToString("u")))
             };
         }
+
+        private static readonly PlainTextFormatter<Type> _formatterForSystemType =
+            new PlainTextFormatter<Type>((type, writer) => type.WriteCSharpDeclarationTo(writer));
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Formatting/Destructurer.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/Destructurer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections;
 using System.Collections.Concurrent;
 
 namespace Microsoft.DotNet.Interactive.Formatting
@@ -31,6 +32,11 @@ namespace Microsoft.DotNet.Interactive.Formatting
             return _cache.GetOrAdd(type, t =>
             {
                 if (t.IsScalar())
+                {
+                    return NonDestructurer.Instance;
+                }
+
+                if (typeof(IEnumerable).IsAssignableFrom(t))
                 {
                     return NonDestructurer.Instance;
                 }

--- a/src/Microsoft.DotNet.Interactive.Formatting/Destructurer.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/Destructurer.cs
@@ -2,22 +2,39 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
+using System.Collections.Concurrent;
 
 namespace Microsoft.DotNet.Interactive.Formatting
 {
     internal static class Destructurer
     {
-        public static IDestructurer<T> Create<T>() => new Destructurer<T>();
+        private static ConcurrentDictionary<Type, IDestructurer> _cache;
 
-        public static IDestructurer Create(Type type)
+        static Destructurer()
         {
-            if (type.IsScalar())
-            {
-                return NonDestructurer.Instance;
-            }
-
-            return (IDestructurer) Activator.CreateInstance(typeof(Destructurer<>).MakeGenericType(type));
+            InitializeCache();
+            Formatter.Clearing += (sender, args) => InitializeCache();
         }
+
+        private static void InitializeCache()
+        {
+            _cache = new ConcurrentDictionary<Type, IDestructurer>();
+        }
+
+        public static IDestructurer GetOrCreate(Type type) =>
+            _cache.GetOrAdd(type, t =>
+            {
+                if (t.IsScalar())
+                {
+                    return NonDestructurer.Instance;
+                }
+
+                if (typeof(Type).IsAssignableFrom(t))
+                {
+                    return NonDestructurer.Instance;
+                }
+
+                return (IDestructurer) Activator.CreateInstance(typeof(Destructurer<>).MakeGenericType(t));
+            });
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Formatting/Destructurer.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/Destructurer.cs
@@ -21,8 +21,14 @@ namespace Microsoft.DotNet.Interactive.Formatting
             _cache = new ConcurrentDictionary<Type, IDestructurer>();
         }
 
-        public static IDestructurer GetOrCreate(Type type) =>
-            _cache.GetOrAdd(type, t =>
+        public static IDestructurer GetOrCreate(Type type)
+        {
+            if (type == null)
+            {
+                return NonDestructurer.Instance;
+            }
+
+            return _cache.GetOrAdd(type, t =>
             {
                 if (t.IsScalar())
                 {
@@ -36,5 +42,6 @@ namespace Microsoft.DotNet.Interactive.Formatting
 
                 return (IDestructurer) Activator.CreateInstance(typeof(Destructurer<>).MakeGenericType(t));
             });
+        }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Formatting/Destructurer{T}.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/Destructurer{T}.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.DotNet.Interactive.Formatting
 {
@@ -42,13 +44,7 @@ namespace Microsoft.DotNet.Interactive.Formatting
                     return;
                 }
 
-                var propertiesAndFields = typeof(T).GetMembers(BindingFlags.Instance | BindingFlags.GetProperty | BindingFlags.GetField | BindingFlags.Public)
-                                                   .Where(m => !m.Name.Contains("<") && !m.Name.Contains("k__BackingField"))
-                                                   .Where(m => m.MemberType == MemberTypes.Property || m.MemberType == MemberTypes.Field)
-                                                   .Where(m => m.MemberType != MemberTypes.Property ||
-                                                               (((PropertyInfo) m).CanRead &&
-                                                                !((PropertyInfo) m).GetIndexParameters().Any()))
-                                                   .ToArray();
+                var propertiesAndFields = typeof(T).GetMembersToFormat();
 
                 getters = propertiesAndFields
                     .ToDictionary(member => member.Name,

--- a/src/Microsoft.DotNet.Interactive.Formatting/DictionaryExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/DictionaryExtensions.cs
@@ -9,6 +9,20 @@ namespace Microsoft.DotNet.Interactive.Formatting
 {
     internal static class DictionaryExtensions
     {
+        public static TValue GetOrAdd<TKey, TValue>(
+            this IDictionary<TKey, TValue> dictionary,
+            TKey key,
+            Func<TKey, TValue> getValue)
+        {
+            if (!dictionary.TryGetValue(key, out var value))
+            {
+                value = getValue(key);
+                dictionary.Add(key, value);
+            }
+
+            return value;
+        }
+
         public static IDictionary<TKey, TValue> Merge<TKey, TValue>(
             this IDictionary<TKey, TValue> dictionary1,
             IDictionary<TKey, TValue> dictionary2,

--- a/src/Microsoft.DotNet.Interactive.Formatting/EnumerableExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/EnumerableExtensions.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.Interactive.Formatting
+{
+    internal static class EnumerableExtensions
+    {
+        public static (IReadOnlyList<T> items, int remainingCount) TakeAndCountRemaining<T>(
+            this IEnumerable<T> source,
+            int count)
+        {
+            using var enumerator = source.GetEnumerator();
+
+            var items = new List<T>();
+
+            while (enumerator.MoveNext())
+            {
+                items.Add(enumerator.Current);
+
+                if (items.Count >= count)
+                {
+                    return (items, CountRemaining());
+                }
+            }
+
+            return (items, 0);
+
+            int CountRemaining()
+            {
+                switch (source)
+                {
+                    case ICollection<T> collection:
+                        return collection.Count - items.Count;
+                    default:
+
+                        var remainingCount = 0;
+
+                        while (enumerator.MoveNext())
+                        {
+                            remainingCount++;
+                        }
+
+                        return remainingCount;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Interactive.Formatting/Formatter.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/Formatter.cs
@@ -457,10 +457,6 @@ namespace Microsoft.DotNet.Interactive.Formatting
 
         private static void ConfigureDefaultPlainTextFormattersForSpecialTypes()
         {
-            // an additional formatter is needed since typeof(Type) == System.RuntimeType, which is not public
-            Register(typeof(Type).GetType(),
-                     (obj, writer) => Formatter<Type>.FormatTo((Type) obj, writer, PlainTextFormatter.MimeType));
-
             // Newtonsoft.Json types -- these implement IEnumerable and their default output is not useful, so use their default ToString
             TryRegisterDefault("Newtonsoft.Json.Linq.JArray, Newtonsoft.Json", (obj, writer) => writer.Write(obj), PlainTextFormatter.MimeType);
             TryRegisterDefault("Newtonsoft.Json.Linq.JObject, Newtonsoft.Json", (obj, writer) => writer.Write(obj), PlainTextFormatter.MimeType);

--- a/src/Microsoft.DotNet.Interactive.Formatting/HtmlFormatter{T}.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/HtmlFormatter{T}.cs
@@ -57,7 +57,7 @@ namespace Microsoft.DotNet.Interactive.Formatting
 
         private static HtmlFormatter<T> CreateForObject(bool includeInternals)
         {
-            var members = typeof(T).GetAllMembers(includeInternals)
+            var members = typeof(T).GetMembersToFormat(includeInternals)
                                    .GetMemberAccessors<T>();
 
             if (members.Length == 0)

--- a/src/Microsoft.DotNet.Interactive.Formatting/PlainTextFormatter{T}.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/PlainTextFormatter{T}.cs
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.Interactive.Formatting
 
             return new PlainTextFormatter<T>(
                 PlainTextFormatter.CreateFormatDelegate<T>(
-                    typeof(T).GetAllMembers(includeInternals).ToArray()));
+                    typeof(T).GetMembersToFormat(includeInternals).ToArray()));
         }
 
         public static PlainTextFormatter<T> CreateForMembers(params Expression<Func<T, object>>[] members)

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -34,40 +34,6 @@
             CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Content Include="$(PkgPackageManagement)\**"
-             Exclude="$(PkgPackageManagement)\**\*.nupkg;$(PkgPackageManagement)\**\*.nuspec;$(PkgPackageManagement)\**\*.sha512;$(PkgPackageManagement)\**\fullclr\**"
-             Link="Modules\PackageManagement\%(RecursiveDir)%(FileName)%(Extension)"
-             PackagePath="contentFiles/any/any/Modules/PackageManagement"
-             PackageCopyToOutput="true"
-             CopyToOutputDirectory="PreserveNewest" 
-             Condition="'$(PkgPackageManagement)' != ''" />
-
-    <Content Include="$(PkgPowerShellGet)\**"
-             Exclude="$(PkgPowerShellGet)\**\*.nupkg;$(PkgPowerShellGet)\**\*.nuspec;$(PkgPowerShellGet)\**\*.sha512"
-             Link="Modules\PowerShellGet\%(RecursiveDir)%(FileName)%(Extension)"
-             PackagePath="contentFiles/any/any/Modules/PowerShellGet"
-             PackageCopyToOutput="true"
-             CopyToOutputDirectory="PreserveNewest" 
-             Condition="'$(PkgPowerShellGet)' != ''" />
-
-    <Content Include="$(PkgMicrosoft_PowerShell_Archive)\**"
-             Exclude="$(PkgMicrosoft_PowerShell_Archive)\**\*.nupkg;$(PkgMicrosoft_PowerShell_Archive)\**\*.nuspec;$(PkgMicrosoft_PowerShell_Archive)\**\*.sha512"
-             Link="Modules\Microsoft.PowerShell.Archive\%(RecursiveDir)%(FileName)%(Extension)"
-             PackagePath="contentFiles/any/any/Modules/Microsoft.PowerShell.Archive"
-             PackageCopyToOutput="true"
-             CopyToOutputDirectory="PreserveNewest" 
-             Condition="'$(PkgMicrosoft_PowerShell_Archive)' != ''" />
-
-    <Content Include="$(PkgThreadJob)\**"
-             Exclude="$(PkgThreadJob)\**\*.nupkg;$(PkgThreadJob)\**\*.nuspec;$(PkgThreadJob)\**\*.sha512"
-             Link="Modules\ThreadJob\%(RecursiveDir)%(FileName)%(Extension)"
-             PackagePath="contentFiles/any/any/Modules/ThreadJob"
-             PackageCopyToOutput="true"
-             CopyToOutputDirectory="PreserveNewest" 
-             Condition="'$(PkgThreadJob)' != ''" />
-
-  </ItemGroup>
 
   <!-- The dependencies for this project -->
   <ItemGroup>

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -34,6 +34,40 @@
             CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="$(PkgPackageManagement)\**"
+             Exclude="$(PkgPackageManagement)\**\*.nupkg;$(PkgPackageManagement)\**\*.nuspec;$(PkgPackageManagement)\**\*.sha512;$(PkgPackageManagement)\**\fullclr\**"
+             Link="Modules\PackageManagement\%(RecursiveDir)%(FileName)%(Extension)"
+             PackagePath="contentFiles/any/any/Modules/PackageManagement"
+             PackageCopyToOutput="true"
+             CopyToOutputDirectory="PreserveNewest" 
+             Condition="'$(PkgPackageManagement)' != ''" />
+
+    <Content Include="$(PkgPowerShellGet)\**"
+             Exclude="$(PkgPowerShellGet)\**\*.nupkg;$(PkgPowerShellGet)\**\*.nuspec;$(PkgPowerShellGet)\**\*.sha512"
+             Link="Modules\PowerShellGet\%(RecursiveDir)%(FileName)%(Extension)"
+             PackagePath="contentFiles/any/any/Modules/PowerShellGet"
+             PackageCopyToOutput="true"
+             CopyToOutputDirectory="PreserveNewest" 
+             Condition="'$(PkgPowerShellGet)' != ''" />
+
+    <Content Include="$(PkgMicrosoft_PowerShell_Archive)\**"
+             Exclude="$(PkgMicrosoft_PowerShell_Archive)\**\*.nupkg;$(PkgMicrosoft_PowerShell_Archive)\**\*.nuspec;$(PkgMicrosoft_PowerShell_Archive)\**\*.sha512"
+             Link="Modules\Microsoft.PowerShell.Archive\%(RecursiveDir)%(FileName)%(Extension)"
+             PackagePath="contentFiles/any/any/Modules/Microsoft.PowerShell.Archive"
+             PackageCopyToOutput="true"
+             CopyToOutputDirectory="PreserveNewest" 
+             Condition="'$(PkgMicrosoft_PowerShell_Archive)' != ''" />
+
+    <Content Include="$(PkgThreadJob)\**"
+             Exclude="$(PkgThreadJob)\**\*.nupkg;$(PkgThreadJob)\**\*.nuspec;$(PkgThreadJob)\**\*.sha512"
+             Link="Modules\ThreadJob\%(RecursiveDir)%(FileName)%(Extension)"
+             PackagePath="contentFiles/any/any/Modules/ThreadJob"
+             PackageCopyToOutput="true"
+             CopyToOutputDirectory="PreserveNewest" 
+             Condition="'$(PkgThreadJob)' != ''" />
+
+  </ItemGroup>
 
   <!-- The dependencies for this project -->
   <ItemGroup>

--- a/src/dotnet-interactive/CommandLine/CommandLineParser.cs
+++ b/src/dotnet-interactive/CommandLine/CommandLineParser.cs
@@ -522,13 +522,14 @@ namespace Microsoft.DotNet.Interactive.App.CommandLine
 
                     Formatter<LaTeXString>.Register((laTeX, writer) => writer.Write(laTeX.ToString()), "text/latex");
                     Formatter<MathString>.Register((math, writer) => writer.Write(math.ToString()), "text/latex");
-                    if (startupOptions.EnableHttpApi && browserFrontendEnvironment is HtmlNotebookFrontedEnvironment jupyterFrontedEnvironment)
+                    if (startupOptions.EnableHttpApi && 
+                        browserFrontendEnvironment is HtmlNotebookFrontedEnvironment frontedEnvironment)
                     {
                         Formatter<ScriptContent>.Register((script, writer) =>
                         {
                             var fullCode = $@"if (typeof window.createDotnetInteractiveClient === typeof Function) {{
-createDotnetInteractiveClient('{jupyterFrontedEnvironment.DiscoveredUri.AbsoluteUri}').then(function (interactive) {{
-let notebookScope = getDotnetInteractiveScope('{jupyterFrontedEnvironment.DiscoveredUri.AbsoluteUri}');
+createDotnetInteractiveClient('{frontedEnvironment.DiscoveredUri.AbsoluteUri}').then(function (interactive) {{
+let notebookScope = getDotnetInteractiveScope('{frontedEnvironment.DiscoveredUri.AbsoluteUri}');
 {script.ScriptValue}
 }});
 }}";


### PR DESCRIPTION
This addresses #63 and #569 and makes a few related formatter improvements.

It improves the display of heterogeneous types in a sequence, including adding a `type` column:

![image](https://user-images.githubusercontent.com/547415/85956750-c5724c80-b93c-11ea-8359-391da9ef395b.png)

It excludes properties where debugger browsability is set to `Never`, producing the following output for discriminated unions:

![image](https://user-images.githubusercontent.com/547415/85958061-9f05de80-b947-11ea-9047-ce0084544571.png)
