### PR TITLE
let vs code handle markdown cells

### DIFF
--- a/src/dotnet-interactive-vscode/src/interactiveNotebook.ts
+++ b/src/dotnet-interactive-vscode/src/interactiveNotebook.ts
@@ -13,7 +13,6 @@ export const notebookCellLanguages: Array<string> = [
     'dotnet-interactive.fsharp',
     'dotnet-interactive.html',
     'dotnet-interactive.javascript',
-    'dotnet-interactive.markdown',
     'dotnet-interactive.pwsh'
 ];
 


### PR DESCRIPTION
VS Code provides a markdown cell type for notebooks, so we don't need to provide a duplicate.

![image](https://user-images.githubusercontent.com/926281/92641322-682b3d80-f293-11ea-9dcc-5fa685e066c9.png)

Fixes #720.