### PR TITLE
fix #899

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/SqlKernelsExtensionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/SqlKernelsExtensionTests.cs
@@ -1,6 +1,5 @@
-﻿// // Copyright (c) .NET Foundation and contributors. All rights reserved.
-// // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/MsSqlKernelConnection.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/MsSqlKernelConnection.cs
@@ -1,5 +1,5 @@
-﻿// // Copyright (c) .NET Foundation and contributors. All rights reserved.
-// // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CommandLine;
 using System.Threading.Tasks;

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/MsSqlRpcObjects.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/MsSqlRpcObjects.cs
@@ -1,5 +1,5 @@
-// // Copyright (c) .NET Foundation and contributors. All rights reserved.
-// // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/SQLiteKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/SQLiteKernel.cs
@@ -1,5 +1,5 @@
-﻿// // Copyright (c) .NET Foundation and contributors. All rights reserved.
-// // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Data.Sqlite;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/SqlConnectionOptions.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/SqlConnectionOptions.cs
@@ -1,5 +1,5 @@
-﻿// // Copyright (c) .NET Foundation and contributors. All rights reserved.
-// // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.DotNet.Interactive.Connection;
 

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/FormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/FormatterTests.cs
@@ -187,7 +187,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
             {
                 var value = "hola! \n \t \" \" ' ' the joy of escapes! and    white  space  ";
 
-                var mimeType = Formatter.PreferredMimeTypeFor(typeof(string));
+                var mimeType = Formatter.GetPreferredMimeTypeFor(typeof(string));
                 var text = value.ToDisplayString(mimeType);
 
                 mimeType.Should().Be("text/plain");
@@ -452,11 +452,11 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
         {
             Formatter.SetPreferredMimeTypeFor(typeof(object), mimeType);
 
-            Formatter.PreferredMimeTypeFor(typeof(int)).Should().Be(mimeType);
-            Formatter.PreferredMimeTypeFor(typeof(object)).Should().Be(mimeType);
-            Formatter.PreferredMimeTypeFor(typeof(string)).Should().Be(mimeType);
-            Formatter.PreferredMimeTypeFor(typeof(Type)).Should().Be(mimeType);
-            Formatter.PreferredMimeTypeFor(typeof(JsonToken)).Should().Be(mimeType);
+            Formatter.GetPreferredMimeTypeFor(typeof(int)).Should().Be(mimeType);
+            Formatter.GetPreferredMimeTypeFor(typeof(object)).Should().Be(mimeType);
+            Formatter.GetPreferredMimeTypeFor(typeof(string)).Should().Be(mimeType);
+            Formatter.GetPreferredMimeTypeFor(typeof(Type)).Should().Be(mimeType);
+            Formatter.GetPreferredMimeTypeFor(typeof(JsonToken)).Should().Be(mimeType);
 
         }
 
@@ -473,11 +473,11 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
             Formatter.SetPreferredMimeTypeFor(typeof(object), "text/html");
             Formatter.SetPreferredMimeTypeFor(typeof(object), mimeType);
 
-            Formatter.PreferredMimeTypeFor(typeof(int)).Should().Be(mimeType);
-            Formatter.PreferredMimeTypeFor(typeof(object)).Should().Be(mimeType);
-            Formatter.PreferredMimeTypeFor(typeof(string)).Should().Be(mimeType);
-            Formatter.PreferredMimeTypeFor(typeof(Type)).Should().Be(mimeType);
-            Formatter.PreferredMimeTypeFor(typeof(JsonToken)).Should().Be(mimeType);
+            Formatter.GetPreferredMimeTypeFor(typeof(int)).Should().Be(mimeType);
+            Formatter.GetPreferredMimeTypeFor(typeof(object)).Should().Be(mimeType);
+            Formatter.GetPreferredMimeTypeFor(typeof(string)).Should().Be(mimeType);
+            Formatter.GetPreferredMimeTypeFor(typeof(Type)).Should().Be(mimeType);
+            Formatter.GetPreferredMimeTypeFor(typeof(JsonToken)).Should().Be(mimeType);
 
         }
 
@@ -489,7 +489,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
         {
             Formatter.SetPreferredMimeTypeFor(typeof(int), mimeType);
 
-            Formatter.PreferredMimeTypeFor(typeof(int)).Should().Be(mimeType);
+            Formatter.GetPreferredMimeTypeFor(typeof(int)).Should().Be(mimeType);
 
         }
 
@@ -502,7 +502,7 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
             Formatter.SetPreferredMimeTypeFor(typeof(int), mimeType);
             Formatter.ResetToDefault();
 
-            Formatter.PreferredMimeTypeFor(typeof(int)).Should().Be("text/html");
+            Formatter.GetPreferredMimeTypeFor(typeof(int)).Should().Be("text/html");
 
         }
 

--- a/src/Microsoft.DotNet.Interactive.Formatting/AnonymousTypeFormatter{T}.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/AnonymousTypeFormatter{T}.cs
@@ -10,8 +10,11 @@ namespace Microsoft.DotNet.Interactive.Formatting
     {
         private readonly Func<FormatContext, T, TextWriter, bool> _format;
 
-        public AnonymousTypeFormatter(Func<FormatContext, T, TextWriter, bool> format, string mimeType, Type type = null)
-            : base(type??typeof(T))
+        public AnonymousTypeFormatter(
+            Func<FormatContext, T, TextWriter, bool> format, 
+            string mimeType, 
+            Type type = null)
+            : base(type)
         {
             if (string.IsNullOrWhiteSpace(mimeType))
             {

--- a/src/Microsoft.DotNet.Interactive.Formatting/DefaultHtmlFormatterSet.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/DefaultHtmlFormatterSet.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Interactive.Formatting
 {
     internal class DefaultHtmlFormatterSet
     {
-        static internal readonly ITypeFormatter[] DefaultFormatters =
+        internal static readonly ITypeFormatter[] DefaultFormatters =
             {
                 new HtmlFormatter<DateTime>((context, dateTime, writer) =>
                 {

--- a/src/Microsoft.DotNet.Interactive.Formatting/FormatterTable.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/FormatterTable.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+
+#nullable enable
+
+namespace Microsoft.DotNet.Interactive.Formatting
+{
+    internal class FormatterTable
+    {
+        private readonly ConcurrentDictionary<(Type type, bool flag), ITypeFormatter> _formatters = new ConcurrentDictionary<(Type type, bool flag), ITypeFormatter>();
+        private readonly Type _genericDef;
+        private readonly string _name;
+
+        internal FormatterTable(Type genericDef, string name)
+        {
+            _genericDef = genericDef;
+            _name = name;
+        }
+
+        internal ITypeFormatter GetFormatter(Type type, bool flag)
+        {
+            return
+                _formatters.GetOrAdd((type, flag),
+                                     tup =>
+                                     {
+                                         return
+                                             (ITypeFormatter)
+                                             _genericDef
+                                                 .MakeGenericType(tup.type)
+                                                 .GetMethod(_name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)
+                                                 .Invoke(null, new object[] { flag });
+                                     });
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Interactive.Formatting/Formatter{T}.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/Formatter{T}.cs
@@ -35,34 +35,6 @@ namespace Microsoft.DotNet.Interactive.Formatting
         }
 
         /// <summary>
-        /// Registers a formatter to be used when formatting instances of type <typeparamref name="T" />.
-        /// </summary>
-        /// <param name="formatter">The formatter.</param>
-        [Obsolete("Please use Formatter.Register<T>(formatter, ...)")]
-        public static void Register(
-            Func<T, string> formatter,
-            string mimeType = PlainTextFormatter.MimeType,
-            bool addToDefaults = false)
-        {
-            Formatter.Register(formatter, mimeType, addToDefaults);
-        }
-
-
-        /// <summary>
-        /// Registers a formatter to be used when formatting instances of type <typeparamref name="T" />.
-        /// </summary>
-        /// <param name="formatter">The formatter.</param>
-        [Obsolete("Please use Formatter.Register<T>(formatter, ...)")]
-        public static void Register(
-            Action<T, TextWriter> formatter,
-            string mimeType = PlainTextFormatter.MimeType,
-            bool addToDefaults = false)
-        {
-            Formatter.Register(formatter, mimeType, addToDefaults);
-        }
-
-
-        /// <summary>
         /// Formats an object and writes it to the specified writer.
         /// </summary>
         /// <param name="obj">The object to be formatted.</param>

--- a/src/Microsoft.DotNet.Interactive.Formatting/TypeExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/TypeExtensions.cs
@@ -105,17 +105,25 @@ namespace Microsoft.DotNet.Interactive.Formatting
             }
 
             var baseChain = actualType;
+
             while (baseChain != null)
             {
                 if (baseChain.IsGenericType && baseChain.GetGenericTypeDefinition().Equals(type))
+                {
                     return true;
+                }
+
                 baseChain = baseChain.BaseType;
             }
+
             foreach (var i in actualType.GetInterfaces())
             {
                 if (i.IsGenericType && i.GetGenericTypeDefinition().Equals(type))
+                {
                     return true;
+                }
             }
+
             return false;
         }
 

--- a/src/Microsoft.DotNet.Interactive.Formatting/TypeFormatter{T}.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/TypeFormatter{T}.cs
@@ -8,11 +8,14 @@ namespace Microsoft.DotNet.Interactive.Formatting
 {
     public abstract class TypeFormatter<T> : ITypeFormatter<T>
     {
-        Type _type;
-        public TypeFormatter(Type type = null) { _type = type ?? typeof(T); }
+        protected TypeFormatter(Type type = null)
+        {
+            Type = type ?? typeof(T);
+        }
+
         public abstract bool Format(FormatContext context, T value, TextWriter writer);
 
-        public Type Type => _type;
+        public Type Type { get; }
 
         public abstract string MimeType { get; }
 

--- a/src/Microsoft.DotNet.Interactive/FormattedValue.cs
+++ b/src/Microsoft.DotNet.Interactive/FormattedValue.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.Interactive
 
             var mimeTypes = MimeTypesFor(type).ToArray();
 
-            var preferredMimeType = Formatter.PreferredMimeTypeFor(type ?? typeof(object));
+            var preferredMimeType = Formatter.GetPreferredMimeTypeFor(type ?? typeof(object));
 
             if (mimeTypes.Length != 1)
             {
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.Interactive
 
             if (type != null)
             {
-                var preferredMimeType = Formatter.PreferredMimeTypeFor(type);
+                var preferredMimeType = Formatter.GetPreferredMimeTypeFor(type);
 
                 if (preferredMimeType == null)
                 {

--- a/src/Microsoft.DotNet.Interactive/KernelInvocationContextExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelInvocationContextExtensions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.Interactive
         {
             var displayId = Guid.NewGuid().ToString();
 
-            mimeType ??= Formatter.PreferredMimeTypeFor(value.GetType());
+            mimeType ??= Formatter.GetPreferredMimeTypeFor(value?.GetType());
 
             var formattedValue = new FormattedValue(
                 mimeType,

--- a/src/dotnet-interactive.Tests/FormatterConfigurationTests.cs
+++ b/src/dotnet-interactive.Tests/FormatterConfigurationTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.Interactive.App.Tests
         {
             var latex = new LaTeXString(@"F(k) = \int_{-\infty}^{\infty} f(x) e^{2\pi i k} dx");
 
-            var mimeType = Formatter.PreferredMimeTypeFor(latex.GetType());
+            var mimeType = Formatter.GetPreferredMimeTypeFor(latex.GetType());
 
             var formattedValue = new FormattedValue(
                 mimeType,
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.Interactive.App.Tests
         {
             var latex = new MathString(@"F(k) = \int_{-\infty}^{\infty} f(x) e^{2\pi i k} dx");
 
-            var mimeType = Formatter.PreferredMimeTypeFor(latex.GetType());
+            var mimeType = Formatter.GetPreferredMimeTypeFor(latex.GetType());
 
             var formattedValue = new FormattedValue(
                 mimeType,
@@ -70,7 +70,7 @@ namespace Microsoft.DotNet.Interactive.App.Tests
         public void ScriptContent_type_is_formatted()
         {
             var script = new ScriptContent("alert('hello');");
-            var mimeType = Formatter.PreferredMimeTypeFor(script.GetType());
+            var mimeType = Formatter.GetPreferredMimeTypeFor(script.GetType());
 
             var formattedValue = new FormattedValue(
                 mimeType,
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.Interactive.App.Tests
         {
             var scriptText = "if (true && false) { alert('hello with embedded <>\" escapes'); };";
             var script = new ScriptContent(scriptText);
-            var mimeType = Formatter.PreferredMimeTypeFor(script.GetType());
+            var mimeType = Formatter.GetPreferredMimeTypeFor(script.GetType());
 
             var formattedValue = new FormattedValue(
                 mimeType,
@@ -102,7 +102,7 @@ namespace Microsoft.DotNet.Interactive.App.Tests
 
             CommandLineParser.SetUpFormatters(frontendEnvironment, new StartupOptions(httpPort: new HttpPort(4242)), 10.Seconds());
             var script = new ScriptContent("alert('hello');");
-            var mimeType = Formatter.PreferredMimeTypeFor(script.GetType());
+            var mimeType = Formatter.GetPreferredMimeTypeFor(script.GetType());
 
             var formattedValue = new FormattedValue(
                 mimeType,
@@ -124,7 +124,7 @@ alert('hello');
 
             CommandLineParser.SetUpFormatters(frontendEnvironment, new StartupOptions(httpPort: new HttpPort(4242)), 1.Seconds());
             var script = new ScriptContent("alert('hello');");
-            var mimeType = Formatter.PreferredMimeTypeFor(script.GetType());
+            var mimeType = Formatter.GetPreferredMimeTypeFor(script.GetType());
 
             Action formatting = () =>  script.ToDisplayString(mimeType);
             formatting.Should()
@@ -139,7 +139,7 @@ alert('hello');
         {
             var obj = JObject.FromObject(new { value = 123, OtherValue = 456 });
 
-            var mimeType = Formatter.PreferredMimeTypeFor(obj.GetType());
+            var mimeType = Formatter.GetPreferredMimeTypeFor(obj.GetType());
             var output = obj.ToDisplayString(JsonFormatter.MimeType);
 
             mimeType.Should().Be(JsonFormatter.MimeType);
@@ -154,7 +154,7 @@ alert('hello');
         {
             var obj = JArray.FromObject(new object[] { "one", 1 });
 
-            var mimeType = Formatter.PreferredMimeTypeFor(obj.GetType());
+            var mimeType = Formatter.GetPreferredMimeTypeFor(obj.GetType());
 
             mimeType.Should().Be(JsonFormatter.MimeType);
 


### PR DESCRIPTION
This fixes #899.

Also:

* rename `PreferredMimeTypeFor` to `GetPreferredMimeTypeFor` 
* remove `addToDefaults` parameter from `Formatter.Register` methods