### PR TITLE
use cell metadata to track language in ipynb metadata in vscode

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/CompleteRequestHandlerTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/CompleteRequestHandlerTests.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Microsoft.DotNet.Interactive.Jupyter.Protocol;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Recipes;
 using Xunit;
 using Xunit.Abstractions;
@@ -32,6 +35,32 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
             JupyterMessageSender.ReplyMessages
                 .Should()
                 .ContainSingle(r => r is CompleteReply);
+        }
+
+        [Fact]
+        public void cell_language_can_be_pulled_from_metadata_when_present()
+        {
+            var metaData = new Dictionary<string, object>()
+            {
+                { "dotnet_interactive", JObject.Parse(JsonConvert.SerializeObject(new { language = "fsharp" })) }
+            };
+            var request = ZeroMQMessage.Create(new CompleteRequest("1+1"), metaData: metaData);
+            var context = new JupyterRequestContext(JupyterMessageSender, request);
+            var language = context.GetLanguage();
+            language
+                .Should()
+                .Be("fsharp");
+        }
+
+        [Fact]
+        public void cell_language_defaults_to_null_when_it_cant_be_found()
+        {
+            var request = ZeroMQMessage.Create(new CompleteRequest("1+1"));
+            var context = new JupyterRequestContext(JupyterMessageSender, request);
+            var language = context.GetLanguage();
+            language
+                .Should()
+                .BeNull();
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/CompleteRequestHandlerTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/CompleteRequestHandlerTests.cs
@@ -6,8 +6,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Microsoft.DotNet.Interactive.Jupyter.Protocol;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using Microsoft.DotNet.Interactive.Notebook;
 using Recipes;
 using Xunit;
 using Xunit.Abstractions;
@@ -42,7 +41,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
         {
             var metaData = new Dictionary<string, object>()
             {
-                { "dotnet_interactive", JObject.Parse(JsonConvert.SerializeObject(new { language = "fsharp" })) }
+                { "dotnet_interactive", new InputCellMetadata { Language = "fsharp" } }
             };
             var request = ZeroMQMessage.Create(new CompleteRequest("1+1"), metaData: metaData);
             var context = new JupyterRequestContext(JupyterMessageSender, request);

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/CustomMetadataParsingTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/CustomMetadataParsingTests.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.DotNet.Interactive.Jupyter.ZMQ;
+using Microsoft.DotNet.Interactive.Notebook;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.DotNet.Interactive.Jupyter.Tests
+{
+    public class CustomMetadataParsingTests
+    {
+        [Fact]
+        public void Input_cell_metadata_can_be_parsed_with_all_fields()
+        {
+            var rawMetadata = new
+            {
+                dotnet_interactive = new InputCellMetadata() { Language = "fsharp" }
+            };
+            var rawMetadataJson = JsonConvert.SerializeObject(rawMetadata);
+            var metadata = MetadataExtensions.DeserializeMetadataFromJsonString(rawMetadataJson);
+            metadata.Should()
+                .ContainKey("dotnet_interactive")
+                .WhichValue
+                .Should()
+                .BeEquivalentTo(new InputCellMetadata() { Language = "fsharp" });
+        }
+
+        [Fact]
+        public void Input_cell_metadata_can_be_parsed_with_no_fields()
+        {
+            var rawMetadata = new
+            {
+                dotnet_interactive = new InputCellMetadata()
+            };
+            var rawMetadataJson = JsonConvert.SerializeObject(rawMetadata);
+            var metadata = MetadataExtensions.DeserializeMetadataFromJsonString(rawMetadataJson);
+            metadata.Should()
+                .ContainKey("dotnet_interactive")
+                .WhichValue
+                .Should()
+                .BeEquivalentTo(new InputCellMetadata() { Language = null });
+        }
+
+        [Fact]
+        public void Input_cell_metadata_is_not_parsed_when_not_present()
+        {
+            var rawMetadata = new
+            {
+                dotnet_interactive_but_not_the_right_shape = new InputCellMetadata() { Language = "fsharp" }
+            };
+            var rawMetadataJson = JsonConvert.SerializeObject(rawMetadata);
+            var metadata = MetadataExtensions.DeserializeMetadataFromJsonString(rawMetadataJson);
+            metadata.Should()
+                .NotContainKey("dotnet_interactive");
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/ExecuteRequestHandlerTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/ExecuteRequestHandlerTests.cs
@@ -11,8 +11,8 @@ using FluentAssertions.Extensions;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Jupyter.Protocol;
+using Microsoft.DotNet.Interactive.Notebook;
 using Microsoft.DotNet.Interactive.Tests;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Pocket;
 using Recipes;
@@ -459,7 +459,7 @@ f();"));
         {
             var metaData = new Dictionary<string, object>()
             {
-                { "dotnet_interactive", JObject.Parse(JsonConvert.SerializeObject(new { language = "fsharp" })) }
+                { "dotnet_interactive", new InputCellMetadata { Language = "fsharp" } }
             };
             var request = ZeroMQMessage.Create(new ExecuteRequest("1+1"), metaData: metaData);
             var context = new JupyterRequestContext(JupyterMessageSender, request);

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/IsCompleteRequestHandlerTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/IsCompleteRequestHandlerTests.cs
@@ -11,8 +11,7 @@ using Xunit;
 using Xunit.Abstractions;
 using ZeroMQMessage = Microsoft.DotNet.Interactive.Jupyter.ZMQ.Message;
 using System.Collections.Generic;
-using Newtonsoft.Json.Linq;
-using Newtonsoft.Json;
+using Microsoft.DotNet.Interactive.Notebook;
 
 namespace Microsoft.DotNet.Interactive.Jupyter.Tests
 {
@@ -58,7 +57,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
         {
             var metaData = new Dictionary<string, object>()
             {
-                { "dotnet_interactive", JObject.Parse(JsonConvert.SerializeObject(new { language = "fsharp" })) }
+                { "dotnet_interactive", new InputCellMetadata { Language = "fsharp" } }
             };
             var request = ZeroMQMessage.Create(new IsCompleteRequest("1+1"), metaData: metaData);
             var context = new JupyterRequestContext(JupyterMessageSender, request);

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterMessageContractTests.Input_cell_honors_custom_metadata.approved.json
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterMessageContractTests.Input_cell_honors_custom_metadata.approved.json
@@ -1,0 +1,6 @@
+data: <IDS|MSG> more: True
+data: 8ba0f29e039958a3c6de74503641e8673d126410e3a86d58ffffd948792fb969 more: True
+data: {"msg_id":"00000000-0000-0000-0000-000000000000","username":"dotnet_kernel","session":"test session","date":"0001-01-01T00:00:00Z","msg_type":"execute_result","version":"5.3"} more: True
+data: {} more: True
+data: {"dotnet_interactive":{"language":"fsharp"}} more: True
+data: {"data":{"text/html":"some result","text/plain":"some result"},"metadata":{},"transient":{"display_id":"none"},"execution_count":12} more: False

--- a/src/Microsoft.DotNet.Interactive.Jupyter/CompleteRequestHandler.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/CompleteRequestHandler.cs
@@ -21,9 +21,10 @@ namespace Microsoft.DotNet.Interactive.Jupyter
         public async Task Handle(JupyterRequestContext context)
         {
             var completeRequest = GetJupyterRequest(context);
+            var targetKernelName = context.GetLanguage();
 
             var position = SourceUtilities.GetPositionFromCursorOffset(completeRequest.Code, completeRequest.CursorPosition);
-            var command = new RequestCompletions(completeRequest.Code, position);
+            var command = new RequestCompletions(completeRequest.Code, position, targetKernelName);
 
             await SendAsync(context, command);
         }

--- a/src/Microsoft.DotNet.Interactive.Jupyter/ExecuteRequestHandler.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/ExecuteRequestHandler.cs
@@ -15,7 +15,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using ZeroMQMessage = Microsoft.DotNet.Interactive.Jupyter.ZMQ.Message;
-using Microsoft.CodeAnalysis.Scripting;
 
 namespace Microsoft.DotNet.Interactive.Jupyter
 {
@@ -38,6 +37,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter
         public async Task Handle(JupyterRequestContext context)
         {
             var executeRequest = GetJupyterRequest(context);
+            string targetKernelName = context.GetLanguage();
 
             _executionCount = executeRequest.Silent ? _executionCount : Interlocked.Increment(ref _executionCount);
             
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter
             var executeInputPayload = new ExecuteInput(executeRequest.Code, _executionCount);
             context.JupyterMessageSender.Send(executeInputPayload);
 
-            var command = new SubmitCode(executeRequest.Code);
+            var command = new SubmitCode(executeRequest.Code, targetKernelName);
 
             await SendAsync(context, command);
         }

--- a/src/Microsoft.DotNet.Interactive.Jupyter/IsCompleteRequestHandler.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/IsCompleteRequestHandler.cs
@@ -20,7 +20,8 @@ namespace Microsoft.DotNet.Interactive.Jupyter
         public async Task Handle(JupyterRequestContext context)
         {
             var isCompleteRequest = GetJupyterRequest(context);
-            var command = new SubmitCode(isCompleteRequest.Code, submissionType: SubmissionType.Diagnose);
+            var targetKernelName = context.GetLanguage();
+            var command = new SubmitCode(isCompleteRequest.Code, targetKernelName, submissionType: SubmissionType.Diagnose);
 
             await SendAsync(context, command);
         }

--- a/src/Microsoft.DotNet.Interactive.Jupyter/JupyterRequestContextExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/JupyterRequestContextExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.DotNet.Interactive.Notebook;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.DotNet.Interactive.Jupyter
 {
@@ -11,9 +10,9 @@ namespace Microsoft.DotNet.Interactive.Jupyter
         public static string GetLanguage(this JupyterRequestContext context)
         {
             if (context.JupyterRequestMessageEnvelope.MetaData.TryGetValue(NotebookFileFormatHandler.MetadataNamespace, out var candidateMetadata) &&
-                candidateMetadata is JObject dotnetMetadata)
+                candidateMetadata is InputCellMetadata inputCellMetadata)
             {
-                return dotnetMetadata["language"]?.ToObject<string>();
+                return inputCellMetadata.Language;
             }
 
             return null;

--- a/src/Microsoft.DotNet.Interactive.Jupyter/JupyterRequestContextExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/JupyterRequestContextExtensions.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.Interactive.Notebook;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.DotNet.Interactive.Jupyter
+{
+    public static class JupyterRequestContextExtensions
+    {
+        public static string GetLanguage(this JupyterRequestContext context)
+        {
+            if (context.JupyterRequestMessageEnvelope.MetaData.TryGetValue(NotebookFileFormatHandler.MetadataNamespace, out var candidateMetadata) &&
+                candidateMetadata is JObject dotnetMetadata)
+            {
+                return dotnetMetadata["language"]?.ToObject<string>();
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Interactive.Jupyter/ZMQ/MetadataExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/ZMQ/MetadataExtensions.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Microsoft.DotNet.Interactive.Notebook;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.DotNet.Interactive.Jupyter.ZMQ
+{
+    public static class MetadataExtensions
+    {
+        public static Dictionary<string, object> DeserializeMetadataFromJsonString(string metadataJson)
+        {
+            var metadata = NetMQExtensions.DeserializeFromJsonString<Dictionary<string, object>>(metadataJson) ?? new Dictionary<string, object>();
+            TryParseWellKnownMetadata(metadata);
+            return metadata;
+        }
+
+        private static void TryParseWellKnownMetadata(Dictionary<string, object> metadata)
+        {
+            foreach (var kvp in metadata)
+            {
+                switch (kvp.Key)
+                {
+                    case "dotnet_interactive" when kvp.Value is JObject jo:
+                        metadata[kvp.Key] = jo.ToObject<InputCellMetadata>();
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Interactive.Jupyter/ZMQ/NetMqExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/ZMQ/NetMqExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.ZMQ
 {
     internal static class NetMQExtensions
     {
-        private static T DeserializeFromJsonString<T>(string source)
+        public static T DeserializeFromJsonString<T>(string source)
         {
             var ret = default(T);
             if (!string.IsNullOrWhiteSpace(source))
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.ZMQ
         {
             var header = JsonConvert.DeserializeObject<Header>(headerJson);
             var parentHeader = DeserializeFromJsonString<Header>(parentHeaderJson);
-            var metaData = DeserializeFromJsonString<Dictionary<string, object>>(metadataJson) ?? new Dictionary<string, object>();
+            var metaData = MetadataExtensions.DeserializeMetadataFromJsonString(metadataJson);
             var content = DeserializeMessageContentFromJsonString(contentJson, header.MessageType);
 
             var message = new Message(header, content, parentHeader, signature, metaData, identifiers);

--- a/src/Microsoft.DotNet.Interactive.Tests/Notebook/JupyterNotebookDocumentFileFormatTests.serialize_entire_file_to_verify_indention.approved.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Notebook/JupyterNotebookDocumentFileFormatTests.serialize_entire_file_to_verify_indention.approved.json
@@ -3,7 +3,11 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    }
+   },
    "source": [
     "// this is csharp"
    ],

--- a/src/Microsoft.DotNet.Interactive/Notebook/InputCellMetadata.cs
+++ b/src/Microsoft.DotNet.Interactive/Notebook/InputCellMetadata.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.Interactive.Notebook
+{
+    public class InputCellMetadata
+    {
+        [JsonProperty("language")]
+        public string Language { get; set; }
+    }
+}

--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -40,10 +40,9 @@
     "PowerShell"
   ],
   "activationEvents": [
-    "onNotebookEditor:dotnet-interactive",
-    "onNotebookEditor:dotnet-interactive-jupyter",
     "onNotebook:dotnet-interactive",
     "onNotebook:dotnet-interactive-jupyter",
+    "onNotebook:*",
     "onCommand:dotnet-interactive.acquire",
     "onCommand:dotnet-interactive.newNotebook",
     "onCommand:dotnet-interactive.openNotebook",

--- a/src/dotnet-interactive-vscode/src/acquisition.ts
+++ b/src/dotnet-interactive-vscode/src/acquisition.ts
@@ -17,7 +17,7 @@ export async function acquireDotnetInteractive(
     reportInstallationStarted: ReportInstallationStarted,
     installInteractive: InstallInteractiveTool,
     reportInstallationFinished: ReportInstallationFinished
-): Promise<InteractiveLaunchOptions | undefined> {
+): Promise<InteractiveLaunchOptions> {
     // Ensure `globalStoragePath` exists.  This prevents a bunch of issues with spawned processes and working directories.
     if (!fs.existsSync(globalStoragePath)) {
         fs.mkdirSync(globalStoragePath);

--- a/src/dotnet-interactive-vscode/src/interactiveClient.ts
+++ b/src/dotnet-interactive-vscode/src/interactiveClient.ts
@@ -111,6 +111,7 @@ export class InteractiveClient {
                 }
 
                 switch (eventEnvelope.eventType) {
+                    // if kernel languages were added, handle those events here
                     case CommandSucceededType:
                         resolve();
                         break;

--- a/src/dotnet-interactive-vscode/src/interactiveNotebook.ts
+++ b/src/dotnet-interactive-vscode/src/interactiveNotebook.ts
@@ -34,6 +34,10 @@ export function getNotebookSpecificLanguage(language: string): string {
     return language;
 }
 
+export function isDotnetInteractiveLanguage(language: string): boolean {
+    return language.startsWith(notebookLanguagePrefix);
+}
+
 export function languageToCellKind(language: string): CellKind {
     switch (language) {
         case 'markdown':

--- a/src/dotnet-interactive-vscode/src/ipynbUtilities.ts
+++ b/src/dotnet-interactive-vscode/src/ipynbUtilities.ts
@@ -1,0 +1,104 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { getNotebookSpecificLanguage } from "./interactiveNotebook";
+
+// the shape of this is meant to match the cell metadata from VS Code
+interface CellMetadata {
+    custom?: { [key: string]: any } | undefined,
+}
+
+export interface DotNetCellMetadata {
+    language: string | undefined,
+}
+
+function isDotNetCellMetadata(arg: any): arg is DotNetCellMetadata {
+    return arg
+        && typeof arg.language === 'string';
+}
+
+export function getDotNetMetadata(metadata: CellMetadata | undefined): DotNetCellMetadata {
+    if (metadata &&
+        metadata.custom &&
+        metadata.custom.metadata &&
+        metadata.custom.metadata.dotnet_interactive &&
+        isDotNetCellMetadata(metadata.custom.metadata.dotnet_interactive)) {
+        return metadata.custom.metadata.dotnet_interactive;
+    }
+
+    return {
+        language: undefined,
+    };
+}
+
+export function withDotNetMetadata(metadata: { [key: string]: any } | undefined, cellMetadata: DotNetCellMetadata): any {
+    let result: { [key: string]: any } = {};
+    if (metadata) {
+        for (const key in metadata) {
+            result[key] = metadata[key];
+        }
+    }
+
+    result.custom = result.custom || {};
+    result.custom.metadata = result.custom.metadata || {};
+    result.custom.metadata.dotnet_interactive = result.custom.metadata.dotnet_interactive || {};
+    for (const key in cellMetadata) {
+        result.custom.metadata.dotnet_interactive[key] = (<any>cellMetadata)[key];
+    }
+
+    return result;
+}
+
+// the shape of this is meant to match the document metadata from VS Code
+export interface DocumentMetadata {
+    custom?: { [key: string]: any } | undefined,
+}
+
+export interface LanguageInfoMetadata {
+    name: string | undefined,
+}
+
+function isLanguageInfoMetadata(arg: any): arg is LanguageInfoMetadata {
+    return arg
+        && typeof arg.name === 'string';
+}
+
+export function getLanguageInfoMetadata(metadata: DocumentMetadata | undefined): LanguageInfoMetadata {
+    let languageMetadata: LanguageInfoMetadata = {
+        name: undefined,
+    };
+
+    if (metadata &&
+        metadata.custom &&
+        metadata.custom.metadata &&
+        metadata.custom.metadata.language_info &&
+        isLanguageInfoMetadata(metadata.custom.metadata.language_info)) {
+        languageMetadata = metadata.custom.metadata.language_info;
+    }
+
+    languageMetadata.name = mapIpynbLanguageName(languageMetadata.name);
+    return languageMetadata;
+}
+
+function mapIpynbLanguageName(name: string | undefined): string | undefined {
+    if (name) {
+        // The .NET Interactive Jupyter kernel serializes the language names as "C#", "F#", and "PowerShell"; these
+        // need to be normalized to .NET Interactive kernel language names.
+        switch (name.toLowerCase()) {
+            case 'c#':
+                return 'csharp';
+            case 'f#':
+                return 'fsharp';
+            case 'powershell':
+                return 'pwsh';
+            default:
+                return name;
+        }
+    }
+
+    return undefined;
+}
+
+export function getCellLanguage(cellMetadata: DotNetCellMetadata, documentMetadata: LanguageInfoMetadata, fallbackLanguage: string): string {
+    return getNotebookSpecificLanguage(cellMetadata.language || documentMetadata.name || fallbackLanguage);
+}

--- a/src/dotnet-interactive-vscode/src/tests/unit/ipynbMetadata.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/ipynbMetadata.test.ts
@@ -1,0 +1,363 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { expect } from 'chai';
+import { DotNetCellMetadata, getCellLanguage, getDotNetMetadata, getLanguageInfoMetadata, LanguageInfoMetadata, withDotNetMetadata } from '../../ipynbUtilities';
+
+describe('ipynb metadata tests', () => {
+
+    //------------------------------------------------------- document metadata
+    it(`document metadata can be read when present`, () => {
+        const documentMetadata = {
+            custom: {
+                metadata: {
+                    language_info: {
+                        name: 'csharp'
+                    }
+                }
+            }
+        };
+        const languageInfoMetadata = getLanguageInfoMetadata(documentMetadata);
+        expect(languageInfoMetadata.name).to.equal('csharp');
+    });
+
+    it(`document metadata well-known values are transformed`, () => {
+        const wellKnownLanguagePairs = [
+            ['C#', 'csharp'],
+            ['F#', 'fsharp'],
+            ['PowerShell', 'pwsh']
+        ];
+        for (const languagePair of wellKnownLanguagePairs) {
+            const languageName = languagePair[0];
+            const expectedResult = languagePair[1];
+            const documentMetadata = {
+                custom: {
+                    metadata: {
+                        language_info: {
+                            name: languageName
+                        }
+                    }
+                }
+            };
+            const languageInfoMetadata = getLanguageInfoMetadata(documentMetadata);
+            expect(languageInfoMetadata.name).to.equal(expectedResult);
+        }
+    });
+
+    it(`document metadata non-special-cased language returns as self`, () => {
+        const documentMetadata = {
+            custom: {
+                metadata: {
+                    language_info: {
+                        name: 'see-sharp'
+                    }
+                }
+            }
+        };
+        const languageInfoMetadata = getLanguageInfoMetadata(documentMetadata);
+        expect(languageInfoMetadata.name).to.equal('see-sharp');
+    });
+
+    it(`document metadata with undefined language also comes back as undefined`, () => {
+        const documentMetadata = {
+            custom: {
+                metadata: {
+                    language_info: {
+                        name: undefined
+                    }
+                }
+            }
+        };
+        const languageInfoMetadata = getLanguageInfoMetadata(documentMetadata);
+        expect(languageInfoMetadata.name).to.equal(undefined);
+    });
+
+    it(`document metadata with non-string value comes back as undefined`, () => {
+        const documentMetadata = {
+            custom: {
+                metadata: {
+                    language_info: {
+                        name: 42
+                    }
+                }
+            }
+        };
+        const languageInfoMetadata = getLanguageInfoMetadata(documentMetadata);
+        expect(languageInfoMetadata.name).to.equal(undefined);
+    });
+
+    it(`document metadata is default when not the correct shape 1`, () => {
+        const documentMetadata = {
+            custom: {
+                metadata_but_not_the_correct_shape: {
+                    language_info: {
+                        name: 'csharp'
+                    }
+                }
+            }
+        };
+        const languageInfoMetadata = getLanguageInfoMetadata(documentMetadata);
+        expect(languageInfoMetadata).to.deep.equal({
+            name: undefined
+        });
+    });
+
+    it(`document metadata is default when not the correct shape 2`, () => {
+        const documentMetadata = {
+            custom: {
+                metadata: {
+                    language_info_but_not_the_correct_shape: {
+                        name: 'csharp'
+                    }
+                }
+            }
+        };
+        const languageInfoMetadata = getLanguageInfoMetadata(documentMetadata);
+        expect(languageInfoMetadata).to.deep.equal({
+            name: undefined
+        });
+    });
+
+    it(`document metadata is default when not the correct shape 3`, () => {
+        const documentMetadata = {
+            custom: {
+                metadata: {
+                    language_info: {
+                        name_but_not_the_correct_shape: 'csharp'
+                    }
+                }
+            }
+        };
+        const languageInfoMetadata = getLanguageInfoMetadata(documentMetadata);
+        expect(languageInfoMetadata).to.deep.equal({
+            name: undefined
+        });
+    });
+
+    //----------------------------------------------------------- cell metadata
+    it(`cell metadata can be read when present`, () => {
+        const cellMetadata = {
+            custom: {
+                metadata: {
+                    dotnet_interactive: {
+                        language: 'see-sharp'
+                    }
+                }
+            }
+        };
+        const dotnetMetadata = getDotNetMetadata(cellMetadata);
+        expect(dotnetMetadata.language).to.equal('see-sharp');
+    });
+
+    it(`cell metadata is empty when not the correct shape 1`, () => {
+        const cellMetadata = {
+            custom: {
+                metadata_but_not_the_correct_shape: {
+                    dotnet_interactive: {
+                        language: 'see-sharp'
+                    }
+                }
+            }
+        };
+        const dotnetMetadata = getDotNetMetadata(cellMetadata);
+        expect(dotnetMetadata.language).to.equal(undefined);
+    });
+
+    it(`cell metadata is empty when not the correct shape 2`, () => {
+        const cellMetadata = {
+            custom: {
+                metadata: {
+                    dotnet_interactive_but_not_the_correct_shape: {
+                        language: 'see-sharp'
+                    }
+                }
+            }
+        };
+        const dotnetMetadata = getDotNetMetadata(cellMetadata);
+        expect(dotnetMetadata.language).to.equal(undefined);
+    });
+
+    it(`cell metadata is empty when not the correct shape 3`, () => {
+        const cellMetadata = {
+            custom: {
+                metadata: {
+                    dotnet_interactive: {
+                        language_but_not_the_correct_shape: 'see-sharp'
+                    }
+                }
+            }
+        };
+        const dotnetMetadata = getDotNetMetadata(cellMetadata);
+        expect(dotnetMetadata.language).to.equal(undefined);
+    });
+
+    it(`cell metadata returns empty info if shape isn't correct`, () => {
+        const cellMetadata = {
+            custom: {
+                metadata: {
+                    dotnet_interactive: {
+                        language: 42 // not a string
+                    }
+                }
+            }
+        };
+        const dotnetMetadata = getDotNetMetadata(cellMetadata);
+        expect(dotnetMetadata.language).to.equal(undefined);
+    });
+
+    it(`cell metadata can be set when empty`, () => {
+        const existingMetadata = {
+        };
+        const dotnetMetadata = {
+            language: 'see-sharp'
+        };
+        const newMetadata = withDotNetMetadata(existingMetadata, dotnetMetadata);
+        expect(newMetadata).to.deep.equal({
+            custom: {
+                metadata: {
+                    dotnet_interactive: {
+                        language: 'see-sharp'
+                    }
+                }
+            }
+        });
+    });
+
+    it(`cell metadata can overwrite old values`, () => {
+        const existingMetadata = {
+            custom: {
+                metadata: {
+                    dotnet_interactive: {
+                        language: 'eff-sharp'
+                    }
+                }
+            }
+        };
+        const dotnetMetadata = {
+            language: 'see-sharp'
+        };
+        const newMetadata = withDotNetMetadata(existingMetadata, dotnetMetadata);
+        expect(newMetadata).to.deep.equal({
+            custom: {
+                metadata: {
+                    dotnet_interactive: {
+                        language: 'see-sharp'
+                    }
+                }
+            }
+        });
+    });
+
+    it(`cell metadata doesn't overwrite other values in dotnet_interactive namespace`, () => {
+        const existingMetadata = {
+            custom: {
+                metadata: {
+                    dotnet_interactive: {
+                        language: 'eff-sharp',
+                        version: 42
+                    }
+                }
+            }
+        };
+        const dotnetMetadata = {
+            language: 'see-sharp'
+        };
+        const newMetadata = withDotNetMetadata(existingMetadata, dotnetMetadata);
+        expect(newMetadata).to.deep.equal({
+            custom: {
+                metadata: {
+                    dotnet_interactive: {
+                        language: 'see-sharp',
+                        version: 42
+                    }
+                }
+            }
+        });
+    });
+
+    it(`cell metadata doesn't overwrite other values or namespaces`, () => {
+        const existingMetadata = {
+            custom: {
+                metadata: {
+                    not_dotnet_interactive: {
+                        some_key: 'some_value'
+                    }
+                }
+            }
+        };
+        const dotnetMetadata = {
+            language: 'see-sharp'
+        };
+        const newMetadata = withDotNetMetadata(existingMetadata, dotnetMetadata);
+        expect(newMetadata).to.deep.equal({
+            custom: {
+                metadata: {
+                    dotnet_interactive: {
+                        language: 'see-sharp'
+                    },
+                    not_dotnet_interactive: {
+                        some_key: 'some_value'
+                    }
+                }
+            }
+        });
+    });
+
+    it(`cell metadata doesn't remove values in non-standard locations`, () => {
+        const existingMetadata = {
+            something_non_standard: {
+                really_odd: 'not sure what this is'
+            }
+        };
+        const dotnetMetadata = {
+            language: 'see-sharp'
+        };
+        const newMetadata = withDotNetMetadata(existingMetadata, dotnetMetadata);
+        expect(newMetadata).to.deep.equal({
+            something_non_standard: {
+                really_odd: 'not sure what this is'
+            },
+            custom: {
+                metadata: {
+                    dotnet_interactive: {
+                        language: 'see-sharp'
+                    }
+                }
+            }
+        });
+    });
+
+    //------------------------------------------------- cell language selection
+    it(`cell language is first determined from cell metadata`, () => {
+        const cellMetadata: DotNetCellMetadata = {
+            language: 'pwsh',
+        };
+        const documentMetadata: LanguageInfoMetadata = {
+            name: 'fsharp',
+        };
+        const cellLanguage = getCellLanguage(cellMetadata, documentMetadata, 'csharp');
+        expect(cellLanguage).to.equal('dotnet-interactive.pwsh');
+    });
+
+    it(`cell language is second determined from document metadata`, () => {
+        const cellMetadata: DotNetCellMetadata = {
+            language: undefined,
+        };
+        const documentMetadata: LanguageInfoMetadata = {
+            name: 'fsharp',
+        };
+        const cellLanguage = getCellLanguage(cellMetadata, documentMetadata, 'csharp');
+        expect(cellLanguage).to.equal('dotnet-interactive.fsharp');
+    });
+
+    it(`cell language is ultimately determined from the fallback value`, () => {
+        const cellMetadata: DotNetCellMetadata = {
+            language: undefined,
+        };
+        const documentMetadata: LanguageInfoMetadata = {
+            name: undefined,
+        };
+        const cellLanguage = getCellLanguage(cellMetadata, documentMetadata, 'csharp');
+        expect(cellLanguage).to.equal('dotnet-interactive.csharp');
+    });
+});

--- a/src/dotnet-interactive-vscode/src/tests/unit/ipynbMetadata.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/ipynbMetadata.test.ts
@@ -5,359 +5,361 @@ import { expect } from 'chai';
 import { DotNetCellMetadata, getCellLanguage, getDotNetMetadata, getLanguageInfoMetadata, LanguageInfoMetadata, withDotNetMetadata } from '../../ipynbUtilities';
 
 describe('ipynb metadata tests', () => {
-
-    //------------------------------------------------------- document metadata
-    it(`document metadata can be read when present`, () => {
-        const documentMetadata = {
-            custom: {
-                metadata: {
-                    language_info: {
-                        name: 'csharp'
-                    }
-                }
-            }
-        };
-        const languageInfoMetadata = getLanguageInfoMetadata(documentMetadata);
-        expect(languageInfoMetadata.name).to.equal('csharp');
-    });
-
-    it(`document metadata well-known values are transformed`, () => {
-        const wellKnownLanguagePairs = [
-            ['C#', 'csharp'],
-            ['F#', 'fsharp'],
-            ['PowerShell', 'pwsh']
-        ];
-        for (const languagePair of wellKnownLanguagePairs) {
-            const languageName = languagePair[0];
-            const expectedResult = languagePair[1];
+    describe('document metadata', () => {
+        it(`document metadata can be read when present`, () => {
             const documentMetadata = {
                 custom: {
                     metadata: {
                         language_info: {
-                            name: languageName
+                            name: 'csharp'
                         }
                     }
                 }
             };
             const languageInfoMetadata = getLanguageInfoMetadata(documentMetadata);
-            expect(languageInfoMetadata.name).to.equal(expectedResult);
-        }
-    });
+            expect(languageInfoMetadata.name).to.equal('csharp');
+        });
 
-    it(`document metadata non-special-cased language returns as self`, () => {
-        const documentMetadata = {
-            custom: {
-                metadata: {
-                    language_info: {
-                        name: 'see-sharp'
+        it(`document metadata well-known values are transformed`, () => {
+            const wellKnownLanguagePairs = [
+                ['C#', 'csharp'],
+                ['F#', 'fsharp'],
+                ['PowerShell', 'pwsh']
+            ];
+            for (const languagePair of wellKnownLanguagePairs) {
+                const languageName = languagePair[0];
+                const expectedResult = languagePair[1];
+                const documentMetadata = {
+                    custom: {
+                        metadata: {
+                            language_info: {
+                                name: languageName
+                            }
+                        }
+                    }
+                };
+                const languageInfoMetadata = getLanguageInfoMetadata(documentMetadata);
+                expect(languageInfoMetadata.name).to.equal(expectedResult);
+            }
+        });
+
+        it(`document metadata non-special-cased language returns as self`, () => {
+            const documentMetadata = {
+                custom: {
+                    metadata: {
+                        language_info: {
+                            name: 'see-sharp'
+                        }
                     }
                 }
-            }
-        };
-        const languageInfoMetadata = getLanguageInfoMetadata(documentMetadata);
-        expect(languageInfoMetadata.name).to.equal('see-sharp');
-    });
+            };
+            const languageInfoMetadata = getLanguageInfoMetadata(documentMetadata);
+            expect(languageInfoMetadata.name).to.equal('see-sharp');
+        });
 
-    it(`document metadata with undefined language also comes back as undefined`, () => {
-        const documentMetadata = {
-            custom: {
-                metadata: {
-                    language_info: {
-                        name: undefined
+        it(`document metadata with undefined language also comes back as undefined`, () => {
+            const documentMetadata = {
+                custom: {
+                    metadata: {
+                        language_info: {
+                            name: undefined
+                        }
                     }
                 }
-            }
-        };
-        const languageInfoMetadata = getLanguageInfoMetadata(documentMetadata);
-        expect(languageInfoMetadata.name).to.equal(undefined);
-    });
+            };
+            const languageInfoMetadata = getLanguageInfoMetadata(documentMetadata);
+            expect(languageInfoMetadata.name).to.equal(undefined);
+        });
 
-    it(`document metadata with non-string value comes back as undefined`, () => {
-        const documentMetadata = {
-            custom: {
-                metadata: {
-                    language_info: {
-                        name: 42
+        it(`document metadata with non-string value comes back as undefined`, () => {
+            const documentMetadata = {
+                custom: {
+                    metadata: {
+                        language_info: {
+                            name: 42
+                        }
                     }
                 }
-            }
-        };
-        const languageInfoMetadata = getLanguageInfoMetadata(documentMetadata);
-        expect(languageInfoMetadata.name).to.equal(undefined);
-    });
+            };
+            const languageInfoMetadata = getLanguageInfoMetadata(documentMetadata);
+            expect(languageInfoMetadata.name).to.equal(undefined);
+        });
 
-    it(`document metadata is default when not the correct shape 1`, () => {
-        const documentMetadata = {
-            custom: {
-                metadata_but_not_the_correct_shape: {
-                    language_info: {
-                        name: 'csharp'
+        it(`document metadata is default when not the correct shape 1`, () => {
+            const documentMetadata = {
+                custom: {
+                    metadata_but_not_the_correct_shape: {
+                        language_info: {
+                            name: 'csharp'
+                        }
                     }
                 }
-            }
-        };
-        const languageInfoMetadata = getLanguageInfoMetadata(documentMetadata);
-        expect(languageInfoMetadata).to.deep.equal({
-            name: undefined
+            };
+            const languageInfoMetadata = getLanguageInfoMetadata(documentMetadata);
+            expect(languageInfoMetadata).to.deep.equal({
+                name: undefined
+            });
+        });
+
+        it(`document metadata is default when not the correct shape 2`, () => {
+            const documentMetadata = {
+                custom: {
+                    metadata: {
+                        language_info_but_not_the_correct_shape: {
+                            name: 'csharp'
+                        }
+                    }
+                }
+            };
+            const languageInfoMetadata = getLanguageInfoMetadata(documentMetadata);
+            expect(languageInfoMetadata).to.deep.equal({
+                name: undefined
+            });
+        });
+
+        it(`document metadata is default when not the correct shape 3`, () => {
+            const documentMetadata = {
+                custom: {
+                    metadata: {
+                        language_info: {
+                            name_but_not_the_correct_shape: 'csharp'
+                        }
+                    }
+                }
+            };
+            const languageInfoMetadata = getLanguageInfoMetadata(documentMetadata);
+            expect(languageInfoMetadata).to.deep.equal({
+                name: undefined
+            });
         });
     });
 
-    it(`document metadata is default when not the correct shape 2`, () => {
-        const documentMetadata = {
-            custom: {
-                metadata: {
-                    language_info_but_not_the_correct_shape: {
-                        name: 'csharp'
+    describe('cell metadata', () => {
+        it(`cell metadata can be read when present`, () => {
+            const cellMetadata = {
+                custom: {
+                    metadata: {
+                        dotnet_interactive: {
+                            language: 'see-sharp'
+                        }
                     }
                 }
-            }
-        };
-        const languageInfoMetadata = getLanguageInfoMetadata(documentMetadata);
-        expect(languageInfoMetadata).to.deep.equal({
-            name: undefined
+            };
+            const dotnetMetadata = getDotNetMetadata(cellMetadata);
+            expect(dotnetMetadata.language).to.equal('see-sharp');
+        });
+
+        it(`cell metadata is empty when not the correct shape 1`, () => {
+            const cellMetadata = {
+                custom: {
+                    metadata_but_not_the_correct_shape: {
+                        dotnet_interactive: {
+                            language: 'see-sharp'
+                        }
+                    }
+                }
+            };
+            const dotnetMetadata = getDotNetMetadata(cellMetadata);
+            expect(dotnetMetadata.language).to.equal(undefined);
+        });
+
+        it(`cell metadata is empty when not the correct shape 2`, () => {
+            const cellMetadata = {
+                custom: {
+                    metadata: {
+                        dotnet_interactive_but_not_the_correct_shape: {
+                            language: 'see-sharp'
+                        }
+                    }
+                }
+            };
+            const dotnetMetadata = getDotNetMetadata(cellMetadata);
+            expect(dotnetMetadata.language).to.equal(undefined);
+        });
+
+        it(`cell metadata is empty when not the correct shape 3`, () => {
+            const cellMetadata = {
+                custom: {
+                    metadata: {
+                        dotnet_interactive: {
+                            language_but_not_the_correct_shape: 'see-sharp'
+                        }
+                    }
+                }
+            };
+            const dotnetMetadata = getDotNetMetadata(cellMetadata);
+            expect(dotnetMetadata.language).to.equal(undefined);
+        });
+
+        it(`cell metadata returns empty info if shape isn't correct`, () => {
+            const cellMetadata = {
+                custom: {
+                    metadata: {
+                        dotnet_interactive: {
+                            language: 42 // not a string
+                        }
+                    }
+                }
+            };
+            const dotnetMetadata = getDotNetMetadata(cellMetadata);
+            expect(dotnetMetadata.language).to.equal(undefined);
+        });
+
+        it(`cell metadata can be set when empty`, () => {
+            const existingMetadata = {
+            };
+            const dotnetMetadata = {
+                language: 'see-sharp'
+            };
+            const newMetadata = withDotNetMetadata(existingMetadata, dotnetMetadata);
+            expect(newMetadata).to.deep.equal({
+                custom: {
+                    metadata: {
+                        dotnet_interactive: {
+                            language: 'see-sharp'
+                        }
+                    }
+                }
+            });
+        });
+
+        it(`cell metadata can overwrite old values`, () => {
+            const existingMetadata = {
+                custom: {
+                    metadata: {
+                        dotnet_interactive: {
+                            language: 'eff-sharp'
+                        }
+                    }
+                }
+            };
+            const dotnetMetadata = {
+                language: 'see-sharp'
+            };
+            const newMetadata = withDotNetMetadata(existingMetadata, dotnetMetadata);
+            expect(newMetadata).to.deep.equal({
+                custom: {
+                    metadata: {
+                        dotnet_interactive: {
+                            language: 'see-sharp'
+                        }
+                    }
+                }
+            });
+        });
+
+        it(`cell metadata doesn't overwrite other values in dotnet_interactive namespace`, () => {
+            const existingMetadata = {
+                custom: {
+                    metadata: {
+                        dotnet_interactive: {
+                            language: 'eff-sharp',
+                            version: 42
+                        }
+                    }
+                }
+            };
+            const dotnetMetadata = {
+                language: 'see-sharp'
+            };
+            const newMetadata = withDotNetMetadata(existingMetadata, dotnetMetadata);
+            expect(newMetadata).to.deep.equal({
+                custom: {
+                    metadata: {
+                        dotnet_interactive: {
+                            language: 'see-sharp',
+                            version: 42
+                        }
+                    }
+                }
+            });
+        });
+
+        it(`cell metadata doesn't overwrite other values or namespaces`, () => {
+            const existingMetadata = {
+                custom: {
+                    metadata: {
+                        not_dotnet_interactive: {
+                            some_key: 'some_value'
+                        }
+                    }
+                }
+            };
+            const dotnetMetadata = {
+                language: 'see-sharp'
+            };
+            const newMetadata = withDotNetMetadata(existingMetadata, dotnetMetadata);
+            expect(newMetadata).to.deep.equal({
+                custom: {
+                    metadata: {
+                        dotnet_interactive: {
+                            language: 'see-sharp'
+                        },
+                        not_dotnet_interactive: {
+                            some_key: 'some_value'
+                        }
+                    }
+                }
+            });
+        });
+
+        it(`cell metadata doesn't remove values in non-standard locations`, () => {
+            const existingMetadata = {
+                something_non_standard: {
+                    really_odd: 'not sure what this is'
+                }
+            };
+            const dotnetMetadata = {
+                language: 'see-sharp'
+            };
+            const newMetadata = withDotNetMetadata(existingMetadata, dotnetMetadata);
+            expect(newMetadata).to.deep.equal({
+                something_non_standard: {
+                    really_odd: 'not sure what this is'
+                },
+                custom: {
+                    metadata: {
+                        dotnet_interactive: {
+                            language: 'see-sharp'
+                        }
+                    }
+                }
+            });
         });
     });
 
-    it(`document metadata is default when not the correct shape 3`, () => {
-        const documentMetadata = {
-            custom: {
-                metadata: {
-                    language_info: {
-                        name_but_not_the_correct_shape: 'csharp'
-                    }
-                }
-            }
-        };
-        const languageInfoMetadata = getLanguageInfoMetadata(documentMetadata);
-        expect(languageInfoMetadata).to.deep.equal({
-            name: undefined
+    describe('cell language selection', () => {
+        it(`cell language is first determined from cell metadata`, () => {
+            const cellMetadata: DotNetCellMetadata = {
+                language: 'pwsh',
+            };
+            const documentMetadata: LanguageInfoMetadata = {
+                name: 'fsharp',
+            };
+            const cellLanguage = getCellLanguage(cellMetadata, documentMetadata, 'csharp');
+            expect(cellLanguage).to.equal('dotnet-interactive.pwsh');
         });
-    });
 
-    //----------------------------------------------------------- cell metadata
-    it(`cell metadata can be read when present`, () => {
-        const cellMetadata = {
-            custom: {
-                metadata: {
-                    dotnet_interactive: {
-                        language: 'see-sharp'
-                    }
-                }
-            }
-        };
-        const dotnetMetadata = getDotNetMetadata(cellMetadata);
-        expect(dotnetMetadata.language).to.equal('see-sharp');
-    });
-
-    it(`cell metadata is empty when not the correct shape 1`, () => {
-        const cellMetadata = {
-            custom: {
-                metadata_but_not_the_correct_shape: {
-                    dotnet_interactive: {
-                        language: 'see-sharp'
-                    }
-                }
-            }
-        };
-        const dotnetMetadata = getDotNetMetadata(cellMetadata);
-        expect(dotnetMetadata.language).to.equal(undefined);
-    });
-
-    it(`cell metadata is empty when not the correct shape 2`, () => {
-        const cellMetadata = {
-            custom: {
-                metadata: {
-                    dotnet_interactive_but_not_the_correct_shape: {
-                        language: 'see-sharp'
-                    }
-                }
-            }
-        };
-        const dotnetMetadata = getDotNetMetadata(cellMetadata);
-        expect(dotnetMetadata.language).to.equal(undefined);
-    });
-
-    it(`cell metadata is empty when not the correct shape 3`, () => {
-        const cellMetadata = {
-            custom: {
-                metadata: {
-                    dotnet_interactive: {
-                        language_but_not_the_correct_shape: 'see-sharp'
-                    }
-                }
-            }
-        };
-        const dotnetMetadata = getDotNetMetadata(cellMetadata);
-        expect(dotnetMetadata.language).to.equal(undefined);
-    });
-
-    it(`cell metadata returns empty info if shape isn't correct`, () => {
-        const cellMetadata = {
-            custom: {
-                metadata: {
-                    dotnet_interactive: {
-                        language: 42 // not a string
-                    }
-                }
-            }
-        };
-        const dotnetMetadata = getDotNetMetadata(cellMetadata);
-        expect(dotnetMetadata.language).to.equal(undefined);
-    });
-
-    it(`cell metadata can be set when empty`, () => {
-        const existingMetadata = {
-        };
-        const dotnetMetadata = {
-            language: 'see-sharp'
-        };
-        const newMetadata = withDotNetMetadata(existingMetadata, dotnetMetadata);
-        expect(newMetadata).to.deep.equal({
-            custom: {
-                metadata: {
-                    dotnet_interactive: {
-                        language: 'see-sharp'
-                    }
-                }
-            }
+        it(`cell language is second determined from document metadata`, () => {
+            const cellMetadata: DotNetCellMetadata = {
+                language: undefined,
+            };
+            const documentMetadata: LanguageInfoMetadata = {
+                name: 'fsharp',
+            };
+            const cellLanguage = getCellLanguage(cellMetadata, documentMetadata, 'csharp');
+            expect(cellLanguage).to.equal('dotnet-interactive.fsharp');
         });
-    });
 
-    it(`cell metadata can overwrite old values`, () => {
-        const existingMetadata = {
-            custom: {
-                metadata: {
-                    dotnet_interactive: {
-                        language: 'eff-sharp'
-                    }
-                }
-            }
-        };
-        const dotnetMetadata = {
-            language: 'see-sharp'
-        };
-        const newMetadata = withDotNetMetadata(existingMetadata, dotnetMetadata);
-        expect(newMetadata).to.deep.equal({
-            custom: {
-                metadata: {
-                    dotnet_interactive: {
-                        language: 'see-sharp'
-                    }
-                }
-            }
+        it(`cell language is ultimately determined from the fallback value`, () => {
+            const cellMetadata: DotNetCellMetadata = {
+                language: undefined,
+            };
+            const documentMetadata: LanguageInfoMetadata = {
+                name: undefined,
+            };
+            const cellLanguage = getCellLanguage(cellMetadata, documentMetadata, 'csharp');
+            expect(cellLanguage).to.equal('dotnet-interactive.csharp');
         });
-    });
-
-    it(`cell metadata doesn't overwrite other values in dotnet_interactive namespace`, () => {
-        const existingMetadata = {
-            custom: {
-                metadata: {
-                    dotnet_interactive: {
-                        language: 'eff-sharp',
-                        version: 42
-                    }
-                }
-            }
-        };
-        const dotnetMetadata = {
-            language: 'see-sharp'
-        };
-        const newMetadata = withDotNetMetadata(existingMetadata, dotnetMetadata);
-        expect(newMetadata).to.deep.equal({
-            custom: {
-                metadata: {
-                    dotnet_interactive: {
-                        language: 'see-sharp',
-                        version: 42
-                    }
-                }
-            }
-        });
-    });
-
-    it(`cell metadata doesn't overwrite other values or namespaces`, () => {
-        const existingMetadata = {
-            custom: {
-                metadata: {
-                    not_dotnet_interactive: {
-                        some_key: 'some_value'
-                    }
-                }
-            }
-        };
-        const dotnetMetadata = {
-            language: 'see-sharp'
-        };
-        const newMetadata = withDotNetMetadata(existingMetadata, dotnetMetadata);
-        expect(newMetadata).to.deep.equal({
-            custom: {
-                metadata: {
-                    dotnet_interactive: {
-                        language: 'see-sharp'
-                    },
-                    not_dotnet_interactive: {
-                        some_key: 'some_value'
-                    }
-                }
-            }
-        });
-    });
-
-    it(`cell metadata doesn't remove values in non-standard locations`, () => {
-        const existingMetadata = {
-            something_non_standard: {
-                really_odd: 'not sure what this is'
-            }
-        };
-        const dotnetMetadata = {
-            language: 'see-sharp'
-        };
-        const newMetadata = withDotNetMetadata(existingMetadata, dotnetMetadata);
-        expect(newMetadata).to.deep.equal({
-            something_non_standard: {
-                really_odd: 'not sure what this is'
-            },
-            custom: {
-                metadata: {
-                    dotnet_interactive: {
-                        language: 'see-sharp'
-                    }
-                }
-            }
-        });
-    });
-
-    //------------------------------------------------- cell language selection
-    it(`cell language is first determined from cell metadata`, () => {
-        const cellMetadata: DotNetCellMetadata = {
-            language: 'pwsh',
-        };
-        const documentMetadata: LanguageInfoMetadata = {
-            name: 'fsharp',
-        };
-        const cellLanguage = getCellLanguage(cellMetadata, documentMetadata, 'csharp');
-        expect(cellLanguage).to.equal('dotnet-interactive.pwsh');
-    });
-
-    it(`cell language is second determined from document metadata`, () => {
-        const cellMetadata: DotNetCellMetadata = {
-            language: undefined,
-        };
-        const documentMetadata: LanguageInfoMetadata = {
-            name: 'fsharp',
-        };
-        const cellLanguage = getCellLanguage(cellMetadata, documentMetadata, 'csharp');
-        expect(cellLanguage).to.equal('dotnet-interactive.fsharp');
-    });
-
-    it(`cell language is ultimately determined from the fallback value`, () => {
-        const cellMetadata: DotNetCellMetadata = {
-            language: undefined,
-        };
-        const documentMetadata: LanguageInfoMetadata = {
-            name: undefined,
-        };
-        const cellLanguage = getCellLanguage(cellMetadata, documentMetadata, 'csharp');
-        expect(cellLanguage).to.equal('dotnet-interactive.csharp');
     });
 });

--- a/src/dotnet-interactive-vscode/src/vscode/commands.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/commands.ts
@@ -11,16 +11,21 @@ import { getEol, isUnsavedNotebook } from './vscodeUtilities';
 import { toNotebookDocument } from './notebookContentProvider';
 import { updateCellMetadata } from './notebookKernel';
 
-export function registerAcquisitionCommands(context: vscode.ExtensionContext, dotnetPath: string) {
+export function registerAcquisitionCommands(context: vscode.ExtensionContext) {
     const config = vscode.workspace.getConfiguration('dotnet-interactive');
     const minDotNetInteractiveVersion = config.get<string>('minimumInteractiveToolVersion');
     const interactiveToolSource = config.get<string>('interactiveToolSource');
 
-    context.subscriptions.push(vscode.commands.registerCommand('dotnet-interactive.acquire', async (args?: InstallInteractiveArgs | undefined): Promise<InteractiveLaunchOptions | undefined> => {
+    context.subscriptions.push(vscode.commands.registerCommand('dotnet-interactive.acquire', async (args?: InstallInteractiveArgs | string | undefined): Promise<InteractiveLaunchOptions> => {
         if (!args) {
+            // unspecified; the best we can do is hope it's on the path
+            args = 'dotnet';
+        }
+
+        if (typeof args === 'string') {
             args = {
-                dotnetPath: dotnetPath,
-                toolVersion: undefined
+                dotnetPath: args,
+                toolVersion: undefined,
             };
         }
 

--- a/src/dotnet-interactive-vscode/src/vscode/extension.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/extension.ts
@@ -10,40 +10,35 @@ import { StdioKernelTransport } from '../stdioKernelTransport';
 import { registerLanguageProviders } from './languageProvider';
 import { execute, registerAcquisitionCommands, registerKernelCommands, registerFileCommands } from './commands';
 
+import { getNotebookSpecificLanguage, getSimpleLanguage, isDotnetInteractiveLanguage, notebookCellLanguages } from '../interactiveNotebook';
 import { IDotnetAcquireResult } from '../interfaces/dotnet';
 import { InteractiveLaunchOptions, InstallInteractiveArgs } from '../interfaces';
 
 import compareVersions = require("compare-versions");
+import { DotNetCellMetadata, getCellLanguage, getDotNetMetadata, getLanguageInfoMetadata, withDotNetMetadata } from '../ipynbUtilities';
 import { processArguments } from '../utilities';
 import { OutputChannelAdapter } from './OutputChannelAdapter';
-import { DotNetInteractiveNotebookKernel } from './notebookKernel';
+import { DotNetInteractiveNotebookKernel, KernelId } from './notebookKernel';
 import { DotNetInteractiveNotebookKernelProvider } from './notebookKernelProvider';
 
 export async function activate(context: vscode.ExtensionContext) {
-    // install dotnet or use global
+    // this must happen first, because some following functions use the acquisition command
+    registerAcquisitionCommands(context);
+
     const config = vscode.workspace.getConfiguration('dotnet-interactive');
     const diagnosticsChannel = new OutputChannelAdapter(vscode.window.createOutputChannel('.NET Interactive : diagnostics'));
-    const minDotNetSdkVersion = config.get<string>('minimumDotNetSdkVersion');
-    let dotnetPath: string;
-    if (await isDotnetUpToDate(minDotNetSdkVersion!)) {
-        dotnetPath = 'dotnet';
-    } else {
-        const commandResult = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', { version: minDotNetSdkVersion, requestingExtensionId: 'ms-dotnettools.dotnet-interactive-vscode' });
-        dotnetPath = commandResult!.dotnetPath;
-    }
 
-    registerAcquisitionCommands(context, dotnetPath);
+    // n.b., this is _not_ resolved here because it's potentially really slow, but needs to be chained off of later
+    const dotnetPromise = getDotnetPath(diagnosticsChannel);
 
-    // install dotnet-interactive
-    const installArgs: InstallInteractiveArgs = {
-        dotnetPath,
-    };
-    const launchOptions = await vscode.commands.executeCommand<InteractiveLaunchOptions>('dotnet-interactive.acquire', installArgs);
-    const apiBootstrapperUri = vscode.Uri.file(path.join(context.extensionPath, 'resources', 'kernelHttpApiBootstrapper.js'));
     // register with VS Code
     const clientMapper = new ClientMapper(async (notebookPath) => {
+        diagnosticsChannel.appendLine(`Creating client for notebook "${notebookPath}"`);
+        const dotnetPath = await dotnetPromise;
+        const launchOptions = await getInteractiveLaunchOptions(dotnetPath);
+
         // prepare kernel transport launch arguments and working directory using a fresh config item so we don't get cached values
-        const config = vscode.workspace.getConfiguration('dotnet-interactive');
+
         const kernelTransportArgs = config.get<Array<string>>('kernelTransportArgs')!;
         const argsTemplate = {
             args: kernelTransportArgs,
@@ -60,6 +55,7 @@ export async function activate(context: vscode.ExtensionContext) {
         let externalUri = await vscode.env.asExternalUri(vscode.Uri.parse(`http://localhost:${transport.httpPort}`));
         //create tunnel for teh kernel transport
         await transport.setExternalUri(externalUri);
+
         return transport;
     });
 
@@ -72,16 +68,87 @@ export async function activate(context: vscode.ExtensionContext) {
         filenamePattern: '*.{dib,dotnet-interactive,ipynb}'
     };
     const notebookContentProvider = new DotNetInteractiveNotebookContentProvider(clientMapper);
+    const apiBootstrapperUri = vscode.Uri.file(path.join(context.extensionPath, 'resources', 'kernelHttpApiBootstrapper.js'));
     const notebookKernel = new DotNetInteractiveNotebookKernel(clientMapper, apiBootstrapperUri);
     const notebookKernelProvider = new DotNetInteractiveNotebookKernelProvider(notebookKernel);
     context.subscriptions.push(vscode.notebook.registerNotebookContentProvider('dotnet-interactive', notebookContentProvider));
     context.subscriptions.push(vscode.notebook.registerNotebookContentProvider('dotnet-interactive-jupyter', notebookContentProvider));
     context.subscriptions.push(vscode.notebook.registerNotebookKernelProvider(selector, notebookKernelProvider));
+    context.subscriptions.push(vscode.notebook.onDidChangeActiveNotebookKernel(async e => await updateDocumentLanguages(e)));
+    context.subscriptions.push(vscode.notebook.onDidChangeCellLanguage(async e => await updateCellLanguageInMetadata(e)));
     context.subscriptions.push(vscode.notebook.onDidCloseNotebookDocument(notebookDocument => clientMapper.closeClient(notebookDocument.uri)));
     context.subscriptions.push(registerLanguageProviders(clientMapper, diagnosticDelay));
 }
 
 export function deactivate() {
+}
+
+// keep the cell's language in metadata in sync with what VS Code thinks it is
+async function updateCellLanguageInMetadata(languageChangeEvent: { cell: vscode.NotebookCell, document: vscode.NotebookDocument, language: string }) {
+    if (isDotnetInteractiveLanguage(languageChangeEvent.language)) {
+        const cellIndex = languageChangeEvent.document.cells.findIndex(c => c === languageChangeEvent.cell);
+        if (cellIndex >= 0) {
+            const edit = new vscode.WorkspaceEdit();
+            const cellMetadata: DotNetCellMetadata = {
+                language: getSimpleLanguage(languageChangeEvent.language),
+            };
+            const metadata = withDotNetMetadata(languageChangeEvent.cell.metadata, cellMetadata);
+            edit.replaceNotebookCellMetadata(languageChangeEvent.document.uri, cellIndex, metadata);
+            await vscode.workspace.applyEdit(edit);
+        }
+    }
+}
+
+async function updateDocumentLanguages(e: { document: vscode.NotebookDocument, kernel: vscode.NotebookKernel | undefined }) {
+    if (e.kernel?.id === KernelId) {
+        // update document language
+        e.document.languages = notebookCellLanguages;
+        const documentLanguageInfo = getLanguageInfoMetadata(e.document.metadata);
+
+        // update cell language
+        const edit = new vscode.WorkspaceEdit();
+        let cellData: Array<vscode.NotebookCellData> = [];
+        for (const cell of e.document.cells) {
+            const cellMetadata = getDotNetMetadata(cell.metadata);
+            const newLanguage = getCellLanguage(cellMetadata, documentLanguageInfo, cell.language);
+            cellData.push({
+                cellKind: cell.cellKind,
+                source: cell.document.getText(),
+                language: newLanguage,
+                outputs: cell.outputs,
+                metadata: cell.metadata,
+            });
+        }
+
+        edit.replaceNotebookCells(e.document.uri, 0, e.document.cells.length, cellData);
+        await vscode.workspace.applyEdit(edit);
+    }
+}
+
+// this function can be slow and should only be called once
+async function getDotnetPath(outputChannel: OutputChannelAdapter): Promise<string> {
+    // use global dotnet or install
+    const config = vscode.workspace.getConfiguration('dotnet-interactive');
+    const minDotNetSdkVersion = config.get<string>('minimumDotNetSdkVersion');
+    let dotnetPath: string;
+    if (await isDotnetUpToDate(minDotNetSdkVersion!)) {
+        dotnetPath = 'dotnet';
+    } else {
+        const commandResult = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', { version: minDotNetSdkVersion, requestingExtensionId: 'ms-dotnettools.dotnet-interactive-vscode' });
+        dotnetPath = commandResult!.dotnetPath;
+    }
+
+    outputChannel.appendLine(`Using dotnet from "${dotnetPath}"`);
+    return dotnetPath;
+}
+
+async function getInteractiveLaunchOptions(dotnetPath: string): Promise<InteractiveLaunchOptions> {
+    // use dotnet-interactive or install
+    const installArgs: InstallInteractiveArgs = {
+        dotnetPath,
+    };
+    const launchOptions = await vscode.commands.executeCommand<InteractiveLaunchOptions>('dotnet-interactive.acquire', installArgs);
+    return launchOptions!;
 }
 
 async function isDotnetUpToDate(minVersion: string): Promise<boolean> {

--- a/src/dotnet-interactive-vscode/src/vscode/notebookKernel.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/notebookKernel.ts
@@ -10,8 +10,10 @@ import { getDiagnosticCollection } from './diagnostics';
 import { getSimpleLanguage } from "../interactiveNotebook";
 import { Diagnostic, DiagnosticSeverity } from "../contracts";
 
+export const KernelId: string = 'dotnet-interactive';
+
 export class DotNetInteractiveNotebookKernel implements vscode.NotebookKernel {
-    id?: string | undefined;
+    id: string = KernelId;
     label: string;
     description?: string | undefined;
     detail?: string | undefined;

--- a/src/dotnet-interactive/ContentFiles/kernels/.net-csharp/kernel.json
+++ b/src/dotnet-interactive/ContentFiles/kernels/.net-csharp/kernel.json
@@ -8,5 +8,11 @@
     "{connection_file}"
   ],
   "display_name": ".NET (C#)",
-  "language": "C#"
+  "language": "C#",
+  "metadata": {
+    "vscode": {
+      "extension_id": "ms-dotnettools.dotnet-interactive-vscode",
+      "kernel_id": "dotnet-interactive"
+    }
+  }
 }

--- a/src/dotnet-interactive/ContentFiles/kernels/.net-fsharp/kernel.json
+++ b/src/dotnet-interactive/ContentFiles/kernels/.net-fsharp/kernel.json
@@ -8,5 +8,11 @@
     "{connection_file}"
   ],
   "display_name": ".NET (F#)",
-  "language": "F#"
+  "language": "F#",
+  "metadata": {
+    "vscode": {
+      "extension_id": "ms-dotnettools.dotnet-interactive-vscode",
+      "kernel_id": "dotnet-interactive"
+    }
+  }
 }

--- a/src/dotnet-interactive/ContentFiles/kernels/.net-powershell/kernel.json
+++ b/src/dotnet-interactive/ContentFiles/kernels/.net-powershell/kernel.json
@@ -8,5 +8,11 @@
     "{connection_file}"
   ],
   "display_name": ".NET (PowerShell)",
-  "language": "PowerShell"
+  "language": "PowerShell",
+  "metadata": {
+    "vscode": {
+      "extension_id": "ms-dotnettools.dotnet-interactive-vscode",
+      "kernel_id": "dotnet-interactive"
+    }
+  }
 }


### PR DESCRIPTION
To make us work better with the Jupyter extension to VS Code, this enables our VS Code kernel to sniff the cell metadata for a language.  To do this, then, our `.ipynb` handler needs to emit this metadata when saving from our end.  The metadata looks like this:

``` json
...
"metadata": {
  "dotnet_interactive": {
    "language": "fsharp"
  }
}
...
```

I've also updated our own Jupyter protocol handler to sniff out this cell metadata and apply it whenever possible.

There was a refactor of our VS Code extension to always activate whenever a notebook is loaded so we can register our kernel.  This meant that our auto-install of .NET and our global tool was moved to when we initialize a notebook.

When a VS Code notebook is switched to our kernel, we iterate through all cells and check for metadata that will help us assign a language.

A follow-up PR will remove our VS Code `.ipynb` handling entirely, but that first requires microsoft/vscode-jupyter#4363 to be addressed, and part of that included adding some metadata to our kernel spec files so they can identify our VS Code version of the kernel:

``` json
...
"metadata": {
  "vscode": {
    "extension_id": "ms-dotnettools.dotnet-interactive-vscode",
    "kernel_id": "dotnet-interactive"
  }
}
...
```

This does complicate the issue of Jupyter Lab.  When we're executing a cell there, the cell metadata is passed back to us and we can use it, but the user currently has no way of viewing/updating the cell metadata.  This will likely require us building/publishing a Jupyter Lab extension specifically for us.  The good news is that we'll likely only need the single `"language"` field, so there should be very little churn on this front.