### PR TITLE
report trx file for npm tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,7 +110,7 @@ stages:
           env:
             TRYDOTNET_PACKAGES_PATH: $(TryDotNetPackagesPath)
 
-        - script: npm run test
+        - script: npm run ciTest
           displayName: NPM tests
           workingDirectory: "$(Build.SourcesDirectory)/src/Microsoft.DotNet.Interactive.Js"
 
@@ -217,7 +217,7 @@ stages:
           env:
             TRYDOTNET_PACKAGES_PATH: $(TryDotNetPackagesPath)
 
-        - script: npm run test
+        - script: npm run ciTest
           displayName: NPM tests
           workingDirectory: "$(Build.SourcesDirectory)/src/Microsoft.DotNet.Interactive.Js"
 

--- a/src/Microsoft.DotNet.Interactive.Js/package-lock.json
+++ b/src/Microsoft.DotNet.Interactive.Js/package-lock.json
@@ -1266,6 +1266,25 @@
         }
       }
     },
+    "mocha-multi-reporters": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/mocha-multi-reporters/-/mocha-multi-reporters-1.1.7.tgz",
+      "integrity": "sha1-zH8/TTL0eFIJQdhSq7ZNmYhYfYI=",
+      "dev": true,
+      "requires": {
+        "debug": "^3.1.0",
+        "lodash": "^4.16.4"
+      }
+    },
+    "mocha-trx-reporter": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/mocha-trx-reporter/-/mocha-trx-reporter-3.2.4.tgz",
+      "integrity": "sha512-hY4rHfzl49TgmgfkkgCskQIiOmi8J8h+/XcuPNz3y5HtdebD7uOKY6o+7LZVB/xg+3zfwmJ+weXqpinnVsJ5kA==",
+      "dev": true,
+      "requires": {
+        "node-trx": "^0.9.1"
+      }
+    },
     "mocha-typescript": {
       "version": "1.1.17",
       "resolved": "https://registry.npmjs.org/mocha-typescript/-/mocha-typescript-1.1.17.tgz",
@@ -1467,6 +1486,16 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "dev": true
+    },
+    "node-trx": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/node-trx/-/node-trx-0.9.2.tgz",
+      "integrity": "sha512-BcLqws24v4cuv/3PknmY1VvS59MW6w+ma+rY52/KCoED0yhZ+fjlFZKNPpUCgiVoZ2jQIUqhRzKVjYesCUk74g==",
+      "dev": true,
+      "requires": {
+        "uuid": "^3.3.2",
+        "xmlbuilder": "^13.0.2"
+      }
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -2301,6 +2330,12 @@
       "requires": {
         "async-limiter": "~1.0.0"
       }
+    },
+    "xmlbuilder": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-13.0.2.tgz",
+      "integrity": "sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ==",
+      "dev": true
     },
     "y18n": {
       "version": "4.0.0",

--- a/src/Microsoft.DotNet.Interactive.Js/package.json
+++ b/src/Microsoft.DotNet.Interactive.Js/package.json
@@ -9,6 +9,7 @@
     "build": "npm run rollup-dotnet-interactive && npm run rollup-dotnet-interactive-code-mirror",
     "build-ci": "rollup -c rollup.config.js",
     "test": "mocha --opts mocha.opts",
+    "ciTest": "npm test -- --reporter mocha-multi-reporters --reporter-options configFile=testConfig.json",
     "rollup-dotnet-interactive": "npm run build-ci -- -i src/dotnet-interactive.ts -o dist/dotnet-interactive.js",
     "rollup-dotnet-interactive-code-mirror": "npm run build-ci -- -i src/dotnet-interactive-code-mirror.ts -o dist/dotnet-interactive-code-mirror.js"
   },
@@ -43,6 +44,8 @@
     "fetch-mock": "9.4.0",
     "mkdirp": "1.0.4",
     "mocha": "7.1.1",
+    "mocha-multi-reporters": "1.1.7",
+    "mocha-trx-reporter": "3.2.4",
     "mocha-typescript": "1.1.17",
     "node-fetch": "^2.6.1",
     "requirejs": "2.3.6",

--- a/src/Microsoft.DotNet.Interactive.Js/testConfig.json
+++ b/src/Microsoft.DotNet.Interactive.Js/testConfig.json
@@ -1,0 +1,6 @@
+{
+    "reporterEnabled": "spec,mocha-trx-reporter",
+    "mochaTrxReporterReporterOptions": {
+        "output": "../../artifacts/TestResults/Release/Microsoft.DotNet.Interactive.Js.trx"
+    }
+}


### PR DESCRIPTION
Turns out we weren't publishing these test results.  A failure would have failed the CI run, but not been very helpful past that.  Thanks to @jonsequitur for noticing and actually caring about the warning on the build page.

I simply copied the way the VS Code extension tests publish a `.trx` file, since we know that works.