### PR TITLE
Trim back on default namespaces for F#

### DIFF
--- a/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernelExtensions.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernelExtensions.fs
@@ -17,8 +17,8 @@ open XPlot.Plotly
 [<AbstractClass; Extension; Sealed>]
 type FSharpKernelExtensions private () =
     
-    static let referenceFromType = fun (typ: Type) -> sprintf "#r \"%s\"" (typ.Assembly.Location.Replace("\\", "/"))
-    static let openNamespaceOrType = fun (whatToOpen: String) -> sprintf "open %s" whatToOpen
+    static let referenceFromType (typ: Type) = sprintf "#r \"%s\"" (typ.Assembly.Location.Replace("\\", "/"))
+    static let openNamespaceOrType (whatToOpen: string) = sprintf "open %s" whatToOpen
 
     [<Extension>]
     static member UseDefaultFormatting(kernel: FSharpKernelBase) =
@@ -29,23 +29,36 @@ type FSharpKernelExtensions private () =
                 referenceFromType typeof<FSharpPocketViewTags>
                 referenceFromType typeof<PlotlyChart>
                 referenceFromType typeof<Formatter>
-                openNamespaceOrType typeof<IHtmlContent>.Namespace
-                openNamespaceOrType typeof<FSharpPocketViewTags>.FullName
-                openNamespaceOrType typeof<FSharpPocketViewTags>.Namespace
-                openNamespaceOrType typeof<PlotlyChart>.Namespace
+                //openNamespaceOrType typeof<IHtmlContent>.Namespace
+                //openNamespaceOrType typeof<FSharpPocketViewTags>.FullName
+                //openNamespaceOrType typeof<FSharpPocketViewTags>.Namespace
+                //openNamespaceOrType typeof<PlotlyChart>.Namespace
                 openNamespaceOrType typeof<Formatter>.Namespace
-            ] |> List.reduce(fun x y -> x + Environment.NewLine + y)
+            ] |> String.concat Environment.NewLine
 
         kernel.DeferCommand(SubmitCode code)
         kernel
 
     [<Extension>]
     static member UseDefaultNamespaces(kernel: FSharpKernelBase) =
-        let code = @"
-open System
-open System.Text
-open System.Threading.Tasks
-open System.Linq"
+        // F# has its own views on what namespaces are open by default in its scripting model
+        kernel
+
+    [<Extension>]
+    static member UseExtraNamespacesForTesting(kernel: FSharpKernelBase) =
+        let code = 
+            [
+                openNamespaceOrType typeof<System.Console>.Namespace
+                openNamespaceOrType typeof<System.Text.StringBuilder>.Namespace
+                openNamespaceOrType typeof<System.Threading.Tasks.Task>.Namespace
+                openNamespaceOrType typeof<System.Linq.Enumerable>.Namespace
+                openNamespaceOrType typeof<IHtmlContent>.Namespace
+                openNamespaceOrType typeof<FSharpPocketViewTags>.FullName
+                openNamespaceOrType typeof<FSharpPocketViewTags>.Namespace
+                openNamespaceOrType typeof<PlotlyChart>.Namespace
+                openNamespaceOrType typeof<Formatter>.Namespace
+            ] |> String.concat Environment.NewLine
+
         kernel.DeferCommand(SubmitCode code)
         kernel
 
@@ -55,7 +68,7 @@ open System.Linq"
             [
                 referenceFromType typeof<FSharpKernelHelpers.IMarker>
                 openNamespaceOrType (typeof<FSharpKernelHelpers.IMarker>.DeclaringType.Namespace + "." + nameof(FSharpKernelHelpers))
-            ] |> List.reduce(fun x y -> x + Environment.NewLine + y)
+            ] |> String.concat Environment.NewLine
 
         kernel.DeferCommand(SubmitCode code)
         kernel

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelFormattingTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelFormattingTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.Interactive.Tests
             string submission,
             string expectedContent)
         {
-            var kernel = CreateKernel(language);
+            var kernel = CreateKernel(language, openTestingNamespaces: true);
 
             await kernel.SendAsync(new SubmitCode(submission));
 
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.Interactive.Tests
             string submission,
             string expectedContent)
         {
-            var kernel = CreateKernel(language);
+            var kernel = CreateKernel(language, openTestingNamespaces: true);
 
             var result = await kernel.SendAsync(new SubmitCode(submission));
 
@@ -87,7 +87,7 @@ namespace Microsoft.DotNet.Interactive.Tests
         [InlineData(Language.FSharp)]
         public async Task Display_helper_can_be_called_without_specifying_class_name(Language language)
         {
-            var kernel = CreateKernel(language);
+            var kernel = CreateKernel(language, openTestingNamespaces: true);
 
             var submission = language switch
             {
@@ -111,7 +111,7 @@ namespace Microsoft.DotNet.Interactive.Tests
         [InlineData(Language.FSharp)]
         public async Task Displayed_value_can_be_updated(Language language)
         {
-            var kernel = CreateKernel(language);
+            var kernel = CreateKernel(language, openTestingNamespaces: true);
 
             var submission = language switch
             {
@@ -144,7 +144,7 @@ namespace Microsoft.DotNet.Interactive.Tests
         [InlineData(Language.FSharp)]
         public async Task Displayed_value_can_be_updated_from_later_submissions(Language language)
         {
-            var kernel = CreateKernel(language);
+            var kernel = CreateKernel(language, openTestingNamespaces: true);
 
             var submissions = language switch
             {
@@ -174,7 +174,7 @@ namespace Microsoft.DotNet.Interactive.Tests
         [InlineData(Language.FSharp)]
         public async Task Value_display_and_update_are_in_right_order(Language language)
         {
-            var kernel = CreateKernel(language);
+            var kernel = CreateKernel(language, openTestingNamespaces: true);
 
             var submission = language switch
             {

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelTestBase.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelTestBase.cs
@@ -75,23 +75,25 @@ namespace Microsoft.DotNet.Interactive.Tests
             _lockReleaser.Dispose();
         }
 
-        protected CompositeKernel CreateCompositeKernel(Language defaultKernelLanguage = Language.CSharp)
+        protected CompositeKernel CreateCompositeKernel(Language defaultKernelLanguage = Language.CSharp,
+            bool openTestingNamespaces = false)
         {
             return CreateCompositeKernel(
                 new[]
                 {
-                    CreateFSharpKernel(),
+                    CreateFSharpKernel(openTestingNamespaces),
                     CreateCSharpKernel(),
                     CreatePowerShellKernel()
                 },
                 defaultKernelLanguage);
         }
 
-        protected CompositeKernel CreateKernel(Language defaultLanguage = Language.CSharp)
+        protected CompositeKernel CreateKernel(Language defaultLanguage = Language.CSharp, 
+            bool openTestingNamespaces = false)
         {
             var languageKernel = defaultLanguage switch
             {
-                Language.FSharp => CreateFSharpKernel(),
+                Language.FSharp => CreateFSharpKernel(openTestingNamespaces),
                 Language.CSharp => CreateCSharpKernel(),
                 Language.PowerShell => CreatePowerShellKernel(),
                 _ => throw new InvalidOperationException($"Unknown language specified: {defaultLanguage}")
@@ -118,15 +120,20 @@ namespace Microsoft.DotNet.Interactive.Tests
             return kernel;
         }
 
-        private Kernel CreateFSharpKernel()
+        private Kernel CreateFSharpKernel(bool openTestingNamespaces)
         {
-            return new FSharpKernel()
+            var kernel =
+                new FSharpKernel()
                 .UseDefaultFormatting()
                 .UseNugetDirective()
                 .UseKernelHelpers()
                 .UseDotNetVariableSharing()
                 .UseWho()
                 .UseDefaultNamespaces();
+            if (openTestingNamespaces)
+                return kernel.UseExtraNamespacesForTesting();
+            else
+                return kernel;
         }
 
         private Kernel CreateCSharpKernel()

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
@@ -862,7 +862,7 @@ Console.Write(""value three"");"
         [InlineData(Language.FSharp)]
         public async Task it_returns_a_similarly_shaped_error(Language language)
         {
-            var kernel = CreateKernel(language);
+            var kernel = CreateKernel(language, openTestingNamespaces: true);
 
             var (source, error) = language switch
             {
@@ -1036,7 +1036,7 @@ Console.Write(2);
         [InlineData(Language.PowerShell)]
         public async Task it_returns_completion_list_for_previously_declared_items(Language language)
         {
-            var kernel = CreateKernel(language);
+            var kernel = CreateKernel(language, openTestingNamespaces: true);
 
             var source = language switch
             {


### PR DESCRIPTION

As mentioned in #645 , there are too many namespaces open by default for F#, and in particular littering the unqualified namespace of the programming model with `a`, `p` etc of the HTML tags is a real problem - I personally had no idea what was going on with the type errors I got when accidentally using these names in code that has nothing to do with HTML.  This is particularly a problem in F# I think but I'm pretty sure you want to pull back on this in C# too

In any case, for F# only the standard namespaces of the F# scripting model should be open by default, plus the one extra default namespace (and anything directly associated with it) for things like `display`

    open Microsoft.DotNet.Interactive.FSharp.FSharpKernelHelpers

The namespaces `System`, `System.Linq` etc. should not be open by default for F# code.  F# already opens `FSharp.Core`, `FSharp.Core.Operators` etc. and that is its standard scripting model.


