### PR TITLE
Update Binder Link URL

### DIFF
--- a/docs/NotebooksLocalExperience.md
+++ b/docs/NotebooksLocalExperience.md
@@ -68,7 +68,7 @@ Once Jupyter has launched in your browser, you have the option to create noteboo
 
 <img src = "https://user-images.githubusercontent.com/547415/78056370-ddd0cc00-7339-11ea-9379-c40f8b5c1ae5.png" width = "70%">
 
-For more information on the .NET notebook experience, please check out our samples and documentation on [Binder](https://mybinder.org/v2/gh/dotnet/interactive/master?urlpath=lab) or in this repo under [`docs`](../docs/readme.md) and [`samples`](../samples/readme.md).
+For more information on the .NET notebook experience, please check out our samples and documentation on [Binder](https://mybinder.org/v2/gh/dotnet/interactive/main?urlpath=lab) or in this repo under [`docs`](../docs/readme.md) and [`samples`](../samples/readme.md).
 
 Once you've created a .NET notebook, you might want to share it with others. In the [next document](CreateBinder.md), you will learn how to share your .NET notebook with others using Binder. 
 


### PR DESCRIPTION
Github recently changed default branches from "master" to "main" and the Binder link needs to be updated to reflect that