### PR TITLE
Update fsharp & remove dependence on FSharp.Compiler.Scripting and reference to Microsoft.DotNet.DependencyManager

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,10 +15,8 @@
 
   <!-- Consolidate FSharp package versions -->
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="5.0.0-beta.21055.6" />
-    <PackageReference Update="FSharp.Compiler.Private.Scripting" Version="11.2.0-beta.21055.6" />
-    <PackageReference Update="FSharp.Compiler.Service" Version="11.2.0-beta.21055.6" />
-    <PackageReference Update="Microsoft.DotNet.DependencyManager" Version="11.2.0-beta.21055.6" />
+    <PackageReference Update="FSharp.Core" Version="5.0.2-beta.21102.10" />
+    <PackageReference Update="FSharp.Compiler.Service" Version="39.0.3-preview.21102.10" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
@@ -23,9 +23,9 @@ open Microsoft.DotNet.Interactive.Commands
 open Microsoft.DotNet.Interactive.Events
 open Microsoft.DotNet.Interactive.Extensions
 open Microsoft.DotNet.Interactive.Formatting
+open Microsoft.DotNet.Interactive.FSharp.ScriptHelpers
 
 open FSharp.Compiler.Interactive.Shell
-open FSharp.Compiler.Scripting
 open FSharp.Compiler.SourceCodeServices
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Pos

--- a/src/Microsoft.DotNet.Interactive.FSharp/FSharpScriptHelpers.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp/FSharpScriptHelpers.fs
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace Microsoft.DotNet.Interactive.FSharp.ScriptHelpers
+
+open System
+open System.Collections.Generic
+open System.IO
+open System.Text
+open System.Threading
+open FSharp.Compiler
+open FSharp.Compiler.Interactive.Shell
+open FSharp.Compiler.SourceCodeServices
+
+[<RequireQualifiedAccess>]
+type LangVersion =
+    | V47
+    | V50
+    | Preview
+
+type FSharpScript(?additionalArgs: string[], ?quiet: bool, ?langVersion: LangVersion) =
+
+    let additionalArgs = defaultArg additionalArgs [||]
+    let quiet = defaultArg quiet true
+    let langVersion = defaultArg langVersion LangVersion.Preview
+    let config = FsiEvaluationSession.GetDefaultConfiguration()
+
+    let computedProfile =
+        // If we are being executed on the desktop framework (we can tell because the assembly containing int is mscorlib) then profile must be mscorlib otherwise use netcore
+        if typeof<int>.Assembly.GetName().Name = "mscorlib" then "mscorlib"
+        else "netcore"
+
+    let baseArgs = [|
+        typeof<FSharpScript>.Assembly.Location;
+        "--noninteractive";
+        "--targetprofile:" + computedProfile
+        if quiet then "--quiet"
+        match langVersion with
+        | LangVersion.V47 -> "--langversion:4.7"
+        | LangVersion.V50 -> "--langversion:5.0"
+        | LangVersion.Preview -> "--langversion:preview"
+        |]
+
+    let argv = Array.append baseArgs additionalArgs
+
+    let fsi = FsiEvaluationSession.Create (config, argv, stdin, stdout, stderr)
+
+    member _.ValueBound = fsi.ValueBound
+
+    member _.Fsi = fsi
+
+    member _.Eval(code: string, ?cancellationToken: CancellationToken) =
+        let cancellationToken = defaultArg cancellationToken CancellationToken.None
+        let ch, errors = fsi.EvalInteractionNonThrowing(code, cancellationToken)
+        match ch with
+        | Choice1Of2 v -> Ok(v), errors
+        | Choice2Of2 ex -> Error(ex), errors
+
+    /// Get the available completion items from the code at the specified location.
+    ///
+    /// <param name="text">The input text on which completions will be calculated</param>
+    /// <param name="line">The 1-based line index</param>
+    /// <param name="column">The 0-based column index</param>
+    member _.GetCompletionItems(text: string, line: int, column: int) =
+        async {
+            let! parseResults, checkResults, _projectResults = fsi.ParseAndCheckInteraction(text)
+            let lineText = text.Split('\n').[line - 1]
+            let partialName = QuickParse.GetPartialLongNameEx(lineText, column - 1)
+            let declarationListInfos = checkResults.GetDeclarationListInfo(Some parseResults, line, lineText, partialName)
+            return declarationListInfos.Items
+        }
+
+    interface IDisposable with
+        member _.Dispose() =
+            (fsi :> IDisposable).Dispose()

--- a/src/Microsoft.DotNet.Interactive.FSharp/Microsoft.DotNet.Interactive.FSharp.fsproj
+++ b/src/Microsoft.DotNet.Interactive.FSharp/Microsoft.DotNet.Interactive.FSharp.fsproj
@@ -33,6 +33,7 @@
     <Compile Include="FsAutoComplete\KeywordList.fs" />
     <Compile Include="FsAutoComplete\InteractiveDirectives.fs" />
     <Compile Include="FsAutoComplete\ParseAndCheckResults.fs" />
+    <Compile Include="FSharpScriptHelpers.fs" />
     <Compile Include="FSharpKernel.fs" />
     <Compile Include="FSharpHtml.fs" />
     <Compile Include="FSharpKernelHelpers.fs" />
@@ -45,7 +46,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FSharp.Compiler.Private.Scripting" />
+    <PackageReference Include="FSharp.Compiler.Service" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftCodeAnalysisCommonVersion)" />
     <PackageReference Include="XPlot.Plotly" Version="3.0.1" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Interactive.Tests/Utility/AsyncContextTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Utility/AsyncContextTests.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 using FluentAssertions;
 
-using FSharp.Compiler.Scripting;
+using Microsoft.DotNet.Interactive.FSharp.ScriptHelpers;
 
 using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.DotNet.Interactive.Utility;

--- a/src/Microsoft.DotNet.Interactive/Microsoft.DotNet.Interactive.csproj
+++ b/src/Microsoft.DotNet.Interactive/Microsoft.DotNet.Interactive.csproj
@@ -36,7 +36,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FSharp.Compiler.Private.Scripting">
+    <PackageReference Include="FSharp.Compiler.Service">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Text.Json" Version="5.0.1" />

--- a/src/Microsoft.DotNet.Interactive/PackageRestoreContext.cs
+++ b/src/Microsoft.DotNet.Interactive/PackageRestoreContext.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.Utility;
 using Pocket;
 using static Pocket.Logger;
-using Microsoft.DotNet.DependencyManager;
+using FSharp.Compiler.DependencyManager;
 using System.Globalization;
 
 namespace Microsoft.DotNet.Interactive

--- a/src/dotnet-interactive/dotnet-interactive.csproj
+++ b/src/dotnet-interactive/dotnet-interactive.csproj
@@ -59,7 +59,7 @@
     </PackageReference>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21072.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
-    <PackageReference Include="FSharp.Compiler.Private.Scripting">
+    <PackageReference Include="FSharp.Compiler.Service">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
Update FSharp Compiler.

Remove reference to Microsoft.DotNet.DependencyManager and remove reference to FSharp.Compiler.Scripting package.