### PR TITLE
SQL kernel updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -381,3 +381,6 @@ src/Microsoft.DotNet.Interactive.nteract.js/dist/
 src/Microsoft.DotNet.Interactive.nteract.js/lib/
 
 .DS_Store
+
+# Rider IDE cache files
+.idea/

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/MSSQLFact.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/MSSQLFact.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.Data.SqlClient;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Xunit;
 
 namespace Microsoft.DotNet.Interactive.ExtensionLab.Tests

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/MSSQLFact.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/MSSQLFact.cs
@@ -1,26 +1,58 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using Microsoft.Data.SqlClient;
-
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Xunit;
 
 namespace Microsoft.DotNet.Interactive.ExtensionLab.Tests
 {
     public sealed class MsSqlFact : FactAttribute
     {
-        public MsSqlFact(string requiredConnectionString)
+        private const string TEST_MSSQL_CONNECTION_STRING = "TEST_MSSQL_CONNECTION_STRING";
+        private static readonly string _skipReason;
+        
+        static MsSqlFact()
         {
-            try
+            _skipReason = TestConnectionAndReturnSkipReason();
+        }
+
+        public MsSqlFact()
+        {
+            if (_skipReason != null)
             {
-                var connection = new SqlConnection(requiredConnectionString);
-                connection.Open();
-                connection.Dispose();
-            }
-            catch
-            {
-                Skip = "Required db connection cannot be found or established";
+                this.Skip = _skipReason;
             }
         }
+        
+        private static string TestConnectionAndReturnSkipReason()
+        {
+            string connectionString = GetConnectionStringForTests();
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                return $"Environment variable {TEST_MSSQL_CONNECTION_STRING} is not set. To run tests that require "
+                + "SQL Server, this environment variable must be set to a valid connection string value.";
+            }
+            
+            try
+            {
+                using var connection = new SqlConnection(connectionString);
+                connection.Open();
+            }
+            catch (Exception e)
+            {
+                return $"A connection could not be established to SQL Server. Verify the connection string value used " +
+                       $"for environment variable {TEST_MSSQL_CONNECTION_STRING} targets a running SQL Server instance. " +
+                       $"Connection failed failed with error: {e}";                    
+            }
+
+            return null;
+        }
+        
+        public static string GetConnectionStringForTests()
+        {
+            return Environment.GetEnvironmentVariable(TEST_MSSQL_CONNECTION_STRING);
+        }  
     }
 }

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/MsSqlConnectionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/MsSqlConnectionTests.cs
@@ -82,7 +82,7 @@ SELECT TOP 100 * FROM Person.Person
 
             events.Should().NotContainErrors();
 
-            result = await kernel.SubmitCodeAsync("adventureworks.AddressTypes.Count()");
+            result = await kernel.SubmitCodeAsync("adventureworks.AddressType.Count()");
 
             events = result.KernelEvents.ToSubscribedList();
 

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/MsSqlConnectionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/MsSqlConnectionTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Threading.Tasks;
 
 using FluentAssertions;
@@ -19,6 +20,14 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab.Tests
         public MsSqlConnectionTests(ITestOutputHelper output)
         {
             _output = output;
+            
+            // FIX: (MsSqlConnectionTests) 
+            if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(MsSqlServiceClient.SqlToolsServiceEnvironmentVariableName)))
+            {
+                Environment.SetEnvironmentVariable(
+                    MsSqlServiceClient.SqlToolsServiceEnvironmentVariableName,
+                    @"/Users/bro/code/sqltoolsservice/src/Microsoft.SqlTools.ServiceLayer/bin/Debug/netcoreapp3.1/osx.10.11-x64/publish/MicrosoftSqlToolsServiceLayer");
+            }
         }
 
         [MsSqlFact("Persist Security Info=False; Integrated Security=true; Initial Catalog=AdventureWorks2019; Server=localhost", Skip = "not ready")]

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/MsSqlConnectionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/MsSqlConnectionTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab.Tests
         {
             var csharpKernel = new CSharpKernel().UseNugetDirective();
             await csharpKernel.SubmitCodeAsync(@$"
-#r ""nuget:runtime.osx-x64.native.microsoft.sqltoolsservice,3.0.0-release.52""
+#r ""nuget:microsoft.sqltoolsservice,3.0.0-release.52""
 ");
             
             var kernel = new CompositeKernel

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/MsSqlConnectionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/MsSqlConnectionTests.cs
@@ -82,7 +82,7 @@ SELECT TOP 100 * FROM Person.Person
 
             events.Should().NotContainErrors();
 
-            result = await kernel.SubmitCodeAsync("adventureworks.AddressType.Count()");
+            result = await kernel.SubmitCodeAsync("adventureworks.AddressTypes.Count()");
 
             events = result.KernelEvents.ToSubscribedList();
 

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.DotNet.Interactive.ExtensionLab.csproj
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.DotNet.Interactive.ExtensionLab.csproj
@@ -40,8 +40,14 @@
   </ItemGroup>
 
  <ItemGroup>
+   <PackageReference Include="Humanizer.Core" Version="2.8.26" />
    <PackageReference Include="Microsoft.Data.Analysis" Version="0.4.0" />
-   <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.0" />
+   <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.1" />
+   <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.1">
+     <PrivateAssets>all</PrivateAssets>
+     <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+   </PackageReference>
+   <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.1" />
    <PackageReference Include="StreamJsonRpc" Version="2.6.121" />
    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.8" />
  </ItemGroup>

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.DotNet.Interactive.ExtensionLab.csproj
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.DotNet.Interactive.ExtensionLab.csproj
@@ -40,14 +40,13 @@
   </ItemGroup>
 
  <ItemGroup>
-   <PackageReference Include="Humanizer.Core" Version="2.8.26" />
    <PackageReference Include="Microsoft.Data.Analysis" Version="0.4.0" />
-   <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.1" />
-   <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.1">
+   <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.0" />
+   <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.8">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
    </PackageReference>
-   <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.1" />
+   <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.8" />
    <PackageReference Include="StreamJsonRpc" Version="2.6.121" />
    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.8" />
  </ItemGroup>

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.SqlTools.ServiceLayer/runtime.osx-x64.runtime.native.Microsoft.SqlTools.ServiceLayer/Class1.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.SqlTools.ServiceLayer/runtime.osx-x64.runtime.native.Microsoft.SqlTools.ServiceLayer/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace runtime.osx_x64.runtime.native.Microsoft.SqlTools.ServiceLayer
-{
-    public class Class1
-    {
-    }
-}

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.SqlTools.ServiceLayer/runtime.rhel-x64.runtime.native.Microsoft.SqlTools.ServiceLayer/Class1.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.SqlTools.ServiceLayer/runtime.rhel-x64.runtime.native.Microsoft.SqlTools.ServiceLayer/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace runtime.rhel_x64.runtime.native.Microsoft.SqlTools.ServiceLayer
-{
-    public class Class1
-    {
-    }
-}

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.SqlTools.ServiceLayer/runtime.win-x64.runtime.native.Microsoft.SqlTools.ServiceLayer/Class1.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.SqlTools.ServiceLayer/runtime.win-x64.runtime.native.Microsoft.SqlTools.ServiceLayer/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace runtime.win_x64.runtime.native.Microsoft.SqlTools.ServiceLayer
-{
-    public class Class1
-    {
-    }
-}

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.SqlTools.ServiceLayer/runtime.win-x86.runtime.native.Microsoft.SqlTools.ServiceLayer/Class1.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.SqlTools.ServiceLayer/runtime.win-x86.runtime.native.Microsoft.SqlTools.ServiceLayer/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace runtime.win_x86.runtime.native.Microsoft.SqlTools.ServiceLayer
-{
-    public class Class1
-    {
-    }
-}

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.SqlTools.ServiceLayer/runtime.win10-arm.runtime.native.Microsoft.SqlTools.ServiceLayer/Class1.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.SqlTools.ServiceLayer/runtime.win10-arm.runtime.native.Microsoft.SqlTools.ServiceLayer/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace runtime.win10_arm.runtime.native.Microsoft.SqlTools.ServiceLayer
-{
-    public class Class1
-    {
-    }
-}

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.SqlTools.ServiceLayer/runtime.win10-arm64.runtime.native.Microsoft.SqlTools.ServiceLayer/Class1.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.SqlTools.ServiceLayer/runtime.win10-arm64.runtime.native.Microsoft.SqlTools.ServiceLayer/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace runtime.win10_arm64.runtime.native.Microsoft.SqlTools.ServiceLayer
-{
-    public class Class1
-    {
-    }
-}

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/MsSqlKernelConnection.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/MsSqlKernelConnection.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.CommandLine;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.Connection;
 using Microsoft.DotNet.Interactive.CSharp;
@@ -21,7 +25,24 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
             MsSqlConnectionOptions options,
             KernelInvocationContext context)
         {
+            var resolvedPackageReferences = ((ISupportNuget)context.HandlingKernel).ResolvedPackageReferences;
+            // Walk through the packages looking for the package that endswith the name "runtime.native.Microsoft.SqlToolsService"
+            // and grab the packageroot
+            var runtimePackageId = "runtime.native.Microsoft.SqlToolsServiceLayer";
+            var runtimePackageIdSuffix = "Microsoft.SqlToolsServiceLayer";
+            var root = resolvedPackageReferences.FirstOrDefault(p => p.PackageName.EndsWith(runtimePackageId, StringComparison.OrdinalIgnoreCase));
+            string pathToService = "";
+            if (root != null)
+            {
+                // Packagename is rubbish, but can be reformatted to compute the path to the binaries
+                var runtimePackageIdPath = root.PackageName.Replace(runtimePackageIdSuffix, "", StringComparison.OrdinalIgnoreCase)
+                                                           .Replace(".", "\\", StringComparison.OrdinalIgnoreCase)
+                                                           .Replace(@"\runtime\", "\\", StringComparison.OrdinalIgnoreCase)
+                                                           .Replace(@"runtime\", @"runtimes\", StringComparison.OrdinalIgnoreCase);
+                pathToService = Path.Combine(root.PackageRoot, runtimePackageIdPath, "MicrosoftSqlToolsServiceLayer.exe");
+            }
             var kernel = new MsSqlKernel(
+                pathToService,
                 options.KernelName,
                 options.ConnectionString);
 
@@ -55,8 +76,8 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
             context.Display($"Scaffolding a `DbContext` and initializing an instance of it called `{options.KernelName}` in the C# kernel.", "text/markdown");
 
             var submission1 = @$"
-#r ""nuget:Microsoft.EntityFrameworkCore.Design""
-#r ""nuget:Microsoft.EntityFrameworkCore.SqlServer""
+#r ""nuget:Microsoft.EntityFrameworkCore.Design,3.1.8""
+#r ""nuget:Microsoft.EntityFrameworkCore.SqlServer,3.1.8""
 
 using System;
 using System.Reflection;

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/MsSqlKernelConnection.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/MsSqlKernelConnection.cs
@@ -90,8 +90,8 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
             context.Display($"Scaffolding a `DbContext` and initializing an instance of it called `{options.KernelName}` in the C# kernel.", "text/markdown");
 
             var submission1 = @$"
-#r ""nuget:Microsoft.EntityFrameworkCore.Design,5.0.1""
-#r ""nuget:Microsoft.EntityFrameworkCore.SqlServer,5.0.1""
+#r ""nuget:Microsoft.EntityFrameworkCore.Design,3.1.8""
+#r ""nuget:Microsoft.EntityFrameworkCore.SqlServer,3.1.8""
 
 using System;
 using System.Reflection;
@@ -124,8 +124,7 @@ var model = scaffolder.ScaffoldModel(
 var code = @""using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata;
-"";
+using Microsoft.EntityFrameworkCore.Metadata;"";
 
 foreach (var file in  new[] {{ model.ContextFile.Code }}.Concat(model.AdditionalFiles.Select(f => f.Code)))
 {{
@@ -138,7 +137,6 @@ foreach (var file in  new[] {{ model.ContextFile.Code }}.Concat(model.Additional
         .Replace(""using System.Collections.Generic;"", """")
         .Replace(""using Microsoft.EntityFrameworkCore;"", """")
         .Replace(""using Microsoft.EntityFrameworkCore.Metadata;"", """")
-        .Replace(Environment.NewLine + ""{{"" + Environment.NewLine, Environment.NewLine)
 
         // trim out the wrapping braces
         .Trim()

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/MsSqlKernelConnection.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/MsSqlKernelConnection.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
             var resolvedPackageReferences = ((ISupportNuget)context.HandlingKernel).ResolvedPackageReferences;
             // Walk through the packages looking for the package that endswith the name "Microsoft.SqlToolsService"
             // and grab the packageroot
-            var runtimePackageIdSuffix = "Microsoft.SqlToolsService";
+            var runtimePackageIdSuffix = "native.Microsoft.SqlToolsService";
             var root = resolvedPackageReferences.FirstOrDefault(p => p.PackageName.EndsWith(runtimePackageIdSuffix, StringComparison.OrdinalIgnoreCase));
             string pathToService = "";
             if (root != null)

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/MsSqlKernelConnection.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/MsSqlKernelConnection.cs
@@ -90,8 +90,8 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
             context.Display($"Scaffolding a `DbContext` and initializing an instance of it called `{options.KernelName}` in the C# kernel.", "text/markdown");
 
             var submission1 = @$"
-#r ""nuget:Microsoft.EntityFrameworkCore.Design,3.1.8""
-#r ""nuget:Microsoft.EntityFrameworkCore.SqlServer,3.1.8""
+#r ""nuget:Microsoft.EntityFrameworkCore.Design,5.0.0""
+#r ""nuget:Microsoft.EntityFrameworkCore.SqlServer,5.0.0""
 
 using System;
 using System.Reflection;

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/MsSqlKernelConnection.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/MsSqlKernelConnection.cs
@@ -90,8 +90,8 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
             context.Display($"Scaffolding a `DbContext` and initializing an instance of it called `{options.KernelName}` in the C# kernel.", "text/markdown");
 
             var submission1 = @$"
-#r ""nuget:Microsoft.EntityFrameworkCore.Design,5.0.0""
-#r ""nuget:Microsoft.EntityFrameworkCore.SqlServer,5.0.0""
+#r ""nuget:Microsoft.EntityFrameworkCore.Design,5.0.1""
+#r ""nuget:Microsoft.EntityFrameworkCore.SqlServer,5.0.1""
 
 using System;
 using System.Reflection;
@@ -124,7 +124,8 @@ var model = scaffolder.ScaffoldModel(
 var code = @""using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata;"";
+using Microsoft.EntityFrameworkCore.Metadata;
+"";
 
 foreach (var file in  new[] {{ model.ContextFile.Code }}.Concat(model.AdditionalFiles.Select(f => f.Code)))
 {{
@@ -137,6 +138,7 @@ foreach (var file in  new[] {{ model.ContextFile.Code }}.Concat(model.Additional
         .Replace(""using System.Collections.Generic;"", """")
         .Replace(""using Microsoft.EntityFrameworkCore;"", """")
         .Replace(""using Microsoft.EntityFrameworkCore.Metadata;"", """")
+        .Replace(Environment.NewLine + ""{{"" + Environment.NewLine, Environment.NewLine)
 
         // trim out the wrapping braces
         .Trim()

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/MsSqlRpcObjects.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/MsSqlRpcObjects.cs
@@ -424,6 +424,69 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
     }
 
     /// <summary>
+    /// Parameters to be sent back with a message notification
+    /// </summary>
+    public class MessageParams
+    {
+        /// <summary>
+        /// URI for the editor that owns the query
+        /// </summary>
+        public string OwnerUri { get; set; }
+
+        /// <summary>
+        /// The message that is being returned
+        /// </summary>
+        public ResultMessage Message { get; set; }
+    }
+
+    /// <summary>
+    /// Result message object with timestamp and actual message
+    /// </summary>
+    public class ResultMessage
+    {
+        /// <summary>
+        /// ID of the batch that generated this message. If null, this message
+        /// was not generated as part of a batch
+        /// </summary>
+        public int? BatchId { get; set; }
+
+        /// <summary>
+        /// Whether or not this message is an error
+        /// </summary>
+        public bool IsError { get; set; }
+
+        /// <summary>
+        /// Timestamp of the message
+        /// Stored in UTC ISO 8601 format; should be localized before displaying to any user
+        /// </summary>
+        public string Time { get; set; }
+
+        /// <summary>
+        /// Message contents
+        /// </summary>
+        public string Message { get; set; }
+
+        /// <summary>
+        /// Constructor with default "Now" time
+        /// </summary>
+        public ResultMessage(string message, bool isError, int? batchId)
+        {
+            BatchId = batchId;
+            IsError = isError;
+            Time = DateTime.Now.ToString("o");
+            Message = message;
+        }
+
+        /// <summary>
+        /// Default constructor, used for deserializing JSON RPC only
+        /// </summary>
+        public ResultMessage()
+        {
+        }
+        public override string ToString() => $"Message on Batch Id:'{BatchId}', IsError:'{IsError}', Message:'{Message}'";
+    }
+
+    /// <summary>
     /// Summary of a batch within a query
     /// </summary>
     public class BatchSummary
@@ -471,6 +534,7 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
         public int EndLine { get; set; }
 
         public int StartColumn { get; set; }
+
         public int StartLine { get; set; }
     }
 

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/MsSqlServiceClient.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/MsSqlServiceClient.cs
@@ -30,6 +30,11 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
             {
                 _serviceExePath = Environment.GetEnvironmentVariable(SqlToolsServiceEnvironmentVariableName);
             }
+
+            if (string.IsNullOrWhiteSpace(_serviceExePath))
+            {
+                throw new ArgumentException("Path to SQL Tools Service executable was not provided.", nameof(serviceExePath));
+            }
         }
 
         public void Initialize()
@@ -43,11 +48,6 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
 
         private void StartProcessAndRedirectIO()
         {
-            if (_serviceExePath == null)
-            {
-                throw new InvalidOperationException("Path to SQL Tools Service executable was not provided.");
-            }
-
             var startInfo = new ProcessStartInfo(_serviceExePath)
             {
                 UseShellExecute = false,

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/MsSqlServiceClient.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/MsSqlServiceClient.cs
@@ -15,11 +15,22 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
 {
     public class MsSqlServiceClient : IDisposable
     {
-        public static readonly MsSqlServiceClient Instance = new MsSqlServiceClient();
-
         private Process _process;
         private JsonRpc _rpc;
         private bool _initialized = false;
+        private readonly string _serviceExePath;
+
+        public const string SqlToolsServiceEnvironmentVariableName = "DOTNET_SQLTOOLSSERVICE";
+
+        public MsSqlServiceClient(string serviceExePath = null)
+        {
+            _serviceExePath = serviceExePath;
+
+            if (string.IsNullOrWhiteSpace(_serviceExePath))
+            {
+                _serviceExePath = Environment.GetEnvironmentVariable(SqlToolsServiceEnvironmentVariableName);
+            }
+        }
 
         public void Initialize()
         {
@@ -32,13 +43,12 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
 
         private void StartProcessAndRedirectIO()
         {
-            var serviceExePath = Environment.GetEnvironmentVariable("DOTNET_SQLTOOLSSERVICE");
-            if (serviceExePath == null)
+            if (_serviceExePath == null)
             {
                 throw new InvalidOperationException("Path to SQL Tools Service executable was not provided.");
             }
 
-            var startInfo = new ProcessStartInfo(serviceExePath)
+            var startInfo = new ProcessStartInfo(_serviceExePath)
             {
                 UseShellExecute = false,
                 RedirectStandardInput = true,
@@ -56,6 +66,7 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
 
             AddLocalRpcMethod(nameof(HandleConnectionCompletion), "connection/complete");
             AddLocalRpcMethod(nameof(HandleQueryCompletion), "query/complete");
+            AddLocalRpcMethod(nameof(HandleQueryMessage), "query/message");
             AddLocalRpcMethod(nameof(HandleIntellisenseReady), "textDocument/intelliSenseReady");
 
             _rpc.StartListening();
@@ -75,6 +86,7 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
         public event EventHandler<ConnectionCompleteParams> OnConnectionComplete;
         public event EventHandler<QueryCompleteParams> OnQueryComplete;
         public event EventHandler<IntelliSenseReadyParams> OnIntellisenseReady;
+        public event EventHandler<MessageParams> OnQueryMessage;
 
         public async Task<bool> ConnectAsync(Uri ownerUri, string connectionStr)
         {
@@ -171,6 +183,11 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
         public void HandleQueryCompletion(QueryCompleteParams queryParams)
         {
             OnQueryComplete(this, queryParams);
+        }
+
+        public void HandleQueryMessage(MessageParams messageParams)
+        {
+            OnQueryMessage(this, messageParams);
         }
 
         public void HandleIntellisenseReady(IntelliSenseReadyParams readyParams)

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/SqlKernelsExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/SqlKernelsExtension.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
 
             KernelInvocationContext.Current?.Display(
                 $@"
-Added `mssql` and `sqlite` to the connection types available using the [`#!connect`](https://github.com/dotnet/interactive/blob/main/docs/connect.md) magic command.",
+* Adds `mssql` and `sqlite` to the connection types available using the [`#!connect`](https://github.com/dotnet/interactive/blob/main/docs/connect.md) magic command.",
                 "text/markdown");
 
             }

--- a/src/dotnet-interactive/dotnet-interactive.csproj
+++ b/src/dotnet-interactive/dotnet-interactive.csproj
@@ -37,6 +37,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Humanizer.Core" Version="2.8.26" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
     <PackageReference Include="Serilog.Sinks.RollingFileAlternate" Version="2.0.9" />
     <PackageReference Include="Pocket.Disposable" Version="1.1.0">

--- a/src/dotnet-interactive/dotnet-interactive.csproj
+++ b/src/dotnet-interactive/dotnet-interactive.csproj
@@ -37,12 +37,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Humanizer.Core" Version="2.8.26" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
     <PackageReference Include="Serilog.Sinks.RollingFileAlternate" Version="2.0.9" />
     <PackageReference Include="Pocket.Disposable" Version="1.1.0">


### PR DESCRIPTION
Various updates to SQL kernel in the ExtensionLabs project:
* Updated the logic to load the SqlToolsService native binary based on the resolved Microsoft.SqlToolsService nuget package.
* Bumped the EF nuget packages to 3.1.8.
* We now explicitly declare the nuget dependencies in the Microsoft.Dotnet.Interactive.ExtensionLabs.csproj.
* Updated the tests that connect to SQL Server to load the connection string from environment variable TEST_MSSQL_CONNECTION_STRING. This will keep connection strings out of the source code, and should prevent accidental credential checkins.
* Misc .cs code changes from Jon's https://github.com/dotnet/interactive/pull/870 branch.

We are not moving to the latest EF 5.X version due to assembly version conflicts with the Humanizer and Microsoft.Extensions.DependencyInjection when the latest versions are pulled in by EF 5.