### PR TITLE
don't track build telemetry on this repo

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,8 +34,6 @@ stages:
       enablePublishTestResults: true
       enablePublishBuildAssets: true
       enablePublishUsingPipelines: $(_PublishUsingPipelines)
-      enableTelemetry: true
-      helixRepo: dotnet/interactive
       jobs:
       - job: Windows_NT
         pool:
@@ -164,8 +162,6 @@ stages:
       enablePublishTestResults: true
       enablePublishBuildAssets: false
       enablePublishUsingPipelines: false
-      enableTelemetry: true
-      helixRepo: dotnet/interactive
       jobs:
       - job: Linux
         pool:
@@ -226,8 +222,6 @@ stages:
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
       enableMicrobuild: true
-      enableTelemetry: true
-      helixRepo: dotnet/interactive
       jobs:
       - job: Dockerfile_official_image
         pool:
@@ -244,8 +238,6 @@ stages:
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
       enableMicrobuild: true
-      enableTelemetry: true
-      helixRepo: dotnet/interactive
       jobs:
       - job: Dockerfile_Main
         pool:
@@ -262,8 +254,6 @@ stages:
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
       enableMicrobuild: true
-      enableTelemetry: true
-      helixRepo: dotnet/interactive
       jobs:
       - job: Dockerfile_Binder_Dependency
         pool:
@@ -280,8 +270,6 @@ stages:
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
       enableMicrobuild: true
-      enableTelemetry: true
-      helixRepo: dotnet/interactive
       jobs:
       - job: IntegrationTest
         dependsOn: Windows_NT


### PR DESCRIPTION
We don't do anything with it and it generates a bunch of warnings on the internal signed build.

~~Marked WIP until the [internal test build](https://dev.azure.com/dnceng/internal/_build/results?buildId=839259&view=results) has passed.~~ Internal build is good.