### PR TITLE
Adopt edit submission api

### DIFF
--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -98,7 +98,7 @@
         },
         "dotnet-interactive.minimumInteractiveToolVersion": {
           "type": "string",
-          "default": "1.0.145102",
+          "default": "1.0.145103",
           "description": "The minimum required version of the .NET Interactive tool."
         }
       }

--- a/src/dotnet-interactive-vscode/src/vscode/commands.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/commands.ts
@@ -7,7 +7,7 @@ import { acquireDotnetInteractive } from '../acquisition';
 import { InstallInteractiveArgs, InteractiveLaunchOptions } from '../interfaces';
 import { ClientMapper } from '../clientMapper';
 import { getEol } from './vscodeUtilities';
-import { toNotebookDocument } from './notebookProvider';
+import { toNotebookDocument, DotNetInteractiveNotebookContentProvider } from './notebookProvider';
 
 export function registerAcquisitionCommands(context: vscode.ExtensionContext, dotnetPath: string) {
     const config = vscode.workspace.getConfiguration('dotnet-interactive');
@@ -92,15 +92,10 @@ export function registerKernelCommands(context: vscode.ExtensionContext, clientM
             document = vscode.notebook.activeNotebookEditor.document;
         }
 
-        const cellCount = document.cells.length;
-        const notebookEditor = vscode.notebook.activeNotebookEditor;
-        if (notebookEditor) {
-            notebookEditor.edit(editBuilder => {
-                for (let i = 0; i < cellCount; i++) {
-                    editBuilder.replaceMetadata(i, { runState: vscode.NotebookCellRunState.Idle });
-                }
-            });
-        }
+        const d = document;
+        document.cells.forEach(async cell => {
+            await DotNetInteractiveNotebookContentProvider.updateCellMetadata(d, cell, { runState: vscode.NotebookCellRunState.Idle });
+        });
 
         clientMapper.closeClient(document.uri);
     }));

--- a/src/dotnet-interactive-vscode/src/vscode/notebookProvider.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/notebookProvider.ts
@@ -119,8 +119,6 @@ export class DotNetInteractiveNotebookContentProvider implements vscode.Notebook
     }
 
     static async updateCellMetadata(document: vscode.NotebookDocument, cell: vscode.NotebookCell, metadata: vscode.NotebookCellMetadata) {
-        // cell.metadata = metadata;
-        // todo: new api when it works
         const cellIndex = document.cells.findIndex(c => c === cell);
         if (cellIndex >= 0) {
             const edit = new vscode.WorkspaceEdit();
@@ -130,9 +128,6 @@ export class DotNetInteractiveNotebookContentProvider implements vscode.Notebook
     }
 
     static async updateCellOutputs(document: vscode.NotebookDocument, cell: vscode.NotebookCell, outputs: vscode.CellOutput[]) {
-        // cell.outputs = [];
-        // cell.outputs = outputs;
-        // todo: new api when it works
         const cellIndex = document.cells.findIndex(c => c === cell);
         if (cellIndex >= 0) {
             const edit = new vscode.WorkspaceEdit();

--- a/src/dotnet-interactive-vscode/src/vscode/vscode.proposed.d.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/vscode.proposed.d.ts
@@ -2076,7 +2076,14 @@ declare module 'vscode' {
 		readonly visible: boolean;
 
 		/**
-		 * Event fired when the visibility of the view changes
+		 * Event fired when the visibility of the view changes.
+		 *
+		 * Actions that trigger a visibility change:
+		 *
+		 * - The view is collapsed or expanded.
+		 * - The user switches to a different view group in the sidebar or panel.
+		 *
+		 * Note that hiding a view using the context menu instead disposes of the view and fires `onDidDispose`.
 		 */
 		readonly onDidChangeVisibility: Event<void>;
 	}
@@ -2085,8 +2092,10 @@ declare module 'vscode' {
 		/**
 		 * Persisted state from the webview content.
 		 *
-		 * To save resources, VS Code normally deallocates webview views that are not visible. For example, if the user
-		 * collapse a view or switching to another top level activity, the underlying webview document is deallocates.
+		 * To save resources, VS Code normally deallocates webview documents (the iframe content) that are not visible.
+		 * For example, when the user collapse a view or switches to another top level activity in the sidebar, the
+		 * `WebviewView` itself is kept alive but the webview's underlying document is deallocated. It is recreated when
+		 * the view becomes visible again.
 		 *
 		 * You can prevent this behavior by setting `retainContextWhenHidden` in the `WebviewOptions`. However this
 		 * increases resource usage and should be avoided wherever possible. Instead, you can use persisted state to


### PR DESCRIPTION
The edit submission api is able to perform in scenarios where the notebook doesn't exist locally (like in a live share session) and routes the edits correctly.

As @jrieken helped me understand earlier:
> The notebook editor and the workspace edit API. The former is OK to use when running commands or other UI-like opertion, but when executing a cell we don't guarantee that a notebook editor exists (e.g your notebook document might be driven via a liveshare session) and then it's better to use the edit-api 
