### PR TITLE
Adds support for XPlot vNext

### DIFF
--- a/dotnet-interactive.sln
+++ b/dotnet-interactive.sln
@@ -55,6 +55,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "interface-generator", "src\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Interactive.FSharp.Wrapper", "src\Microsoft.DotNet.Interactive.FSharp.Wrapper\Microsoft.DotNet.Interactive.FSharp.Wrapper.csproj", "{89672116-94E4-4F17-A64A-AA049410F595}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "XPlot.Plotly", "..\XPlot\src\XPlot.Plotly\XPlot.Plotly.fsproj", "{81679D53-0BC9-4D83-9263-5CFEEA94B528}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -341,6 +343,18 @@ Global
 		{89672116-94E4-4F17-A64A-AA049410F595}.Release|x64.Build.0 = Release|Any CPU
 		{89672116-94E4-4F17-A64A-AA049410F595}.Release|x86.ActiveCfg = Release|Any CPU
 		{89672116-94E4-4F17-A64A-AA049410F595}.Release|x86.Build.0 = Release|Any CPU
+		{81679D53-0BC9-4D83-9263-5CFEEA94B528}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{81679D53-0BC9-4D83-9263-5CFEEA94B528}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{81679D53-0BC9-4D83-9263-5CFEEA94B528}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{81679D53-0BC9-4D83-9263-5CFEEA94B528}.Debug|x64.Build.0 = Debug|Any CPU
+		{81679D53-0BC9-4D83-9263-5CFEEA94B528}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{81679D53-0BC9-4D83-9263-5CFEEA94B528}.Debug|x86.Build.0 = Debug|Any CPU
+		{81679D53-0BC9-4D83-9263-5CFEEA94B528}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{81679D53-0BC9-4D83-9263-5CFEEA94B528}.Release|Any CPU.Build.0 = Release|Any CPU
+		{81679D53-0BC9-4D83-9263-5CFEEA94B528}.Release|x64.ActiveCfg = Release|Any CPU
+		{81679D53-0BC9-4D83-9263-5CFEEA94B528}.Release|x64.Build.0 = Release|Any CPU
+		{81679D53-0BC9-4D83-9263-5CFEEA94B528}.Release|x86.ActiveCfg = Release|Any CPU
+		{81679D53-0BC9-4D83-9263-5CFEEA94B528}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Microsoft.DotNet.Interactive.CSharp/Microsoft.DotNet.Interactive.CSharp.csproj
+++ b/src/Microsoft.DotNet.Interactive.CSharp/Microsoft.DotNet.Interactive.CSharp.csproj
@@ -18,6 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\XPlot\src\XPlot.Plotly\XPlot.Plotly.fsproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Interactive.Formatting\Microsoft.DotNet.Interactive.Formatting.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Interactive\Microsoft.DotNet.Interactive.csproj" />
   </ItemGroup>
@@ -31,7 +32,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="$(MicrosoftCodeAnalysisCommonVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting.Common" Version="$(MicrosoftCodeAnalysisCommonVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftCodeAnalysisCommonVersion)" />
-    <PackageReference Include="XPlot.Plotly" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Interactive.FSharp/Microsoft.DotNet.Interactive.FSharp.fsproj
+++ b/src/Microsoft.DotNet.Interactive.FSharp/Microsoft.DotNet.Interactive.FSharp.fsproj
@@ -33,6 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\XPlot\src\XPlot.Plotly\XPlot.Plotly.fsproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Interactive.Formatting\Microsoft.DotNet.Interactive.Formatting.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Interactive\Microsoft.DotNet.Interactive.csproj" />
   </ItemGroup>
@@ -40,7 +41,6 @@
   <ItemGroup>
     <PackageReference Include="FSharp.Compiler.Private.Scripting" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftCodeAnalysisWorkspacesCommonVersion)" />
-    <PackageReference Include="XPlot.Plotly" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
@@ -77,7 +77,7 @@ for ($j = 0; $j -le 4; $j += 4 ) {
 
             var accelerator = typeof(PSObject).Assembly.GetType("System.Management.Automation.TypeAccelerators");
             dynamic typeAccelerators = accelerator.GetProperty("Get").GetValue(null);
-            Assert.Equal(typeAccelerators["Graph.Scatter"].FullName, $"{typeof(Graph).FullName}+Scatter");
+            Assert.Equal(typeAccelerators["Graph.Scatter"].FullName, $"Scatter");
             Assert.Equal(typeAccelerators["Layout"].FullName, $"{typeof(Layout).FullName}+Layout");
             Assert.Equal(typeAccelerators["Chart"].FullName, typeof(Chart).FullName);
         }

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Commands/NewPlotlyChartCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Commands/NewPlotlyChartCommand.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using XPlot.Plotly;
-using static XPlot.Plotly.Graph;
 
 namespace Microsoft.DotNet.Interactive.PowerShell.Commands
 {

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -71,6 +71,7 @@
 
   <!-- The dependencies for this project -->
   <ItemGroup>
+    <ProjectReference Include="..\..\..\XPlot\src\XPlot.Plotly\XPlot.Plotly.fsproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Interactive.Formatting\Microsoft.DotNet.Interactive.Formatting.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Interactive\Microsoft.DotNet.Interactive.csproj" />
   </ItemGroup>
@@ -78,7 +79,6 @@
   <ItemGroup>
     <PackageReference Include="System.IO.Pipelines" Version="4.7.1" />
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.0" />
-    <PackageReference Include="XPlot.Plotly" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.Interactive.PowerShell
             // Register type accelerators for Plotly.
             var accelerator = typeof(PSObject).Assembly.GetType("System.Management.Automation.TypeAccelerators");
             MethodInfo addAccelerator = accelerator.GetMethod("Add", new Type[] { typeof(string), typeof(Type) });
-            foreach (Type type in typeof(Graph).GetNestedTypes())
+            foreach (Type type in typeof(Trace).Assembly.GetTypes().Where(t => t.BaseType == typeof(Trace)))
             {
                 addAccelerator.Invoke(null, new object[] { $"Graph.{type.Name}", type });
             }

--- a/src/XPlot.DotNet.Interactive.KernelExtensions/XPlot.DotNet.Interactive.KernelExtensions.csproj
+++ b/src/XPlot.DotNet.Interactive.KernelExtensions/XPlot.DotNet.Interactive.KernelExtensions.csproj
@@ -7,10 +7,10 @@
 
   <ItemGroup>
     <PackageReference Include="FSharp.Core" />
-    <PackageReference Include="XPlot.Plotly" Version="3.0.1" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\XPlot\src\XPlot.Plotly\XPlot.Plotly.fsproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Interactive\Microsoft.DotNet.Interactive.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
This pull request will fail CI. It is submitted for illustration purposes.

Related to #534 

This pull request shows some of the changes that will be required to build `interactive` against the next version of `XPlot.Plotly`. These changes may be avoided by breaking the dependency on XPlot per #582. 