### PR TITLE
fix #r immediately after language selector

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
@@ -948,5 +948,31 @@ typeof(System.Device.Gpio.GpioController).Assembly.Location
             }
             // (OSPlatform.OSX is not supported by this library
         }
+
+        [Fact]
+        public async Task Pound_r_nuget_works_immediately_after_a_language_selector()
+        {
+            var kernel = CreateCompositeKernel(defaultKernelLanguage: Language.CSharp);
+
+            var code = @"
+#!csharp
+#r ""nuget: System.Text.Json, 4.6.0""
+";
+
+            var command = new SubmitCode(code);
+
+            var result = await kernel.SendAsync(command);
+
+            using var events = result.KernelEvents.ToSubscribedList();
+
+            events
+                .Should()
+                .ContainSingle<PackageAdded>()
+                .Which
+                .PackageReference
+                .PackageName
+                .Should()
+                .Be("System.Text.Json");
+        }
     }
 }

--- a/src/Microsoft.DotNet.Interactive/Parsing/DirectiveNode.cs
+++ b/src/Microsoft.DotNet.Interactive/Parsing/DirectiveNode.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.Interactive.Parsing
         internal DirectiveNode(
             DirectiveToken directiveToken,
             SourceText sourceText,
-            PolyglotSyntaxTree? syntaxTree) : base("#!", sourceText, syntaxTree)
+            PolyglotSyntaxTree? syntaxTree) : base(directiveToken.DirectiveName, sourceText, syntaxTree)
         {
             Add(directiveToken);
         }

--- a/src/Microsoft.DotNet.Interactive/Parsing/PolyglotSyntaxParser.cs
+++ b/src/Microsoft.DotNet.Interactive/Parsing/PolyglotSyntaxParser.cs
@@ -149,6 +149,7 @@ namespace Microsoft.DotNet.Interactive.Parsing
             void AppendAsLanguageNode(SyntaxNodeOrToken nodeOrToken)
             {
                 if (rootNode.ChildNodes.LastOrDefault() is LanguageNode previousLanguageNode &&
+                    previousLanguageNode is not KernelNameDirectiveNode &&
                     previousLanguageNode.KernelName == currentKernelName)
                 {
                     previousLanguageNode.Add(nodeOrToken);


### PR DESCRIPTION
When a submission is split into syntax nodes, a language switcher directive, e.g., `#!csharp`, was setting the kernel name to `#!` instead of `csharp`.  The result of this was that when the following was submitted:

```
#!csharp
#r "nuget: SomePackage"
```

The `#r` was inappropriately associated with the kernel `#!` which doesn't exist so it was never flagged as a directive that needed to be handled.  The fix is to set the kernel name appropriately, but then to also not let code submissions get appended to a language switcher node.

~~To enable testing the `DirectiveCommand` type needed to be exposed, but granting `InternalsVisibleTo` the test project opened up a whole other can of worms.  There likely needs to be a discussion around if exposing this type is appropriate.~~

This was also verified manually.

Fixes #921.