### PR TITLE
use cell's first line to set language if possible

### DIFF
--- a/src/dotnet-interactive-vscode/src/ipynbUtilities.ts
+++ b/src/dotnet-interactive-vscode/src/ipynbUtilities.ts
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { getNotebookSpecificLanguage } from "./interactiveNotebook";
+import { getNotebookSpecificLanguage, notebookCellLanguages } from "./interactiveNotebook";
 
 // the shape of this is meant to match the cell metadata from VS Code
 interface CellMetadata {
@@ -99,6 +99,16 @@ function mapIpynbLanguageName(name: string | undefined): string | undefined {
     return undefined;
 }
 
-export function getCellLanguage(cellMetadata: DotNetCellMetadata, documentMetadata: LanguageInfoMetadata, fallbackLanguage: string): string {
-    return getNotebookSpecificLanguage(cellMetadata.language || documentMetadata.name || fallbackLanguage);
+export function getCellLanguage(cellText: string, cellMetadata: DotNetCellMetadata, documentMetadata: LanguageInfoMetadata, fallbackLanguage: string): string {
+    const cellLines = cellText.split('\n').map(line => line.trim());
+    let cellLanguageSpecifier: string | undefined = undefined;
+    if (cellLines.length > 0 && cellLines[0].startsWith('#!')) {
+        const cellLanguage = cellLines[0].substr(2);
+        const notebookSpecficLanguage = getNotebookSpecificLanguage(cellLanguage);
+        if (notebookCellLanguages.includes(notebookSpecficLanguage)) {
+            cellLanguageSpecifier = cellLanguage;
+        }
+    }
+
+    return getNotebookSpecificLanguage(cellLanguageSpecifier || cellMetadata.language || documentMetadata.name || fallbackLanguage);
 }

--- a/src/dotnet-interactive-vscode/src/tests/unit/ipynbMetadata.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/ipynbMetadata.test.ts
@@ -329,7 +329,7 @@ describe('ipynb metadata tests', () => {
     });
 
     describe('cell language selection', () => {
-        it(`cell language is first determined from cell text`, () => {
+        it(`sets the cell language first from cell text`, () => {
             const cellMetadata: DotNetCellMetadata = {
                 language: 'pwsh',
             };
@@ -341,7 +341,7 @@ describe('ipynb metadata tests', () => {
             expect(cellLanguage).to.equal('dotnet-interactive.javascript');
         });
 
-        it(`cell language is not set from a non-language specifier on the first line`, () => {
+        it(`does not use the cell text for the language if a non-language specifier is on the first line`, () => {
             const cellMetadata: DotNetCellMetadata = {
                 language: 'pwsh',
             };
@@ -353,7 +353,7 @@ describe('ipynb metadata tests', () => {
             expect(cellLanguage).to.equal('dotnet-interactive.pwsh');
         });
 
-        it(`cell language is second determined from cell metadata`, () => {
+        it(`sets the cell language second from cell metadata`, () => {
             const cellMetadata: DotNetCellMetadata = {
                 language: 'pwsh',
             };
@@ -365,7 +365,7 @@ describe('ipynb metadata tests', () => {
             expect(cellLanguage).to.equal('dotnet-interactive.pwsh');
         });
 
-        it(`cell language is third determined from document metadata`, () => {
+        it(`sets the cell language third from document metadata`, () => {
             const cellMetadata: DotNetCellMetadata = {
                 language: undefined,
             };
@@ -377,7 +377,7 @@ describe('ipynb metadata tests', () => {
             expect(cellLanguage).to.equal('dotnet-interactive.fsharp');
         });
 
-        it(`cell language is ultimately determined from the fallback value`, () => {
+        it(`sets the cell language finally from the fallback value`, () => {
             const cellMetadata: DotNetCellMetadata = {
                 language: undefined,
             };

--- a/src/dotnet-interactive-vscode/src/tests/unit/ipynbMetadata.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/ipynbMetadata.test.ts
@@ -329,25 +329,51 @@ describe('ipynb metadata tests', () => {
     });
 
     describe('cell language selection', () => {
-        it(`cell language is first determined from cell metadata`, () => {
+        it(`cell language is first determined from cell text`, () => {
             const cellMetadata: DotNetCellMetadata = {
                 language: 'pwsh',
             };
             const documentMetadata: LanguageInfoMetadata = {
                 name: 'fsharp',
             };
-            const cellLanguage = getCellLanguage(cellMetadata, documentMetadata, 'csharp');
+            const cellText = '#!javascript\r\nalert(1+1);';
+            const cellLanguage = getCellLanguage(cellText, cellMetadata, documentMetadata, 'csharp');
+            expect(cellLanguage).to.equal('dotnet-interactive.javascript');
+        });
+
+        it(`cell language is not set from a non-language specifier on the first line`, () => {
+            const cellMetadata: DotNetCellMetadata = {
+                language: 'pwsh',
+            };
+            const documentMetadata: LanguageInfoMetadata = {
+                name: 'fsharp',
+            };
+            const cellText = '#!about\r\n1+1';
+            const cellLanguage = getCellLanguage(cellText, cellMetadata, documentMetadata, 'csharp');
             expect(cellLanguage).to.equal('dotnet-interactive.pwsh');
         });
 
-        it(`cell language is second determined from document metadata`, () => {
+        it(`cell language is second determined from cell metadata`, () => {
+            const cellMetadata: DotNetCellMetadata = {
+                language: 'pwsh',
+            };
+            const documentMetadata: LanguageInfoMetadata = {
+                name: 'fsharp',
+            };
+            const cellText = '1+1';
+            const cellLanguage = getCellLanguage(cellText, cellMetadata, documentMetadata, 'csharp');
+            expect(cellLanguage).to.equal('dotnet-interactive.pwsh');
+        });
+
+        it(`cell language is third determined from document metadata`, () => {
             const cellMetadata: DotNetCellMetadata = {
                 language: undefined,
             };
             const documentMetadata: LanguageInfoMetadata = {
                 name: 'fsharp',
             };
-            const cellLanguage = getCellLanguage(cellMetadata, documentMetadata, 'csharp');
+            const cellText = '1+1';
+            const cellLanguage = getCellLanguage(cellText, cellMetadata, documentMetadata, 'csharp');
             expect(cellLanguage).to.equal('dotnet-interactive.fsharp');
         });
 
@@ -358,7 +384,8 @@ describe('ipynb metadata tests', () => {
             const documentMetadata: LanguageInfoMetadata = {
                 name: undefined,
             };
-            const cellLanguage = getCellLanguage(cellMetadata, documentMetadata, 'csharp');
+            const cellText = '1+1';
+            const cellLanguage = getCellLanguage(cellText, cellMetadata, documentMetadata, 'csharp');
             expect(cellLanguage).to.equal('dotnet-interactive.csharp');
         });
     });

--- a/src/dotnet-interactive-vscode/src/vscode/extension.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/extension.ts
@@ -115,10 +115,11 @@ async function updateDocumentMetadata(e: { document: vscode.NotebookDocument, ke
         let cellData: Array<vscode.NotebookCellData> = [];
         for (const cell of e.document.cells) {
             const cellMetadata = getDotNetMetadata(cell.metadata);
-            const newLanguage = getCellLanguage(cellMetadata, documentLanguageInfo, cell.language);
+            const cellText = cell.document.getText();
+            const newLanguage = getCellLanguage(cellText, cellMetadata, documentLanguageInfo, cell.language);
             cellData.push({
                 cellKind: cell.cellKind,
-                source: cell.document.getText(),
+                source: cellText,
                 language: newLanguage,
                 outputs: cell.outputs,
                 metadata: cell.metadata,


### PR DESCRIPTION
When loading an `.ipynb` notebook, peek at the first line to see if a language is set, e.g., `#!pwsh`.  If so, use that as the cell's language, otherwise fall back to the previous methods.