### PR TITLE
try to use a reasonable fallback working directory if it can't be determined

### DIFF
--- a/src/dotnet-interactive-vscode/src/tests/unit/misc.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/misc.test.ts
@@ -21,7 +21,7 @@ describe('Miscellaneous tests', () => {
             ],
             workingDirectory: '{global_storage_path}'
         };
-        let actual = processArguments(template, 'replacement-working-dir/notebook-file.dib', 'replacement-dotnet-path', 'replacement-global-storage-path');
+        let actual = processArguments(template, 'replacement-working-dir/notebook-file.dib', 'unused-working-dir', 'replacement-dotnet-path', 'replacement-global-storage-path');
         expect(actual).to.deep.equal({
             command: 'replacement-dotnet-path',
             args: [
@@ -34,6 +34,26 @@ describe('Miscellaneous tests', () => {
                 'replacement-working-dir'
             ],
             workingDirectory: 'replacement-global-storage-path'
+        });
+    });
+
+    it(`uses the fallback working directory when it can't be reasonably determined`, () => {
+        const template = {
+            args: [
+                '{dotnet_path}',
+                '--working-dir',
+                '{working_dir}'
+            ],
+            workingDirectory: '{global_storage_path}'
+        };
+        let actual = processArguments(template, 'notebook-file-with-no-dir.dib', 'fallback-working-dir', 'dotnet-path', 'global-storage-path');
+        expect(actual).to.deep.equal({
+            command: 'dotnet-path',
+            args: [
+                '--working-dir',
+                'fallback-working-dir'
+            ],
+            workingDirectory: 'global-storage-path'
         });
     });
 

--- a/src/dotnet-interactive-vscode/src/utilities.ts
+++ b/src/dotnet-interactive-vscode/src/utilities.ts
@@ -6,12 +6,18 @@ import { NotebookCellDisplayOutput, NotebookCellErrorOutput, NotebookCellTextOut
 import { ProcessStart } from "./interfaces";
 import { Uri } from './interfaces/vscode';
 
-export function processArguments(template: { args: Array<string>, workingDirectory: string }, notebookPath: string, dotnetPath: string, globalStoragePath: string): ProcessStart {
+export function processArguments(template: { args: Array<string>, workingDirectory: string }, notebookPath: string, fallbackWorkingDirectory: string, dotnetPath: string, globalStoragePath: string): ProcessStart {
+    let workingDirectory = path.parse(notebookPath).dir;
+    if (workingDirectory === '') {
+        workingDirectory = fallbackWorkingDirectory;
+    }
+
     let map: { [key: string]: string } = {
         'dotnet_path': dotnetPath,
         'global_storage_path': globalStoragePath,
-        'working_dir': path.dirname(notebookPath)
+        'working_dir': workingDirectory
     };
+
     let processed = template.args.map(a => performReplacement(a, map));
     return {
         command: processed[0],

--- a/src/dotnet-interactive-vscode/src/vscode/extension.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/extension.ts
@@ -44,7 +44,13 @@ export async function activate(context: vscode.ExtensionContext) {
             args: kernelTransportArgs,
             workingDirectory: config.get<string>('kernelTransportWorkingDirectory')!
         };
-        const processStart = processArguments(argsTemplate, notebookPath, dotnetPath, launchOptions!.workingDirectory);
+
+        // ensure a reasonable working directory is selected
+        const fallbackWorkingDirectory = (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0)
+            ? vscode.workspace.workspaceFolders[0].uri.fsPath
+            : '.';
+
+        const processStart = processArguments(argsTemplate, notebookPath, fallbackWorkingDirectory, dotnetPath, launchOptions!.workingDirectory);
         let notification = {
             displayError: async (message: string) => { await vscode.window.showErrorMessage(message, { modal: false }); },
             displayInfo: async (message: string) => { await vscode.window.showInformationMessage(message, { modal: false }); },


### PR DESCRIPTION
When a notebook has no location on disk, a working directory can't be determined, so to prevent the user from accidentally working in the extensions global storage location, we instead sniff out the host's workspace folder and try to use that instead.

Old:
![image](https://user-images.githubusercontent.com/926281/105560757-a157cd80-5cc9-11eb-8d5c-3e96b57f10e0.png)

New:
![image](https://user-images.githubusercontent.com/926281/105560673-58a01480-5cc9-11eb-9612-39f9438a8170.png)
