### PR TITLE
enable extension to expose static content

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Js/package-lock.json
+++ b/src/Microsoft.DotNet.Interactive.Js/package-lock.json
@@ -1095,9 +1095,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "lodash.isequal": {

--- a/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/contracts.ts
+++ b/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/contracts.ts
@@ -183,7 +183,7 @@ export interface InputRequested extends KernelEvent {
 export interface KernelExtensionLoaded extends KernelEvent {
     extensionType: string;
     contentSourceName: string;
-    isContentProvider: boolean;
+    isStaticContentSource: boolean;
 }
 
 export interface KernelReady extends KernelEvent {

--- a/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/contracts.ts
+++ b/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/contracts.ts
@@ -182,8 +182,7 @@ export interface InputRequested extends KernelEvent {
 
 export interface KernelExtensionLoaded extends KernelEvent {
     extensionType: string;
-    contentSourceName: string;
-    isStaticContentSource: boolean;
+    kernelName: string;
 }
 
 export interface KernelReady extends KernelEvent {

--- a/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/contracts.ts
+++ b/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/contracts.ts
@@ -181,7 +181,6 @@ export interface InputRequested extends KernelEvent {
 }
 
 export interface KernelExtensionLoaded extends KernelEvent {
-    extensionType: string;
 }
 
 export interface KernelReady extends KernelEvent {

--- a/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/contracts.ts
+++ b/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/contracts.ts
@@ -182,7 +182,6 @@ export interface InputRequested extends KernelEvent {
 
 export interface KernelExtensionLoaded extends KernelEvent {
     extensionType: string;
-    kernelName: string;
 }
 
 export interface KernelReady extends KernelEvent {

--- a/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/contracts.ts
+++ b/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/contracts.ts
@@ -87,6 +87,7 @@ export const ErrorProducedType = "ErrorProduced";
 export const HoverTextProducedType = "HoverTextProduced";
 export const IncompleteCodeSubmissionReceivedType = "IncompleteCodeSubmissionReceived";
 export const InputRequestedType = "InputRequested";
+export const KernelExtensionLoadedType = "KernelExtensionLoaded";
 export const KernelReadyType = "KernelReady";
 export const PackageAddedType = "PackageAdded";
 export const PasswordRequestedType = "PasswordRequested";
@@ -109,6 +110,7 @@ export type KernelEventType =
     | typeof HoverTextProducedType
     | typeof IncompleteCodeSubmissionReceivedType
     | typeof InputRequestedType
+    | typeof KernelExtensionLoadedType
     | typeof KernelReadyType
     | typeof PackageAddedType
     | typeof PasswordRequestedType
@@ -176,6 +178,12 @@ export interface IncompleteCodeSubmissionReceived extends KernelEvent {
 
 export interface InputRequested extends KernelEvent {
     prompt: string;
+}
+
+export interface KernelExtensionLoaded extends KernelEvent {
+    extensionType: string;
+    contentSourceName: string;
+    isContentProvider: boolean;
 }
 
 export interface KernelReady extends KernelEvent {

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelExtensionLoadingTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelExtensionLoadingTests.cs
@@ -15,6 +15,7 @@ using static Microsoft.DotNet.Interactive.Tests.Utility.KernelExtensionTestHelpe
 
 namespace Microsoft.DotNet.Interactive.Tests
 {
+
     [LogTestNamesToPocketLogger]
     public class LanguageKernelExtensionLoadingTests : LanguageKernelTestBase
     {

--- a/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.Event_contract_has_not_been_broken.approved.KernelExtensionLoaded.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.Event_contract_has_not_been_broken.approved.KernelExtensionLoaded.json
@@ -1,0 +1,1 @@
+{"event":{"extensionType":"customExtension","contentSourceName":null,"isContentProvider":false},"eventType":"KernelExtensionLoaded","command":{"token":"the-token","commandType":"SubmitCode","command":{"code":"#r \"nuget:package\" ","submissionType":0,"targetKernelName":null}}}

--- a/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.Event_contract_has_not_been_broken.approved.KernelExtensionLoaded.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.Event_contract_has_not_been_broken.approved.KernelExtensionLoaded.json
@@ -1,1 +1,1 @@
-{"event":{"extensionType":"customExtension","kernelName":null},"eventType":"KernelExtensionLoaded","command":{"token":"the-token","commandType":"SubmitCode","command":{"code":"#r \"nuget:package\" ","submissionType":0,"targetKernelName":null}}}
+{"event":{"extensionType":"customExtension"},"eventType":"KernelExtensionLoaded","command":{"token":"the-token","commandType":"SubmitCode","command":{"code":"#r \"nuget:package\" ","submissionType":0,"targetKernelName":null}}}

--- a/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.Event_contract_has_not_been_broken.approved.KernelExtensionLoaded.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.Event_contract_has_not_been_broken.approved.KernelExtensionLoaded.json
@@ -1,1 +1,1 @@
-{"event":{"extensionType":"customExtension","contentSourceName":null,"isStaticContentSource":false},"eventType":"KernelExtensionLoaded","command":{"token":"the-token","commandType":"SubmitCode","command":{"code":"#r \"nuget:package\" ","submissionType":0,"targetKernelName":null}}}
+{"event":{"extensionType":"customExtension","kernelName":null},"eventType":"KernelExtensionLoaded","command":{"token":"the-token","commandType":"SubmitCode","command":{"code":"#r \"nuget:package\" ","submissionType":0,"targetKernelName":null}}}

--- a/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.Event_contract_has_not_been_broken.approved.KernelExtensionLoaded.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.Event_contract_has_not_been_broken.approved.KernelExtensionLoaded.json
@@ -1,1 +1,1 @@
-{"event":{"extensionType":"customExtension"},"eventType":"KernelExtensionLoaded","command":{"token":"the-token","commandType":"SubmitCode","command":{"code":"#r \"nuget:package\" ","submissionType":0,"targetKernelName":null}}}
+{"event":{},"eventType":"KernelExtensionLoaded","command":{"token":"the-token","commandType":"SubmitCode","command":{"code":"#r \"nuget:package\" ","submissionType":0,"targetKernelName":null}}}

--- a/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.Event_contract_has_not_been_broken.approved.KernelExtensionLoaded.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.Event_contract_has_not_been_broken.approved.KernelExtensionLoaded.json
@@ -1,1 +1,1 @@
-{"event":{"extensionType":"customExtension","contentSourceName":null,"isContentProvider":false},"eventType":"KernelExtensionLoaded","command":{"token":"the-token","commandType":"SubmitCode","command":{"code":"#r \"nuget:package\" ","submissionType":0,"targetKernelName":null}}}
+{"event":{"extensionType":"customExtension","contentSourceName":null,"isStaticContentSource":false},"eventType":"KernelExtensionLoaded","command":{"token":"the-token","commandType":"SubmitCode","command":{"code":"#r \"nuget:package\" ","submissionType":0,"targetKernelName":null}}}

--- a/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.cs
@@ -3,17 +3,22 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+
 using Assent;
+
 using FluentAssertions;
+
 using Microsoft.AspNetCore.Html;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Server;
-using Microsoft.DotNet.Interactive.Utility;
+
 using Pocket;
+
 using Xunit;
 using Xunit.Abstractions;
 
@@ -71,7 +76,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Server
         {
             var _configuration = new Configuration()
                                  .UsingExtension($"{command.GetType().Name}.json")
-                                 .SetInteractive(false);
+                                 .SetInteractive(Debugger.IsAttached);
 
             command.SetToken("the-token");
 
@@ -86,7 +91,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Server
         {
             var _configuration = new Configuration()
                                  .UsingExtension($"{@event.GetType().Name}.json")
-                                 .SetInteractive(true);
+                                 .SetInteractive(Debugger.IsAttached);
 
             @event.Command?.SetToken("the-token");
 

--- a/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.cs
@@ -284,6 +284,8 @@ namespace Microsoft.DotNet.Interactive.Tests.Server
                 yield return new WorkingDirectoryChanged(
                     "some/different/directory",
                     new ChangeWorkingDirectory("some/different/directory"));
+
+                yield return new KernelExtensionLoaded("customExtension", null, false, new SubmitCode(@"#r ""nuget:package"" "));
             }
         }
 

--- a/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Server
         {
             var _configuration = new Configuration()
                                  .UsingExtension($"{@event.GetType().Name}.json")
-                                 .SetInteractive(false);
+                                 .SetInteractive(true);
 
             @event.Command?.SetToken("the-token");
 
@@ -285,7 +285,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Server
                     "some/different/directory",
                     new ChangeWorkingDirectory("some/different/directory"));
 
-                yield return new KernelExtensionLoaded("customExtension", new SubmitCode(@"#r ""nuget:package"" "));
+                yield return new KernelExtensionLoaded(new SubmitCode(@"#r ""nuget:package"" "));
             }
         }
 

--- a/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Server/SerializationTests.cs
@@ -285,7 +285,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Server
                     "some/different/directory",
                     new ChangeWorkingDirectory("some/different/directory"));
 
-                yield return new KernelExtensionLoaded("customExtension", null, false, new SubmitCode(@"#r ""nuget:package"" "));
+                yield return new KernelExtensionLoaded("customExtension", new SubmitCode(@"#r ""nuget:package"" "));
             }
         }
 

--- a/src/Microsoft.DotNet.Interactive/Events/KernelExtensionLoaded.cs
+++ b/src/Microsoft.DotNet.Interactive/Events/KernelExtensionLoaded.cs
@@ -15,18 +15,15 @@ namespace Microsoft.DotNet.Interactive.Events
         [JsonIgnore]
         public IKernelExtension KernelExtension { get; }
 
-        public string KernelName { get; }
 
         [JsonConstructor]
-        public KernelExtensionLoaded(string extensionType, string kernelName, bool isStaticContentSource ,KernelCommand command = null) : base(command)
+        public KernelExtensionLoaded(string extensionType,KernelCommand command = null) : base(command)
         {
             ExtensionType = extensionType;
-            KernelName = kernelName;
         }
-        public KernelExtensionLoaded(IKernelExtension kernelExtension, string kernelName, KernelCommand command = null) : base(command)
+        public KernelExtensionLoaded(IKernelExtension kernelExtension, KernelCommand command = null) : base(command)
         {
             KernelExtension = kernelExtension;
-            KernelName = kernelName;
             ExtensionType = kernelExtension.GetType().Name;
 
         }

--- a/src/Microsoft.DotNet.Interactive/Events/KernelExtensionLoaded.cs
+++ b/src/Microsoft.DotNet.Interactive/Events/KernelExtensionLoaded.cs
@@ -15,29 +15,21 @@ namespace Microsoft.DotNet.Interactive.Events
         [JsonIgnore]
         public IKernelExtension KernelExtension { get; }
 
+        public string KernelName { get; }
+
         [JsonConstructor]
-        public KernelExtensionLoaded(string extensionType, string contentSourceName, bool isStaticContentSource ,KernelCommand command = null) : base(command)
+        public KernelExtensionLoaded(string extensionType, string kernelName, bool isStaticContentSource ,KernelCommand command = null) : base(command)
         {
             ExtensionType = extensionType;
-            ContentSourceName = contentSourceName;
-            IsStaticContentSource = isStaticContentSource;
+            KernelName = kernelName;
         }
-        public KernelExtensionLoaded(IKernelExtension kernelExtension, KernelCommand command = null) : base(command)
+        public KernelExtensionLoaded(IKernelExtension kernelExtension, string kernelName, KernelCommand command = null) : base(command)
         {
             KernelExtension = kernelExtension;
+            KernelName = kernelName;
             ExtensionType = kernelExtension.GetType().Name;
 
-            if (kernelExtension is IStaticContentSource contentSource)
-            {
-                IsStaticContentSource = true;
-                ContentSourceName = contentSource.Name;
-            }
-
         }
-
-        public string ContentSourceName { get; }
-
-        public bool IsStaticContentSource { get;  }
 
         public override string ToString() => $"{base.ToString()}: {ExtensionType}";
     }

--- a/src/Microsoft.DotNet.Interactive/Events/KernelExtensionLoaded.cs
+++ b/src/Microsoft.DotNet.Interactive/Events/KernelExtensionLoaded.cs
@@ -10,24 +10,18 @@ namespace Microsoft.DotNet.Interactive.Events
 {
     public class KernelExtensionLoaded : KernelEvent
     {
-        public string ExtensionType { get; }
-
         [JsonIgnore]
         public IKernelExtension KernelExtension { get; }
 
 
         [JsonConstructor]
-        public KernelExtensionLoaded(string extensionType,KernelCommand command = null) : base(command)
+        public KernelExtensionLoaded(KernelCommand command = null) : base(command)
         {
-            ExtensionType = extensionType;
         }
         public KernelExtensionLoaded(IKernelExtension kernelExtension, KernelCommand command = null) : base(command)
         {
             KernelExtension = kernelExtension;
-            ExtensionType = kernelExtension.GetType().Name;
 
         }
-
-        public override string ToString() => $"{base.ToString()}: {ExtensionType}";
     }
 }

--- a/src/Microsoft.DotNet.Interactive/Events/KernelExtensionLoaded.cs
+++ b/src/Microsoft.DotNet.Interactive/Events/KernelExtensionLoaded.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+using Microsoft.DotNet.Interactive.Commands;
+
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.Interactive.Events
+{
+    public class KernelExtensionLoaded : KernelEvent
+    {
+        public string ExtensionType { get; }
+
+        [JsonIgnore]
+        public IKernelExtension KernelExtension { get; }
+
+        [JsonConstructor]
+        public KernelExtensionLoaded(string extensionType, string contentSourceName, bool isContentProvider ,KernelCommand command = null) : base(command)
+        {
+            ExtensionType = extensionType;
+            ContentSourceName = contentSourceName;
+            IsContentProvider = isContentProvider;
+        }
+        public KernelExtensionLoaded(IKernelExtension kernelExtension, KernelCommand command = null) : base(command)
+        {
+            KernelExtension = kernelExtension;
+            ExtensionType = kernelExtension.GetType().Name;
+
+            if (kernelExtension is IStaticContentSource contentSource)
+            {
+                IsContentProvider = true;
+                ContentSourceName = contentSource.Name;
+            }
+
+        }
+
+        public string ContentSourceName { get; }
+
+        public bool IsContentProvider { get;  }
+
+        public override string ToString() => $"{base.ToString()}: {ExtensionType}";
+    }
+}

--- a/src/Microsoft.DotNet.Interactive/Events/KernelExtensionLoaded.cs
+++ b/src/Microsoft.DotNet.Interactive/Events/KernelExtensionLoaded.cs
@@ -16,11 +16,11 @@ namespace Microsoft.DotNet.Interactive.Events
         public IKernelExtension KernelExtension { get; }
 
         [JsonConstructor]
-        public KernelExtensionLoaded(string extensionType, string contentSourceName, bool isContentProvider ,KernelCommand command = null) : base(command)
+        public KernelExtensionLoaded(string extensionType, string contentSourceName, bool isStaticContentSource ,KernelCommand command = null) : base(command)
         {
             ExtensionType = extensionType;
             ContentSourceName = contentSourceName;
-            IsContentProvider = isContentProvider;
+            IsStaticContentSource = isStaticContentSource;
         }
         public KernelExtensionLoaded(IKernelExtension kernelExtension, KernelCommand command = null) : base(command)
         {
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.Interactive.Events
 
             if (kernelExtension is IStaticContentSource contentSource)
             {
-                IsContentProvider = true;
+                IsStaticContentSource = true;
                 ContentSourceName = contentSource.Name;
             }
 
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.Interactive.Events
 
         public string ContentSourceName { get; }
 
-        public bool IsContentProvider { get;  }
+        public bool IsStaticContentSource { get;  }
 
         public override string ToString() => $"{base.ToString()}: {ExtensionType}";
     }

--- a/src/Microsoft.DotNet.Interactive/Events/PackageAdded.cs
+++ b/src/Microsoft.DotNet.Interactive/Events/PackageAdded.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+
 using Microsoft.DotNet.Interactive.Commands;
 
 namespace Microsoft.DotNet.Interactive.Events

--- a/src/Microsoft.DotNet.Interactive/Extensions/AssemblyBasedExtensionLoader.cs
+++ b/src/Microsoft.DotNet.Interactive/Extensions/AssemblyBasedExtensionLoader.cs
@@ -128,7 +128,7 @@ namespace Microsoft.DotNet.Interactive.Extensions
                     try
                     {
                         await extension.OnLoadAsync(kernel);
-
+                        context.Publish(new KernelExtensionLoaded(extension));
                         displayed.Update(
                             $"Loaded kernel extension \"{extensionType.Name}\" from assembly {assemblyFile.FullName}");
                     }

--- a/src/Microsoft.DotNet.Interactive/Extensions/AssemblyBasedExtensionLoader.cs
+++ b/src/Microsoft.DotNet.Interactive/Extensions/AssemblyBasedExtensionLoader.cs
@@ -128,7 +128,7 @@ namespace Microsoft.DotNet.Interactive.Extensions
                     try
                     {
                         await extension.OnLoadAsync(kernel);
-                        context.Publish(new KernelExtensionLoaded(extension));
+                        context.Publish(new KernelExtensionLoaded(extension, kernel.Name));
                         displayed.Update(
                             $"Loaded kernel extension \"{extensionType.Name}\" from assembly {assemblyFile.FullName}");
                     }

--- a/src/Microsoft.DotNet.Interactive/Extensions/AssemblyBasedExtensionLoader.cs
+++ b/src/Microsoft.DotNet.Interactive/Extensions/AssemblyBasedExtensionLoader.cs
@@ -128,7 +128,7 @@ namespace Microsoft.DotNet.Interactive.Extensions
                     try
                     {
                         await extension.OnLoadAsync(kernel);
-                        context.Publish(new KernelExtensionLoaded(extension, kernel.Name));
+                        context.Publish(new KernelExtensionLoaded(extension));
                         displayed.Update(
                             $"Loaded kernel extension \"{extensionType.Name}\" from assembly {assemblyFile.FullName}");
                     }

--- a/src/Microsoft.DotNet.Interactive/IStaticContentSource.cs
+++ b/src/Microsoft.DotNet.Interactive/IStaticContentSource.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Interactive
+{
+    public interface IStaticContentSource
+    {
+        public string Name { get; }
+    }
+}

--- a/src/Microsoft.DotNet.Interactive/Server/KernelEventEnvelope.cs
+++ b/src/Microsoft.DotNet.Interactive/Server/KernelEventEnvelope.cs
@@ -66,6 +66,7 @@ namespace Microsoft.DotNet.Interactive.Server
                 [nameof(StandardErrorValueProduced)] = typeof(KernelEventEnvelope<StandardErrorValueProduced>),
                 [nameof(StandardOutputValueProduced)] = typeof(KernelEventEnvelope<StandardOutputValueProduced>),
                 [nameof(WorkingDirectoryChanged)] = typeof(KernelEventEnvelope<WorkingDirectoryChanged>),
+                [nameof(KernelExtensionLoaded)] = typeof(KernelEventEnvelope<KernelExtensionLoaded>),
             };
 
             _eventTypesByEventTypeName = _envelopeTypesByEventTypeName

--- a/src/dotnet-interactive-vscode/src/contracts.ts
+++ b/src/dotnet-interactive-vscode/src/contracts.ts
@@ -183,7 +183,7 @@ export interface InputRequested extends KernelEvent {
 export interface KernelExtensionLoaded extends KernelEvent {
     extensionType: string;
     contentSourceName: string;
-    isContentProvider: boolean;
+    isStaticContentSource: boolean;
 }
 
 export interface KernelReady extends KernelEvent {

--- a/src/dotnet-interactive-vscode/src/contracts.ts
+++ b/src/dotnet-interactive-vscode/src/contracts.ts
@@ -182,8 +182,7 @@ export interface InputRequested extends KernelEvent {
 
 export interface KernelExtensionLoaded extends KernelEvent {
     extensionType: string;
-    contentSourceName: string;
-    isStaticContentSource: boolean;
+    kernelName: string;
 }
 
 export interface KernelReady extends KernelEvent {

--- a/src/dotnet-interactive-vscode/src/contracts.ts
+++ b/src/dotnet-interactive-vscode/src/contracts.ts
@@ -181,7 +181,6 @@ export interface InputRequested extends KernelEvent {
 }
 
 export interface KernelExtensionLoaded extends KernelEvent {
-    extensionType: string;
 }
 
 export interface KernelReady extends KernelEvent {

--- a/src/dotnet-interactive-vscode/src/contracts.ts
+++ b/src/dotnet-interactive-vscode/src/contracts.ts
@@ -182,7 +182,6 @@ export interface InputRequested extends KernelEvent {
 
 export interface KernelExtensionLoaded extends KernelEvent {
     extensionType: string;
-    kernelName: string;
 }
 
 export interface KernelReady extends KernelEvent {

--- a/src/dotnet-interactive-vscode/src/contracts.ts
+++ b/src/dotnet-interactive-vscode/src/contracts.ts
@@ -87,6 +87,7 @@ export const ErrorProducedType = "ErrorProduced";
 export const HoverTextProducedType = "HoverTextProduced";
 export const IncompleteCodeSubmissionReceivedType = "IncompleteCodeSubmissionReceived";
 export const InputRequestedType = "InputRequested";
+export const KernelExtensionLoadedType = "KernelExtensionLoaded";
 export const KernelReadyType = "KernelReady";
 export const PackageAddedType = "PackageAdded";
 export const PasswordRequestedType = "PasswordRequested";
@@ -109,6 +110,7 @@ export type KernelEventType =
     | typeof HoverTextProducedType
     | typeof IncompleteCodeSubmissionReceivedType
     | typeof InputRequestedType
+    | typeof KernelExtensionLoadedType
     | typeof KernelReadyType
     | typeof PackageAddedType
     | typeof PasswordRequestedType
@@ -176,6 +178,12 @@ export interface IncompleteCodeSubmissionReceived extends KernelEvent {
 
 export interface InputRequested extends KernelEvent {
     prompt: string;
+}
+
+export interface KernelExtensionLoaded extends KernelEvent {
+    extensionType: string;
+    contentSourceName: string;
+    isContentProvider: boolean;
 }
 
 export interface KernelReady extends KernelEvent {

--- a/src/dotnet-interactive.Tests/FileProviderTests.cs
+++ b/src/dotnet-interactive.Tests/FileProviderTests.cs
@@ -63,10 +63,9 @@ namespace Microsoft.DotNet.Interactive.App.Tests
 #i ""nuget:{nupkg.Directory.FullName}""
 #r ""nuget:{packageName},{packageVersion}""            ");
 
-            var file = provider.GetFileInfo("extensions/TestKernelExtension/resources/file.txt");
+            Action action = () => provider.GetFileInfo("extensions/TestKernelExtension/resources/file.txt");
 
-            file.Should()
-                .NotBeNull();
+            action.Should().Throw<StaticContentSourceNotFoundException>();
         }
 
         [Theory]
@@ -112,10 +111,10 @@ namespace Microsoft.DotNet.Interactive.App.Tests
             var kernel = CreateKernel(language);
             var provider = new FileProvider(kernel);
 
-            var file = provider.GetFileInfo("extensions/not_found/resources/file.txt");
+            Action action
+                = () => provider.GetFileInfo("extensions/not_found/resources/file.txt");
 
-            file.Should()
-                .NotBeNull();
+            action.Should().Throw<StaticContentSourceNotFoundException>();
         }
     }
 }

--- a/src/dotnet-interactive.Tests/FileProviderTests.cs
+++ b/src/dotnet-interactive.Tests/FileProviderTests.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Microsoft.DotNet.Interactive.App.Http;
+using Microsoft.DotNet.Interactive.Tests;
+using Microsoft.DotNet.Interactive.Tests.Utility;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.Interactive.App.Tests
+{
+    public class FileProviderTests : LanguageKernelTestBase
+    {
+        public FileProviderTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Theory]
+        [InlineData(Language.CSharp)]
+        [InlineData(Language.FSharp)]
+        public void It_loads_content_from_root_provider(Language language)
+        {
+            var kernel = CreateKernel(language);
+            var provider = new FileProvider(kernel);
+
+            var file = provider.GetFileInfo("resources/dotnet-interactive.js");
+
+            file.Should()
+                .NotBeNull();
+        }
+
+        [Theory]
+        [InlineData(Language.CSharp)]
+        [InlineData(Language.FSharp)]
+        public async Task It_does_not_track_extensions_that_are_not_file_providers(Language language)
+        {
+
+            var kernel = CreateKernel(language);
+            var provider = new FileProvider(kernel);
+
+            var projectDir = DirectoryUtility.CreateDirectory();
+
+            var packageName = $"MyTestExtension.{Path.GetRandomFileName()}";
+            var packageVersion = "2.0.0-" + Guid.NewGuid().ToString("N");
+            var guid = Guid.NewGuid().ToString();
+
+            var nupkg = await KernelExtensionTestHelper.CreateExtensionNupkg(
+                projectDir,
+                $"await kernel.SendAsync(new SubmitCode(\"\\\"{guid}\\\"\"));",
+                packageName,
+                packageVersion);
+
+
+
+            await kernel.SubmitCodeAsync($@"
+#i ""nuget:{nupkg.Directory.FullName}""
+#r ""nuget:{packageName},{packageVersion}""            ");
+
+            var file = provider.GetFileInfo("extensions/TestKernelExtension/resources/file.txt");
+
+            file.Should()
+                .NotBeNull();
+        }
+
+        [Theory]
+        [InlineData(Language.CSharp)]
+        [InlineData(Language.FSharp)]
+        public async Task It_tracks_extensions_that_are_not_file_providers(Language language)
+        {
+
+            var kernel = CreateKernel(language);
+            var provider = new FileProvider(kernel);
+
+            var projectDir = DirectoryUtility.CreateDirectory();
+            var fileToEmbed = new FileInfo(Path.Combine(projectDir.FullName, "file.txt"));
+            File.WriteAllText(fileToEmbed.FullName, "for testing only");
+            var packageName = $"MyTestExtension.{Path.GetRandomFileName()}";
+            var packageVersion = "2.0.0-" + Guid.NewGuid().ToString("N");
+            var guid = Guid.NewGuid().ToString();
+
+            var nupkg = await KernelExtensionTestHelper.CreateExtensionNupkg(
+                projectDir,
+                $"await kernel.SendAsync(new SubmitCode(\"\\\"{guid}\\\"\"));",
+                packageName,
+                packageVersion,
+                fileToEmbed);
+
+
+
+            await kernel.SubmitCodeAsync($@"
+#i ""nuget:{nupkg.Directory.FullName}""
+#r ""nuget:{packageName},{packageVersion}""            ");
+
+            var file = provider.GetFileInfo("extensions/TestKernelExtension/resources/file.txt");
+
+            file.Should()
+                .NotBeNull();
+        }
+
+        [Theory]
+        [InlineData(Language.CSharp)]
+        [InlineData(Language.FSharp)]
+        public void it_cannot_resolve_unregistered_extensions(Language language)
+        {
+            var kernel = CreateKernel(language);
+            var provider = new FileProvider(kernel);
+
+            var file = provider.GetFileInfo("extensions/not_found/resources/file.txt");
+
+            file.Should()
+                .NotBeNull();
+        }
+    }
+}

--- a/src/dotnet-interactive/Http/FileProvider.cs
+++ b/src/dotnet-interactive/Http/FileProvider.cs
@@ -57,6 +57,7 @@ namespace Microsoft.DotNet.Interactive.App.Http
 
         private string ProcessPath(string path)
         {
+            path = path.TrimStart('/');
             if (path.StartsWith("extensions/"))
             {
                 return string.Join("/", path.Split(new[] {"/"}, StringSplitOptions.RemoveEmptyEntries).Skip(2));
@@ -67,6 +68,7 @@ namespace Microsoft.DotNet.Interactive.App.Http
 
         private IFileProvider SelectProvider(string path)
         {
+            path = path.TrimStart('/');
             if (path.StartsWith("extensions/"))
             {
                 var name = path.Split(new[] {"/"}, StringSplitOptions.RemoveEmptyEntries)[1];

--- a/src/dotnet-interactive/Http/FileProvider.cs
+++ b/src/dotnet-interactive/Http/FileProvider.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Reactive.Linq;
+using Microsoft.DotNet.Interactive.Events;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.DotNet.Interactive.App.Http
+{
+    public class FileProvider : IFileProvider, IDisposable
+    {
+        private readonly EmbeddedFileProvider _root;
+        private readonly IDisposable _eventSubscription;
+
+        public FileProvider(Kernel kernel)
+        {
+            if (kernel == null) throw new ArgumentNullException(nameof(kernel));
+
+            _root = new EmbeddedFileProvider(typeof(FileProvider).Assembly);
+            _eventSubscription = kernel.KernelEvents
+                .OfType<KernelExtensionLoaded>()
+                .Subscribe(@event => RegisterExtension(@event.KernelExtension));
+        }
+
+        private void RegisterExtension(IKernelExtension kernelExtension)
+        {
+            if (kernelExtension is IStaticContentSource source)
+            {
+
+            }
+        }
+
+        public IFileInfo GetFileInfo(string subpath)
+        {
+            var provider = SelectProvider(subpath);
+            var path = ProcessPath(subpath);
+            return provider.GetFileInfo(path);
+        }
+
+        public IDirectoryContents GetDirectoryContents(string subpath)
+        {
+            var provider = SelectProvider(subpath);
+            var path = ProcessPath(subpath);
+            return provider.GetDirectoryContents(path);
+        }
+
+        public IChangeToken Watch(string filter)
+        {
+            return NullChangeToken.Singleton;
+        }
+
+        private string ProcessPath(string path)
+        {
+            if (path.StartsWith("extensions/"))
+            {
+                throw new NotImplementedException();
+            }
+
+            return path;
+        }
+
+        private IFileProvider SelectProvider(string path)
+        {
+            if (path.StartsWith("extensions/"))
+            {
+                throw new NotImplementedException();
+            }
+
+            return _root;
+        }
+
+        public void Dispose()
+        {
+            _eventSubscription.Dispose();
+        }
+    }
+}

--- a/src/dotnet-interactive/Http/StaticContentSourceNotFoundException.cs
+++ b/src/dotnet-interactive/Http/StaticContentSourceNotFoundException.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.DotNet.Interactive.App.Http
+{
+    public class StaticContentSourceNotFoundException : Exception
+    {
+        public StaticContentSourceNotFoundException(string name):base($"Cannot find static content source {name}")
+        {
+            
+        }
+    }
+}

--- a/src/dotnet-interactive/HttpApiBootstrapper.cs
+++ b/src/dotnet-interactive/HttpApiBootstrapper.cs
@@ -78,17 +78,17 @@ function loadDotnetInteractiveApi() {
         .then((root) => {
             // use probing to find host url and api resources
             // load interactive helpers and language services
-            let dotnet_require = require.config({
+            let dotnetInteractiveRequire = require.config({
                 context: '$CACHE_BUSTER$',
                 paths: {
                     'dotnet-interactive': `${root}resources`
                 }
             }) || require;
-            if (!window.dotnet_require) {
-                window.dotnet_require = dotnet_require;
+            if (!window.dotnetInteractiveRequire) {
+                window.dotnetInteractiveRequire = dotnetInteractiveRequire;
             }
         
-            dotnet_require([
+            dotnetInteractiveRequire([
                     'dotnet-interactive/dotnet-interactive'
                 ],
                 function (dotnet) {

--- a/src/dotnet-interactive/HttpApiBootstrapper.cs
+++ b/src/dotnet-interactive/HttpApiBootstrapper.cs
@@ -88,7 +88,7 @@ function loadDotnetInteractiveApi() {
             let dotnetInteractiveExtensionsRequire = require.config({
                 context: '$CACHE_BUSTER$',
                 paths: {
-                    'dotnet-interactive': `${root}extensions`
+                    'dotnet-interactive-extensions': `${root}extensions`
                 }
             }) || require;
             if (!window.dotnetInteractiveRequire) {

--- a/src/dotnet-interactive/HttpApiBootstrapper.cs
+++ b/src/dotnet-interactive/HttpApiBootstrapper.cs
@@ -84,8 +84,19 @@ function loadDotnetInteractiveApi() {
                     'dotnet-interactive': `${root}resources`
                 }
             }) || require;
+
+            let dotnetInteractiveExtensionsRequire = require.config({
+                context: '$CACHE_BUSTER$',
+                paths: {
+                    'dotnet-interactive': `${root}extensions`
+                }
+            }) || require;
             if (!window.dotnetInteractiveRequire) {
                 window.dotnetInteractiveRequire = dotnetInteractiveRequire;
+            }
+
+            if (!window.dotnetInteractiveExtensionsRequire) {
+                window.dotnetInteractiveExtensionsRequire = dotnetInteractiveExtensionsRequire;
             }
         
             dotnetInteractiveRequire([

--- a/src/dotnet-interactive/Startup.cs
+++ b/src/dotnet-interactive/Startup.cs
@@ -66,9 +66,10 @@ namespace Microsoft.DotNet.Interactive.App
             var operation = Pocket.Logger.Log.OnEnterAndExit();
             if (StartupOptions.EnableHttpApi)
             {
+                var kernel = serviceProvider.GetRequiredService<Kernel>();
                 app.UseStaticFiles(new StaticFileOptions
                 {
-                    FileProvider = new EmbeddedFileProvider(typeof(Startup).Assembly)
+                    FileProvider = new FileProvider(kernel)
                 });
                 app.UseWebSockets();
                 app.UseCors("default");
@@ -82,7 +83,7 @@ namespace Microsoft.DotNet.Interactive.App
                         r.Routes.Add(new DiscoveryRouter(frontendEnvironment));
                     }
 
-                    var kernel = serviceProvider.GetRequiredService<Kernel>();
+                   
                     var startupOptions = serviceProvider.GetRequiredService<StartupOptions>();
                     if (startupOptions.EnableHttpApi)
                     {


### PR DESCRIPTION
kernel extensions can provide content if they implement the ```IStaticContentSource``` interface