### PR TITLE
reset cell execution state on kernel termination

### DIFF
--- a/src/dotnet-interactive-vscode/src/clientMapper.ts
+++ b/src/dotnet-interactive-vscode/src/clientMapper.ts
@@ -36,9 +36,7 @@ export class ClientMapper {
         }
     }
 
-    closeAllClients() {
-        for (let fsPath of this.clientMap.keys()) {
-            this.closeClient({ fsPath });
-        }
+    isDotNetClient(uri: Uri): boolean {
+        return this.clientMap.has(uri.fsPath);
     }
 }


### PR DESCRIPTION
If a kernel has to be restarted because it's stuck, we need to set each cell's state as idle so it's executable again after restart.