### PR TITLE
DataFrame type generator extension sample

### DIFF
--- a/docs/variable-sharing.md
+++ b/docs/variable-sharing.md
@@ -1,11 +1,20 @@
 # Variable sharing
 
-Because .NET Interactive enables you to write code in multiple languages within a single notebook, it can be useful to share state between the different languages. There are three subkernels that run on .NET Core in the same process in the typical configuration of `dotnet-interactive`. You can share variables between them using the `#!share` magic command.
+.NET Interactive enables you to write code in multiple languages within a single notebook and in order to take advantage of those languages' different strengths, you might find it useful to share data between them. By default, .NET Interactive provides [subkernels](kernels-overview.md) for three different languages within the same process. You can share variables between .NET subkernels using the `#!share` magic command.
 
 <img src="https://user-images.githubusercontent.com/547415/82468160-55d48c00-9a77-11ea-89f6-6b167d4cf8a2.png" width="40%">
 
-_**Note**: When sharing a variable with a kernel where its compilation requirements aren't met, for example due to a missing `using` (C#) or `open` (F#) declaration or a missing assembly reference, this operation will fail. This limitation may be lifted in the future but for now, if you want to share variables of types that aren't imported by default, you will have to explicitly run the necessary import code in the destination kernel._
-
-Variables are shared by reference for reference types. A consequence of this is that if you share a mutable object, changes to its state will be visible across kernels:
+Variables are shared by reference for reference types. A consequence of this is that if you share a mutable object, changes to its state will be visible across subkernels:
 
 <img src="https://user-images.githubusercontent.com/547415/82737074-009cb280-9ce3-11ea-82a2-8ef509cb7122.png" width="40%">
+
+## Direct data entry with `#!value`
+
+
+
+## Limitations
+
+Variable sharing has some limitations to be aware of. When sharing a variable with a subkernel where its compilation requirements aren't met, for example due to a missing `using` (C#) or `open` (F#) declaration, a custom type defined in the notebook, or a missing assembly reference, `#!share` will fail. This limitation may be lifted in the future but for now, if you want to share variables of types that aren't imported by default, you will have to explicitly run the necessary import code in the destination kernel.
+
+<img src="https://user-images.githubusercontent.com/547415/88083515-0292be80-cb38-11ea-953d-a392f9dda784.png" width="40%">
+

--- a/samples/extensions/ClockExtension/ClockExtension.csproj
+++ b/samples/extensions/ClockExtension/ClockExtension.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="microsoft.dotnet.interactive" Version="1.0.0-beta.20324.1" />
-    <PackageReference Include="microsoft.dotnet.interactive.formatting" Version="1.0.0-beta.20324.1" />
+    <PackageReference Include="microsoft.dotnet.interactive" Version="1.0.0-beta.20372.2" />
+    <PackageReference Include="microsoft.dotnet.interactive.csharp" Version="1.0.0-beta.20372.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/DataFrameTypeGeneratorTests.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/DataFrameTypeGeneratorTests.cs
@@ -1,0 +1,215 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using FluentAssertions;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.Data.Analysis;
+using Microsoft.DotNet.Interactive.Commands;
+using Microsoft.DotNet.Interactive.CSharp;
+using Microsoft.DotNet.Interactive.Events;
+using Microsoft.DotNet.Interactive.Tests.Utility;
+using Xunit;
+
+namespace Microsoft.DotNet.Interactive.ExtensionLab.Tests
+{
+    public class DataFrameTypeGeneratorTests
+    {
+        [Fact]
+        public async Task it_builds_a_type_based_on_a_DataFrame()
+        {
+            using var kernel = await CreateKernelAndGenerateType();
+
+            kernel.TryGetVariable("frame", out DataFrame newFrame)
+                  .Should()
+                  .BeTrue();
+
+            newFrame.GetType().BaseType.Should().Be<DataFrame>();
+            newFrame.GetType().Name.Should().Be("DataFrame_From_frame");
+        }
+
+        [Fact]
+        public async Task Custom_DataFrame_contains_source_frame_data()
+        {
+            using var kernel = await CreateKernelAndGenerateType();
+
+            kernel.TryGetVariable("frame", out DataFrame newFrame)
+                  .Should()
+                  .BeTrue();
+
+            newFrame.Rows.Count.Should().Be(3);
+        }
+
+        [Fact]
+        public async Task completions_show_custom_DataFrame_members()
+        {
+            using var kernel = await CreateKernelAndGenerateType();
+
+            var markupCode = "frame.Where(s => s.$$)";
+
+            MarkupTestFile.GetPosition(markupCode, out var code, out var position);
+
+            var events = await kernel.SendAsync(new RequestCompletions(code, new LinePosition(0, position.Value)));
+
+            events
+                .KernelEvents
+                .ToSubscribedList()
+                .Should()
+                .ContainSingle<CompletionsProduced>()
+                .Which
+                .Completions
+                .Select(c => c.DisplayText)
+                .Should()
+                .Contain(new[] { "name", "is_available", "price" });
+        }
+
+        [Fact]
+        public void Custom_DataFrame_can_be_sliced_with_LINQ()
+        {
+            var frame = CreateDataFrame();
+
+            var bananaFrame = new DerivedDataFrame(frame.Columns);
+
+            bananaFrame.Count(row => row.is_available)
+                       .Should()
+                       .Be(1);
+        }
+
+        [Fact]
+        public async Task The_generated_source_code_can_be_displayed()
+        {
+            var kernel = new CSharpKernel()
+                .UseNugetDirective();
+
+            await new DataFrameTypeGeneratorExtension().OnLoadAsync(kernel);
+
+            await kernel.SubmitCodeAsync($@"
+#r ""{typeof(DataFrame).Assembly.Location}""
+using Microsoft.Data.Analysis;
+");
+            await kernel.SetVariableAsync("frame", CreateDataFrame());
+
+            var result = await kernel.SubmitCodeAsync("#!linqify frame --show-code");
+
+            result.KernelEvents
+                  .ToSubscribedList()
+                  .Should()
+                  .NotContainErrors();
+
+            result.KernelEvents
+                  .ToSubscribedList()
+                  .Should()
+                  .ContainSingle<DisplayedValueProduced>()
+                  .Which
+                  .FormattedValues
+                  .Should()
+                  .ContainSingle()
+                  .Which
+                  .Value
+                  .Should()
+                  .ContainAll(
+                      "public class DataFrame_", 
+                      "public System.String name => ");
+        }
+
+        [Fact]
+        public async Task Completions_suggest_existing_DataFrame_variables()
+        {
+            var kernel = new CSharpKernel()
+                .UseNugetDirective();
+
+            await new DataFrameTypeGeneratorExtension().OnLoadAsync(kernel);
+
+            await kernel.SubmitCodeAsync($@"
+#r ""{typeof(DataFrame).Assembly.Location}""
+using Microsoft.Data.Analysis;
+");
+            var dataFrameVariableName = "myDataFrame";
+            await kernel.SetVariableAsync(dataFrameVariableName, CreateDataFrame());
+
+            var code = "#!linqify ";
+            var result = await kernel.SendAsync(new RequestCompletions(code, new LinePosition(0, code.Length)));
+
+            result.KernelEvents.ToSubscribedList().Should().ContainSingle<CompletionsProduced>()
+                  .Which
+                  .Completions
+                  .Select(c => c.DisplayText)
+                  .Should()
+                  .Contain(dataFrameVariableName);
+        }
+
+        private static async Task<CSharpKernel> CreateKernelAndGenerateType(
+            string magicCommand = "#!linqify frame")
+        {
+            var kernel = new CSharpKernel()
+                .UseNugetDirective();
+
+            await new DataFrameTypeGeneratorExtension().OnLoadAsync(kernel);
+
+            await kernel.SubmitCodeAsync($@"
+#r ""{typeof(DataFrame).Assembly.Location}""
+using Microsoft.Data.Analysis;
+");
+            await kernel.SetVariableAsync("frame", CreateDataFrame());
+
+            await kernel.SubmitCodeAsync(magicCommand);
+
+            return kernel;
+        }
+
+        private static DataFrame CreateDataFrame()
+        {
+            var names = new StringDataFrameColumn("name", 3);
+            names[0] = "apple";
+            names[1] = "pineapple";
+            names[2] = "durian";
+
+            var prices = new PrimitiveDataFrameColumn<decimal>("price", 3);
+            prices[0] = 12.2m;
+            prices[1] = 22.12m;
+            prices[2] = 3_000_000m;
+
+            var availabilities = new BooleanDataFrameColumn("is_available", 3);
+            availabilities[0] = false;
+            availabilities[1] = false;
+            availabilities[2] = true;
+
+            return new DataFrame(
+                names,
+                prices,
+                availabilities);
+        }
+    }
+
+    public class DerivedDataFrame : DataFrame, IEnumerable<DerivedDataFrameRow>
+    {
+        public DerivedDataFrame(IEnumerable<DataFrameColumn> columns)
+            : base(columns)
+        {
+        }
+
+        public IEnumerator<DerivedDataFrameRow> GetEnumerator() =>
+            Rows.Select(row => new DerivedDataFrameRow(row)).GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() =>
+            GetEnumerator();
+    }
+
+    public class DerivedDataFrameRow
+    {
+        private readonly DataFrameRow _sourceRow;
+
+        public DerivedDataFrameRow(DataFrameRow sourceRow)
+        {
+            _sourceRow = sourceRow;
+        }
+
+        public String name => (String) _sourceRow[0];
+        public Decimal price => (Decimal) _sourceRow[1];
+        public Boolean is_available => (Boolean) _sourceRow[2];
+    }
+}

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/DownloadTests.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/DownloadTests.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.DotNet.Interactive.CSharp;
 using Microsoft.DotNet.Interactive.Events;
-using Microsoft.DotNet.Interactive.Tests;
 using Microsoft.DotNet.Interactive.Tests.Utility;
 using Xunit;
 

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/Microsoft.DotNet.Interactive.ExtensionLab.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/Microsoft.DotNet.Interactive.ExtensionLab.Tests.csproj
@@ -13,14 +13,23 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Microsoft.DotNet.Interactive.Tests\Utility\MarkupTestFile.cs" Link="MarkupTestFile.cs" />
+    <Compile Include="..\Microsoft.DotNet.Interactive.Tests\Utility\TestUtility.cs" Link="TestUtility.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.DotNet.Interactive.CSharp\Microsoft.DotNet.Interactive.CSharp.csproj" />
+    <PackageReference Include="microsoft.dotnet.interactive" Version="1.0.0-beta.20372.2" />
+    <PackageReference Include="microsoft.dotnet.interactive.csharp" Version="1.0.0-beta.20372.2" />
+    <PackageReference Include="microsoft.dotnet.interactive.fsharp" Version="1.0.0-beta.20372.2" />
+    <PackageReference Include="microsoft.data.analysis" Version="0.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.Interactive.ExtensionLab\Microsoft.DotNet.Interactive.ExtensionLab.csproj" />
-    <ProjectReference Include="..\Microsoft.DotNet.Interactive.FSharp\Microsoft.DotNet.Interactive.FSharp.fsproj" />
-    <ProjectReference Include="..\Microsoft.DotNet.Interactive.Tests\Microsoft.DotNet.Interactive.Tests.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/DataFrameTypeGeneratorExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/DataFrameTypeGeneratorExtension.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Data.Analysis;
+using Microsoft.DotNet.Interactive.Commands;
+using Microsoft.DotNet.Interactive.CSharp;
+
+namespace Microsoft.DotNet.Interactive.ExtensionLab
+{
+    public class DataFrameTypeGeneratorExtension : IKernelExtension
+    {
+        public Task OnLoadAsync(Kernel rootKernel)
+        {
+            rootKernel.VisitSubkernelsAndSelf(kernel =>
+            {
+                if (kernel is CSharpKernel cSharpKernel)
+                {
+                    var command = new Command("#!linqify", "Replaces the specified Microsoft.Data.Analysis.DataFrame with a derived type for LINQ access to the contained data")
+                    {
+                        new Option<bool>("--show-code", "Display the C# code for the generated DataFrame types"),
+                        new Argument<string>("variable-name", "The name of the variable to replace")
+                            .AddSuggestions(match => cSharpKernel.ScriptState
+                                                                 .Variables
+                                                                 .Where(v => v.Value is DataFrame)
+                                                                 .Select(v => v.Name))
+                    };
+                            
+                    cSharpKernel.AddDirective(command);
+
+                    command.Handler = CommandHandler.Create<string, bool, KernelInvocationContext>(CompileStuff);
+
+                    async Task CompileStuff(
+                        string variableName,
+                        bool showCode,
+                        KernelInvocationContext context)
+                    {
+                        if (cSharpKernel.TryGetVariable<DataFrame>(variableName, out var dataFrame))
+                        {
+                            var code = BuildTypedDataFrameCode(
+                                dataFrame,
+                                variableName);
+
+                            if (showCode)
+                            {
+                                await context.DisplayAsync(code);
+                            }
+
+                            cSharpKernel.TryGetVariable(variableName, out DataFrame oldFrame);
+
+                            await cSharpKernel.SendAsync(new SubmitCode(code));
+
+                            cSharpKernel.TryGetVariable(variableName, out DataFrame newFrame);
+
+                            foreach (var column in oldFrame.Columns)
+                            {
+                                newFrame.Columns.Add(column);
+                            }
+                        }
+                    }
+                }
+            });
+
+            return Task.CompletedTask;
+        }
+
+        public string BuildTypedDataFrameCode(
+            DataFrame sourceDataFrame,
+            string variableName)
+        {
+            var sb = new StringBuilder();
+
+            var frameTypeName = $"DataFrame_From_{variableName}";
+            var frameRowTypeName = $"DataFrameRow_From_{variableName}";
+
+            sb.Append($@"
+public class {frameTypeName} : DataFrame, IEnumerable<{frameRowTypeName}>
+{{
+    public {frameTypeName}()
+    {{
+    }}
+
+    public IEnumerator<{frameRowTypeName}> GetEnumerator() =>
+        Rows.Select(row => new {frameRowTypeName}(row)).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() =>
+        GetEnumerator();
+}}
+
+public class {frameRowTypeName}
+{{
+    private readonly DataFrameRow _sourceRow;
+    
+    public {frameRowTypeName}(DataFrameRow sourceRow)
+    {{
+        _sourceRow = sourceRow;
+    }}
+
+{RowProperties()}
+
+}}
+
+var {variableName} = new {frameTypeName}();
+");
+
+            string RowProperties() =>
+                string.Join(Environment.NewLine,
+                            sourceDataFrame
+                                .Columns
+                                .Select((col, i) => $"    public {col.DataType.FullName} {col.Name} => ({col.DataType.FullName}) _sourceRow[{i}];"));
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.DotNet.Interactive.ExtensionLab.csproj
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.DotNet.Interactive.ExtensionLab.csproj
@@ -9,6 +9,7 @@
     <PackageDescription>Experimental kernel extensions for dotnet-interactive</PackageDescription>
     <PackageTags>dotnet-interactive</PackageTags>
     <IncludeBuildOutput>true</IncludeBuildOutput>
+    <NoWarn>$(NoWarn);NU5100</NoWarn><!-- dll outside of lib/ folder -->
   </PropertyGroup>
 
  <ItemGroup>

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.DotNet.Interactive.ExtensionLab.csproj
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.DotNet.Interactive.ExtensionLab.csproj
@@ -8,11 +8,20 @@
     <IsPackable>true</IsPackable>
     <PackageDescription>Experimental kernel extensions for dotnet-interactive</PackageDescription>
     <PackageTags>dotnet-interactive</PackageTags>
+    <IncludeBuildOutput>true</IncludeBuildOutput>
   </PropertyGroup>
 
+ <ItemGroup>
+   <PackageReference Include="Microsoft.Data.Analysis" Version="0.4.0" />
+ </ItemGroup>
+
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.DotNet.Interactive.Formatting\Microsoft.DotNet.Interactive.Formatting.csproj" />
-    <ProjectReference Include="..\Microsoft.DotNet.Interactive\Microsoft.DotNet.Interactive.csproj" />
+    <PackageReference Include="microsoft.dotnet.interactive" Version="1.0.0-beta.20372.2" />
+    <PackageReference Include="microsoft.dotnet.interactive.csharp" Version="1.0.0-beta.20372.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="$(OutputPath)/Microsoft.DotNet.Interactive.ExtensionLab.dll" Pack="true" PackagePath="interactive-extensions/dotnet" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Interactive.Tests/KernelExtensionsTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/KernelExtensionsTests.cs
@@ -177,5 +177,60 @@ namespace Microsoft.DotNet.Interactive.Tests
 
             visited.Should().BeEquivalentTo("child", "grandchild");
         }
+
+        [Fact]
+        public void VisitSubkernelsAndSelf_visits_subkernels_and_self()
+        {
+            var visited = new List<string>();
+            var child = new CompositeKernel
+            {
+                Name = "child"
+            };
+            var grandchild = new CompositeKernel
+            {
+                Name = "grandchild"
+            };
+            var parent = new CompositeKernel
+            {
+                Name = "parent"
+            };
+            child.Add(grandchild);
+            parent.Add(child);
+
+            parent.VisitSubkernelsAndSelf(kernel =>
+            {
+                visited.Add(kernel.Name);
+            }, true);
+
+            visited.Should().BeEquivalentTo("child", "parent", "grandchild");
+        }
+
+        [Fact]
+        public async Task VisitSubkernelsAndSelfAsync_visits_subkernels_and_self()
+        {
+            var visited = new List<string>();
+            var child = new CompositeKernel
+            {
+                Name = "child"
+            };
+            var grandchild = new CompositeKernel
+            {
+                Name = "grandchild"
+            };
+            var parent = new CompositeKernel
+            {
+                Name = "parent"
+            };
+            child.Add(grandchild);
+            parent.Add(child);
+
+            await parent.VisitSubkernelsAndSelfAsync(kernel =>
+            {
+                visited.Add(kernel.Name);
+                return Task.CompletedTask;
+            }, true);
+
+            visited.Should().BeEquivalentTo("child", "parent", "grandchild");
+        }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Tests/Utility/TestUtility.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Utility/TestUtility.cs
@@ -246,7 +246,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Utility
                     await Task.Delay(200);
                 }
 
-                return should.ContainSingle<T>(where);
+                return should.ContainSingle(where);
             }).Result;
         }
     }

--- a/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
@@ -256,6 +256,16 @@ namespace Microsoft.DotNet.Interactive
             }
         }
 
+        public static void VisitSubkernelsAndSelf(
+            this Kernel kernel,
+            Action<Kernel> onVisit,
+            bool recursive = false)
+        {
+            onVisit(kernel);
+
+            VisitSubkernels(kernel, onVisit, recursive);
+        }
+
         public static async Task VisitSubkernelsAsync(
             this Kernel kernel,
             Func<Kernel, Task> onVisit,
@@ -283,6 +293,16 @@ namespace Microsoft.DotNet.Interactive
                     }
                 }
             }
+        }
+
+        public static async Task VisitSubkernelsAndSelfAsync(
+            this Kernel kernel,
+            Func<Kernel, Task> onVisit,
+            bool recursive = false)
+        {
+            await onVisit(kernel);
+
+            await VisitSubkernelsAsync(kernel, onVisit, recursive);
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive/KernelInvocationContext.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelInvocationContext.cs
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.Interactive
                 return;
             }
 
-            var command = @event.Command as KernelCommand;
+            var command = @event.Command;
 
             if (command == null ||
                 Command == command ||


### PR DESCRIPTION
This adds an extension to the ExtensionLab to generate derived `DataFrame` types based on data, for example from a loaded CSV file. 

Suggestions on the magic command name?

![image](https://user-images.githubusercontent.com/547415/88333470-2810fb00-cce5-11ea-9fe8-ffa511210ad9.png)

