### PR TITLE
ensure stdio server sets the working directory

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Tests/NamedPipeConnectionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/NamedPipeConnectionTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.DotNet.Interactive.Commands;
@@ -73,6 +74,6 @@ x");
                                       .BeTrue();
         }
 
-        void StartServer(Kernel remoteKernel, string pipeName) => Task.Run(() => { remoteKernel.EnableApiOverNamedPipe(pipeName); });
+        void StartServer(Kernel remoteKernel, string pipeName) => Task.Run(() => { remoteKernel.EnableApiOverNamedPipe(pipeName, new DirectoryInfo(Environment.CurrentDirectory)); });
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Tests/Server/KernelServerTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Server/KernelServerTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Server
             };
 
             
-            _kernelServer = kernel.CreateKernelServer(new StreamReader(new MemoryStream()), new StringWriter());
+            _kernelServer = kernel.CreateKernelServer(new StreamReader(new MemoryStream()), new StringWriter(), new DirectoryInfo(Environment.CurrentDirectory));
             
             _kernelEvents = _kernelServer
                             .Output

--- a/src/Microsoft.DotNet.Interactive/Server/KernelClientServerExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/Server/KernelClientServerExtensions.cs
@@ -11,12 +11,12 @@ namespace Microsoft.DotNet.Interactive.Server
 {
     public static class ConnectableKernel
     {
-        public static  KernelServer CreateKernelServer(this Kernel kernel, DirectoryInfo workingDir = null)
+        public static  KernelServer CreateKernelServer(this Kernel kernel, DirectoryInfo workingDir)
         {
             return kernel.CreateKernelServer(Console.In, Console.Out, workingDir);
         }
 
-        public static KernelServer CreateKernelServer(this Kernel kernel, TextReader inputStream, TextWriter outputStream, DirectoryInfo workingDir = null)
+        public static KernelServer CreateKernelServer(this Kernel kernel, TextReader inputStream, TextWriter outputStream, DirectoryInfo workingDir)
         {
             if (kernel == null)
             {
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.Interactive.Server
             return kernelClient;
         }
 
-        public static KernelServer CreateKernelServer(this Kernel kernel, NamedPipeServerStream local)
+        public static KernelServer CreateKernelServer(this Kernel kernel, NamedPipeServerStream local, DirectoryInfo workingDir)
         {
             if (kernel == null)
             {
@@ -58,17 +58,17 @@ namespace Microsoft.DotNet.Interactive.Server
             }
             var input = new PipeStreamInputStream(local);
             var output = new PipeStreamOutputStream(local);
-            var kernelServer = new KernelServer(kernel, input, output);
+            var kernelServer = new KernelServer(kernel, input, output, workingDir);
             kernel.RegisterForDisposal(kernelServer);
             return kernelServer;
         }
 
-        public static T EnableApiOverNamedPipe<T>(this T kernel, string pipeName) where T : Kernel
+        public static T EnableApiOverNamedPipe<T>(this T kernel, string pipeName, DirectoryInfo workingDir) where T : Kernel
         {
             var serverStream = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Message, PipeOptions.Asynchronous);
 
             serverStream.WaitForConnection();
-            CreateKernelServer(kernel, serverStream);
+            CreateKernelServer(kernel, serverStream, workingDir);
             return kernel;
         }
 

--- a/src/Microsoft.DotNet.Interactive/Server/KernelServer.cs
+++ b/src/Microsoft.DotNet.Interactive/Server/KernelServer.cs
@@ -17,16 +17,20 @@ namespace Microsoft.DotNet.Interactive.Server
         private readonly IOutputTextStream _output;
         private readonly CompositeDisposable _disposables;
 
-
         public KernelServer(
             Kernel kernel,
             IInputTextStream input,
             IOutputTextStream output,
-            DirectoryInfo workingDir = null)
+            DirectoryInfo workingDir)
         {
             _kernel = kernel ?? throw new ArgumentNullException(nameof(kernel));
             _input = input ?? throw new ArgumentNullException(nameof(input));
             _output = output ?? throw new ArgumentNullException(nameof(output));
+
+            if (workingDir is null)
+            {
+                throw new ArgumentNullException(nameof(workingDir));
+            }
 
             _disposables = new CompositeDisposable
             {
@@ -38,11 +42,7 @@ namespace Microsoft.DotNet.Interactive.Server
                 _input
             };
 
-            if (workingDir is { })
-            {
-                Environment.CurrentDirectory = workingDir.FullName;
-            }
-
+            Environment.CurrentDirectory = workingDir.FullName;
             WriteEventToOutput(new KernelReady());
         }
 

--- a/src/dotnet-interactive/CommandLine/CommandLineParser.cs
+++ b/src/dotnet-interactive/CommandLine/CommandLineParser.cs
@@ -331,6 +331,7 @@ namespace Microsoft.DotNet.Interactive.App.CommandLine
 
                 var workingDirOption = new Option<DirectoryInfo>(
                     "--working-dir",
+                    () => new DirectoryInfo(Environment.CurrentDirectory),
                     "Working directory to which to change after launching the kernel.");
 
                 var stdIOCommand = new Command(
@@ -354,7 +355,7 @@ namespace Microsoft.DotNet.Interactive.App.CommandLine
 
                         kernel.UseQuitCommand(disposeOnQuit, cancellationToken);
                         
-                        var kernelServer = kernel.CreateKernelServer();
+                        var kernelServer = kernel.CreateKernelServer(startupOptions.WorkingDir);
 
                         if (startupOptions.EnableHttpApi)
                         {


### PR DESCRIPTION
A recent refactoring stopped passing the `--working-dir` option to the kernel server.