### PR TITLE
Microsoft DotNet Interactive Dependencies.

### DIFF
--- a/src/Microsoft.DotNet.Interactive/Microsoft.DotNet.Interactive.csproj
+++ b/src/Microsoft.DotNet.Interactive/Microsoft.DotNet.Interactive.csproj
@@ -32,7 +32,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FSharp.Compiler.Private.Scripting" />
+    <PackageReference Include="FSharp.Compiler.Private.Scripting">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
    <ItemGroup>	


### PR DESCRIPTION
The Microsoft.DotNet.Interactive nuget package has a dependency on the internal only FSharp.Compiler.Private.Scripting package.  This dependency is only necessary when building the notebook solution, so the project has been adjusted to remove the nuget package dependency.
