### PR TITLE
pre load 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-…

### DIFF
--- a/samples/ExtensionLab/ExtensionLab-DataFrame.dib
+++ b/samples/ExtensionLab/ExtensionLab-DataFrame.dib
@@ -20,8 +20,7 @@ Next, let's load up the `Microsoft.DotNet.Interactive.ExtensionLab` package.
 
 #!csharp
 
-#i "nuget:https://dotnet.myget.org/F/fsharp/api/v2/package"
-#r "nuget:Microsoft.DotNet.Interactive.ExtensionLab,1.0.0-beta.20426.1" 
+#r "nuget:Microsoft.DotNet.Interactive.ExtensionLab,*-*" 
 
 #!markdown
 

--- a/samples/ExtensionLab/ExtensionLab-SQL connections.dib
+++ b/samples/ExtensionLab/ExtensionLab-SQL connections.dib
@@ -15,7 +15,7 @@ This sample demonstrates how to use the `#!connect` extension
 #!csharp
 
 #i "c:\temp"
-#r "nuget:Microsoft.DotNet.Interactive.ExtensionLab" 
+#r "nuget:Microsoft.DotNet.Interactive.ExtensionLab, *-*"
 
 #!csharp
 

--- a/src/Microsoft.DotNet.Interactive.Tests/PackageRestoreContextTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/PackageRestoreContextTests.cs
@@ -185,10 +185,11 @@ namespace Microsoft.DotNet.Interactive.Tests
         public async Task Can_add_to_list_of_added_sources()
         {
             using var restoreContext = new PackageRestoreContext();
+
+            var savedRestoreSources = restoreContext.RestoreSources.ToArray();
             restoreContext.AddRestoreSource("https://completely FakerestoreSource");
             await restoreContext.RestoreAsync();
-
-            var restoreSources = restoreContext.RestoreSources;
+            var restoreSources = restoreContext.RestoreSources.Where(p => !savedRestoreSources.Contains(p));
             restoreSources.Should()
                           .ContainSingle("https://completely FakerestoreSource");
         }
@@ -197,11 +198,12 @@ namespace Microsoft.DotNet.Interactive.Tests
         public async Task Can_add_same_source_to_list_of_added_sources_without_error()
         {
             using var restoreContext = new PackageRestoreContext();
-            restoreContext.AddRestoreSource("https://completely FakerestoreSource");
-            restoreContext.AddRestoreSource("https://completely FakerestoreSource");
 
+            var savedRestoreSources = restoreContext.RestoreSources.ToArray();
+            restoreContext.AddRestoreSource("https://completely FakerestoreSource");
+            restoreContext.AddRestoreSource("https://completely FakerestoreSource");
             await restoreContext.RestoreAsync();
-            var restoreSources = restoreContext.RestoreSources;
+            var restoreSources = restoreContext.RestoreSources.Where(p => !savedRestoreSources.Contains(p));
             restoreSources.Should()
                           .ContainSingle("https://completely FakerestoreSource");
         }

--- a/src/Microsoft.DotNet.Interactive/PackageRestoreContext.cs
+++ b/src/Microsoft.DotNet.Interactive/PackageRestoreContext.cs
@@ -25,6 +25,8 @@ namespace Microsoft.DotNet.Interactive
 
         public PackageRestoreContext()
         {
+            // By default look in to the package source  "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
+            AddRestoreSource("https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json");
             _dependencies = new DependencyProvider(AssemblyProbingPaths, NativeProbingRoots);
             AppDomain.CurrentDomain.AssemblyLoad += OnAssemblyLoad;
         }

--- a/src/Microsoft.DotNet.Interactive/PackageRestoreContext.cs
+++ b/src/Microsoft.DotNet.Interactive/PackageRestoreContext.cs
@@ -25,8 +25,11 @@ namespace Microsoft.DotNet.Interactive
 
         public PackageRestoreContext()
         {
-            // By default look in to the package source  "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
+            // By default look in to the package sources
+            //    "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
+            //    "https://dotnet.myget.org/F/dotnet-try/api/v3/index.json"
             AddRestoreSource("https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json");
+            AddRestoreSource("https://dotnet.myget.org/F/dotnet-try/api/v3/index.json");
             _dependencies = new DependencyProvider(AssemblyProbingPaths, NativeProbingRoots);
             AppDomain.CurrentDomain.AssemblyLoad += OnAssemblyLoad;
         }


### PR DESCRIPTION
People using the ExtensionLab package have seen package resolution errors.

We fixed the underlying issue by removing from it the dependency on the fsharp.compiler.private.scripting package.  However, this change, ensures that the notebook will be able to find it, if script authors choose to use earlier versions of the package.

Update the samples so that they can select the latest preview versions of the package.