### PR TITLE
Fix #1028 --- Nuget can not be used with dotnet interactive in private networks

### DIFF
--- a/src/Microsoft.DotNet.Interactive/PackageRestoreContext.cs
+++ b/src/Microsoft.DotNet.Interactive/PackageRestoreContext.cs
@@ -28,9 +28,6 @@ namespace Microsoft.DotNet.Interactive
 
         public PackageRestoreContext()
         {
-            // By default look in to the package sources
-            //    "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
-            AddRestoreSource("https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json");
             _dependencies = new DependencyProvider(AssemblyProbingPaths, NativeProbingRoots);
             AppDomain.CurrentDomain.AssemblyLoad += OnAssemblyLoad;
         }


### PR DESCRIPTION
Nuget is not really very flexible with unreachable sources, so remove this default internal source.

Script authors and tests dependent on this feed will need to specify it explicitly.