### PR TITLE
force stdio server to use UTF-8 encoding

### DIFF
--- a/src/Microsoft.DotNet.Interactive/Server/KernelClientServerExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/Server/KernelClientServerExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Pipes;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Client;
 
@@ -14,6 +15,8 @@ namespace Microsoft.DotNet.Interactive.Server
     {
         public static  KernelServer CreateKernelServer(this Kernel kernel, DirectoryInfo workingDir)
         {
+            Console.InputEncoding = Encoding.UTF8;
+            Console.OutputEncoding = Encoding.UTF8;
             return kernel.CreateKernelServer(Console.In, Console.Out, workingDir);
         }
 

--- a/src/dotnet-interactive.IntegrationTests/StdioKernelTests.cs
+++ b/src/dotnet-interactive.IntegrationTests/StdioKernelTests.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.DotNet.Interactive.Commands;
@@ -50,6 +50,23 @@ namespace Microsoft.DotNet.Interactive.App.IntegrationTests
                 .Should()
                 .EventuallyContainSingle<DisplayEvent>(
                     where: d => d.FormattedValues.Any(fv => fv.Value.Trim() == expected),
+                    timeout: 10_000);
+        }
+
+        [IntegrationFact]
+        public async Task stdio_server_encoding_is_utf_8()
+        {
+            using var client = await CreateClient();
+
+            var events = client.Events.ToSubscribedList();
+
+            client.SubmitCommand(new SubmitCode("System.Console.InputEncoding.EncodingName + \"/\" + System.Console.OutputEncoding.EncodingName"));
+            var expected = Encoding.UTF8.EncodingName + "/" + Encoding.UTF8.EncodingName;
+
+            events
+                .Should()
+                .EventuallyContainSingle<DisplayEvent>(
+                    where: d => d.FormattedValues.Any(FormattedValue => FormattedValue.Value == expected),
                     timeout: 10_000);
         }
     }


### PR DESCRIPTION
When the stdio server process is started, the input encoding defaults to code page 437 which is very restrictive and makes it so almost all operations with non-ASCII characters will be corrupted, so I force it to UTF-8.  Since this is set on process start, the only way to properly test it was via an integration test.

I also verified this works in VS Code.

Fixes #812.