### PR TITLE
invert package version setting

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -329,8 +329,7 @@ stages:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng/common/templates/post-build/post-build.yml
     parameters:
-      # falling back to publish v1 temporarily
-      #publishingInfraVersion: 3
+      publishingInfraVersion: 3
       # Symbol validation is not entirely reliable as of yet, so should be turned off until https://github.com/dotnet/arcade/issues/2871 is resolved.
       enableSymbolValidation: false
       # SourceLink improperly looks for generated files.  See https://github.com/dotnet/arcade/issues/3069

--- a/eng/AfterSolutionBuild.targets
+++ b/eng/AfterSolutionBuild.targets
@@ -9,6 +9,9 @@
   because there's no expected `-beta.*` infix.  The fix is to not allow it to be picked up by the repack targets by
   temporarily renaming it before the `PackageReleasePackages` target and restoring it's name after.  The same thing
   is done for the symbol packages (`*.symbols.nupkg`), too.
+
+  To work around https://github.com/dotnet/arcade/issues/6616 we also have to artifically ensure the variable
+  `$(PreReleaseVersionLabel)` is set.
   -->
 
   <ItemGroup>
@@ -20,12 +23,19 @@
   <Target Name="RenameDotNetTryOutputPackage" BeforeTargets="PackageReleasePackages">
     <Move SourceFiles="%(StableVersionPackages.FullPath)" DestinationFiles="%(StableVersionPackages.FullPath).renamed" />
     <Move SourceFiles="%(SymbolPackages.FullPath)" DestinationFiles="%(SymbolPackages.FullPath).renamed" />
+    <PropertyGroup>
+      <OldPreReleaseVersionLabel>$(PreReleaseVersionLabel)</OldPreReleaseVersionLabel>
+      <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
+    </PropertyGroup>
   </Target>
 
   <!-- Removes the `.renamed` extension from the dotnet-* packages. -->
   <Target Name="RestoreDotNetTryOutputPackage" AfterTargets="PackageReleasePackages">
     <Move SourceFiles="%(StableVersionPackages.FullPath).renamed" DestinationFiles="%(StableVersionPackages.FullPath)" />
     <Move SourceFiles="%(SymbolPackages.FullPath).renamed" DestinationFiles="%(SymbolPackages.FullPath)" />
+    <PropertyGroup>
+      <PreReleaseVersionLabel>$(OldPreReleaseVersionLabel)</PreReleaseVersionLabel>
+    </PropertyGroup>
   </Target>
 
   <!-- Removes files from the `*.symbols.nupkg` packages that cause errors with symbol publishing. -->

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,6 +1,5 @@
 <Project>
   <PropertyGroup>
-    <!-- falling back to publish v1 temporarily -->
-    <!-- <PublishingVersion>3</PublishingVersion> -->
+    <PublishingVersion>3</PublishingVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,8 +11,16 @@
     <MajorVersion>1</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
-    <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
+    <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
+    <PreReleaseVersionLabel></PreReleaseVersionLabel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(UseGlobalToolVersion)' == 'true'">
+    <AutoGenerateAssemblyVersion>false</AutoGenerateAssemblyVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(UseBetaVersion)' == 'true'">
+    <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
+    <AutoGenerateAssemblyVersion>false</AutoGenerateAssemblyVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- package settings -->

--- a/src/Microsoft.DotNet.Interactive.CSharp.Tests/Directory.Build.props
+++ b/src/Microsoft.DotNet.Interactive.CSharp.Tests/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/Microsoft.DotNet.Interactive.CSharp/Directory.Build.props
+++ b/src/Microsoft.DotNet.Interactive.CSharp/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/Directory.Build.props
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Directory.Build.props
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/Microsoft.DotNet.Interactive.FSharp.Tests/Directory.Build.props
+++ b/src/Microsoft.DotNet.Interactive.FSharp.Tests/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/Microsoft.DotNet.Interactive.FSharp/Directory.Build.props
+++ b/src/Microsoft.DotNet.Interactive.FSharp/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/Directory.Build.props
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/Microsoft.DotNet.Interactive.Formatting/Directory.Build.props
+++ b/src/Microsoft.DotNet.Interactive.Formatting/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/Microsoft.DotNet.Interactive.Http/Directory.Build.props
+++ b/src/Microsoft.DotNet.Interactive.Http/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/Directory.Build.props
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/Microsoft.DotNet.Interactive.Jupyter/Directory.Build.props
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/Microsoft.DotNet.Interactive.PowerShell.Tests/Directory.Build.props
+++ b/src/Microsoft.DotNet.Interactive.PowerShell.Tests/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Directory.Build.props
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/Microsoft.DotNet.Interactive.Recipes/Directory.Build.props
+++ b/src/Microsoft.DotNet.Interactive.Recipes/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/Microsoft.DotNet.Interactive.Telemetry.Tests/Directory.Build.props
+++ b/src/Microsoft.DotNet.Interactive.Telemetry.Tests/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/Microsoft.DotNet.Interactive.Telemetry/Directory.Build.props
+++ b/src/Microsoft.DotNet.Interactive.Telemetry/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/Microsoft.DotNet.Interactive.Tests/Directory.Build.props
+++ b/src/Microsoft.DotNet.Interactive.Tests/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/Microsoft.DotNet.Interactive/Directory.Build.props
+++ b/src/Microsoft.DotNet.Interactive/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/XPlot.DotNet.Interactive.KernelExtensions/Directory.Build.props
+++ b/src/XPlot.DotNet.Interactive.KernelExtensions/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/dotnet-interactive.IntegrationTests/Directory.Build.props
+++ b/src/dotnet-interactive.IntegrationTests/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/dotnet-interactive.Profiler/Directory.Build.props
+++ b/src/dotnet-interactive.Profiler/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/dotnet-interactive.Tests/Directory.Build.props
+++ b/src/dotnet-interactive.Tests/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/dotnet-interactive/Directory.Build.props
+++ b/src/dotnet-interactive/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseGlobalToolVersion>true</UseGlobalToolVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/dotnet-interactive/dotnet-interactive.csproj
+++ b/src/dotnet-interactive/dotnet-interactive.csproj
@@ -15,8 +15,6 @@
     <PackageDescription>Command line tool for interactive programming with C#, F#, and PowerShell, including support for Jupyter Notebooks.</PackageDescription>
     <PackageTags>dotnet interactive Jupyter csharp fsharp PowerShell</PackageTags>
     <PackAsTool>true</PackAsTool>
-    <AutoGenerateAssemblyVersion>false</AutoGenerateAssemblyVersion>
-    <PreReleaseVersionLabel></PreReleaseVersionLabel>
     <Description>.NET Interactive</Description>
     <NoWarn>$(NoWarn);8002</NoWarn><!-- Markdig isn't strongly signed -->
     <NoWarn>$(NoWarn);NU5129</NoWarn><!-- Improper warning about missing props file.  See https://github.com/NuGet/Home/issues/8627 -->

--- a/src/interface-generator/Directory.Build.props
+++ b/src/interface-generator/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>


### PR DESCRIPTION
Similar to dotnet/command-line-api#1113 and dotnet/command-line-api#1114, this PR is a workaround for dotnet/arcade#6616.  An [internal build](https://dev.azure.com/dnceng/internal/_build/results?buildId=905373&view=results) shows the correct assembly versions, package versions, and expected properties to allow publish to pass.

This required that every project have its own `Directory.Build.props` so they can specify which version number settings to apply.  dotnet/command-line-api already had these files.

Once the Arcade issue is fixed, the cleanup of this will be mostly removing the added files.