### PR TITLE
Fix abstract class on demand formatter registration

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/FormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/FormatterTests.cs
@@ -335,8 +335,6 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
         [Theory]
         [InlineData("text/plain")]
-        [InlineData("text/plain")]
-        [InlineData("text/html")]
         [InlineData("text/html")]
         public void Formatters_can_be_registered_on_demand_for_open_generic_classes(string mimeType)
         {
@@ -362,8 +360,6 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
         [Theory]
         [InlineData("text/plain")]
-        [InlineData("text/plain")]
-        [InlineData("text/html")]
         [InlineData("text/html")]
         public void Formatters_can_be_registered_on_demand_for_open_generic_interfaces(string mimeType)
         {

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/FormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/FormatterTests.cs
@@ -32,7 +32,8 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
             public void Default_formatter_for_Type_displays_generic_parameter_name_for_multiple_parameter_generic_type()
             {
                 typeof(Dictionary<string, IEnumerable<int>>).ToDisplayString()
-                                                            .Should().Be("System.Collections.Generic.Dictionary<System.String,System.Collections.Generic.IEnumerable<System.Int32>>");
+                                                            .Should().Be(
+                                                                "System.Collections.Generic.Dictionary<System.String,System.Collections.Generic.IEnumerable<System.Int32>>");
             }
 
             [Fact]
@@ -219,14 +220,25 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
         }
 
         [Theory]
-        [InlineData("text/plain")]
-        [InlineData("text/html")]
-        public void Custom_formatters_can_be_registered_for_types_not_known_until_runtime(string mimeType)
+        [InlineData("text/plain", false)]
+        [InlineData("text/plain", true)]
+        [InlineData("text/html", false)]
+        [InlineData("text/html", true)]
+        public void Formatters_can_be_registered_for_concrete_types(string mimeType, bool useGenericRegisterMethod)
         {
-            Formatter.Register(
-                type: typeof(FileInfo),
-                formatter: (filInfo, writer) => writer.Write("hello"),
-                mimeType);
+            if (useGenericRegisterMethod)
+            {
+                Formatter.Register<FileInfo>(
+                    formatter: (filInfo, writer) => writer.Write("hello"),
+                    mimeType);
+            }
+            else
+            {
+                Formatter.Register(
+                    type: typeof(FileInfo),
+                    formatter: (filInfo, writer) => writer.Write("hello"),
+                    mimeType);
+            }
 
             new FileInfo(@"c:\temp\foo.txt").ToDisplayString(mimeType)
                                             .Should()
@@ -234,22 +246,41 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
         }
 
         [Theory]
-        [InlineData("text/plain")]
-        [InlineData("text/html")]
-        public void Custom_formatters_can_be_registered_for_interfaces(string mimeType)
+        [InlineData("text/plain", false)]
+        [InlineData("text/plain", true)]
+        [InlineData("text/html", false)]
+        [InlineData("text/html", true)]
+        public void Formatters_can_be_registered_on_demand_for_non_generic_interfaces(string mimeType, bool useGenericRegisterMethod)
         {
-            Formatter.Register(
-                type: typeof(IEnumerable),
-                formatter: (obj, writer) =>
-                {
-                    var i = 0;
-                    foreach (var item in (IEnumerable) obj)
+            if (useGenericRegisterMethod)
+            {
+                Formatter.Register<IEnumerable>(
+                    formatter: (obj, writer) =>
                     {
-                        i++;
-                    }
+                        var i = 0;
+                        foreach (var item in obj)
+                        {
+                            i++;
+                        }
 
-                    writer.Write(i);
-                }, mimeType);
+                        writer.Write(i);
+                    }, mimeType);
+            }
+            else
+            {
+                Formatter.Register(
+                    type: typeof(IEnumerable),
+                    formatter: (obj, writer) =>
+                    {
+                        var i = 0;
+                        foreach (var item in (IEnumerable) obj)
+                        {
+                            i++;
+                        }
+
+                        writer.Write(i);
+                    }, mimeType);
+            }
 
             var list = new ArrayList { 1, 2, 3, 4, 5 };
 
@@ -259,9 +290,55 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
         }
 
         [Theory]
+        [InlineData("text/plain", false)]
+        [InlineData("text/plain", true)]
+        [InlineData("text/html", false)]
+        [InlineData("text/html", true)]
+        public void Formatters_can_be_registered_on_demand_for_abstract_classes(string mimeType, bool useGenericRegisterMethod)
+        {
+            if (useGenericRegisterMethod)
+            {
+                Formatter.Register<AbstractClass>(
+                    (obj, writer) => writer.Write(obj.GetType().Name.ToUpperInvariant()), mimeType);
+            }
+            else
+            {
+                Formatter.Register(
+                    type: typeof(AbstractClass),
+                    formatter: (obj, writer) => writer.Write(obj.GetType().Name.ToUpperInvariant()), mimeType);
+            }
+
+            var instanceOf1 = new ConcreteClass1InheritingAbstractClass();
+
+            instanceOf1.ToDisplayString(mimeType)
+                       .Should()
+                       .Be(instanceOf1.GetType().Name.ToUpperInvariant());
+
+            var instanceOf2 = new ConcreteClass2InheritingAbstractClass();
+
+            instanceOf2.ToDisplayString(mimeType)
+                       .Should()
+                       .Be(instanceOf2.GetType().Name.ToUpperInvariant());
+        }
+
+        public abstract class AbstractClass
+        {
+        };
+
+        public class ConcreteClass1InheritingAbstractClass : AbstractClass
+        {
+        };
+
+        public class ConcreteClass2InheritingAbstractClass : AbstractClass
+        {
+        };
+
+        [Theory]
+        [InlineData("text/plain")]
         [InlineData("text/plain")]
         [InlineData("text/html")]
-        public void Custom_formatters_can_be_registered_for_open_generic_classes(string mimeType)
+        [InlineData("text/html")]
+        public void Formatters_can_be_registered_on_demand_for_open_generic_classes(string mimeType)
         {
             Formatter.Register(
                 type: typeof(List<>),
@@ -282,18 +359,20 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
                 .Should()
                 .Be(list.Count.ToString());
         }
-        
-        [Theory(Skip = "bug is here?")]
+
+        [Theory]
+        [InlineData("text/plain")]
         [InlineData("text/plain")]
         [InlineData("text/html")]
-        public void Custom_formatters_can_be_registered_for_open_generic_interfaces(string mimeType)
+        [InlineData("text/html")]
+        public void Formatters_can_be_registered_on_demand_for_open_generic_interfaces(string mimeType)
         {
             Formatter.Register(
                 type: typeof(IList<>),
                 formatter: (obj, writer) =>
                 {
                     var i = 0;
-                    foreach (var item in (IEnumerable) obj)
+                    foreach (var _ in (IEnumerable) obj)
                     {
                         i++;
                     }

--- a/src/Microsoft.DotNet.Interactive.Formatting/Formatter.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/Formatter.cs
@@ -379,6 +379,13 @@ namespace Microsoft.DotNet.Interactive.Formatting
             return TypeFormatters.Keys.Where(k => k.type == type).Select(k => k.mimeType);
         }
 
+        public static void Register<T>(
+            Action<T, TextWriter> formatter,
+            string mimeType = PlainTextFormatter.MimeType)
+        {
+            Formatter<T>.Register(formatter, mimeType);
+        }
+
         public static void Register(
             Type type,
             Action<object, TextWriter> formatter,
@@ -386,63 +393,72 @@ namespace Microsoft.DotNet.Interactive.Formatting
         {
             if (!type.CanBeInstantiated())
             {
-                switch (mimeType)
+                RegisterLazilyForConcreteTypesOf(type, formatter, mimeType);
+            }
+            else
+            {
+                var delegateType = typeof(Action<,>).MakeGenericType(type, typeof(TextWriter));
+
+                var genericRegisterMethod = typeof(Formatter<>)
+                                            .MakeGenericType(type)
+                                            .GetMethod(nameof(Formatter<object>.Register), new[]
+                                            {
+                                                delegateType,
+                                                typeof(string)
+                                            });
+
+                genericRegisterMethod.Invoke(null, new object[] { formatter, mimeType });
+            }
+        }
+
+        public static void RegisterLazilyForConcreteTypesOf(
+            Type type, 
+            Action<object, TextWriter> formatter, 
+            string mimeType)
+        {
+            switch (mimeType)
+            {
+                case HtmlFormatter.MimeType:
+                    HtmlFormatter.DefaultFormatters.AddFormatterFactory(CreateIfMatched);
+                    break;
+
+                case PlainTextFormatter.MimeType:
+                    PlainTextFormatter.DefaultFormatters.AddFormatterFactory(CreateIfMatched);
+                    break;
+            }
+
+            return;
+
+            ITypeFormatter CreateIfMatched(Type actualType)
+            {
+                var isMatch = false;
+
+                if (type.IsGenericTypeDefinition &&
+                    actualType.IsConstructedGenericType)
                 {
-                    case HtmlFormatter.MimeType:
-                        HtmlFormatter.DefaultFormatters.AddFormatterFactory(CreateIfMatched);
-                        break;
-
-                    case PlainTextFormatter.MimeType:
-                        PlainTextFormatter.DefaultFormatters.AddFormatterFactory(CreateIfMatched);
-                        break;
-                }
-
-                return;
-
-                ITypeFormatter CreateIfMatched(Type actualType)
-                {
-                    var isMatch = false;
-
-                    if (type.IsGenericTypeDefinition &&
-                        actualType.IsConstructedGenericType)
-                    {
-                        if (type == actualType.GetGenericTypeDefinition())
-                        {
-                            isMatch = true;
-                        }
-
-                        if (type.IsInterface &&
-                            actualType.GetInterfaces()
-                                      .Any(i => i.IsConstructedGenericType &&
-                                                i.GetGenericTypeDefinition() == type))
-                        {
-                            isMatch = true;
-                        }
-                    }
-
-                    if (type.IsInterface &&
-                        type.IsAssignableFrom(actualType))
+                    if (type == actualType.GetGenericTypeDefinition())
                     {
                         isMatch = true;
                     }
 
-                    return isMatch
-                               ? Create(actualType, formatter, mimeType)
-                               : null;
+                    if (type.IsInterface &&
+                        actualType.GetInterfaces()
+                                  .Any(i => i.IsConstructedGenericType &&
+                                            i.GetGenericTypeDefinition() == type))
+                    {
+                        isMatch = true;
+                    }
                 }
+
+                if (type.IsAssignableFrom(actualType))
+                {
+                    isMatch = true;
+                }
+            
+                return isMatch
+                           ? Create(actualType, formatter, mimeType)
+                           : null;
             }
-
-            var delegateType = typeof(Action<,>).MakeGenericType(type, typeof(TextWriter));
-
-            var genericRegisterMethod = typeof(Formatter<>)
-                                        .MakeGenericType(type)
-                                        .GetMethod(nameof(Formatter<object>.Register), new[]
-                                        {
-                                            delegateType,
-                                            typeof(string)
-                                        });
-
-            genericRegisterMethod.Invoke(null, new object[] { formatter, mimeType });
         }
 
         public static void Register(ITypeFormatter formatter)

--- a/src/Microsoft.DotNet.Interactive.Formatting/Formatter{T}.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/Formatter{T}.cs
@@ -52,6 +52,13 @@ namespace Microsoft.DotNet.Interactive.Formatting
                     (o, writer) => formatter((T) o, writer),
                     mimeType);
             }
+            else if (!typeof(T).CanBeInstantiated())
+            {
+                Formatter.RegisterLazilyForConcreteTypesOf(
+                    typeof(T), 
+                    (o, writer) => formatter((T) o, writer), mimeType);
+                return;
+            }
 
             Formatter.TypeFormatters[(typeof(T), mimeType)] = new AnonymousTypeFormatter<T>(formatter, mimeType);
         }


### PR DESCRIPTION
A few fixes here:

* Add `Formatter.Register<T>` which is much more intuitive than `Formatter<T>.Register`. The latter could potentiall be made internal later.

* Fix on-demand registration of formatters for abstract classes.

* Add the more explicit (but redundant) `Formatter.RegisterLazilyForConcreteTypesOf`. The various `Formatter.Register` variants delegate to this method when called with a non-instantiable type.