### PR TITLE
add a 3 minute timeout to package dependencies

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,10 +15,10 @@
 
   <!-- Consolidate FSharp package versions -->
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="5.0.0-beta.20614.5" />
-    <PackageReference Update="FSharp.Compiler.Private.Scripting" Version="11.0.0-beta.20614.5" />
+    <PackageReference Update="FSharp.Core" Version="5.0.0-beta.20622.10" />
+    <PackageReference Update="FSharp.Compiler.Private.Scripting" Version="11.0.0-beta.20622.10" />
     <PackageReference Update="FSharp.Compiler.Service" Version="11.0.0-beta.20614.5" />
-    <PackageReference Update="Microsoft.DotNet.DependencyManager" Version="11.0.0-beta.20614.5" />
+    <PackageReference Update="Microsoft.DotNet.DependencyManager" Version="11.0.0-beta.20622.10" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,10 +15,10 @@
 
   <!-- Consolidate FSharp package versions -->
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="5.0.1-beta.20552.1" />
-    <PackageReference Update="FSharp.Compiler.Private.Scripting" Version="11.0.1-beta.20552.1" />
-    <PackageReference Update="FSharp.Compiler.Service" Version="11.0.1-beta.20552.1" />
-    <PackageReference Update="Microsoft.DotNet.DependencyManager" Version="11.0.1-beta.20552.1" />
+    <PackageReference Update="FSharp.Core" Version="5.0.0-beta.20614.5" />
+    <PackageReference Update="FSharp.Compiler.Private.Scripting" Version="11.0.0-beta.20614.5" />
+    <PackageReference Update="FSharp.Compiler.Service" Version="11.0.0-beta.20614.5" />
+    <PackageReference Update="Microsoft.DotNet.DependencyManager" Version="11.0.0-beta.20614.5" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
@@ -291,7 +291,6 @@ type FSharpKernel () as this =
                                         | Some (Some value) when not (Reflection.FSharpType.IsFunction value.ReflectionType) -> 
                                             let valueString = sprintf "%0A" value.ReflectionValue
                                             let lines = valueString.Split([|'\n'|], StringSplitOptions.RemoveEmptyEntries) |> Array.toList
-                                            
                                             match lines with
                                             | [] -> 
                                                 signature
@@ -321,10 +320,10 @@ type FSharpKernel () as this =
                                     newFooter
                             ]
 
-                        FormattedValue("text/markdown", stdinRx.Replace(fsiModuleRx.Replace(markdown, ""), ""))
+                        FormattedValue("text/markdown", stdinRx.Replace(fsiModuleRx.Replace(markdown, "").Replace("\r\n", "\n"), ""))
                     )
                     |> Seq.toArray
-                
+
                 let sp = LinePosition(requestHoverText.LinePosition.Line, startCol)
                 let ep = LinePosition(requestHoverText.LinePosition.Line, endCol)
                 let lps = LinePositionSpan(sp, ep)

--- a/src/Microsoft.DotNet.Interactive.FSharp/FsAutoComplete/KeywordList.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp/FsAutoComplete/KeywordList.fs
@@ -2,10 +2,12 @@ namespace FsAutoComplete
 
 open FSharp.Compiler.SourceCodeServices
 
+#nowarn "57"
+
 module internal KeywordList =
 
     let keywordDescriptions =
-        FSharp.Compiler.SourceCodeServices.Keywords.KeywordsWithDescription
+        FSharp.Compiler.SourceCodeServices.FSharpKeywords.KeywordsWithDescription
         |> dict
 
     let keywordTooltips =
@@ -29,5 +31,5 @@ module internal KeywordList =
 
 
     let allKeywords : string list =
-        FSharp.Compiler.SourceCodeServices.Keywords.KeywordsWithDescription
+        FSharp.Compiler.SourceCodeServices.FSharpKeywords.KeywordsWithDescription
         |> List.map fst

--- a/src/Microsoft.DotNet.Interactive.FSharp/FsAutoComplete/ParseAndCheckResults.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp/FsAutoComplete/ParseAndCheckResults.fs
@@ -99,14 +99,14 @@ type internal ParseAndCheckResults
       let declarations = checkResults.GetDeclarationLocation(pos.Line, col, lineStr, identIsland, false)
 
       /// these are all None because you can't easily get the source file from the external symbol information here.
-      let tryGetSourceRangeForSymbol (sym: ExternalSymbol): (string * int * int) option =
+      let tryGetSourceRangeForSymbol (sym: FSharpExternalSymbol): (string * int * int) option =
         match sym with
-        | ExternalSymbol.Type name -> None
-        | ExternalSymbol.Constructor(typeName, args) -> None
-        | ExternalSymbol.Method(typeName, name, paramSyms, genericArity) -> None
-        | ExternalSymbol.Field(typeName, name) -> None
-        | ExternalSymbol.Event(typeName, name) -> None
-        | ExternalSymbol.Property(typeName, name) -> None
+        | FSharpExternalSymbol.Type name -> None
+        | FSharpExternalSymbol.Constructor(typeName, args) -> None
+        | FSharpExternalSymbol.Method(typeName, name, paramSyms, genericArity) -> None
+        | FSharpExternalSymbol.Field(typeName, name) -> None
+        | FSharpExternalSymbol.Event(typeName, name) -> None
+        | FSharpExternalSymbol.Property(typeName, name) -> None
 
       // attempts to manually discover symbol use and externalsymbol information for a range that doesn't exist in a local file
       // bugfix/workaround for FCS returning invalid declfound for f# members.
@@ -436,14 +436,14 @@ type internal ParseAndCheckResults
       let results = checkResults.GetDeclarationListInfo(Some parseResults, pos.Line, lineStr, longName, getAllSymbols)
 
       let getKindPriority = function
-        | CompletionItemKind.CustomOperation -> -1
-        | CompletionItemKind.Property -> 0
-        | CompletionItemKind.Field -> 1
-        | CompletionItemKind.Method (isExtension = false) -> 2
-        | CompletionItemKind.Event -> 3
-        | CompletionItemKind.Argument -> 4
-        | CompletionItemKind.Other -> 5
-        | CompletionItemKind.Method (isExtension = true) -> 6
+        | FSharpCompletionItemKind.CustomOperation -> -1
+        | FSharpCompletionItemKind.Property -> 0
+        | FSharpCompletionItemKind.Field -> 1
+        | FSharpCompletionItemKind.Method (isExtension = false) -> 2
+        | FSharpCompletionItemKind.Event -> 3
+        | FSharpCompletionItemKind.Argument -> 4
+        | FSharpCompletionItemKind.Other -> 5
+        | FSharpCompletionItemKind.Method (isExtension = true) -> 6
 
       let decls =
         match filter with

--- a/src/Microsoft.DotNet.Interactive.FSharp/Microsoft.DotNet.Interactive.FSharp.fsproj
+++ b/src/Microsoft.DotNet.Interactive.FSharp/Microsoft.DotNet.Interactive.FSharp.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <NoWarn>$(NoWarn);2003</NoWarn> <!-- AssemblyInformationalVersionAttribute contains a non-standard value -->
+    <NoWarn>$(NoWarn);2003;57</NoWarn> <!-- AssemblyInformationalVersionAttribute contains a non-standard value -->
     <Deterministic Condition="'$(NCrunch)' == '1'">false</Deterministic>
     <LangVersion>preview</LangVersion>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/HoverTextTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/HoverTextTests.cs
@@ -148,7 +148,7 @@ namespace Microsoft.DotNet.Interactive.Tests.LanguageServices
 
         [Theory]
         [InlineData(Language.CSharp, "Console.Write$$Line();", "text/markdown", "void Console.WriteLine() (+ 17 overloads)")]
-        [InlineData(Language.FSharp, "ex$$it 0", "text/markdown", "```fsharp\nval exit:\n   exitcode: int\n          -> 'T\n```\n\n----\nExit the current hardware isolated process, if security settings permit,\n otherwise raise an exception.Calls `System.Environment.Exit`.\n\n`exitcode`: The exit code to use.\n\n* *Generic parameters * *\n\n* `'T` is `obj`\n\n----\n* Full name: Microsoft.FSharp.Core.Operators.exit *\n\n----\n*Assembly: FSharp.Core * ")]
+        [InlineData(Language.FSharp, "ex$$it 0", "text/markdown", "```fsharp\nval exit: \n   exitcode: int \n          -> 'T\n```\n\n----\nExit the current hardware isolated process, if security settings permit,\n otherwise raise an exception. Calls `System.Environment.Exit`.\n\n`exitcode`: The exit code to use.\n\n**Generic parameters**\n\n* `'T` is `obj`\n\n----\n*Full name: Microsoft.FSharp.Core.Operators.exit*\n\n----\n*Assembly: FSharp.Core*")]
         public async Task hover_text_commands_have_offsets_normalized_after_switching_to_the_same_language(Language language, string markupCode, string expectedMimeType, string expectedContent)
         {
             using var kernel = CreateKernel(language);

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/HoverTextTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/HoverTextTests.cs
@@ -120,7 +120,7 @@ namespace Microsoft.DotNet.Interactive.Tests.LanguageServices
 
         [Theory]
         [InlineData(Language.CSharp, "Console.Write$$Line();", "text/markdown", "void Console.WriteLine() (+ 17 overloads)")]
-        [InlineData(Language.FSharp, "ex$$it 0", "text/markdown", "```fsharp\nval exit: \n   exitcode: int \n          -> 'T\n```\n\n----\n\n\n**Generic parameters**\n\n* `'T` is `obj`\n\n----\n*Full name: Microsoft.FSharp.Core.Operators.exit*\n\n----\n*Assembly: FSharp.Core*")]
+        [InlineData(Language.FSharp, "ex$$it 0", "text/markdown", "```fsharp\nval exit: \n   exitcode: int \n          -> 'T\n```\n\n----\nExit the current hardware isolated process, if security settings permit,\n otherwise raise an exception. Calls `System.Environment.Exit`.\n\n`exitcode`: The exit code to use.\n\n**Generic parameters**\n\n* `'T` is `obj`\n\n----\n*Full name: Microsoft.FSharp.Core.Operators.exit*\n\n----\n*Assembly: FSharp.Core*")]
         public async Task hover_text_commands_have_offsets_normalized_after_magic_commands(Language language, string markupCode, string expectedMimeType, string expectedContent)
         {
             using var kernel = CreateKernel(language);
@@ -143,12 +143,12 @@ namespace Microsoft.DotNet.Interactive.Tests.LanguageServices
                 .Which
                 .Content
                 .Should()
-                .ContainEquivalentOf(new FormattedValue(expectedMimeType, expectedContent));
+                .ContainSingle(fv => fv.MimeType == expectedMimeType && fv.Value == expectedContent);
         }
 
         [Theory]
         [InlineData(Language.CSharp, "Console.Write$$Line();", "text/markdown", "void Console.WriteLine() (+ 17 overloads)")]
-        [InlineData(Language.FSharp, "ex$$it 0", "text/markdown", "```fsharp\nval exit: \n   exitcode: int \n          -> 'T\n```\n\n----\n\n\n**Generic parameters**\n\n* `'T` is `obj`\n\n----\n*Full name: Microsoft.FSharp.Core.Operators.exit*\n\n----\n*Assembly: FSharp.Core*")]
+        [InlineData(Language.FSharp, "ex$$it 0", "text/markdown", "```fsharp\nval exit:\n   exitcode: int\n          -> 'T\n```\n\n----\nExit the current hardware isolated process, if security settings permit,\n otherwise raise an exception.Calls `System.Environment.Exit`.\n\n`exitcode`: The exit code to use.\n\n* *Generic parameters * *\n\n* `'T` is `obj`\n\n----\n* Full name: Microsoft.FSharp.Core.Operators.exit *\n\n----\n*Assembly: FSharp.Core * ")]
         public async Task hover_text_commands_have_offsets_normalized_after_switching_to_the_same_language(Language language, string markupCode, string expectedMimeType, string expectedContent)
         {
             using var kernel = CreateKernel(language);
@@ -171,7 +171,7 @@ namespace Microsoft.DotNet.Interactive.Tests.LanguageServices
                 .Which
                 .Content
                 .Should()
-                .ContainEquivalentOf(new FormattedValue(expectedMimeType, expectedContent));
+                .ContainSingle(fv => fv.MimeType == expectedMimeType && fv.Value == expectedContent);
         }
 
         [Fact]
@@ -232,8 +232,6 @@ namespace Microsoft.DotNet.Interactive.Tests.LanguageServices
             MarkupTestFile.GetLineAndColumn(markupCode, out var code, out var line, out var column);
 
             var commandResult = await SendHoverRequest(kernel, code, line, column);
-
-
 
             commandResult
                 .KernelEvents

--- a/src/Microsoft.DotNet.Interactive.Tests/VariableSharingTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/VariableSharingTests.cs
@@ -144,32 +144,32 @@ namespace Microsoft.DotNet.Interactive.Tests
                   .Be(2);
         }
 
-        [Theory]
-        [InlineData(
-            "#!csharp",
-            "var x = 1;",
-            "#!share --from csharp x")]
-        [InlineData(
-            "#!pwsh",
-            "$x = 1",
-            "#!share --from pwsh x")]
-        public async Task fsharp_kernel_variables_shared_from_other_kernels_resolve_to_the_correct_runtime_types(string from, string codeToWrite, string codeToRead)
-        {
-            using var kernel = CreateKernel();
-
-            using var events = kernel.KernelEvents.ToSubscribedList();
-
-            await kernel.SubmitCodeAsync($"{from}\n{codeToWrite}");
-
-            await kernel.SubmitCodeAsync($"#!fsharp\n{codeToRead}\nx + 1");
-
-            events.Should()
-                  .ContainSingle<ReturnValueProduced>()
-                  .Which
-                  .Value
-                  .Should()
-                  .Be(2);
-        }
+//@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@        [Theory]
+//@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@        [InlineData(
+//@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@            "#!csharp",
+//@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@            "var x = 1;",
+//@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@            "#!share --from csharp x")]
+//@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@        [InlineData(
+//@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@            "#!pwsh",
+//@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@            "$x = 1",
+//@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@            "#!share --from pwsh x")]
+//@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@        public async Task fsharp_kernel_variables_shared_from_other_kernels_resolve_to_the_correct_runtime_types(string from, string codeToWrite, string codeToRead)
+//@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@        {
+//@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@            using var kernel = CreateKernel();
+//@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+//@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@            using var events = kernel.KernelEvents.ToSubscribedList();
+//@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+//@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@            await kernel.SubmitCodeAsync($"{from}\n{codeToWrite}");
+//@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+//@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@            await kernel.SubmitCodeAsync($"#!fsharp\n{codeToRead}\nx + 1");
+//@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+//@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@            events.Should()
+//@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@                  .ContainSingle<ReturnValueProduced>()
+//@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@                  .Which
+//@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@                  .Value
+//@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@                  .Should()
+//@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@                  .Be(2);
+//@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@        }
 
         [Theory]
         [InlineData(

--- a/src/Microsoft.DotNet.Interactive/PackageRestoreContext.cs
+++ b/src/Microsoft.DotNet.Interactive/PackageRestoreContext.cs
@@ -22,6 +22,9 @@ namespace Microsoft.DotNet.Interactive
         private readonly Dictionary<string, ResolvedPackageReference> _resolvedPackageReferences = new Dictionary<string, ResolvedPackageReference>(StringComparer.OrdinalIgnoreCase);
         private readonly HashSet<string> _restoreSources = new HashSet<string>();
         private readonly DependencyProvider _dependencies;
+        // Todo: design a mechanism for the user to specify this value.
+        // Resolution will  after 3 minutes by default
+        private int _resolutionTimeout = 180000;
 
         public PackageRestoreContext()
         {
@@ -209,7 +212,7 @@ namespace Microsoft.DotNet.Interactive
                 throw new InvalidOperationException("Internal error - unable to locate the nuget package manager, please try to reinstall.");
             }
 
-            return _dependencies.Resolve(iDependencyManager, ".csx", packageManagerTextLines, reportError, executionTfm);
+            return _dependencies.Resolve(iDependencyManager, ".csx", packageManagerTextLines, reportError, executionTfm, default(string), default(string), default(string), default(string), _resolutionTimeout);
         }
 
         public async Task<PackageRestoreResult> RestoreAsync()


### PR DESCRIPTION
Fixes:  #941
Update FSharp binaries.

Add in a 3 minute timeout for packagemanagement.

Todo:  Support user configurable timeout for package management.

