### PR TITLE
[VSCode] set tool version on package build

### DIFF
--- a/eng/package/PackVSCodeExtension.ps1
+++ b/eng/package/PackVSCodeExtension.ps1
@@ -9,15 +9,25 @@ Set-StrictMode -version 2.0
 $ErrorActionPreference = "Stop"
 
 try {
-    # set version
+    # get JSON model for package.json
+    Write-Host "Getting JSON package model"
+    $packageJsonPath = Join-Path (Get-Location) "package.json"
+    $packageJsonContents = (Get-Content $packageJsonPath | Out-String | ConvertFrom-Json)
+
+    # set package version
     Write-Host "Setting package version to $stableToolVersionNumber"
-    npm version $stableToolVersionNumber
+    $packageJsonContents.version = $stableToolVersionNumber
+
+    # set tool version
+    Write-Host "Setting tool version to $stableToolVersionNumber"
+    $packageJsonContents.contributes.configuration.properties."dotnet-interactive.minimumInteractiveToolVersion"."default" = $stableToolVersionNumber
 
     # append git sha to package description
-    $packageJsonPath = Join-Path (Get-Location) "package.json"
     Write-Host "Appending git sha to description in $packageJsonPath"
-    $packageJsonContents = (Get-Content $packageJsonPath | Out-String | ConvertFrom-Json)
     $packageJsonContents.description += "  Git SHA $gitSha"
+
+    # write out updated JSON
+    Write-Host "Writing updated package.json"
     $packageJsonContents | ConvertTo-Json -depth 100 | Out-File $packageJsonPath
 
     # create destination


### PR DESCRIPTION
Set the VS Code tool version to be the one just built.  With the recently added kernel smoke tests, we have more assurance that the tool we just built is correct.  This also reduces the friction of updating the tool version by not requiring 2 separate builds and enables breaking changes to be made in one PR.

~~Marking as WIP until the [internal full-signed build](https://dev.azure.com/dnceng/internal/_build/results?buildId=709908&view=results) also passes and has been manually verified.~~ Manual build and verification was good.