### PR TITLE
check for double encoding

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
         {
 
             [Fact]
-            public void does_not_double_encode_json_string()
+            public void does_not_double_encode_HTML_string()
             {
                 var htmlString = "<b>Text</b>";
                 var formatter = HtmlFormatter.GetPreferredFormatterFor<string>();

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
@@ -24,6 +24,22 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
     {
         public class Objects : FormatterTestBase
         {
+
+            [Fact]
+            public void does_not_double_encode_json_string()
+            {
+                var htmlString = "<b>Text</b>";
+                var formatter = HtmlFormatter.GetPreferredFormatterFor<string>();
+                var writer = new StringWriter();
+
+                formatter.Format(htmlString, writer);
+
+                writer
+                    .ToString()
+                    .Should()
+                    .Be(htmlString);
+            }
+
             [Fact]
             public void Formatters_are_generated_on_the_fly_when_HTML_mime_type_is_requested()
             {

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/JsonFormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/JsonFormatterTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using FluentAssertions;
@@ -27,6 +28,21 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
                 .ToString()
                 .Should()
                 .Be(jtoken.ToString(Newtonsoft.Json.Formatting.None));
+        }
+
+        [Fact]
+        public void does_not_double_encode_json_string()
+        {
+            var jsonString = "{\"property\": 1}";
+            var formatter = JsonFormatter.GetPreferredFormatterFor<string>();
+            var writer = new StringWriter();
+
+            formatter.Format(jsonString, writer);
+
+            writer
+                .ToString()
+                .Should()
+                .Be(jsonString);
         }
 
         public static IEnumerable<object[]> JTokens()


### PR DESCRIPTION
displaying html and json literals produce double encoded values,

As Reported in #769