### PR TITLE
report all data when `dotnet new tool-manifest` fails

### DIFF
--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -115,7 +115,7 @@
         },
         "dotnet-interactive.minimumInteractiveToolVersion": {
           "type": "string",
-          "default": "1.0.150201",
+          "default": "1.0.160801",
           "description": "The minimum required version of the .NET Interactive tool."
         }
       }

--- a/src/dotnet-interactive-vscode/src/vscode/commands.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/commands.ts
@@ -197,7 +197,7 @@ async function getInteractiveVersion(dotnetPath: string, globalStoragePath: stri
 async function createToolManifest(dotnetPath: string, globalStoragePath: string): Promise<void> {
     const result = await execute(dotnetPath, ['new', 'tool-manifest'], globalStoragePath);
     if (result.code !== 0) {
-        throw new Error('Unable to create local tool manifest.');
+        throw new Error(`Unable to create local tool manifest.  Command failed with code ${result.code}.\n\nSTDOUT:\n${result.output}\n\nSTDERR:\n${result.error}`);
     }
 }
 


### PR DESCRIPTION
This is to help investigate #933 in case there's any helpful information in STDOUT or STDERR.