### PR TITLE
migrate to net5.0

### DIFF
--- a/DEVELOPER-GUIDE.md
+++ b/DEVELOPER-GUIDE.md
@@ -119,11 +119,11 @@ If you've made changes to `dotnet-interactive` and want to try them out with Vis
       -  "run",
       -  "dotnet-interactive",
       -  "--",
-      +  "/PATH/TO/REPO/ROOT/artifacts/bin/dotnet-interactive/Debug/netcoreapp3.1/Microsoft.DotNet.Interactive.App.dll",
+      +  "/PATH/TO/REPO/ROOT/artifacts/bin/dotnet-interactive/Debug/net5.0/Microsoft.DotNet.Interactive.App.dll",
          "[vscode]",
          "stdio",
-         "--http-port-range",
-         "1000-3000"
+         "--working-dir",
+         "{working_dir}"
        ]
       ```
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
     <SystemDiagnosticsProcessVersion>4.3.0</SystemDiagnosticsProcessVersion>
     <SystemReactiveVersion>4.4.1</SystemReactiveVersion>
     <SystemRuntimeExtensionsVersion>4.3.0</SystemRuntimeExtensionsVersion>
-    <MicrosoftCodeAnalysisCommonVersion>3.7.0</MicrosoftCodeAnalysisCommonVersion>
+    <MicrosoftCodeAnalysisCommonVersion>3.8.0</MicrosoftCodeAnalysisCommonVersion>
     <TaskExtensionsVersion>0.1.8580001</TaskExtensionsVersion>
   </PropertyGroup>
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ variables:
   - name: _DotNetArtifactsCategory
     value: .NETCore
   - name: DotNetSdkVersion
-    value: '3.1.200'
+    value: '5.0.100'
   - name: TryDotNetPackagesPath
     value: $(Build.SourcesDirectory)/artifacts/.trydotnet/packages
   - name: NodeJSVersion
@@ -196,7 +196,7 @@ stages:
             versionSpec: $(NodeJSVersion)
 
         - task: UseDotNet@2
-          displayName: Add dotnet 3.0
+          displayName: Add dotnet
           inputs:
             packageType: sdk
             version: $(DotNetSdkVersion)
@@ -293,7 +293,7 @@ stages:
         - checkout: self
           clean: true
         - task: UseDotNet@2
-          displayName: Add dotnet 3.0
+          displayName: Add dotnet
           inputs:
             packageType: sdk
             version: $(DotNetSdkVersion)

--- a/eng/AfterSolutionBuild.targets
+++ b/eng/AfterSolutionBuild.targets
@@ -33,8 +33,8 @@
     <ItemGroup>
       <SymbolPackageWithBadFiles Include="$(ArtifactsShippingPackagesDir)\Microsoft.dotnet-interactive.*.symbols.nupkg" />
 
-      <SymbolPackageFilesToStrip Include="tools/netcoreapp3.1/any/runtimes/linux-musl-x64/native/libpsl-native.so" />
-      <SymbolPackageFilesToStrip Include="tools/netcoreapp3.1/any/runtimes/linux-x64/native/libmi.so" />
+      <SymbolPackageFilesToStrip Include="tools/net5.0/any/runtimes/linux-musl-x64/native/libpsl-native.so" />
+      <SymbolPackageFilesToStrip Include="tools/net5.0/any/runtimes/linux-x64/native/libmi.so" />
     </ItemGroup>
     <PropertyGroup>
       <PackageTempPath>$([System.IO.Path]::GetTempPath())/$([System.Guid]::NewGuid())</PackageTempPath>

--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "3.1.200",
+    "version": "5.0.100",
     "rollForward": "latestMinor"
   },
   "tools": {
-    "dotnet": "3.1.200",
+    "dotnet": "5.0.100",
     "rollForward": "latestMinor"
   },
   "msbuild-sdks": {

--- a/samples/connect-wpf/WpfConnect.csproj
+++ b/samples/connect-wpf/WpfConnect.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>WinExe</OutputType>
     <UseWPF>true</UseWPF>
     <DisableArcade>1</DisableArcade>

--- a/samples/extensions/ClockExtension/ClockExtension.csproj
+++ b/samples/extensions/ClockExtension/ClockExtension.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IncludeBuildOutput>true</IncludeBuildOutput>
     <IsPackable>true</IsPackable>
     <PackageDescription>Renders a clock in dotnet-interactive using SVG</PackageDescription>

--- a/samples/extensions/Library.InteractiveExtension/Library.InteractiveExtension.csproj
+++ b/samples/extensions/Library.InteractiveExtension/Library.InteractiveExtension.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/samples/extensions/Library.nuget/Library.nuget.csproj
+++ b/samples/extensions/Library.nuget/Library.nuget.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
 
     <PackageId>Library</PackageId>

--- a/samples/extensions/Library/Library.csproj
+++ b/samples/extensions/Library/Library.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/samples/extensions/SampleExtensions.Tests/SampleExtensions.Tests.csproj
+++ b/samples/extensions/SampleExtensions.Tests/SampleExtensions.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Interactive.CSharp.Tests/Microsoft.DotNet.Interactive.CSharp.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.CSharp.Tests/Microsoft.DotNet.Interactive.CSharp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Deterministic Condition="'$(NCrunch)' == '1'">false</Deterministic>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/Microsoft.DotNet.Interactive.ExtensionLab.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/Microsoft.DotNet.Interactive.ExtensionLab.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <NoWarn>$(NoWarn);8002;VSTHRD002;VSTHRD200</NoWarn> <!-- Assent isn't strongly signed -->
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Inspector/CSharpDecompiler/CSharpDecompiler.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Inspector/CSharpDecompiler/CSharpDecompiler.cs
@@ -15,7 +15,9 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab.Inspector.CSharpDecompiler
         {
             var decompilationLanguageVersion = Defaults.GetDecompilationLanguageVersion(inspectionOptions.DecompilationLanguage);
 
-            var decompiler = new ICSharpCode.Decompiler.CSharp.CSharpDecompiler(module: assembly, assemblyResolver: new UniversalAssemblyResolver($"{Defaults.InternalAssemblyName}.dll", true, "net5.0"), new DecompilerSettings(decompilationLanguageVersion))
+            var assemblyResolver = new UniversalAssemblyResolver($"{Defaults.InternalAssemblyName}.dll", true, ".NETCoreApp,Version=v5.0");
+            var settings = new DecompilerSettings(decompilationLanguageVersion);
+            var decompiler = new ICSharpCode.Decompiler.CSharp.CSharpDecompiler(module: assembly, assemblyResolver: assemblyResolver, settings: settings)
             {
                 DebugInfoProvider = debugInfoProvider
             };

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Inspector/CSharpDecompiler/CSharpDecompiler.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Inspector/CSharpDecompiler/CSharpDecompiler.cs
@@ -15,7 +15,11 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab.Inspector.CSharpDecompiler
         {
             var decompilationLanguageVersion = Defaults.GetDecompilationLanguageVersion(inspectionOptions.DecompilationLanguage);
 
-            var assemblyResolver = new UniversalAssemblyResolver($"{Defaults.InternalAssemblyName}.dll", true, ".NETCoreApp,Version=v5.0");
+            var systemPrivateCoreLibLocation = typeof(object).Assembly.Location;
+            using var peStream = File.OpenRead(systemPrivateCoreLibLocation);
+            using var systemPrivateCoreLib = new PEFile(Path.GetFileName(systemPrivateCoreLibLocation), peStream);
+            var targetFramework = systemPrivateCoreLib.DetectTargetFrameworkId();
+            var assemblyResolver = new UniversalAssemblyResolver($"{Defaults.InternalAssemblyName}.dll", true, targetFramework);
             var settings = new DecompilerSettings(decompilationLanguageVersion);
             var decompiler = new ICSharpCode.Decompiler.CSharp.CSharpDecompiler(module: assembly, assemblyResolver: assemblyResolver, settings: settings)
             {

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Inspector/CSharpDecompiler/CSharpDecompiler.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Inspector/CSharpDecompiler/CSharpDecompiler.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab.Inspector.CSharpDecompiler
         {
             var decompilationLanguageVersion = Defaults.GetDecompilationLanguageVersion(inspectionOptions.DecompilationLanguage);
 
-            var decompiler = new ICSharpCode.Decompiler.CSharp.CSharpDecompiler(module: assembly, assemblyResolver: new UniversalAssemblyResolver($"{Defaults.InternalAssemblyName}.dll", true, "netcoreapp3.1"), new DecompilerSettings(decompilationLanguageVersion))
+            var decompiler = new ICSharpCode.Decompiler.CSharp.CSharpDecompiler(module: assembly, assemblyResolver: new UniversalAssemblyResolver($"{Defaults.InternalAssemblyName}.dll", true, "net5.0"), new DecompilerSettings(decompilationLanguageVersion))
             {
                 DebugInfoProvider = debugInfoProvider
             };

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Inspector/PdbDebugInfoProvider.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Inspector/PdbDebugInfoProvider.cs
@@ -41,6 +41,7 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab.Inspector
         private readonly MetadataReader _reader;
 
         public string Description => "";
+        public string SourceFileName => "";
 
         public PdbDebugInfoProvider(Stream symbolStream)
         {

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.DotNet.Interactive.ExtensionLab.csproj
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.DotNet.Interactive.ExtensionLab.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
  <PropertyGroup>
@@ -62,7 +62,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="bin\Debug\netcoreapp3.1\/Microsoft.DotNet.Interactive.ExtensionLab.dll" />
+    <None Remove="bin\Debug\net5.0\Microsoft.DotNet.Interactive.ExtensionLab.dll" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.DotNet.Interactive.ExtensionLab.csproj
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.DotNet.Interactive.ExtensionLab.csproj
@@ -48,7 +48,7 @@
 
  <ItemGroup>
    <PackageReference Include="Iced" Version="1.8.0" />
-   <PackageReference Include="ICSharpCode.Decompiler" Version="6.1.0.5902" />
+   <PackageReference Include="ICSharpCode.Decompiler" Version="7.0.0.6225-preview1" />
    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(MicrosoftCodeAnalysisCommonVersion)" />
    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCommonVersion)" />
    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="1.1.132302" />

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <!--- Do not glob C# source files and other project items -->
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.SqlTools.ServiceLayer/runtime.osx-x64.runtime.native.Microsoft.SqlTools.ServiceLayer/runtime.osx-x64.runtime.native.Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.SqlTools.ServiceLayer/runtime.osx-x64.runtime.native.Microsoft.SqlTools.ServiceLayer/runtime.osx-x64.runtime.native.Microsoft.SqlTools.ServiceLayer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <!--- Do not glob C# source files and other project items -->
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.SqlTools.ServiceLayer/runtime.rhel-x64.runtime.native.Microsoft.SqlTools.ServiceLayer/runtime.rhel-x64.runtime.native.Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.SqlTools.ServiceLayer/runtime.rhel-x64.runtime.native.Microsoft.SqlTools.ServiceLayer/runtime.rhel-x64.runtime.native.Microsoft.SqlTools.ServiceLayer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <!--- Do not glob C# source files and other project items -->
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.SqlTools.ServiceLayer/runtime.win-x64.runtime.native.Microsoft.SqlTools.ServiceLayer/runtime.win-x64.runtime.native.Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.SqlTools.ServiceLayer/runtime.win-x64.runtime.native.Microsoft.SqlTools.ServiceLayer/runtime.win-x64.runtime.native.Microsoft.SqlTools.ServiceLayer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <!--- Do not glob C# source files and other project items -->
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.SqlTools.ServiceLayer/runtime.win-x86.runtime.native.Microsoft.SqlTools.ServiceLayer/runtime.win-x86.runtime.native.Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.SqlTools.ServiceLayer/runtime.win-x86.runtime.native.Microsoft.SqlTools.ServiceLayer/runtime.win-x86.runtime.native.Microsoft.SqlTools.ServiceLayer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <!--- Do not glob C# source files and other project items -->
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.SqlTools.ServiceLayer/runtime.win10-arm.runtime.native.Microsoft.SqlTools.ServiceLayer/runtime.win10-arm.runtime.native.Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.SqlTools.ServiceLayer/runtime.win10-arm.runtime.native.Microsoft.SqlTools.ServiceLayer/runtime.win10-arm.runtime.native.Microsoft.SqlTools.ServiceLayer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <!--- Do not glob C# source files and other project items -->
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.SqlTools.ServiceLayer/runtime.win10-arm64.runtime.native.Microsoft.SqlTools.ServiceLayer/runtime.win10-arm64.runtime.native.Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.SqlTools.ServiceLayer/runtime.win10-arm64.runtime.native.Microsoft.SqlTools.ServiceLayer/runtime.win10-arm64.runtime.native.Microsoft.SqlTools.ServiceLayer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <!--- Do not glob C# source files and other project items -->
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>

--- a/src/Microsoft.DotNet.Interactive.FSharp.Tests/Microsoft.DotNet.Interactive.FSharp.Tests.fsproj
+++ b/src/Microsoft.DotNet.Interactive.FSharp.Tests/Microsoft.DotNet.Interactive.FSharp.Tests.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Deterministic Condition="'$(NCrunch)' == '1'">false</Deterministic>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
@@ -36,8 +36,9 @@ type FSharpKernelBase () as this =
 
     static let lockObj = Object();
 
-    let createScript () =  
-        lock lockObj (fun () -> new FSharpScript(additionalArgs=[|"/langversion:preview"|]))
+    let createScript () =
+        // work around ref/impl type resolution; see https://github.com/dotnet/fsharp/issues/10496
+        lock lockObj (fun () -> new FSharpScript(additionalArgs=[|"/langversion:preview"; "/usesdkrefs-"|]))
 
     let script = lazy createScript ()
 

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/Microsoft.DotNet.Interactive.Formatting.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/Microsoft.DotNet.Interactive.Formatting.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);8002</NoWarn><!-- Assent isn't strongly signed -->
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Interactive.Http/Microsoft.DotNet.Interactive.Http.csproj
+++ b/src/Microsoft.DotNet.Interactive.Http/Microsoft.DotNet.Interactive.Http.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/Microsoft.DotNet.Interactive.Jupyter.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/Microsoft.DotNet.Interactive.Jupyter.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssetTargetFallback>portable-net45+win8+wp8+wpa81</AssetTargetFallback>
     <NoWarn>$(NoWarn);8002</NoWarn><!-- Assent isn't strongly signed -->

--- a/src/Microsoft.DotNet.Interactive.Jupyter/Microsoft.DotNet.Interactive.Jupyter.csproj
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/Microsoft.DotNet.Interactive.Jupyter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Microsoft.DotNet.Interactive.PowerShell.Tests/Microsoft.DotNet.Interactive.PowerShell.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.PowerShell.Tests/Microsoft.DotNet.Interactive.PowerShell.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <NoWarn>$(NoWarn);8002;CS8002</NoWarn>
     <Deterministic Condition="'$(NCrunch)' == '1'">false</Deterministic>

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <NoWarn>$(NoWarn);2003;CS8002;NU1608;</NoWarn> <!-- AssemblyInformationalVersionAttribute contains a non-standard value -->
     <NoWarn>$(NoWarn);NU5100</NoWarn><!-- dll outside of lib/ folder; expected since it's under contentFiles/any/any/Modules/ -->

--- a/src/Microsoft.DotNet.Interactive.Recipes/Microsoft.DotNet.Interactive.Recipes.csproj
+++ b/src/Microsoft.DotNet.Interactive.Recipes/Microsoft.DotNet.Interactive.Recipes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Interactive.Telemetry.Tests/Microsoft.DotNet.Interactive.Telemetry.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.Telemetry.Tests/Microsoft.DotNet.Interactive.Telemetry.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AssetTargetFallback>portable-net45+win8+wp8+wpa81</AssetTargetFallback>
     <NoWarn>$(NoWarn);8002</NoWarn><!-- Assent isn't strongly signed -->
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Interactive.Telemetry/Microsoft.DotNet.Interactive.Telemetry.csproj
+++ b/src/Microsoft.DotNet.Interactive.Telemetry/Microsoft.DotNet.Interactive.Telemetry.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
@@ -19,6 +19,7 @@ using Xunit;
 using Xunit.Abstractions;
 
 #pragma warning disable 8509
+#pragma warning disable 8524
 namespace Microsoft.DotNet.Interactive.Tests
 {
     public sealed class LanguageKernelTests : LanguageKernelTestBase

--- a/src/Microsoft.DotNet.Interactive.Tests/Microsoft.DotNet.Interactive.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.Tests/Microsoft.DotNet.Interactive.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssetTargetFallback>portable-net45+win8+wp8+wpa81</AssetTargetFallback>
     <NoWarn>$(NoWarn);8002</NoWarn><!-- Assent isn't strongly signed -->

--- a/src/Microsoft.DotNet.Interactive.Tests/Utility/KernelExtensionTestHelper.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Utility/KernelExtensionTestHelper.cs
@@ -102,6 +102,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Utility
                                .GetDirectories("bin", SearchOption.AllDirectories)
                                .Single()
                                .GetFiles($"{extensionName}.dll", SearchOption.AllDirectories)
+                               .Where(f => f.Directory.Name != "ref")
                                .Single();
 
             if (copyDllTo != null)

--- a/src/Microsoft.DotNet.Interactive.Tests/Utility/KernelExtensionTestHelper.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Utility/KernelExtensionTestHelper.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Utility
 <Project Sdk=""Microsoft.NET.Sdk"">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackageId>{packageName}</PackageId>
     <PackageVersion>{packageVersion}</PackageVersion>
@@ -136,7 +136,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Utility
 <Project Sdk=""Microsoft.NET.Sdk"">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AssemblyName>{extensionName}</AssemblyName>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Interactive.Tests/VariableSharingTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/VariableSharingTests.cs
@@ -126,7 +126,7 @@ namespace Microsoft.DotNet.Interactive.Tests
             "#!pwsh",
             "$x = 1",
             "#!share --from pwsh x")]
-        public async Task csharp_kernel_can_operate_on_variables_shared_from_other_kernels(string from, string codeToWrite, string codeToRead)
+        public async Task csharp_kernel_variables_shared_from_other_kernels_resolve_to_the_correct_runtime_type(string from, string codeToWrite, string codeToRead)
         {
             using var kernel = CreateKernel();
 
@@ -153,7 +153,7 @@ namespace Microsoft.DotNet.Interactive.Tests
             "#!pwsh",
             "$x = 1",
             "#!share --from pwsh x")]
-        public async Task fsharp_kernel_can_operate_on_variables_shared_from_other_kernels(string from, string codeToWrite, string codeToRead)
+        public async Task fsharp_kernel_variables_shared_from_other_kernels_resolve_to_the_correct_runtime_types(string from, string codeToWrite, string codeToRead)
         {
             using var kernel = CreateKernel();
 
@@ -180,7 +180,7 @@ namespace Microsoft.DotNet.Interactive.Tests
             "#!fsharp",
             "let x = 1",
             "#!share --from fsharp x")]
-        public async Task pwsh_kernel_can_operate_on_variables_shared_from_other_kernels(string from, string codeToWrite, string codeToRead)
+        public async Task pwsh_kernel_variables_shared_from_other_kernels_resolve_to_the_correct_runtime_type(string from, string codeToWrite, string codeToRead)
         {
             using var kernel = CreateKernel();
 

--- a/src/Microsoft.DotNet.Interactive.Tests/VariableSharingTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/VariableSharingTests.cs
@@ -117,6 +117,92 @@ namespace Microsoft.DotNet.Interactive.Tests
                   .Be("123:System.Int32");
         }
 
+        [Theory]
+        [InlineData(
+            "#!fsharp",
+            "let x = 1",
+            "#!share --from fsharp x")]
+        [InlineData(
+            "#!pwsh",
+            "$x = 1",
+            "#!share --from pwsh x")]
+        public async Task csharp_kernel_can_operate_on_variables_shared_from_other_kernels(string from, string codeToWrite, string codeToRead)
+        {
+            using var kernel = CreateKernel();
+
+            using var events = kernel.KernelEvents.ToSubscribedList();
+
+            await kernel.SubmitCodeAsync($"{from}\n{codeToWrite}");
+
+            await kernel.SubmitCodeAsync($"#!csharp\n{codeToRead}\nx + 1");
+
+            events.Should()
+                  .ContainSingle<ReturnValueProduced>()
+                  .Which
+                  .Value
+                  .Should()
+                  .Be(2);
+        }
+
+        [Theory]
+        [InlineData(
+            "#!csharp",
+            "var x = 1;",
+            "#!share --from csharp x")]
+        [InlineData(
+            "#!pwsh",
+            "$x = 1",
+            "#!share --from pwsh x")]
+        public async Task fsharp_kernel_can_operate_on_variables_shared_from_other_kernels(string from, string codeToWrite, string codeToRead)
+        {
+            using var kernel = CreateKernel();
+
+            using var events = kernel.KernelEvents.ToSubscribedList();
+
+            await kernel.SubmitCodeAsync($"{from}\n{codeToWrite}");
+
+            await kernel.SubmitCodeAsync($"#!fsharp\n{codeToRead}\nx + 1");
+
+            events.Should()
+                  .ContainSingle<ReturnValueProduced>()
+                  .Which
+                  .Value
+                  .Should()
+                  .Be(2);
+        }
+
+        [Theory]
+        [InlineData(
+            "#!csharp",
+            "var x = 1;",
+            "#!share --from csharp x")]
+        [InlineData(
+            "#!fsharp",
+            "let x = 1",
+            "#!share --from fsharp x")]
+        public async Task pwsh_kernel_can_operate_on_variables_shared_from_other_kernels(string from, string codeToWrite, string codeToRead)
+        {
+            using var kernel = CreateKernel();
+
+            using var events = kernel.KernelEvents.ToSubscribedList();
+
+            await kernel.SubmitCodeAsync($"{from}\n{codeToWrite}");
+
+            await kernel.SubmitCodeAsync($"#!pwsh\n{codeToRead}\n$x + 1");
+
+            events.Should()
+                  .ContainSingle<StandardOutputValueProduced>()
+                  .Which
+                  .FormattedValues
+                  .Should()
+                  .ContainSingle(v => v.MimeType == PlainTextFormatter.MimeType)
+                  .Which
+                  .Value
+                  .Trim()
+                  .Should()
+                  .Be("2");
+        }
+
         [Fact(Skip = "not implemented")]
         public async Task Directives_can_access_local_kernel_variables()
         {

--- a/src/Microsoft.DotNet.Interactive/Microsoft.DotNet.Interactive.csproj
+++ b/src/Microsoft.DotNet.Interactive/Microsoft.DotNet.Interactive.csproj
@@ -16,8 +16,8 @@
   <PropertyGroup>
     <MicrosoftCodeAnalysisAnalyzersVersion>2.9.6</MicrosoftCodeAnalysisAnalyzersVersion>	
     <SystemRuntimeLoaderVersion>4.3.0</SystemRuntimeLoaderVersion>	
-    <SystemCollectionsImmutableVersion>5.0.0-preview.8.20407.11</SystemCollectionsImmutableVersion>	
-    <SystemReflectionMetadataVersion>5.0.0-preview.8.20407.11</SystemReflectionMetadataVersion>	
+    <SystemCollectionsImmutableVersion>5.0.0</SystemCollectionsImmutableVersion>	
+    <SystemReflectionMetadataVersion>5.0.0</SystemReflectionMetadataVersion>	
     <SystemCommandLineVersion>2.0.0-beta1.20478.1</SystemCommandLineVersion>	
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Interactive/PackageRestoreContext.cs
+++ b/src/Microsoft.DotNet.Interactive/PackageRestoreContext.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Interactive
 {
     public class PackageRestoreContext : IDisposable
     {
-        private const string restoreTfm = "netcoreapp3.1";
+        private const string restoreTfm = "net5.0";
         private readonly ConcurrentDictionary<string, PackageReference> _requestedPackageReferences = new ConcurrentDictionary<string, PackageReference>(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, ResolvedPackageReference> _resolvedPackageReferences = new Dictionary<string, ResolvedPackageReference>(StringComparer.OrdinalIgnoreCase);
         private readonly HashSet<string> _restoreSources = new HashSet<string>();

--- a/src/XPlot.DotNet.Interactive.KernelExtensions/XPlot.DotNet.Interactive.KernelExtensions.csproj
+++ b/src/XPlot.DotNet.Interactive.KernelExtensions/XPlot.DotNet.Interactive.KernelExtensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <NoWarn>$(NoWarn);CS8002</NoWarn><!-- XPlot.Plotly doesn't have a strong name -->
   </PropertyGroup>
 

--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -110,7 +110,7 @@
         },
         "dotnet-interactive.minimumDotNetSdkVersion": {
           "type": "string",
-          "default": "3.1",
+          "default": "5.0",
           "description": "The minimum required version of the .NET SDK."
         },
         "dotnet-interactive.minimumInteractiveToolVersion": {

--- a/src/dotnet-interactive.IntegrationTests/dotnet-interactive.IntegrationTests.csproj
+++ b/src/dotnet-interactive.IntegrationTests/dotnet-interactive.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Microsoft.DotNet.Interactive.App.IntegrationTests</RootNamespace>
     <NoWarn>$(NoWarn);8002</NoWarn><!-- Assent isn't strongly signed -->
     <IsPackable>false</IsPackable>

--- a/src/dotnet-interactive.Profiler/dotnet-interactive.Profiler.csproj
+++ b/src/dotnet-interactive.Profiler/dotnet-interactive.Profiler.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Microsoft.DotNet.Interactive.Profiler</RootNamespace>
   </PropertyGroup>
 

--- a/src/dotnet-interactive.Tests/dotnet-interactive.Tests.csproj
+++ b/src/dotnet-interactive.Tests/dotnet-interactive.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Microsoft.DotNet.Interactive.App.Tests</RootNamespace>
     <NoWarn>$(NoWarn);8002</NoWarn> <!-- Assent isn't strongly signed -->
     <IsPackable>false</IsPackable>

--- a/src/dotnet-interactive/(Recipes)/VersionSensor.cs
+++ b/src/dotnet-interactive/(Recipes)/VersionSensor.cs
@@ -21,7 +21,7 @@ namespace Recipes
                                             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
                                             .InformationalVersion,
                 AssemblyVersion = assembly.GetName().Version.ToString(),
-                BuildDate = new FileInfo(new Uri(assembly.CodeBase).LocalPath).CreationTimeUtc.ToString("o")
+                BuildDate = new FileInfo(assembly.Location).CreationTimeUtc.ToString("o")
             };
 
             AssignServiceVersionTo(info);

--- a/src/dotnet-interactive/dotnet-interactive.csproj
+++ b/src/dotnet-interactive/dotnet-interactive.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Microsoft.DotNet.Interactive.App</RootNamespace>
     <AssemblyName>Microsoft.DotNet.Interactive.App</AssemblyName>
     <LangVersion>Latest</LangVersion>

--- a/src/interface-generator/interface-generator.csproj
+++ b/src/interface-generator/interface-generator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Microsoft.DotNet.Interactive.InterfaceGen.App</RootNamespace>
     <AssemblyName>Microsoft.DotNet.Interactive.InterfaceGen.App</AssemblyName>
   </PropertyGroup>


### PR DESCRIPTION
Retarget to `net5.0`.  This will enable `#r` to other `net5.0` assemblies.

During testing an issue was found where F# doesn't follow ref->impl type forwards.  An issue has been created at dotnet/fsharp#10496 and a workaround applied to this codebase.  I also included a testcase with this scenario.

Creating as draft until all CI issues have been worked out.

~~An issue with ILSpy which powers the `#!inspect` magic command has been found and filed at icsharpcode/ILSpy#2228 and a local workaround has been added.~~

The 5.0 SDK requires MSBuild 16.8 which requires VS 16.8.  The internal VMs have been updated.