### PR TITLE
set document kernelspec if not present

### DIFF
--- a/src/dotnet-interactive-vscode/src/ipynbUtilities.ts
+++ b/src/dotnet-interactive-vscode/src/ipynbUtilities.ts
@@ -39,9 +39,9 @@ export function withDotNetMetadata(metadata: { [key: string]: any } | undefined,
         }
     }
 
-    result.custom = result.custom || {};
-    result.custom.metadata = result.custom.metadata || {};
-    result.custom.metadata.dotnet_interactive = result.custom.metadata.dotnet_interactive || {};
+    result.custom ||= {};
+    result.custom.metadata ||= {};
+    result.custom.metadata.dotnet_interactive ||= {};
     for (const key in cellMetadata) {
         result.custom.metadata.dotnet_interactive[key] = (<any>cellMetadata)[key];
     }
@@ -111,4 +111,28 @@ export function getCellLanguage(cellText: string, cellMetadata: DotNetCellMetada
     }
 
     return getNotebookSpecificLanguage(cellLanguageSpecifier || cellMetadata.language || documentMetadata.name || fallbackLanguage);
+}
+
+export function withDotNetKernelMetadata(metadata: { [key: string]: any } | undefined): any | undefined {
+    // clone the existing metadata
+    let result: { [key: string]: any } = {};
+    if (metadata) {
+        for (const key in metadata) {
+            result[key] = metadata[key];
+        }
+    }
+
+    result.custom ||= {};
+    result.custom.metadata ||= {};
+
+    // set kernelspec only if there's nothing present
+    if (!result.custom.metadata.kernelspec) {
+        result.custom.metadata.kernelspec = {
+            display_name: '.NET (C#)',
+            language: 'C#',
+            name: '.net-csharp',
+        };
+    }
+
+    return result;
 }

--- a/src/dotnet-interactive-vscode/src/tests/unit/ipynbMetadata.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/ipynbMetadata.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { expect } from 'chai';
-import { DotNetCellMetadata, getCellLanguage, getDotNetMetadata, getLanguageInfoMetadata, LanguageInfoMetadata, withDotNetMetadata } from '../../ipynbUtilities';
+import { DotNetCellMetadata, getCellLanguage, getDotNetMetadata, getLanguageInfoMetadata, LanguageInfoMetadata, withDotNetKernelMetadata, withDotNetMetadata } from '../../ipynbUtilities';
 
 describe('ipynb metadata tests', () => {
     describe('document metadata', () => {
@@ -130,6 +130,132 @@ describe('ipynb metadata tests', () => {
             const languageInfoMetadata = getLanguageInfoMetadata(documentMetadata);
             expect(languageInfoMetadata).to.deep.equal({
                 name: undefined
+            });
+        });
+    });
+
+    describe('kernelspec metadata', () => {
+        it(`sets kernelspec data when document metadata is undefined`, () => {
+            const documentMetadata = undefined;
+            const newDocumentMetadata = withDotNetKernelMetadata(documentMetadata);
+            expect(newDocumentMetadata).to.deep.equal({
+                custom: {
+                    metadata: {
+                        kernelspec: {
+                            display_name: '.NET (C#)',
+                            language: 'C#',
+                            name: '.net-csharp',
+                        }
+                    }
+                }
+            });
+        });
+
+        it(`sets kernelspec data when not present`, () => {
+            const documentMetadata = {
+                custom: {
+                }
+            };
+            const newDocumentMetadata = withDotNetKernelMetadata(documentMetadata);
+            expect(newDocumentMetadata).to.deep.equal({
+                custom: {
+                    metadata: {
+                        kernelspec: {
+                            display_name: '.NET (C#)',
+                            language: 'C#',
+                            name: '.net-csharp',
+                        }
+                    }
+                }
+            });
+        });
+
+        it(`doesn't set kernelspec data when already present`, () => {
+            const documentMetadata = {
+                custom: {
+                    metadata: {
+                        kernelspec: {
+                            some_existing_key: 'some existing value'
+                        }
+                    }
+                }
+            };
+            const newDocumentMetadata = withDotNetKernelMetadata(documentMetadata);
+            expect(newDocumentMetadata).to.deep.equal({
+                custom: {
+                    metadata: {
+                        kernelspec: {
+                            some_existing_key: 'some existing value'
+                        }
+                    }
+                }
+            });
+        });
+
+        it(`preserves other metadata while setting kernelspec`, () => {
+            const documentMetadata = {
+                custom: {
+                    metadata: {
+                        some_custom_metadata: {
+                            key1: 'value 1'
+                        }
+                    },
+                    some_other_custom_data: {
+                        key2: 'value 2'
+                    }
+                }
+            };
+            const newDocumentMetadata = withDotNetKernelMetadata(documentMetadata);
+            expect(newDocumentMetadata).to.deep.equal({
+                custom: {
+                    metadata: {
+                        kernelspec: {
+                            display_name: '.NET (C#)',
+                            language: 'C#',
+                            name: '.net-csharp',
+                        },
+                        some_custom_metadata: {
+                            key1: 'value 1'
+                        }
+                    },
+                    some_other_custom_data: {
+                        key2: 'value 2'
+                    }
+                }
+            });
+        });
+
+        it(`preserves other metadata when kernelspec is already present`, () => {
+            const documentMetadata = {
+                custom: {
+                    metadata: {
+                        kernelspec: {
+                            some_existing_key: 'some existing value'
+                        },
+                        some_custom_metadata: {
+                            key1: 'value 1'
+                        }
+                    },
+                    some_other_custom_data: {
+                        key2: 'value 2'
+                    }
+                }
+            };
+            const newDocumentMetadata = withDotNetKernelMetadata(documentMetadata);
+            expect(newDocumentMetadata).to.deep.equal({
+                custom: {
+                    metadata: {
+                        kernelspec: {
+                            some_existing_key: 'some existing value'
+                        },
+                        some_custom_metadata: {
+                            key1: 'value 1'
+                        }
+                    },
+                    some_other_custom_data: {
+                        key2: 'value 2'
+                    }
+                }
             });
         });
     });

--- a/src/dotnet-interactive-vscode/src/vscode/extension.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/extension.ts
@@ -15,10 +15,10 @@ import { IDotnetAcquireResult } from '../interfaces/dotnet';
 import { InteractiveLaunchOptions, InstallInteractiveArgs } from '../interfaces';
 
 import compareVersions = require("compare-versions");
-import { DotNetCellMetadata, getLanguageInfoMetadata, withDotNetMetadata } from '../ipynbUtilities';
+import { DotNetCellMetadata, withDotNetMetadata } from '../ipynbUtilities';
 import { processArguments } from '../utilities';
 import { OutputChannelAdapter } from './OutputChannelAdapter';
-import { DotNetInteractiveNotebookKernel, KernelId, updateCellLanguages } from './notebookKernel';
+import { DotNetInteractiveNotebookKernel, KernelId, updateCellLanguages, updateDocumentKernelspecMetadata } from './notebookKernel';
 import { DotNetInteractiveNotebookKernelProvider } from './notebookKernelProvider';
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -114,7 +114,8 @@ async function updateDocumentMetadata(e: { document: vscode.NotebookDocument, ke
         // update document language
         e.document.languages = notebookCellLanguages;
 
-        // update cell languages
+        // update various metadata
+        await updateDocumentKernelspecMetadata(e.document);
         await updateCellLanguages(e.document);
 
         // force creation of the client so we don't have to wait for the user to execute a cell to get the tool

--- a/src/dotnet-interactive-vscode/src/vscode/notebookKernel.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/notebookKernel.ts
@@ -9,7 +9,7 @@ import { CellOutput } from '../interfaces/vscode';
 import { getDiagnosticCollection } from './diagnostics';
 import { getSimpleLanguage } from "../interactiveNotebook";
 import { Diagnostic, DiagnosticSeverity } from "../contracts";
-import { getCellLanguage, getDotNetMetadata, getLanguageInfoMetadata } from '../ipynbUtilities';
+import { getCellLanguage, getDotNetMetadata, getLanguageInfoMetadata, withDotNetKernelMetadata } from '../ipynbUtilities';
 
 export const KernelId: string = 'dotnet-interactive';
 
@@ -91,6 +91,13 @@ export async function updateCellOutputs(document: vscode.NotebookDocument, cell:
         edit.replaceNotebookCellOutput(document.uri, cellIndex, outputs);
         await vscode.workspace.applyEdit(edit);
     }
+}
+
+export async function updateDocumentKernelspecMetadata(document: vscode.NotebookDocument): Promise<void> {
+    const edit = new vscode.WorkspaceEdit();
+    const documentKernelMetadata = withDotNetKernelMetadata(document.metadata);
+    edit.replaceNotebookMetadata(document.uri, documentKernelMetadata);
+    await vscode.workspace.applyEdit(edit);
 }
 
 export async function updateCellLanguages(document: vscode.NotebookDocument): Promise<void> {


### PR DESCRIPTION
When our kernel is selected, add the `kernelspec` document metadata that Jupyter Lab/Classic would expect to see.  This will make the experience better when User1 creates a new notebook in VS Code then shares it with User2 that's using Jupyter Lab.

I arbitrarily chose to set the C# kernel, because each cell saves its own language, so it doesn't really matter which one (C#/F#/PowerShell) we set.

Currently I'm perfectly mimicking the metadata set by Jupyter:

``` json
...
"metadata": {
  "kernelspec": {
    "display_name": ".NET (C#)",
    "language": "C#",
    "name": ".net-csharp"
  }
}
...
```

but we can add any other custom stuff as we deem necessary. 