### PR TITLE
ensure cell language is always defined

### DIFF
--- a/src/dotnet-interactive-vscode/src/vscode/notebookContentProvider.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/notebookContentProvider.ts
@@ -161,8 +161,13 @@ export function toNotebookDocument(document: vscode.NotebookDocument): NotebookD
 }
 
 function toNotebookCell(cell: vscode.NotebookCell): NotebookCell {
+    // `cell.language` doesn't always specify a value.  Using this workaround until
+    // issue https://github.com/microsoft/vscode/issues/107917 has been fixed.
+    const cellLanguage = !cell.language && cell.cellKind === vscode.CellKind.Markdown
+        ? "markdown"
+        : cell.language;
     return {
-        language: getSimpleLanguage(cell.language),
+        language: getSimpleLanguage(cellLanguage),
         contents: cell.document.getText(),
         outputs: cell.outputs.map(toNotebookCellOutput)
     };


### PR DESCRIPTION
Due to bug microsoft/vscode#107917, the property `cell.language` isn't always defined.  In the meantime, add a workaround to prevent any issues with file saving.

Fixes #811 (kind of).