### PR TITLE
refactor vscode to make future work easier

### DIFF
--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -33,7 +33,7 @@
     "onCommand:dotnet-interactive.openNotebook",
     "onCommand:dotnet-interactive.saveAsNotebook"
   ],
-  "main": "./out/extension.js",
+  "main": "./out/vscode/extension.js",
   "extensionDependencies": [
     "ms-dotnettools.vscode-dotnet-runtime"
   ],
@@ -99,7 +99,7 @@
         },
         "dotnet-interactive.minimumInteractiveToolVersion": {
           "type": "string",
-          "default": "1.0.146104",
+          "default": "1.0.146501",
           "description": "The minimum required version of the .NET Interactive tool."
         }
       }

--- a/src/dotnet-interactive-vscode/src/vscode/OutputChannelAdapter.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/OutputChannelAdapter.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { ReportChannel } from "./interfaces/vscode";
+import { ReportChannel } from "../interfaces/vscode";
 
 export class OutputChannelAdapter implements ReportChannel {
 

--- a/src/dotnet-interactive-vscode/src/vscode/commands.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/commands.ts
@@ -8,7 +8,8 @@ import { acquireDotnetInteractive } from '../acquisition';
 import { InstallInteractiveArgs, InteractiveLaunchOptions } from '../interfaces';
 import { ClientMapper } from '../clientMapper';
 import { getEol, isUnsavedNotebook } from './vscodeUtilities';
-import { toNotebookDocument, DotNetInteractiveNotebookContentProvider } from './notebookProvider';
+import { toNotebookDocument } from './notebookContentProvider';
+import { updateCellMetadata } from './notebookKernel';
 
 export function registerAcquisitionCommands(context: vscode.ExtensionContext, dotnetPath: string) {
     const config = vscode.workspace.getConfiguration('dotnet-interactive');
@@ -26,7 +27,7 @@ export function registerAcquisitionCommands(context: vscode.ExtensionContext, do
         const launchOptions = await acquireDotnetInteractive(
             args,
             minDotNetInteractiveVersion!,
-            context.globalStoragePath,
+            context.globalStorageUri.fsPath,
             getInteractiveVersion,
             createToolManifest,
             async (version: string) => { await vscode.window.showInformationMessage(`Installing .NET Interactive version ${version}...`); },
@@ -95,7 +96,7 @@ export function registerKernelCommands(context: vscode.ExtensionContext, clientM
 
         const d = document;
         document.cells.forEach(async cell => {
-            await DotNetInteractiveNotebookContentProvider.updateCellMetadata(d, cell, { runState: vscode.NotebookCellRunState.Idle });
+            await updateCellMetadata(d, cell, { runState: vscode.NotebookCellRunState.Idle });
         });
 
         clientMapper.closeClient(document.uri);

--- a/src/dotnet-interactive-vscode/src/vscode/extension.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/extension.ts
@@ -3,18 +3,18 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { ClientMapper } from './clientMapper';
+import { ClientMapper } from '../clientMapper';
 
-import { DotNetInteractiveNotebookContentProvider } from './vscode/notebookProvider';
-import { StdioKernelTransport } from './stdioKernelTransport';
-import { registerLanguageProviders } from './vscode/languageProvider';
-import { execute, registerAcquisitionCommands, registerKernelCommands, registerFileCommands } from './vscode/commands';
+import { DotNetInteractiveNotebookContentProvider } from './notebookProvider';
+import { StdioKernelTransport } from '../stdioKernelTransport';
+import { registerLanguageProviders } from './languageProvider';
+import { execute, registerAcquisitionCommands, registerKernelCommands, registerFileCommands } from './commands';
 
-import { IDotnetAcquireResult } from './interfaces/dotnet';
-import { InteractiveLaunchOptions, InstallInteractiveArgs } from './interfaces';
+import { IDotnetAcquireResult } from '../interfaces/dotnet';
+import { InteractiveLaunchOptions, InstallInteractiveArgs } from '../interfaces';
 
-import compareVersions = require("../node_modules/compare-versions");
-import { processArguments } from './utilities';
+import compareVersions = require("compare-versions");
+import { processArguments } from '../utilities';
 import { OutputChannelAdapter } from './OutputChannelAdapter';
 
 export async function activate(context: vscode.ExtensionContext) {

--- a/src/dotnet-interactive-vscode/src/vscode/extension.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/extension.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { ClientMapper } from '../clientMapper';
 
-import { DotNetInteractiveNotebookContentProvider } from './notebookProvider';
+import { DotNetInteractiveNotebookContentProvider } from './notebookContentProvider';
 import { StdioKernelTransport } from '../stdioKernelTransport';
 import { registerLanguageProviders } from './languageProvider';
 import { execute, registerAcquisitionCommands, registerKernelCommands, registerFileCommands } from './commands';
@@ -16,6 +16,8 @@ import { InteractiveLaunchOptions, InstallInteractiveArgs } from '../interfaces'
 import compareVersions = require("compare-versions");
 import { processArguments } from '../utilities';
 import { OutputChannelAdapter } from './OutputChannelAdapter';
+import { DotNetInteractiveNotebookKernel } from './notebookKernel';
+import { DotNetInteractiveNotebookKernelProvider } from './notebookKernelProvider';
 
 export async function activate(context: vscode.ExtensionContext) {
     // install dotnet or use global
@@ -69,10 +71,12 @@ export async function activate(context: vscode.ExtensionContext) {
         viewType: ['dotnet-interactive', 'dotnet-interactive-jupyter'],
         filenamePattern: '*.{dib,dotnet-interactive,ipynb}'
     };
-    const notebookProvider = new DotNetInteractiveNotebookContentProvider(clientMapper, diagnosticsChannel, apiBootstrapperUri);
-    context.subscriptions.push(vscode.notebook.registerNotebookContentProvider('dotnet-interactive', notebookProvider));
-    context.subscriptions.push(vscode.notebook.registerNotebookContentProvider('dotnet-interactive-jupyter', notebookProvider));
-    context.subscriptions.push(vscode.notebook.registerNotebookKernelProvider(selector, notebookProvider));
+    const notebookContentProvider = new DotNetInteractiveNotebookContentProvider(clientMapper);
+    const notebookKernel = new DotNetInteractiveNotebookKernel(clientMapper, apiBootstrapperUri);
+    const notebookKernelProvider = new DotNetInteractiveNotebookKernelProvider(notebookKernel);
+    context.subscriptions.push(vscode.notebook.registerNotebookContentProvider('dotnet-interactive', notebookContentProvider));
+    context.subscriptions.push(vscode.notebook.registerNotebookContentProvider('dotnet-interactive-jupyter', notebookContentProvider));
+    context.subscriptions.push(vscode.notebook.registerNotebookKernelProvider(selector, notebookKernelProvider));
     context.subscriptions.push(vscode.notebook.onDidCloseNotebookDocument(notebookDocument => clientMapper.closeClient(notebookDocument.uri)));
     context.subscriptions.push(registerLanguageProviders(clientMapper, diagnosticDelay));
 }

--- a/src/dotnet-interactive-vscode/src/vscode/notebookKernel.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/notebookKernel.ts
@@ -1,0 +1,87 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import * as vscode from 'vscode';
+
+import { toVsCodeDiagnostic } from "./vscodeUtilities";
+import { ClientMapper } from "../clientMapper";
+import { CellOutput } from '../interfaces/vscode';
+import { getDiagnosticCollection } from './diagnostics';
+import { getSimpleLanguage } from "../interactiveNotebook";
+import { Diagnostic, DiagnosticSeverity } from "../contracts";
+
+export class DotNetInteractiveNotebookKernel implements vscode.NotebookKernel {
+    id?: string | undefined;
+    label: string;
+    description?: string | undefined;
+    detail?: string | undefined;
+    isPreferred?: boolean | undefined;
+    preloads?: vscode.Uri[] | undefined;
+
+    constructor(readonly clientMapper: ClientMapper, apiBootstrapperUri: vscode.Uri) {
+        this.label = ".NET Interactive";
+        this.preloads = [apiBootstrapperUri];
+    }
+
+    async executeAllCells(document: vscode.NotebookDocument): Promise<void> {
+        for (let cell of document.cells) {
+            await this.executeCell(document, cell);
+        }
+    }
+
+    async executeCell(document: vscode.NotebookDocument, cell: vscode.NotebookCell): Promise<void> {
+        const startTime = Date.now();
+        await updateCellMetadata(document, cell, {
+            runStartTime: startTime,
+            runState: vscode.NotebookCellRunState.Running,
+        });
+        await updateCellOutputs(document, cell, []);
+        let client = await this.clientMapper.getOrAddClient(document.uri);
+        let source = cell.document.getText();
+        function outputObserver(outputs: Array<CellOutput>) {
+            updateCellOutputs(document, cell, outputs).then(() => { });
+        }
+
+        let diagnosticCollection = getDiagnosticCollection(cell.uri);
+        function diagnosticObserver(diags: Array<Diagnostic>) {
+            diagnosticCollection.set(cell.uri, diags.filter(d => d.severity !== DiagnosticSeverity.Hidden).map(toVsCodeDiagnostic));
+        }
+        return client.execute(source, getSimpleLanguage(cell.language), outputObserver, diagnosticObserver).then(async () => {
+            await updateCellMetadata(document, cell, {
+                runState: vscode.NotebookCellRunState.Success,
+                lastRunDuration: Date.now() - startTime,
+            });
+        }).catch(async () => {
+            await updateCellMetadata(document, cell, {
+                runState: vscode.NotebookCellRunState.Error,
+                lastRunDuration: Date.now() - startTime,
+            });
+        });
+    }
+
+    cancelCellExecution(document: vscode.NotebookDocument, cell: vscode.NotebookCell): void {
+        // not supported
+    }
+
+    cancelAllCellsExecution(document: vscode.NotebookDocument): void {
+        // not supported
+    }
+}
+
+export async function updateCellMetadata(document: vscode.NotebookDocument, cell: vscode.NotebookCell, metadata: vscode.NotebookCellMetadata): Promise<void> {
+    const cellIndex = document.cells.findIndex(c => c === cell);
+    if (cellIndex >= 0) {
+        const edit = new vscode.WorkspaceEdit();
+        edit.replaceNotebookCellMetadata(document.uri, cellIndex, metadata);
+        await vscode.workspace.applyEdit(edit);
+    }
+}
+
+export async function updateCellOutputs(document: vscode.NotebookDocument, cell: vscode.NotebookCell, outputs: vscode.CellOutput[]): Promise<void> {
+    const cellIndex = document.cells.findIndex(c => c === cell);
+    if (cellIndex >= 0) {
+        const edit = new vscode.WorkspaceEdit();
+        edit.replaceNotebookCellOutput(document.uri, cellIndex, outputs);
+        await vscode.workspace.applyEdit(edit);
+    }
+}

--- a/src/dotnet-interactive-vscode/src/vscode/notebookKernelProvider.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/notebookKernelProvider.ts
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import * as vscode from 'vscode';
+
+import { DotNetInteractiveNotebookKernel } from "./notebookKernel";
+
+export class DotNetInteractiveNotebookKernelProvider implements vscode.NotebookKernelProvider<DotNetInteractiveNotebookKernel> {
+    constructor(readonly kernel: DotNetInteractiveNotebookKernel) {
+    }
+
+    onDidChangeKernels?: vscode.Event<vscode.NotebookDocument | undefined> | undefined;
+
+    provideKernels(document: vscode.NotebookDocument, token: vscode.CancellationToken): vscode.ProviderResult<DotNetInteractiveNotebookKernel[]> {
+        return [this.kernel];
+    }
+}

--- a/src/dotnet-interactive-vscode/src/vscode/vscode.d.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/vscode.d.ts
@@ -4700,7 +4700,7 @@ declare module 'vscode' {
 	 * The *effective* value (returned by [`get`](#WorkspaceConfiguration.get)) is computed by overriding or merging the values in the following order.
 	 *
 	 * ```
-	 * `defaultValue`
+	 * `defaultValue` (if defined in `package.json` otherwise derived from the value's type)
 	 * `globalValue` (if defined)
 	 * `workspaceValue` (if defined)
 	 * `workspaceFolderValue` (if defined)
@@ -10598,6 +10598,26 @@ declare module 'vscode' {
 		 * resource state.
 		 */
 		readonly decorations?: SourceControlResourceDecorations;
+
+		/**
+		 * Context value of the resource state. This can be used to contribute resource specific actions.
+		 * For example, if a resource is given a context value as `diffable`. When contributing actions to `scm/resourceState/context`
+		 * using `menus` extension point, you can specify context value for key `scmResourceState` in `when` expressions, like `scmResourceState == diffable`.
+		 * ```
+		 *	"contributes": {
+		 *		"menus": {
+		 *			"scm/resourceState/context": [
+		 *				{
+		 *					"command": "extension.diff",
+		 *					"when": "scmResourceState == diffable"
+		 *				}
+		 *			]
+		 *		}
+		 *	}
+		 * ```
+		 * This will show action `extension.diff` only for resources with `contextValue` is `diffable`.
+		 */
+		readonly contextValue?: string;
 	}
 
 	/**

--- a/src/dotnet-interactive-vscode/src/vscode/vscode.proposed.d.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/vscode.proposed.d.ts
@@ -2040,32 +2040,6 @@ declare module 'vscode' {
 
 	//#endregion
 
-	//#region Support `scmResourceState` in `when` clauses #86180 https://github.com/microsoft/vscode/issues/86180
-
-	export interface SourceControlResourceState {
-		/**
-		 * Context value of the resource state. This can be used to contribute resource specific actions.
-		 * For example, if a resource is given a context value as `diffable`. When contributing actions to `scm/resourceState/context`
-		 * using `menus` extension point, you can specify context value for key `scmResourceState` in `when` expressions, like `scmResourceState == diffable`.
-		 * ```
-		 *	"contributes": {
-		 *		"menus": {
-		 *			"scm/resourceState/context": [
-		 *				{
-		 *					"command": "extension.diff",
-		 *					"when": "scmResourceState == diffable"
-		 *				}
-		 *			]
-		 *		}
-		 *	}
-		 * ```
-		 * This will show action `extension.diff` only for resources with `contextValue` is `diffable`.
-		 */
-		readonly contextValue?: string;
-	}
-
-	//#endregion
-
 	//#region https://github.com/microsoft/vscode/issues/104436
 
 	export enum ExtensionRuntime {
@@ -2280,6 +2254,18 @@ declare module 'vscode' {
 		isWritableFileSystem(scheme: string): boolean | undefined;
 	}
 
+
+	//#endregion
+
+	//#region https://github.com/microsoft/vscode/issues/105667
+
+	export interface TreeView<T> {
+		/**
+		 * An optional human-readable description that will be rendered in the title of the view.
+		 * Setting the title description to null, undefined, or empty string will remove the title description from the view.
+		 */
+		description?: string | undefined;
+	}
 
 	//#endregion
 }


### PR DESCRIPTION
There is no functional change in this PR.

1. `extension.ts` and `OutputChannelAdapter.ts` are moved into the `vscode` directory.  This way, _only_ files in this directory depend on the VS Code APIs, which means everything else can be directly unit-tested.

2. Split the implementation of `notebookProvider.ts` into three separate files, one for each interface that it implemented.  This will make future testing work easier to add.

Doing this as a separate PR so that future testing/refactoring work doesn't have these changes thrown in as well, making it harder to review.