### PR TITLE
show informational toast for tool acquisition

### DIFF
--- a/src/dotnet-interactive-vscode/src/OutputChannelAdapter.ts
+++ b/src/dotnet-interactive-vscode/src/OutputChannelAdapter.ts
@@ -2,9 +2,8 @@ import * as vscode from 'vscode';
 import { ReportChannel } from "./interfaces/vscode";
 
 export class OutputChannelAdapter implements ReportChannel{
-    
+
     constructor(private channel: vscode.OutputChannel) {   
-        
     }
 
     getName(): string {

--- a/src/dotnet-interactive-vscode/src/acquisition.ts
+++ b/src/dotnet-interactive-vscode/src/acquisition.ts
@@ -6,7 +6,6 @@ import * as path from 'path';
 import { InstallInteractiveTool, InstallInteractiveArgs, CreateToolManifest, GetCurrentInteractiveVersion, InteractiveLaunchOptions, ReportInstallationStarted, ReportInstallationFinished } from './interfaces';
 
 import compareVersions = require("../node_modules/compare-versions");
-import { ReportChannel } from './interfaces/vscode';
 
 // The acquisition function.  Uses predefined callbacks for external command invocations to make testing easier.
 export async function acquireDotnetInteractive(
@@ -17,8 +16,7 @@ export async function acquireDotnetInteractive(
     createToolManifest: CreateToolManifest,
     reportInstallationStarted: ReportInstallationStarted,
     installInteractive: InstallInteractiveTool,
-    reportInstallationFinished: ReportInstallationFinished,
-    reportingChannel: ReportChannel
+    reportInstallationFinished: ReportInstallationFinished
     ): Promise<InteractiveLaunchOptions | undefined>
 {
     // Ensure `globalStoragePath` exists.  This prevents a bunch of issues with spawned processes and working directories.
@@ -40,14 +38,12 @@ export async function acquireDotnetInteractive(
     const requiredVersion = args.toolVersion ?? minDotNetInteractiveVersion;
     const currentVersion = await getInteractiveVersion(args.dotnetPath, globalStoragePath);
     if (currentVersion && compareVersions.compare(currentVersion, requiredVersion, '>=')) {
-        reportingChannel.appendLine(`Using version ${currentVersion}`);
         // current is acceptable
         return launchOptions;
     }
 
     // no current version installed or it's out of date
     reportInstallationStarted(requiredVersion);
-    reportingChannel.appendLine(`Acquiring`);
     await installInteractive({
             dotnetPath: args.dotnetPath,
             toolVersion: requiredVersion

--- a/src/dotnet-interactive-vscode/src/extension.ts
+++ b/src/dotnet-interactive-vscode/src/extension.ts
@@ -19,12 +19,7 @@ import { OutputChannelAdapter } from './OutputChannelAdapter';
 export async function activate(context: vscode.ExtensionContext) {
     // install dotnet or use global
     const config = vscode.workspace.getConfiguration('dotnet-interactive');
-    const dotnetInteractiveChannel = new OutputChannelAdapter(vscode.window.createOutputChannel('.NET Interactive'));
-    dotnetInteractiveChannel.show();
-
     const diagnosticsChannel = new OutputChannelAdapter(vscode.window.createOutputChannel('.NET Interactive : diagnostics'));
-    diagnosticsChannel.show();
-
     const minDotNetSdkVersion = config.get<string>('minimumDotNetSdkVersion');
     let dotnetPath: string;
     if (await isDotnetUpToDate(minDotNetSdkVersion!)) {
@@ -62,7 +57,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     const diagnosticDelay = config.get<number>('liveDiagnosticDelay') || 500; // fall back to something reasonable
 
-    context.subscriptions.push(vscode.notebook.registerNotebookContentProvider('dotnet-interactive', new DotNetInteractiveNotebookContentProvider(clientMapper, dotnetInteractiveChannel)));
+    context.subscriptions.push(vscode.notebook.registerNotebookContentProvider('dotnet-interactive', new DotNetInteractiveNotebookContentProvider(clientMapper)));
     context.subscriptions.push(vscode.notebook.onDidCloseNotebookDocument(notebookDocument => clientMapper.closeClient(notebookDocument.uri)));
     context.subscriptions.push(registerLanguageProviders(clientMapper, diagnosticDelay));
 }

--- a/src/dotnet-interactive-vscode/src/tests/RecordingOutputChannel.ts
+++ b/src/dotnet-interactive-vscode/src/tests/RecordingOutputChannel.ts
@@ -5,8 +5,8 @@ import { ReportChannel } from "../interfaces/vscode";
 
 export class RecordingChannel implements ReportChannel{
     private name: string;
-    constructor(channelName?:string) {        
-            this.name = channelName || "testChannel";
+    constructor(channelName?:string) {
+        this.name = channelName || "testChannel";
     }
     getName(): string {
         return this.name;

--- a/src/dotnet-interactive-vscode/src/tests/unit/acquisition.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/acquisition.test.ts
@@ -9,16 +9,9 @@ use(require('chai-fs'));
 
 import { acquireDotnetInteractive } from '../../acquisition';
 import { InstallInteractiveArgs } from '../../interfaces';
-import { RecordingChannel } from '../RecordingOutputChannel';
 import { withFakeGlobalStorageLocation } from './utilities';
 
 describe('Acquisition tests', () => {
-
-    let acquisitionChannel: RecordingChannel;
-
-    beforeEach(() => {
-        acquisitionChannel = new RecordingChannel();
-    });
 
     function getInteractiveVersionThatReturnsNoVersionFound(dotnetPath: string, globalStoragePath: string): Promise<string | undefined> {
         return new Promise<string | undefined>((resolve, reject) => {
@@ -100,8 +93,7 @@ describe('Acquisition tests', () => {
                 createEmptyToolManifest, // create manifest when asked
                 report,
                 installInteractiveToolWithSpecificVersion('42.42.42'), // 'install' this version when asked
-                report, 
-                acquisitionChannel);
+                report);
 
             expect(launchOptions).to.deep.equal({
                 workingDirectory: globalStoragePath
@@ -141,8 +133,7 @@ describe('Acquisition tests', () => {
                 createEmptyToolManifest, // create manifest when asked
                 report,
                 installInteractiveToolWithSpecificVersion('42.42.42'), // 'install' this version when asked
-                report,
-                acquisitionChannel);
+                report);
 
             expect(globalStoragePath).to.be.a.directory();
             expect(manifestPath).to.be.file().with.json;
@@ -179,8 +170,7 @@ describe('Acquisition tests', () => {
                 createToolManifestThatThrows, // throw if acquisition tries to create another manifest
                 report,
                 installInteractiveToolWithSpecificVersion('42.42.42'), // 'install' this version when asked
-                report,
-                acquisitionChannel);
+                report);
 
             expect(globalStoragePath).to.be.a.directory();
             const manifestPath = path.join(globalStoragePath, '.config', 'dotnet-tools.json');
@@ -218,8 +208,7 @@ describe('Acquisition tests', () => {
                 createToolManifestThatThrows, // throw if acquisition tries to create another manifest
                 report,
                 installInteractiveToolWithSpecificVersion('42.42.42'), // 'install' this version when asked
-                report,
-                acquisitionChannel);
+                report);
 
             expect(globalStoragePath).to.be.a.directory();
             const manifestPath = path.join(globalStoragePath, '.config', 'dotnet-tools.json');
@@ -257,8 +246,7 @@ describe('Acquisition tests', () => {
                 createToolManifestThatThrows, // throw if acquisition tries to create another manifest
                 report,
                 installInteractiveToolWithSpecificVersion('42.42.42'), // 'install' this version when asked
-                report,
-                acquisitionChannel);
+                report);
 
             expect(globalStoragePath).to.be.a.directory();
             const manifestPath = path.join(globalStoragePath, '.config', 'dotnet-tools.json');
@@ -298,8 +286,7 @@ describe('Acquisition tests', () => {
                 createToolManifestThatThrows, // throw if acquisition tries to create another manifest
                 report,
                 installInteractiveToolThatAlwaysThrows, // throw if acquisition tries to install
-                report,
-                acquisitionChannel);
+                report);
 
             expect(globalStoragePath).to.be.a.directory();
             const manifestPath = path.join(globalStoragePath, '.config', 'dotnet-tools.json');

--- a/src/dotnet-interactive-vscode/src/vscode/commands.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/commands.ts
@@ -7,15 +7,12 @@ import * as jp from '../interop/jupyter';
 import { acquireDotnetInteractive } from '../acquisition';
 import { InstallInteractiveArgs, InteractiveLaunchOptions } from '../interfaces';
 import { serializeNotebook } from '../interactiveNotebook';
-import { OutputChannelAdapter } from '../OutputChannelAdapter';
 import { ClientMapper } from '../clientMapper';
 
 export function registerAcquisitionCommands(context: vscode.ExtensionContext, dotnetPath: string) {
     const config = vscode.workspace.getConfiguration('dotnet-interactive');
     const minDotNetInteractiveVersion = config.get<string>('minimumInteractiveToolVersion');
     const interactiveToolSource = config.get<string>('interactiveToolSource');
-    const acquireChannel = new OutputChannelAdapter(vscode.window.createOutputChannel('.NET Interactive : tool acquisition'));
-    acquireChannel.show();
 
     context.subscriptions.push(vscode.commands.registerCommand('dotnet-interactive.acquire', async (args?: InstallInteractiveArgs | undefined): Promise<InteractiveLaunchOptions | undefined> => {
         if (!args) {
@@ -31,10 +28,9 @@ export function registerAcquisitionCommands(context: vscode.ExtensionContext, do
             context.globalStoragePath,
             getInteractiveVersion,
             createToolManifest,
-            (version: string) => { acquireChannel.append(`Installing .NET Interactive version ${version}...`); },
+            async (version: string) => { vscode.window.showInformationMessage(`Installing .NET Interactive version ${version}...`); },
             installInteractiveTool,
-            () => { acquireChannel.append('.NET Interactive installation complete.'); },
-            acquireChannel);
+            async () => { await vscode.window.showInformationMessage('.NET Interactive installation complete.'); });
         return launchOptions;
     }));
 

--- a/src/dotnet-interactive-vscode/src/vscode/notebookProvider.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/notebookProvider.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import { ClientMapper } from './../clientMapper';
 import { parseNotebook, serializeNotebook, notebookCellLanguages, getSimpleLanguage, getNotebookSpecificLanguage, languageToCellKind, backupNotebook, asNotebookFile } from '../interactiveNotebook';
 import { RawNotebookCell } from '../interfaces';
-import { CellOutput, ReportChannel } from '../interfaces/vscode';
+import { CellOutput } from '../interfaces/vscode';
 import { Diagnostic, DiagnosticSeverity } from './../contracts';
 import { toVsCodeDiagnostic } from './vscodeUtilities';
 import { getDiagnosticCollection } from './diagnostics';
@@ -16,7 +16,7 @@ export class DotNetInteractiveNotebookContentProvider implements vscode.Notebook
     kernel: vscode.NotebookKernel;
     label: string;
 
-    constructor(readonly clientMapper: ClientMapper, private readonly globalChannel : ReportChannel) {
+    constructor(readonly clientMapper: ClientMapper) {
         this.kernel = this;
         this.label = ".NET Interactive";
     }


### PR DESCRIPTION
Also remove unused output channels and don't `show()` by default.

![image](https://user-images.githubusercontent.com/926281/87183935-ee2f0600-c29b-11ea-8057-602c5e420745.png)

Kind of fixes #634.  (Not really; we can't control how long it takes, but it's at least a little more obvious that it's happening.)
