### PR TITLE
Handle duplicate column names in MSSQL and SQLite query results.

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/SqlKernelsExtensionTests.can_handle_duplicate_columns_in_query_results.approved.json
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/SqlKernelsExtensionTests.can_handle_duplicate_columns_in_query_results.approved.json
@@ -1,0 +1,41 @@
+{
+  "schema": {
+    "primaryKey": [],
+    "fields": [
+      {
+        "name": "Apples",
+        "type": "integer"
+      },
+      {
+        "name": "Bananas",
+        "type": "integer"
+      },
+      {
+        "name": "Apples (2)",
+        "type": "integer"
+      },
+      {
+        "name": "BANANAS",
+        "type": "integer"
+      },
+      {
+        "name": "Apples (3)",
+        "type": "integer"
+      },
+      {
+        "name": "BaNaNaS",
+        "type": "integer"
+      }
+    ]
+  },
+  "data": [
+    {
+      "Apples": 1,
+      "Bananas": 2,
+      "Apples (2)": 3,
+      "BANANAS": 4,
+      "Apples (3)": 5,
+      "BaNaNaS": 6
+    }
+  ]
+}

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/SqlKernelsExtensionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/SqlKernelsExtensionTests.cs
@@ -90,17 +90,6 @@ SELECT * FROM fruit
             } while (reader.NextResult());
         }
 
-        [Fact]
-        public void can_alias_duplicate_column_names_in_sql_results()
-        {
-            var testNames = new string[] { "apple", "banana", "apple", "orange", "orange", "BANANA", "orange", "BaNaNa" };
-            var expectedAliases = new string[] { "apple", "banana", "apple (1)", "orange", "orange (1)", "BANANA", "orange (2)", "BaNaNa" };
-
-            SqlKernelUtils.AliasDuplicateColumnNames(testNames);
-
-            Assert.Equal(expectedAliases, testNames);
-        }
-
         public void Dispose()
         {
             Formatter.ResetToDefault();

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/SqlKernelsExtensionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/SqlKernelsExtensionTests.cs
@@ -90,6 +90,17 @@ SELECT * FROM fruit
             } while (reader.NextResult());
         }
 
+        [Fact]
+        public void can_alias_duplicate_column_names_in_sql_results()
+        {
+            var testNames = new string[] { "apple", "banana", "apple", "orange", "orange", "BANANA", "orange", "BaNaNa" };
+            var expectedAliases = new string[] { "apple", "banana", "apple (1)", "orange", "orange (1)", "BANANA", "orange (2)", "BaNaNa" };
+
+            SqlKernelUtils.AliasDuplicateColumnNames(testNames);
+
+            Assert.Equal(expectedAliases, testNames);
+        }
+
         public void Dispose()
         {
             Formatter.ResetToDefault();

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/MsSqlKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/MsSqlKernel.cs
@@ -191,27 +191,7 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
         {
             var columnNames = columnInfo.Select(info => info.ColumnName).ToArray();
 
-            // Some column names can be duplicates, either due to deliberate aliasing
-            // with the AS keyword, or due to being unnamed columns. The Table Schema
-            // spec requires column names to be unique, so we have to iterate through
-            // the column names and append a number to the duplicates to distinguish
-            // them from the others.
-            var nameCounts = new Dictionary<string, int>(capacity: columnNames.Length);
-            for (int i = 0; i < columnNames.Length; i++)
-            {
-                string columnName = columnNames[i];
-                int count;
-                if (nameCounts.TryGetValue(columnName, out count))
-                {
-                    // Use the old count value so that duplicates start at 1. Example: "MyColumn (1)"
-                    columnNames[i] = columnName + $" ({count})";
-                    nameCounts[columnName] = count + 1;
-                }
-                else
-                {
-                    nameCounts[columnName] = 1;
-                }
-            }
+            SqlKernelUtils.AliasDuplicateColumnNames(columnNames);
 
             var displayTable = new List<(string, object)[]>();
             foreach (CellValue[] row in rows)

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/MsSqlKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/MsSqlKernel.cs
@@ -189,11 +189,11 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
 
         private IEnumerable<IEnumerable<IEnumerable<(string, object)>>> GetEnumerableTable(ColumnInfo[] columnInfo, CellValue[][] rows)
         {
+            var displayTable = new List<(string, object)[]>();
             var columnNames = columnInfo.Select(info => info.ColumnName).ToArray();
 
             SqlKernelUtils.AliasDuplicateColumnNames(columnNames);
 
-            var displayTable = new List<(string, object)[]>();
             foreach (CellValue[] row in rows)
             {
                 var displayRow = new (string, object)[row.Length];

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/SQLiteKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/SQLiteKernel.cs
@@ -57,6 +57,8 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
                 var values = new object[reader.FieldCount];
                 var names = Enumerable.Range(0, reader.FieldCount).Select(reader.GetName).ToArray();
 
+                SqlKernelUtils.AliasDuplicateColumnNames(names);
+
                 // holds the result of a single statement within the query
                 var table = new List<(string, object)[]>();
 

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/SqlKernelUtils.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/SqlKernelUtils.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.DotNet.Interactive.ExtensionLab
 {
-    public static class SqlKernelUtils
+    internal static class SqlKernelUtils
     {
         /// <summary>
         /// Appends a number to the end of duplicate column names in the provided
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
         /// The array of column names to be aliased. Note: The provided array will
         /// be modified by this method.
         /// </param>
-        public static void AliasDuplicateColumnNames(string[] columnNames)
+        internal static void AliasDuplicateColumnNames(string[] columnNames)
         {
             var nameCounts = new Dictionary<string, int>(capacity: columnNames.Length);
             for (int i = 0; i < columnNames.Length; i++)
@@ -26,9 +26,8 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
                 int count;
                 if (nameCounts.TryGetValue(columnName, out count))
                 {
-                    // Use the old count value so that duplicates start at 1. Example: "MyColumn (1)"
+                    nameCounts[columnName] = ++count;
                     columnNames[i] = columnName + $" ({count})";
-                    nameCounts[columnName] = count + 1;
                 }
                 else
                 {

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/SqlKernelUtils.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/SqlKernelUtils.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Interactive.ExtensionLab
+{
+    public static class SqlKernelUtils
+    {
+        /// <summary>
+        /// Appends a number to the end of duplicate column names in the provided
+        /// string array. Some column names in SQL query results can be duplicates
+        /// either from deliberate aliasing with the AS keyword, or from being
+        /// unnamed columns, but column names have to be unique in a Table Schema.
+        /// </summary>
+        /// <param name="columnNames">
+        /// The array of column names to be aliased. Note: The provided array will
+        /// be modified by this method.
+        /// </param>
+        public static void AliasDuplicateColumnNames(string[] columnNames)
+        {
+            var nameCounts = new Dictionary<string, int>(capacity: columnNames.Length);
+            for (int i = 0; i < columnNames.Length; i++)
+            {
+                string columnName = columnNames[i];
+                int count;
+                if (nameCounts.TryGetValue(columnName, out count))
+                {
+                    // Use the old count value so that duplicates start at 1. Example: "MyColumn (1)"
+                    columnNames[i] = columnName + $" ({count})";
+                    nameCounts[columnName] = count + 1;
+                }
+                else
+                {
+                    nameCounts[columnName] = 1;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/interactive/issues/983

Table Schemas require column names to be unique, but SQL query results can have duplicate columns names due to aliasing or being unnamed. This change solves that problem by appending a number to the end of a duplicate column name, similar to what would happen if you download duplicate files in a web browser.