### PR TITLE
Improves cross-platform support by using Join-Path

### DIFF
--- a/src/dotnet-interactive/build-and-install-dotnet-interactive.ps1
+++ b/src/dotnet-interactive/build-and-install-dotnet-interactive.ps1
@@ -4,22 +4,22 @@ $ErrorActionPreference = "Stop"
 $thisDir = Split-Path -Parent $PSCommandPath
 $toolLocation = ""
 $toolVersion = ""
-dotnet run -p "$thisDir\..\interface-generator" --out-file "$thisDir\..\dotnet-interactive-vscode\src\contracts.ts"
+dotnet run -p (Join-Path -Path $thisDir ".." "interface-generator") --out-file (Join-Path $thisDir ".." "dotnet-interactive-vscode" "src" "contracts.ts")
 
-dotnet run -p "$thisDir\..\interface-generator" --out-file "$thisDir\..\Microsoft.DotNet.Interactive.Js\src\dotnet-interactive\contracts.ts"
+dotnet run -p (Join-Path -Path $thisDir ".." "interface-generator") --out-file (Join-Path $thisDir ".." "Microsoft.DotNet.Interactive.Js" "src" "dotnet-interactive" "contracts.ts")
 
 if (Test-Path 'env:DisableArcade') {
-    dotnet pack "$thisDir\dotnet-interactive.csproj" /p:Version=0.0.0
-    $script:toolLocation = "$thisDir\bin\debug"
+    dotnet pack (Join-Path $thisDir "dotnet-interactive.csproj") /p:Version=0.0.0
+    $script:toolLocation = Join-Path $thisDir "bin" "debug"
     $script:toolVersion = "0.0.0"
 } else {
     if ($IsLinux -or $IsMacOS) {
-        & "$thisDir\..\..\build.sh" --pack
+        & "$thisDir/../../build.sh" --pack
     } else {
         & "$thisDir\..\..\build.cmd" -pack
     }
 
-    $script:toolLocation = "$thisDir\..\..\artifacts\packages\Debug\Shipping"
+    $script:toolLocation = Join-Path $thisDir ".." ".." "artifacts" "packages" "Debug" "Shipping"
     $script:toolVersion = "1.0.0-dev"
 }
 


### PR DESCRIPTION
Related to #534 

The script `src/dotnet-interactive/build-and-install-dotnet-interactive.ps1` was failing to run on macOS, because Windows-style path separators were being used.