### PR TITLE
update cell languages after each execution

### DIFF
--- a/src/dotnet-interactive-vscode/package-lock.json
+++ b/src/dotnet-interactive-vscode/package-lock.json
@@ -2385,9 +2385,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
 			"dev": true
 		},
 		"uc.micro": {

--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -274,7 +274,7 @@
     "mocha-multi-reporters": "1.1.7",
     "mocha-trx-reporter": "3.2.4",
     "tmp": "0.2.1",
-    "typescript": "3.8.3",
+    "typescript": "4.1.3",
     "vsce": "1.75.0",
     "vscode-oniguruma": "1.3.1",
     "vscode-test": "1.3.0",


### PR DESCRIPTION
Re-use the code that sets the cell language to also update it after execution so that e.g., if a cell is C# but the first line is `#!fsharp`, the cell's language is updated to `F# (.NET Interactive)`.

Also updating to TypeScript 4 to allow the `||=` operator.

Fixes #981.