### PR TITLE
add command for new blank notebook

### DIFF
--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -27,6 +27,7 @@
     "onNotebookEditor:dotnet-interactive",
     "onNotebookEditor:dotnet-interactive-jupyter",
     "onCommand:dotnet-interactive.acquire",
+    "onCommand:dotnet-interactive.newNotebook",
     "onCommand:dotnet-interactive.openNotebook",
     "onCommand:dotnet-interactive.saveAsNotebook"
   ],
@@ -98,7 +99,7 @@
         },
         "dotnet-interactive.minimumInteractiveToolVersion": {
           "type": "string",
-          "default": "1.0.145103",
+          "default": "1.0.145201",
           "description": "The minimum required version of the .NET Interactive tool."
         }
       }
@@ -117,6 +118,10 @@
         "title": ".NET Interactive: Save notebook as..."
       },
       {
+        "command": "dotnet-interactive.newNotebook",
+        "title": ".NET Interactive: Create new blank notebook"
+      },
+      {
         "command": "dotnet-interactive.restartCurrentNotebookKernel",
         "title": ".NET Interactive: Restart the current notebook's kernel"
       },
@@ -127,6 +132,13 @@
       {
         "command": "dotnet-interactive.stopAllNotebookKernels",
         "title": ".NET Interactive: Stop all notebook kernels"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "dotnet-interactive.newNotebook",
+        "key": "ctrl+alt+shift+n",
+        "mac": "cmd+alt+shift+n"
       }
     ],
     "languages": [

--- a/src/dotnet-interactive-vscode/src/clientMapper.ts
+++ b/src/dotnet-interactive-vscode/src/clientMapper.ts
@@ -27,6 +27,24 @@ export class ClientMapper {
         return client;
     }
 
+    reassociateClient(oldUri: Uri, newUri: Uri) {
+        const oldKey = ClientMapper.keyFromUri(oldUri);
+        const newKey = ClientMapper.keyFromUri(newUri);
+        if (oldKey === newKey) {
+            // no change
+            return;
+        }
+
+        const client = this.clientMap.get(oldKey);
+        if (!client) {
+            // no old client found, nothing to do
+            return;
+        }
+
+        this.clientMap.set(newKey, client);
+        this.clientMap.delete(oldKey);
+    }
+
     closeClient(uri: Uri) {
         let key = ClientMapper.keyFromUri(uri);
         let client = this.clientMap.get(key);

--- a/src/dotnet-interactive-vscode/src/extension.ts
+++ b/src/dotnet-interactive-vscode/src/extension.ts
@@ -7,7 +7,7 @@ import { ClientMapper } from './clientMapper';
 import { DotNetInteractiveNotebookContentProvider } from './vscode/notebookProvider';
 import { StdioKernelTransport } from './stdioKernelTransport';
 import { registerLanguageProviders } from './vscode/languageProvider';
-import { execute, registerAcquisitionCommands, registerKernelCommands, registerFileFormatCommands } from './vscode/commands';
+import { execute, registerAcquisitionCommands, registerKernelCommands, registerFileCommands } from './vscode/commands';
 
 import { IDotnetAcquireResult } from './interfaces/dotnet';
 import { InteractiveLaunchOptions, InstallInteractiveArgs } from './interfaces';
@@ -53,7 +53,7 @@ export async function activate(context: vscode.ExtensionContext) {
     });
 
     registerKernelCommands(context, clientMapper);
-    registerFileFormatCommands(context, clientMapper);
+    registerFileCommands(context, clientMapper);
 
     const diagnosticDelay = config.get<number>('liveDiagnosticDelay') || 500; // fall back to something reasonable
 

--- a/src/dotnet-interactive-vscode/src/tests/unit/client.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/client.test.ts
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 import { ClientMapper } from '../../clientMapper';
 import { TestKernelTransport } from './testKernelTransport';
 import { CellOutput, CellOutputKind } from '../../interfaces/vscode';
-import { CodeSubmissionReceivedType, CompleteCodeSubmissionReceivedType, CommandSucceededType, DisplayedValueProducedType, ReturnValueProducedType, UpdateDisplayedValueType, DisplayedValueUpdatedType } from '../../contracts';
+import { CodeSubmissionReceivedType, CompleteCodeSubmissionReceivedType, CommandSucceededType, DisplayedValueProducedType, ReturnValueProducedType, DisplayedValueUpdatedType } from '../../contracts';
 
 describe('InteractiveClient tests', () => {
     it('command execution returns deferred events', async () => {
@@ -326,5 +326,23 @@ describe('InteractiveClient tests', () => {
                 }
             }
         ]);
+    });
+
+    it('clientMapper can reassociate clients', (done) => {
+        let transportCreated = false;
+        const clientMapper = new ClientMapper(async (_notebookPath) => {
+            if (transportCreated) {
+                done('transport already created; this function should not have been called again');
+            }
+
+            transportCreated = true;
+            return new TestKernelTransport({});
+        });
+        clientMapper.getOrAddClient({ fsPath: 'test-path.dib' }).then(_client => {
+            clientMapper.reassociateClient({ fsPath: 'test-path.dib' }, { fsPath: 'updated-path.dib' });
+            clientMapper.getOrAddClient({ fsPath: 'updated-path.dib' }).then(_reassociatedClient => {
+                done();
+            });
+        });
     });
 });

--- a/src/dotnet-interactive-vscode/src/vscode/commands.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/commands.ts
@@ -3,10 +3,11 @@
 
 import * as vscode from 'vscode';
 import * as cp from 'child_process';
+import * as path from 'path';
 import { acquireDotnetInteractive } from '../acquisition';
 import { InstallInteractiveArgs, InteractiveLaunchOptions } from '../interfaces';
 import { ClientMapper } from '../clientMapper';
-import { getEol } from './vscodeUtilities';
+import { getEol, isUnsavedNotebook } from './vscodeUtilities';
 import { toNotebookDocument, DotNetInteractiveNotebookContentProvider } from './notebookProvider';
 
 export function registerAcquisitionCommands(context: vscode.ExtensionContext, dotnetPath: string) {
@@ -107,7 +108,7 @@ export function registerKernelCommands(context: vscode.ExtensionContext, clientM
     }));
 }
 
-export function registerFileFormatCommands(context: vscode.ExtensionContext, clientMapper: ClientMapper) {
+export function registerFileCommands(context: vscode.ExtensionContext, clientMapper: ClientMapper) {
 
     const eol = getEol();
 
@@ -115,6 +116,32 @@ export function registerFileFormatCommands(context: vscode.ExtensionContext, cli
         'Jupyter Notebooks': ['ipynb'],
         '.NET Interactive Notebooks': ['dib', 'dotnet-interactive']
     };
+
+    function workspaceHasUnsavedNotebookWithName(fileName: string): boolean {
+        return vscode.workspace.textDocuments.findIndex(textDocument => {
+            if (textDocument.notebook) {
+                const notebookUri = textDocument.notebook.uri;
+                return isUnsavedNotebook(notebookUri) && path.basename(notebookUri.fsPath) === fileName;
+            }
+
+            return false;
+        }) >= 0;
+    }
+
+    function getNewNotebookName(): string {
+        let suffix = 1;
+        while (workspaceHasUnsavedNotebookWithName(`Untitled-${suffix}.dib`)) {
+            suffix++;
+        }
+
+        return `Untitled-${suffix}.dib`;
+    }
+
+    context.subscriptions.push(vscode.commands.registerCommand('dotnet-interactive.newNotebook', async () => {
+        const fileName = getNewNotebookName();
+        const newUri = vscode.Uri.file(fileName).with({ scheme: 'untitled', path: fileName });
+        await vscode.commands.executeCommand('vscode.openWith', newUri, 'dotnet-interactive');
+    }));
 
     context.subscriptions.push(vscode.commands.registerCommand('dotnet-interactive.openNotebook', async (notebookUri: vscode.Uri | undefined) => {
         // ensure we have a notebook uri

--- a/src/dotnet-interactive-vscode/src/vscode/vscodeUtilities.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/vscodeUtilities.ts
@@ -59,3 +59,7 @@ export function getEol(): Eol {
             }
     }
 }
+
+export function isUnsavedNotebook(uri: vscode.Uri): boolean {
+    return uri.scheme === 'untitled';
+}


### PR DESCRIPTION
The new command's display name is ".NET Interactive: Create new blank notebook" for two reasons:

1. All of our other command names start with ".NET Interactive:" to remove any ambiguity and I thought that should continue.
2. The Python command to create a new Jupyter notebook is ["Create New Blank Jupyter Notebook"](https://github.com/microsoft/vscode-python/blob/de1a7bcd3d1eb337db27f60e5953cc5d325585a3/package.nls.json#L114).

I've added a keybinding of `Ctrl+Alt+Shift+N` to invoke this.  It's extremely verbose, but I don't want to steal any existing keybinding, and unfortunately that means we can't use the chord `Ctrl+N, D` because that causes the default `Ctrl+N` to be unbound because it's waiting for a chord to continue, and that's bad.  An alternative is to not have a default keybinding and let users add their own that simply invokes the command `dotnet-interactive.newNotebook`.  I'm open to either approach.

As for changes to code, there were really only 3 of note:

1. To create a new untitled notebook, I avoided calling `workbench.action.files.newUntitledFile { viewType: 'dotnet-interactive' }` because that creates a new notebook with the name `Untitled-1` (note, no file extension) and when the user hits `Ctrl+S`, the save dialog defaults to the `.txt` extension, and that can cause a whole bunch of problems because the file format is chosen depending on the extension, and if the user chooses `.txt` (or `.my-notebook`, etc.) we have no idea how to serialize the notebook.  Instead, I manually create a URI with the `.dib` file extension pre-applied.  This means when the user finally saves their notebook, it'll have the correct extension.  It's still possible for them to manually override this, but that's on them; if they're mangling the file extensions we can't help them.  To enable multiple unsaved notebooks, I look through the existing notebooks until I can find a numeric suffix that's unused, e.g., `Untitled-9.dib`.

2. Add the method `ClientMapper.reassociateClient`.  This is necessary because the notebook's runtime is associated with the notebook's URI.  In normal scenarios, this will be something like `C:\Users\brettfo\Desktop\my-notebook.dib`.  In the case of a new unsaved notebook, the URI is `Untitled-1.dib`.  Initially this is fine, but as soon as the user saves the notebook, the URI will suddenly be a file path like above and since we don't want them to loose their current runtime values and leave around a stale kernel, the reassociate method does exactly that: reassociates the kernel process with the new URI.

3. VS Code will call `openNotebook` when creating a new notebook viewer, but if it's an unsaved notebook created through the new command, nothing exists on disk.  The fix for this was simple; if it's a new unsaved file, short-circuit everything and create an empty notebook.