### PR TITLE
use hosted pool for ci build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,8 @@ stages:
       - job: Windows_NT
         pool:
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-            vmImage: windows-2019
+            name: NetCorePublic-Pool
+            queue: BuildPool.Windows.10.Amd64.VS2019.Open
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
             name: NetCoreInternal-Pool
             queue: buildpool.windows.10.amd64.vs2019
@@ -83,7 +84,7 @@ stages:
         - task: NodeTool@0
           displayName: Add NodeJS/npm
           inputs:
-            versionSpec: $(NodeJSVersion)        
+            versionSpec: $(NodeJSVersion)
 
         - task: UseDotNet@2
           displayName: Use .NET SDK 5.0


### PR DESCRIPTION
Use hosted machine pool for CI builds to try and make PRs stable.

Results of force-pushing and looking at the Windows runs:

Run | Status | Time
-|-|-
1 | pass | 12m
2 | pass | 12m
3 | pass | 12m
4 | pass | 14m
5 | pass | 13m
6 | pass | 13m
7 | pass | 10m
8 | pass | 12m
9 | pass | 14m
10 | pass | 12m

This raises the awkward question of "what's different" between the public `windows-2019` image and the hosted pool, but that may be best left for another day.

dotnet/roslyn is using this public pool, so we shouldn't have any issues about machine availability since we have much less traffic than them and are much faster.