### PR TITLE
Magic command completion improvements

### DIFF
--- a/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
@@ -103,6 +103,13 @@ namespace Microsoft.DotNet.Interactive.CSharp
             return Task.FromResult(SyntaxFactory.IsCompleteSubmission(syntaxTree));
         }
 
+        public override IReadOnlyCollection<string> GetVariableNames() =>
+            ScriptState?.Variables
+                       .Select(v => v.Name)
+                       .Distinct()
+                       .ToArray() ??
+            Array.Empty<string>();
+
         public override bool TryGetVariable<T>(
             string name,
             out T value)

--- a/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
@@ -133,6 +133,11 @@ type FSharpKernelBase () as this =
         |> List.filter (fun x -> x.Name <> "it") // don't report special variable `it`
         |> List.map (fun x -> CurrentVariable(x.Name, x.Value.ReflectionType, x.Value.ReflectionValue))
 
+    override _.GetVariableNames() =
+        this.GetCurrentVariables()
+        |> List.map (fun x -> x.Name)
+        :> IReadOnlyCollection<string>
+
     override _.TryGetVariable<'a>(name: string, [<Out>] value: 'a byref) =
         match script.Value.Fsi.TryFindBoundValue(name) with
         | Some cv ->

--- a/src/Microsoft.DotNet.Interactive.Formatting/Microsoft.DotNet.Interactive.Formatting.csproj
+++ b/src/Microsoft.DotNet.Interactive.Formatting/Microsoft.DotNet.Interactive.Formatting.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="2.2.0" />
     <PackageReference Include="microsoft.csharp" Version="4.7.0" />
-    <PackageReference Include="System.CommandLine.Rendering" Version="0.3.0-alpha.20309.1" />
+    <PackageReference Include="System.CommandLine.Rendering" Version="0.3.0-alpha.20352.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Management.Automation.Language;
@@ -114,6 +115,12 @@ namespace Microsoft.DotNet.Interactive.PowerShell
 
             RegisterForDisposal(pwsh);
             return pwsh;
+        }
+
+        public override IReadOnlyCollection<string> GetVariableNames()
+        {
+            // FIX: (GetVariableNames) 
+            return Array.Empty<string>();
         }
 
         public override bool TryGetVariable<T>(string name, out T value)

--- a/src/Microsoft.DotNet.Interactive.Telemetry/Microsoft.DotNet.Interactive.Telemetry.csproj
+++ b/src/Microsoft.DotNet.Interactive.Telemetry/Microsoft.DotNet.Interactive.Telemetry.csproj
@@ -9,6 +9,6 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.14.0" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.6.0" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20309.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20352.2" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelTestBase.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelTestBase.cs
@@ -141,7 +141,8 @@ namespace Microsoft.DotNet.Interactive.Tests
 
         private Kernel CreatePowerShellKernel()
         {
-            return new PowerShellKernel();
+            return new PowerShellKernel()
+                .UseDotNetVariableSharing();
         }
 
         public async Task SubmitCode(Kernel kernel, string[] submissions, SubmissionType submissionType = SubmissionType.Run)

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/CompletionTests.MagicCommands.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/CompletionTests.MagicCommands.cs
@@ -1,0 +1,251 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using FluentAssertions;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.DotNet.Interactive.Commands;
+using Microsoft.DotNet.Interactive.CSharp;
+using Microsoft.DotNet.Interactive.Events;
+using Microsoft.DotNet.Interactive.FSharp;
+using Microsoft.DotNet.Interactive.PowerShell;
+using Microsoft.DotNet.Interactive.Tests.Utility;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.Interactive.Tests.LanguageServices
+{
+    public partial class CompletionTests
+    {
+        public class MagicCommands : LanguageKernelTestBase
+        {
+            public MagicCommands(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Theory]
+            // commands
+            [InlineData("[|#!c|]", "#!csharp")]
+            [InlineData("[|#!|]", "#!csharp,#!who,#!whos")]
+            [InlineData("[|#!w|]", "#!who,#!whos")]
+            [InlineData("[|#!w|]\n", "#!who,#!whos")]
+            [InlineData("[|#!w|] \n", "#!who,#!whos")]
+            // options
+            [InlineData("#!share [||]", "--from")]
+            public void Completions_are_available_for_magic_commands(
+                string markupCode,
+                string expected)
+            {
+                var kernel = CreateKernel();
+
+                markupCode
+                    .ParseMarkupCode()
+                    .PositionsInMarkedSpans()
+                    .Should()
+                    .ProvideCompletions(kernel)
+                    .Which
+                    .Should()
+                    .AllSatisfy(
+                        requestCompleted =>
+                            requestCompleted
+                                .Completions.Select(i => i.DisplayText)
+                                      .Should()
+                                      .Contain(expected.Split(","),
+                                               because: $"position {requestCompleted.LinePositionSpan} should provide completions"));
+            }
+
+            [Fact]
+            public void Insertion_range_is_correct_for_option_completions()
+            {
+                var kernel = CreateKernel();
+
+                "#!share fr[||]"
+                    .ParseMarkupCode()
+                    .PositionsInMarkedSpans()
+                    .Should()
+                    .ProvideCompletions(kernel)
+                    .Which
+                    .Should()
+                    .AllSatisfy(c =>
+                                    c.LinePositionSpan
+                                     .Should()
+                                     .BeEquivalentTo(new LinePositionSpan(
+                                                         new LinePosition(0, 8),
+                                                         new LinePosition(0, 10))));
+            }
+
+            [Fact]
+            public void Insertion_range_is_correct_for_command_completions()
+            {
+                var kernel = CreateKernel();
+
+                "#!wh[||]"
+                    .ParseMarkupCode()
+                    .PositionsInMarkedSpans()
+                    .Should()
+                    .ProvideCompletions(kernel)
+                    .Which
+                    .Should()
+                    .AllSatisfy(c =>
+                                    c.LinePositionSpan
+                                     .Should()
+                                     .BeEquivalentTo(new LinePositionSpan(
+                                                         new LinePosition(0, 0),
+                                                         new LinePosition(0, 4))));
+            }
+
+            [Fact]
+            public void Completions_include_magic_commands_from_all_kernels()
+            {
+                var markupCode = "[|#!|]";
+                var expected = new[] { "#!csharp", "#!fsharp", "#!pwsh", "#!who" };
+
+                using var kernel = new CompositeKernel
+                {
+                    new CSharpKernel().UseWho(),
+                    new FSharpKernel().UseWho(),
+                    new PowerShellKernel()
+                };
+
+                markupCode
+                    .ParseMarkupCode()
+                    .PositionsInMarkedSpans()
+                    .Should()
+                    .ProvideCompletions(kernel)
+                    .Which
+                    .Should()
+                    .AllSatisfy(
+                        requestCompleted =>
+                            requestCompleted
+                                .Completions
+                                .Select(i => i.DisplayText)
+                                .Should()
+                                .Contain(expected,
+                                         because: $"position {requestCompleted.LinePositionSpan} should provide completions"));
+            }
+
+            [Fact]
+            public void Inner_symbol_completions_do_not_include_top_level_symbols()
+            {
+                var kernel = CreateKernel();
+
+                "#!share [| |]"
+                    .ParseMarkupCode()
+                    .PositionsInMarkedSpans()
+                    .Should()
+                    .ProvideCompletions(kernel)
+                    .Which
+                    .Should()
+                    .AllSatisfy(
+                        requestCompleted =>
+                            requestCompleted
+                                .Completions
+                                .Select(i => i.DisplayText)
+                                .Should()
+                                .NotContain(c => c.Contains("#!")));
+            }
+
+            [Fact]
+            public async Task Completions_do_not_include_duplicates()
+            {
+                var cSharpKernel = new CSharpKernel();
+
+                using var compositeKernel = new CompositeKernel
+                {
+                    cSharpKernel
+                };
+
+                compositeKernel.DefaultKernelName = cSharpKernel.Name;
+
+                var commandName = "#!hello";
+                compositeKernel.AddDirective(new Command(commandName)
+                {
+                    Handler = CommandHandler.Create(() => { })
+                });
+                cSharpKernel.AddDirective(new Command(commandName)
+                {
+                    Handler = CommandHandler.Create(() => { })
+                });
+
+                var result = await compositeKernel.SendAsync(new RequestCompletions("#!", new LinePosition(0, 2)));
+
+                var events = result.KernelEvents.ToSubscribedList();
+
+                events
+                    .Should()
+                    .ContainSingle<CompletionsProduced>()
+                    .Which
+                    .Completions
+                    .Should()
+                    .ContainSingle(e => e.DisplayText == commandName);
+            }
+
+            [Theory]
+            [InlineData("[|#!d|]", "#!directiveOnChild,#!directiveOnParent", Language.CSharp)]
+            [InlineData("[|#!dir|]\n", "#!directiveOnChild,#!directiveOnParent", Language.CSharp)]
+            [InlineData("[|#!d|]", "#!directiveOnChild,#!directiveOnParent", Language.FSharp)]
+            [InlineData("[|#!dir|]\n", "#!directiveOnChild,#!directiveOnParent", Language.FSharp)]
+            [InlineData("[|#!d|]", "#!directiveOnChild,#!directiveOnParent", Language.PowerShell)]
+            [InlineData("[|#!dir|]\n", "#!directiveOnChild,#!directiveOnParent", Language.PowerShell)]
+            public void Completions_are_available_for_magic_commands_added_at_runtime_to_child_and_parent_kernels(
+                string markupCode,
+                string expected,
+                Language defaultLanguage)
+            {
+                var kernel = CreateCompositeKernel(defaultLanguage);
+
+                var kernelToExtend = kernel.FindKernel(defaultLanguage.LanguageName());
+
+                kernelToExtend.AddDirective(new Command("#!directiveOnChild")
+                {
+                    Handler = CommandHandler.Create(() => { })
+                });
+
+                kernel.AddDirective(new Command("#!directiveOnParent")
+                {
+                    Handler = CommandHandler.Create(() => { })
+                });
+
+                markupCode
+                    .ParseMarkupCode()
+                    .PositionsInMarkedSpans()
+                    .Should()
+                    .ProvideCompletions(kernel)
+                    .Which
+                    .Should()
+                    .AllSatisfy(
+                        requestCompleted =>
+                            requestCompleted
+                                .Completions
+                                .Select(i => i.DisplayText)
+                                .Should()
+                                .Contain(expected.Split(","),
+                                         because: $"position {requestCompleted.LinePositionSpan} should provide completions"));
+            }
+
+            [Fact]
+            public async Task Magic_command_completion_documentation_does_not_include_root_command_name()
+            {
+                var exeName = RootCommand.ExecutableName;
+
+                var kernel = CreateKernel();
+
+                var result = await kernel.SendAsync(new RequestCompletions("#!", new LinePosition(0, 2)));
+
+                var events = result.KernelEvents.ToSubscribedList();
+
+                events
+                    .Should()
+                    .ContainSingle<CompletionsProduced>()
+                    .Which
+                    .Completions
+                    .Select(i => i.Documentation)
+                    .Should()
+                    .NotContain(i => i.Contains(exeName));
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/CompletionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/CompletionTests.cs
@@ -188,6 +188,67 @@ namespace Microsoft.DotNet.Interactive.Tests.LanguageServices
         }
 
         [Fact]
+        public void Insertion_range_is_correct_for_magic_command_option_completions()
+        {
+            var kernel = CreateKernel();
+
+            "#!share fr[||]"
+                .ParseMarkupCode()
+                .PositionsInMarkedSpans()
+                .Should()
+                .ProvideCompletions(kernel)
+                .Which
+                .Should()
+                .AllSatisfy(c =>
+                                c.LinePositionSpan
+                                 .Should()
+                                 .BeEquivalentTo(new LinePositionSpan(
+                                                     new LinePosition(0, 8),
+                                                     new LinePosition(0, 10))));
+        }
+
+        [Fact]
+        public void Insertion_range_is_correct_for_magic_command_completions()
+        {
+            var kernel = CreateKernel();
+
+            "#!wh[||]"
+                .ParseMarkupCode()
+                .PositionsInMarkedSpans()
+                .Should()
+                .ProvideCompletions(kernel)
+                .Which
+                .Should()
+                .AllSatisfy(c =>
+                                c.LinePositionSpan
+                                 .Should()
+                                 .BeEquivalentTo(new LinePositionSpan(
+                                                     new LinePosition(0, 0),
+                                                     new LinePosition(0, 4))));
+        }
+
+        [Fact]
+        public void Magic_command_option_completions_do_not_include_magic_commands()
+        {
+            var kernel = CreateKernel();
+
+            "#!share [| |]"
+                .ParseMarkupCode()
+                .PositionsInMarkedSpans()
+                .Should()
+                .ProvideCompletions(kernel)
+                .Which
+                .Should()
+                .AllSatisfy(
+                    requestCompleted =>
+                        requestCompleted
+                            .Completions
+                            .Select(i => i.DisplayText)
+                            .Should()
+                            .NotContain(c => c.Contains("#!")));
+        }
+
+        [Fact]
         public void Magic_command_completions_include_magic_commands_from_all_kernels()
         {
             var markupCode = "[|#!|]";
@@ -264,7 +325,7 @@ namespace Microsoft.DotNet.Interactive.Tests.LanguageServices
             string expected,
             Language defaultLanguage)
         {
-            var kernel = CreateKernel(defaultLanguage);
+            var kernel = CreateCompositeKernel(defaultLanguage);
 
             var kernelToExtend = kernel.FindKernel(defaultLanguage.LanguageName());
 

--- a/src/Microsoft.DotNet.Interactive/DotNetLanguageKernel.cs
+++ b/src/Microsoft.DotNet.Interactive/DotNetLanguageKernel.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Interactive
@@ -14,5 +15,7 @@ namespace Microsoft.DotNet.Interactive
         public abstract bool TryGetVariable<T>(string name, out T value);
 
         public abstract Task SetVariableAsync(string name, object value);
+
+        public abstract IReadOnlyCollection<string> GetVariableNames();
     }
 }

--- a/src/Microsoft.DotNet.Interactive/Kernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Kernel.cs
@@ -393,11 +393,21 @@ namespace Microsoft.DotNet.Interactive
                                                 .Lines
                                                 .GetPosition(command.LinePosition);
 
-                var resultRange = new LinePositionSpan(
-                    new LinePosition(command.LinePosition.Line, 0),
-                    command.LinePosition);
+                var completions = GetDirectiveCompletionItems(
+                    directiveNode, 
+                    requestPosition);
+                
+                var upToCursor =
+                    directiveNode.Text[..command.LinePosition.Character];
 
-                var completions = GetDirectiveCompletionItems(directiveNode, requestPosition);
+                var indexOfPreviousSpace =
+                    Math.Max(
+                        0, 
+                        upToCursor.LastIndexOf(" ", StringComparison.CurrentCultureIgnoreCase) + 1);
+
+                var resultRange = new LinePositionSpan(
+                    new LinePosition(command.LinePosition.Line, indexOfPreviousSpace),
+                    command.LinePosition);
 
                 context.Publish(
                     new CompletionsProduced(
@@ -407,18 +417,44 @@ namespace Microsoft.DotNet.Interactive
             return Task.CompletedTask;
         }
 
-        private protected virtual IReadOnlyList<CompletionItem> GetDirectiveCompletionItems(
-            DirectiveNode directiveNode, 
+        private IReadOnlyList<CompletionItem> GetDirectiveCompletionItems(
+            DirectiveNode directiveNode,
             int requestPosition)
         {
-            var parseResult = directiveNode.GetDirectiveParseResult();
+            var directiveParsers = new List<Parser>();
 
-            var completions = parseResult
-                              .GetSuggestions(requestPosition)
-                              .Select(s => SubmissionParser.CompletionItemFor(s, parseResult))
-                              .ToArray();
+            directiveParsers.AddRange(
+                GetDirectiveParsersForCompletion(directiveNode, requestPosition));
 
-            return completions;
+            var allCompletions = new List<CompletionItem>();
+            var topDirectiveParser = SubmissionParser.GetDirectiveParser();
+            var prefix = topDirectiveParser.Configuration.RootCommand.Name + " ";
+            requestPosition += prefix.Length;
+
+            foreach (var parser in directiveParsers)
+            {
+                var effectiveText = $"{prefix}{directiveNode.Text}";
+
+                var parseResult = parser.Parse(effectiveText);
+
+                var completions = parseResult
+                                  .GetSuggestions(requestPosition)
+                                  .Select(s => SubmissionParser.CompletionItemFor(s, parseResult))
+                                  .ToArray();
+
+                allCompletions.AddRange(completions);
+            }
+
+            return allCompletions
+                   .Distinct(CompletionItemComparer.Instance)
+                   .ToArray();
+        }
+
+        private protected virtual IEnumerable<Parser> GetDirectiveParsersForCompletion(
+            DirectiveNode directiveNode,
+            int requestPosition)
+        {
+            yield return SubmissionParser.GetDirectiveParser();
         }
 
         private protected void TrySetHandler(

--- a/src/Microsoft.DotNet.Interactive/Microsoft.DotNet.Interactive.csproj
+++ b/src/Microsoft.DotNet.Interactive/Microsoft.DotNet.Interactive.csproj
@@ -18,7 +18,7 @@
     <MicrosoftCodeAnalysisAnalyzersVersion>2.9.6</MicrosoftCodeAnalysisAnalyzersVersion>	
     <SystemRuntimeLoaderVersion>4.3.0</SystemRuntimeLoaderVersion>	
     <SystemReactiveVersion>4.3.2</SystemReactiveVersion>	
-    <SystemCommandLineVersion>2.0.0-beta1.20309.1</SystemCommandLineVersion>	
+    <SystemCommandLineVersion>2.0.0-beta1.20352.2</SystemCommandLineVersion>	
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Interactive/Parsing/SubmissionParser.cs
+++ b/src/Microsoft.DotNet.Interactive/Parsing/SubmissionParser.cs
@@ -271,10 +271,9 @@ namespace Microsoft.DotNet.Interactive.Parsing
 
             var kind = symbol switch
             {
-                IArgument _ => "Value",
                 IOption _ => "Property",
                 ICommand _ => "Method",
-                _ => null
+                _ => "Value"
             };
 
             var helpBuilder = new DirectiveHelpBuilder(
@@ -287,7 +286,10 @@ namespace Microsoft.DotNet.Interactive.Parsing
                 filterText: name,
                 sortText: name,
                 insertText: name,
-                documentation: helpBuilder.GetHelpForSymbol(symbol));
+                documentation:
+                symbol != null
+                    ? helpBuilder.GetHelpForSymbol(symbol)
+                    : null);
         }
 
         private void EnsureRootCommandIsInitialized()

--- a/src/dotnet-interactive/dotnet-interactive.csproj
+++ b/src/dotnet-interactive/dotnet-interactive.csproj
@@ -68,7 +68,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20309.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20352.2" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />
     <PackageReference Include="TaskExtensions" Version="0.1.8580001">
       <PrivateAssets>all</PrivateAssets>

--- a/src/interface-generator/interface-generator.csproj
+++ b/src/interface-generator/interface-generator.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20309.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20352.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This fixes a few issues with magic command completions:

* Insertion of an inner symbol (e.g. `#!share --from`) no longer overwrites the whole line
* When requesting inner symbol completions (e.g. `#!share --fr`⇥), it no longer suggests top-level symbols (e.g. `#!who`)
* `#!share` suggests kernel and variable names:

![image](https://user-images.githubusercontent.com/547415/86490673-0c858680-bd1d-11ea-9ff1-080c42042edd.png)

![image](https://user-images.githubusercontent.com/547415/86490669-098a9600-bd1d-11ea-8cdd-52dd34b08fd9.png)
