### PR TITLE
use ipynb handling from jupyter extension

### DIFF
--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -41,7 +41,6 @@
   ],
   "activationEvents": [
     "onNotebook:dotnet-interactive",
-    "onNotebook:dotnet-interactive-jupyter",
     "onNotebook:*",
     "onCommand:dotnet-interactive.acquire",
     "onCommand:dotnet-interactive.newNotebook",
@@ -50,7 +49,8 @@
   ],
   "main": "./out/vscode/extension.js",
   "extensionDependencies": [
-    "ms-dotnettools.vscode-dotnet-runtime"
+    "ms-dotnettools.vscode-dotnet-runtime",
+    "ms-toolsai.jupyter"
   ],
   "contributes": {
     "notebookProvider": [
@@ -62,16 +62,6 @@
             "filenamePattern": "*.{dib,dotnet-interactive}"
           }
         ]
-      },
-      {
-        "viewType": "dotnet-interactive-jupyter",
-        "displayName": ".NET Interactive for Jupyter Notebooks",
-        "selector": [
-          {
-            "filenamePattern": "*.ipynb"
-          }
-        ],
-        "priority": "option"
       }
     ],
     "configuration": {

--- a/src/dotnet-interactive-vscode/src/vscode/notebookKernel.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/notebookKernel.ts
@@ -17,7 +17,7 @@ export class DotNetInteractiveNotebookKernel implements vscode.NotebookKernel {
     label: string;
     description?: string | undefined;
     detail?: string | undefined;
-    isPreferred?: boolean | undefined;
+    isPreferred: boolean = true;
     preloads?: vscode.Uri[] | undefined;
 
     constructor(readonly clientMapper: ClientMapper, apiBootstrapperUri: vscode.Uri) {


### PR DESCRIPTION
Let the Jupyter extension handle the `.ipynb` file format.  This means the commands to open an .NET Interactive `.ipynb` notebook or to create a new one simply open the Jupyter editor and select our kernel.

Regular handling of `.dib` files is unchanged; it routes through our own stuff.