### PR TITLE
always run restore when building with arcade

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,2 +1,2 @@
 @echo off 
-powershell -noprofile -executionPolicy RemoteSigned -file "%~dp0eng\build.ps1" -build -binaryLog %*
+powershell -noprofile -executionPolicy RemoteSigned -file "%~dp0eng\build.ps1" -build -restore -binaryLog %*

--- a/build.sh
+++ b/build.sh
@@ -13,4 +13,4 @@ while [[ -h $source ]]; do
 done
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd)"
 
-. "$scriptroot/eng/build.sh" --build --binaryLog "$@"
+. "$scriptroot/eng/build.sh" --build --restore --binaryLog "$@"


### PR DESCRIPTION
These scripts are only run during a local build, but it should make it easier to fall into the pit of success.