### PR TITLE
fix struct deserialization

### DIFF
--- a/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
@@ -149,7 +149,7 @@ namespace Microsoft.DotNet.Interactive.CSharp
             
             var document = _workspace.UpdateWorkingDocument(command.Code);
             var text = await document.GetTextAsync();
-            var cursorPosition = text.Lines.GetPosition(command.LinePosition.AsCodeAnalysisLinePosition());
+            var cursorPosition = text.Lines.GetPosition(command.LinePosition.ToCodeAnalysisLinePosition());
             var service = QuickInfoService.GetService(document);
             var info = await service.GetQuickInfoAsync(document, cursorPosition);
             

--- a/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
@@ -149,7 +149,7 @@ namespace Microsoft.DotNet.Interactive.CSharp
             
             var document = _workspace.UpdateWorkingDocument(command.Code);
             var text = await document.GetTextAsync();
-            var cursorPosition = text.Lines.GetPosition(command.LinePosition);
+            var cursorPosition = text.Lines.GetPosition(command.LinePosition.AsCodeAnalysisLinePosition());
             var service = QuickInfoService.GetService(document);
             var info = await service.GetQuickInfoAsync(document, cursorPosition);
             
@@ -158,8 +158,8 @@ namespace Microsoft.DotNet.Interactive.CSharp
                 return;
             }
 
-            var scriptSpanStart = text.Lines.GetLinePosition(0);
-            var linePosSpan = text.Lines.GetLinePositionSpan(info.Span);
+            var scriptSpanStart = LinePosition.FromCodeAnalysisLinePosition(text.Lines.GetLinePosition(0));
+            var linePosSpan = LinePositionSpan.FromCodeAnalysisLinePositionSpan(text.Lines.GetLinePositionSpan(info.Span));
             var correctedLinePosSpan = linePosSpan.SubtractLineOffset(scriptSpanStart);
 
             context.Publish(

--- a/src/Microsoft.DotNet.Interactive.CSharp/LanguageServiceExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/LanguageServiceExtensions.cs
@@ -4,24 +4,11 @@
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis.QuickInfo;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.DotNet.Interactive.CSharp
 {
     public static class LanguageServiceExtensions
     {
-        public static LinePosition SubtractLineOffset(this LinePosition linePos, LinePosition offset)
-        {
-            return new LinePosition(linePos.Line - offset.Line, linePos.Character);
-        }
-
-        public static LinePositionSpan SubtractLineOffset(this LinePositionSpan linePosSpan, LinePosition offset)
-        {
-            return new LinePositionSpan(
-                linePosSpan.Start.SubtractLineOffset(offset),
-                linePosSpan.End.SubtractLineOffset(offset));
-        }
-
         public static string ToMarkdownString(this QuickInfoItem info)
         {
             var stringBuilder = new StringBuilder();

--- a/src/Microsoft.DotNet.Interactive.CSharp/SignatureHelp/SignatureHelpGenerator.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/SignatureHelp/SignatureHelpGenerator.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
 
@@ -83,7 +83,7 @@ namespace Microsoft.DotNet.Interactive.CSharp.SignatureHelp
         private static async Task<InvocationContext> GetInvocation(Document document, LinePosition linePosition)
         {
             var text = await document.GetTextAsync();
-            var position = text.Lines.GetPosition(linePosition) - 1; // backtrack into the actual invocation
+            var position = Math.Max(text.Lines.GetPosition(linePosition.AsCodeAnalysisLinePosition()) - 1, 0); // backtrack into the actual invocation
             var tree = await document.GetSyntaxTreeAsync();
             var root = await tree.GetRootAsync();
             var node = root.FindToken(position).Parent;

--- a/src/Microsoft.DotNet.Interactive.CSharp/SignatureHelp/SignatureHelpGenerator.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/SignatureHelp/SignatureHelpGenerator.cs
@@ -83,7 +83,7 @@ namespace Microsoft.DotNet.Interactive.CSharp.SignatureHelp
         private static async Task<InvocationContext> GetInvocation(Document document, LinePosition linePosition)
         {
             var text = await document.GetTextAsync();
-            var position = Math.Max(text.Lines.GetPosition(linePosition.AsCodeAnalysisLinePosition()) - 1, 0); // backtrack into the actual invocation
+            var position = Math.Max(text.Lines.GetPosition(linePosition.ToCodeAnalysisLinePosition()) - 1, 0); // backtrack into the actual invocation
             var tree = await document.GetSyntaxTreeAsync();
             var root = await tree.GetRootAsync();
             var node = root.FindToken(position).Parent;

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/DataFrameTypeGeneratorTests.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/DataFrameTypeGeneratorTests.cs
@@ -4,10 +4,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using FluentAssertions;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Text;
+using FluentAssertions;
 using Microsoft.Data.Analysis;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.CSharp;

--- a/src/Microsoft.DotNet.Interactive.FSharp.Tests/KernelTests.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp.Tests/KernelTests.fs
@@ -3,14 +3,14 @@
 
 namespace Microsoft.DotNet.Interactive.FSharp.Tests
 
+open System.Collections.Generic
+
+open FluentAssertions
 open Microsoft.DotNet.Interactive
 open Microsoft.DotNet.Interactive.FSharp
-open Xunit
-open FluentAssertions
 open Microsoft.DotNet.Interactive.Commands
-open Microsoft.CodeAnalysis.Text
 open Microsoft.DotNet.Interactive.Events
-open System.Collections.Generic
+open Xunit
 
 type KernelTests() =
     let withKernel (action : Kernel -> (unit -> seq<KernelEvent>) -> 'a) =

--- a/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
@@ -16,18 +16,15 @@ open System.Threading.Tasks
 
 open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.Tags
-open Microsoft.CodeAnalysis.Text
 open Microsoft.DotNet.Interactive
 open Microsoft.DotNet.Interactive.Formatting
 open Microsoft.DotNet.Interactive.Commands
 open Microsoft.DotNet.Interactive.Events
 open Microsoft.DotNet.Interactive.Extensions
-open Microsoft.DotNet.Interactive.Formatting
 open Microsoft.DotNet.Interactive.FSharp.ScriptHelpers
 
 open FSharp.Compiler.Interactive.Shell
 open FSharp.Compiler.SourceCodeServices
-open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Pos
 open FsAutoComplete
 
@@ -332,14 +329,14 @@ type FSharpKernel () as this =
                 let sp = LinePosition(requestHoverText.LinePosition.Line, startCol)
                 let ep = LinePosition(requestHoverText.LinePosition.Line, endCol)
                 let lps = LinePositionSpan(sp, ep)
-                context.Publish(HoverTextProduced(requestHoverText, results, Nullable lps))
+                context.Publish(HoverTextProduced(requestHoverText, results, lps))
 
             | Result.Error err ->
                 let sp = LinePosition(requestHoverText.LinePosition.Line, col)
                 let ep = LinePosition(requestHoverText.LinePosition.Line, col)
                 let lps = LinePositionSpan(sp, ep)
                 let reply = [| FormattedValue("text/markdown", "") |]
-                context.Publish(HoverTextProduced(requestHoverText, reply, Nullable lps))
+                context.Publish(HoverTextProduced(requestHoverText, reply, lps))
                 ()
         }
 

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/CustomMetadataParsingTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/CustomMetadataParsingTests.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using FluentAssertions;
 using Microsoft.DotNet.Interactive.Jupyter.ZMQ;
 using Microsoft.DotNet.Interactive.Notebook;
+using Microsoft.DotNet.Interactive.Tests.Utility;
 using Xunit;
 
 namespace Microsoft.DotNet.Interactive.Jupyter.Tests
@@ -24,7 +25,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
                 .ContainKey("dotnet_interactive")
                 .WhichValue
                 .Should()
-                .BeEquivalentTo(new InputCellMetadata("fsharp"));
+                .BeEquivalentToRespectingRuntimeTypes(new InputCellMetadata("fsharp"));
         }
 
         [Fact]
@@ -40,7 +41,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
                 .ContainKey("dotnet_interactive")
                 .WhichValue
                 .Should()
-                .BeEquivalentTo(new InputCellMetadata() );
+                .BeEquivalentToRespectingRuntimeTypes(new InputCellMetadata() );
         }
 
         [Fact]

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/HistorySerializationTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/HistorySerializationTests.cs
@@ -6,7 +6,7 @@ using System.Text.Json;
 using FluentAssertions;
 
 using Microsoft.DotNet.Interactive.Jupyter.Protocol;
-
+using Microsoft.DotNet.Interactive.Tests.Utility;
 using Xunit;
 
 namespace Microsoft.DotNet.Interactive.Jupyter.Tests
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
 
             var serialized = @"{""history"":[[0,0,""input value""],[1,0,""input value""],[2,0,[""input value"",""output result""]]]}";
             var historyReply = JsonSerializer.Deserialize<HistoryReply>(serialized);
-            historyReply.Should().BeEquivalentTo(new HistoryReply(new HistoryElement[]
+            historyReply.Should().BeEquivalentToRespectingRuntimeTypes(new HistoryReply(new HistoryElement[]
             {
                 new InputHistoryElement(0, 0, "input value"),
                 new InputHistoryElement(1, 0, "input value"),
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
 
             var serialized = @"{""history"":[]}";
             var historyReply = JsonSerializer.Deserialize<HistoryReply>(serialized);
-            historyReply.Should().BeEquivalentTo(new HistoryReply(new HistoryElement[]{}));
+            historyReply.Should().BeEquivalentToRespectingRuntimeTypes(new HistoryReply(new HistoryElement[]{}));
         }
 
         [Fact]
@@ -74,7 +74,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
         {
             var serialized = @"{""history"":null}";
             var historyReply = JsonSerializer.Deserialize<HistoryReply>(serialized);
-            historyReply.Should().BeEquivalentTo(new HistoryReply());
+            historyReply.Should().BeEquivalentToRespectingRuntimeTypes(new HistoryReply());
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Jupyter/CompleteRequestHandler.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/CompleteRequestHandler.cs
@@ -52,8 +52,8 @@ namespace Microsoft.DotNet.Interactive.Jupyter
             {
                 if (completionsProduced.LinePositionSpan != null)
                 {
-                    startPosition = SourceUtilities.GetCursorOffsetFromPosition(command.Code, completionsProduced.LinePositionSpan.GetValueOrDefault().Start);
-                    endPosition = SourceUtilities.GetCursorOffsetFromPosition(command.Code, completionsProduced.LinePositionSpan.GetValueOrDefault().End);
+                    startPosition = SourceUtilities.GetCursorOffsetFromPosition(command.Code, completionsProduced.LinePositionSpan.Start);
+                    endPosition = SourceUtilities.GetCursorOffsetFromPosition(command.Code, completionsProduced.LinePositionSpan.End);
                 }
                 else
                 {

--- a/src/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
@@ -259,7 +259,7 @@ for ($j = 0; $j -le 4; $j += 4 ) {
                 e => e.Should().BeOfType<CodeSubmissionReceived>(),
                 e => e.Should().BeOfType<CompleteCodeSubmissionReceived>(),
                 e => e.Should().BeOfType<DiagnosticsProduced>().Which.Diagnostics.Count.Should().Be(0),
-                e => e.Should().BeOfType<DisplayedValueProduced>().Which.FormattedValues.ElementAt(0).Should().BeEquivalentTo(fv),
+                e => e.Should().BeOfType<DisplayedValueProduced>().Which.FormattedValues.ElementAt(0).Should().BeEquivalentToRespectingRuntimeTypes(fv),
                 e => e.Should().BeOfType<CommandSucceeded>()
             );
         }

--- a/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -11,7 +11,6 @@ using System.Management.Automation.Runspaces;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Formatting;

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
@@ -3,10 +3,11 @@
 
 using System;
 using System.IO;
-using FluentAssertions;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.CSharp;
 using Microsoft.DotNet.Interactive.Events;
@@ -17,8 +18,6 @@ using Newtonsoft.Json;
 using Recipes;
 using Xunit;
 using Xunit.Abstractions;
-using System.Runtime.InteropServices;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.DotNet.Interactive.Tests
 {

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Formatting;

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/CompletionTests.MagicCommands.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/CompletionTests.MagicCommands.cs
@@ -1,13 +1,11 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
-using FluentAssertions;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Text;
+using FluentAssertions;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Connection;
 using Microsoft.DotNet.Interactive.CSharp;
@@ -77,7 +75,7 @@ namespace Microsoft.DotNet.Interactive.Tests.LanguageServices
                     .AllSatisfy(c =>
                                     c.LinePositionSpan
                                      .Should()
-                                     .BeEquivalentTo(new LinePositionSpan(
+                                     .BeEquivalentToRespectingRuntimeTypes(new LinePositionSpan(
                                                          new LinePosition(0, 8),
                                                          new LinePosition(0, 10))));
             }
@@ -97,7 +95,7 @@ namespace Microsoft.DotNet.Interactive.Tests.LanguageServices
                     .AllSatisfy(c =>
                                     c.LinePositionSpan
                                      .Should()
-                                     .BeEquivalentTo(new LinePositionSpan(
+                                     .BeEquivalentToRespectingRuntimeTypes(new LinePositionSpan(
                                                          new LinePosition(0, 0),
                                                          new LinePosition(0, 4))));
             }

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/CompletionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/CompletionTests.cs
@@ -1,12 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.CommandLine;
-using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Tests.Utility;

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/HoverTextTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/HoverTextTests.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Tests.Utility;

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/LanguageServiceAssertionExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/LanguageServiceAssertionExtensions.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
-using FluentAssertions;
 using System.Linq;
 using System.Threading.Tasks;
+using FluentAssertions;
 using FluentAssertions.Collections;
 using FluentAssertions.Execution;
 using Microsoft.CodeAnalysis.Text;
@@ -26,7 +25,7 @@ namespace Microsoft.DotNet.Interactive.Tests.LanguageServices
                 markedUpCode.Span.Start,
                 markedUpCode.Span.Length + 1))
             {
-                var linePosition = markedUpCode.SourceText.Lines.GetLinePosition(position);
+                var linePosition = LinePosition.FromCodeAnalysisLinePosition(markedUpCode.SourceText.Lines.GetLinePosition(position));
 
                 yield return new MarkedUpCodeLinePosition(markedUpCode, linePosition);
             }

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/SignatureHelpTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/SignatureHelpTests.cs
@@ -3,7 +3,6 @@
 
 using System.Threading.Tasks;
 using FluentAssertions;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Tests.Utility;

--- a/src/Microsoft.DotNet.Interactive.Tests/Notebook/DibNotebookDocumentFileFormatTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Notebook/DibNotebookDocumentFileFormatTests.cs
@@ -3,6 +3,7 @@
 
 using FluentAssertions;
 using Microsoft.DotNet.Interactive.Notebook;
+using Microsoft.DotNet.Interactive.Tests.Utility;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -134,7 +135,7 @@ let x = 1
 let y = 2");
             notebook.Cells
                 .Should()
-                .BeEquivalentTo(new[]
+                .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
                     new NotebookCell("csharp", "var x = 1;\nvar y = 2;"),
                     new NotebookCell("fsharp", "let x = 1\nlet y = 2")
@@ -156,7 +157,7 @@ Get-Item
 ");
             notebook.Cells
                 .Should()
-                .BeEquivalentTo(new[]
+                .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
                     new NotebookCell("csharp", "//"),
                     new NotebookCell("pwsh", "Get-Item")
@@ -192,7 +193,7 @@ Get-Item
 ");
             notebook.Cells
                 .Should()
-                .BeEquivalentTo(new[]
+                .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
                     new NotebookCell("csharp", "// first line of C#\n\n\n\n// last line of C#"),
                     new NotebookCell("fsharp", "// first line of F#\n\n\n\n// last line of F#")
@@ -209,7 +210,7 @@ This is `markdown`.
 ");
             notebook.Cells
                 .Should()
-                .BeEquivalentTo(new[]
+                .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
                     new NotebookCell("markdown", "This is `markdown`.")
                 });
@@ -239,7 +240,7 @@ This is `markdown` with an alias.
 ");
             notebook.Cells
                 .Should()
-                .BeEquivalentTo(new[]
+                .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
                     new NotebookCell("csharp", "// this is csharp 1"),
                     new NotebookCell("csharp", "// this is csharp 2"),
@@ -268,7 +269,7 @@ This is `markdown` with an alias.
             var notebook = ParseDib(code);
             notebook.Cells
                 .Should()
-                .BeEquivalentTo(new[]
+                .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
                     new NotebookCell("csharp", "1+1"),
                     new NotebookCell("fsharp", "[1;2;3;4]\n|> List.sum")
@@ -307,7 +308,7 @@ var x = 1;
 2+2");
             notebook.Cells
                 .Should()
-                .BeEquivalentTo(new[]
+                .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
                     new NotebookCell("csharp", "1+1"),
                     new NotebookCell("fsharp", "2+2")

--- a/src/Microsoft.DotNet.Interactive.Tests/Notebook/JupyterNotebookDocumentFileFormatTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Notebook/JupyterNotebookDocumentFileFormatTests.cs
@@ -9,6 +9,7 @@ using FluentAssertions;
 using FluentAssertions.Execution;
 using FluentAssertions.Json;
 using Microsoft.DotNet.Interactive.Notebook;
+using Microsoft.DotNet.Interactive.Tests.Utility;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -74,7 +75,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Notebook
             var notebook = ParseJupyter(jupyter);
             notebook.Cells
                 .Should()
-                .BeEquivalentTo(new[]
+                .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
                     new NotebookCell(language, "// this is the code")
                 });
@@ -106,7 +107,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Notebook
             var notebook = ParseJupyter(jupyter);
             notebook.Cells
                 .Should()
-                .BeEquivalentTo(new[]
+                .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
                     new NotebookCell("csharp", "// this is assumed to be csharp"),
                     new NotebookCell("csharp", "// this is still assumed to be csharp")
@@ -234,7 +235,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Notebook
             var notebook = ParseJupyter(jupyter);
             notebook.Cells
                 .Should()
-                .BeEquivalentTo(new[]
+                .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
                     new NotebookCell("csharp", "// this is the code")
                 });
@@ -342,7 +343,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Notebook
             var notebook = ParseJupyter(jupyter);
             notebook.Cells
                 .Should()
-                .BeEquivalentTo(new[]
+                .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
                     new NotebookCell("csharp", "// this is csharp 1"),
                     new NotebookCell("csharp", "// this is csharp 2"),
@@ -390,7 +391,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Notebook
             var notebook = ParseJupyter(jupyter);
             notebook.Cells
                 .Should()
-                .BeEquivalentTo(new[]
+                .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
                     new NotebookCell("fsharp", "// this is the code")
                 });
@@ -434,7 +435,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Notebook
             var notebook = ParseJupyter(jupyter);
             notebook.Cells
                 .Should()
-                .BeEquivalentTo(new[]
+                .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
                     new NotebookCell("csharp", "// this is csharp\n#!fsharp\n// and this is fsharp")
                 });
@@ -478,7 +479,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Notebook
             var notebook = ParseJupyter(jupyter);
             notebook.Cells
                 .Should()
-                .BeEquivalentTo(new[]
+                .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
                     new NotebookCell("csharp", "#!probably-a-magic-command\n// but this is csharp")
                 });
@@ -502,7 +503,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Notebook
             var notebook = ParseJupyter(jupyter);
             notebook.Cells
                 .Should()
-                .BeEquivalentTo(new[]
+                .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
                     new NotebookCell("markdown", "This is `markdown`.")
                 });
@@ -530,7 +531,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Notebook
             var notebook = ParseJupyter(jupyter);
             notebook.Cells
                 .Should()
-                .BeEquivalentTo(new[]
+                .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
                     new NotebookCell("markdown", "This is `markdown`.\nSo is this.")
                 });
@@ -574,7 +575,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Notebook
             var notebook = ParseJupyter(jupyter);
             notebook.Cells
                 .Should()
-                .BeEquivalentTo(new[]
+                .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
                     new NotebookCell("csharp", "line 1\nline 2\nline 3\n")
                 });
@@ -625,7 +626,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Notebook
             var notebook = ParseJupyter(jupyter);
             notebook.Cells
                 .Should()
-                .BeEquivalentTo(new[]
+                .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
                     new NotebookCell("csharp", "line 1\nline 2\nline 3\nline 4")
                 });
@@ -867,7 +868,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Notebook
                 .ContainSingle()
                 .Which
                 .Should()
-                .BeEquivalentTo(new NotebookCellTextOutput("this is text"));
+                .BeEquivalentToRespectingRuntimeTypes(new NotebookCellTextOutput("this is text"));
         }
 
         [Fact]
@@ -909,7 +910,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Notebook
                 .ContainSingle()
                 .Which
                 .Should()
-                .BeEquivalentTo(new NotebookCellTextOutput("this is text\nso is this"));
+                .BeEquivalentToRespectingRuntimeTypes(new NotebookCellTextOutput("this is text\nso is this"));
         }
 
         [Fact]
@@ -988,7 +989,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Notebook
                 .ContainSingle()
                 .Which
                 .Should()
-                .BeEquivalentTo(new NotebookCellDisplayOutput(new Dictionary<string, object>
+                .BeEquivalentToRespectingRuntimeTypes(new NotebookCellDisplayOutput(new Dictionary<string, object>
                 {
                     { "text/html", "this is html" }
                 }));
@@ -1070,7 +1071,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Notebook
                 .ContainSingle()
                 .Which
                 .Should()
-                .BeEquivalentTo(new NotebookCellErrorOutput("e-name", "e-value", new[]
+                .BeEquivalentToRespectingRuntimeTypes(new NotebookCellErrorOutput("e-name", "e-value", new[]
                 {
                     "at func1()",
                     "at func2()"

--- a/src/Microsoft.DotNet.Interactive.Tests/Notebook/RoundTripNotebookDocumentFileFormatTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Notebook/RoundTripNotebookDocumentFileFormatTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.DotNet.Interactive.Notebook;
+using Microsoft.DotNet.Interactive.Tests.Utility;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -43,7 +44,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Notebook
             var roundTrippedNotebook = ParseFromString(fileName, content);
             roundTrippedNotebook
                 .Should()
-                .BeEquivalentTo(originalNotebook);
+                .BeEquivalentToRespectingRuntimeTypes(originalNotebook);
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive/Commands/LanguageServiceCommand.cs
+++ b/src/Microsoft.DotNet.Interactive/Commands/LanguageServiceCommand.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.DotNet.Interactive.Parsing;
 
 namespace Microsoft.DotNet.Interactive.Commands
@@ -35,7 +34,7 @@ namespace Microsoft.DotNet.Interactive.Commands
         public LinePosition LinePosition { get; protected set; }
 
         internal abstract LanguageServiceCommand With(
-            LanguageNode languageNode, 
+            LanguageNode languageNode,
             LinePosition position);
 
         internal LanguageNode LanguageNode { get; }

--- a/src/Microsoft.DotNet.Interactive/Commands/RequestCompletions.cs
+++ b/src/Microsoft.DotNet.Interactive/Commands/RequestCompletions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.DotNet.Interactive.Parsing;
 
 namespace Microsoft.DotNet.Interactive.Commands
@@ -9,7 +8,7 @@ namespace Microsoft.DotNet.Interactive.Commands
     public class RequestCompletions : LanguageServiceCommand
     {
         public RequestCompletions(
-            string code, 
+            string code,
             LinePosition linePosition, 
             string targetKernelName = null)
             : base(code, linePosition, targetKernelName)
@@ -17,7 +16,7 @@ namespace Microsoft.DotNet.Interactive.Commands
         }
 
         internal RequestCompletions(
-            LanguageNode languageNode, 
+            LanguageNode languageNode,
             LinePosition linePosition, 
             KernelCommand parent = null) 
             : base(languageNode, linePosition, parent)
@@ -25,7 +24,7 @@ namespace Microsoft.DotNet.Interactive.Commands
         }
 
         internal override LanguageServiceCommand With(
-            LanguageNode languageNode, 
+            LanguageNode languageNode,
             LinePosition position)
         {
             return new RequestCompletions(languageNode, position, Parent);

--- a/src/Microsoft.DotNet.Interactive/Commands/RequestHoverText.cs
+++ b/src/Microsoft.DotNet.Interactive/Commands/RequestHoverText.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.DotNet.Interactive.Parsing;
 
 namespace Microsoft.DotNet.Interactive.Commands

--- a/src/Microsoft.DotNet.Interactive/Commands/RequestSignatureHelp.cs
+++ b/src/Microsoft.DotNet.Interactive/Commands/RequestSignatureHelp.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.DotNet.Interactive.Parsing;
 
 namespace Microsoft.DotNet.Interactive.Commands

--- a/src/Microsoft.DotNet.Interactive/Diagnostic.cs
+++ b/src/Microsoft.DotNet.Interactive/Diagnostic.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.DotNet.Interactive
 {
@@ -39,7 +38,7 @@ namespace Microsoft.DotNet.Interactive
         {
             var fileLocation = diagnostic.Location.GetLineSpan();
             return new Diagnostic(
-                new LinePositionSpan(fileLocation.StartLinePosition, fileLocation.EndLinePosition),
+                new LinePositionSpan(LinePosition.FromCodeAnalysisLinePosition(fileLocation.StartLinePosition), LinePosition.FromCodeAnalysisLinePosition(fileLocation.EndLinePosition)),
                 diagnostic.Severity,
                 diagnostic.Id,
                 diagnostic.GetMessage());

--- a/src/Microsoft.DotNet.Interactive/Events/CompletionsProduced.cs
+++ b/src/Microsoft.DotNet.Interactive/Events/CompletionsProduced.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Extensions;
 
@@ -11,12 +10,12 @@ namespace Microsoft.DotNet.Interactive.Events
 {
     public class CompletionsProduced : KernelEvent
     {
-        private readonly LinePositionSpan? _linePositionSpan;
+        private readonly LinePositionSpan _linePositionSpan;
 
         public CompletionsProduced(
             IEnumerable<CompletionItem> completions,
             RequestCompletions command,
-            LinePositionSpan? linePositionSpan = null) : base(command)
+            LinePositionSpan linePositionSpan = null) : base(command)
         {
             Completions = completions ?? throw new ArgumentNullException(nameof(completions));
             _linePositionSpan = linePositionSpan;
@@ -25,7 +24,7 @@ namespace Microsoft.DotNet.Interactive.Events
         /// <summary>
         /// The range of where to replace in a completion request.
         /// </summary>
-        public LinePositionSpan? LinePositionSpan => this.CalculateLineOffsetFromParentCommand(_linePositionSpan);
+        public LinePositionSpan LinePositionSpan => this.CalculateLineOffsetFromParentCommand(_linePositionSpan);
 
         /// <summary>
         /// The list of completions.

--- a/src/Microsoft.DotNet.Interactive/Events/HoverTextProduced.cs
+++ b/src/Microsoft.DotNet.Interactive/Events/HoverTextProduced.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Extensions;
 
@@ -11,9 +10,9 @@ namespace Microsoft.DotNet.Interactive.Events
 {
     public class HoverTextProduced : KernelEvent
     {
-        private readonly LinePositionSpan? _linePositionSpan;
+        private readonly LinePositionSpan _linePositionSpan;
 
-        public HoverTextProduced(RequestHoverText command, IReadOnlyCollection<FormattedValue> content, LinePositionSpan? linePositionSpan = null)
+        public HoverTextProduced(RequestHoverText command, IReadOnlyCollection<FormattedValue> content, LinePositionSpan linePositionSpan = null)
             : base(command)
         {
             if (content == null)
@@ -32,6 +31,6 @@ namespace Microsoft.DotNet.Interactive.Events
 
         public IReadOnlyCollection<FormattedValue> Content { get; }
 
-        public LinePositionSpan? LinePositionSpan => this.CalculateLineOffsetFromParentCommand(_linePositionSpan);
+        public LinePositionSpan LinePositionSpan => this.CalculateLineOffsetFromParentCommand(_linePositionSpan);
     }
 }

--- a/src/Microsoft.DotNet.Interactive/Extensions/EventExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/Extensions/EventExtensions.cs
@@ -13,25 +13,24 @@ namespace Microsoft.DotNet.Interactive.Extensions
 {
     internal static class EventExtensions
     {
-        public static LinePositionSpan? CalculateLineOffsetFromParentCommand(this KernelEvent @event, LinePositionSpan? initialRange)
+        public static LinePositionSpan CalculateLineOffsetFromParentCommand(this KernelEvent @event, LinePositionSpan initialRange)
         {
-            if (!initialRange.HasValue)
+            if (initialRange is null)
             {
                 return null;
             }
 
-            var range = initialRange.GetValueOrDefault();
             var requestCommand = @event.Command as LanguageServiceCommand;
             if (requestCommand?.Parent is LanguageServiceCommand parentRequest)
             {
                 var requestPosition = requestCommand.LinePosition;
                 var lineOffset = parentRequest.LinePosition.Line - requestPosition.Line;
                 return new LinePositionSpan(
-                    new LinePosition(range.Start.Line + lineOffset, range.Start.Character),
-                    new LinePosition(range.End.Line + lineOffset, range.End.Character));
+                    new LinePosition(initialRange.Start.Line + lineOffset, initialRange.Start.Character),
+                    new LinePosition(initialRange.End.Line + lineOffset, initialRange.End.Character));
             }
 
-            return range;
+            return initialRange;
         }
 
         public static IReadOnlyCollection<Diagnostic> RemapDiagnosticsFromRequestingCommand(this KernelEvent @event, IReadOnlyCollection<Diagnostic> diagnostics)

--- a/src/Microsoft.DotNet.Interactive/Kernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Kernel.cs
@@ -396,7 +396,7 @@ namespace Microsoft.DotNet.Interactive
             {
                 var requestPosition = SourceText.From(command.Code)
                                                 .Lines
-                                                .GetPosition(command.LinePosition);
+                                                .GetPosition(command.LinePosition.AsCodeAnalysisLinePosition());
 
                 var completions = GetDirectiveCompletionItems(
                     directiveNode,

--- a/src/Microsoft.DotNet.Interactive/Kernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Kernel.cs
@@ -396,7 +396,7 @@ namespace Microsoft.DotNet.Interactive
             {
                 var requestPosition = SourceText.From(command.Code)
                                                 .Lines
-                                                .GetPosition(command.LinePosition.AsCodeAnalysisLinePosition());
+                                                .GetPosition(command.LinePosition.ToCodeAnalysisLinePosition());
 
                 var completions = GetDirectiveCompletionItems(
                     directiveNode,

--- a/src/Microsoft.DotNet.Interactive/LinePosition.cs
+++ b/src/Microsoft.DotNet.Interactive/LinePosition.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.DotNet.Interactive
+{
+    public class LinePosition : IEquatable<LinePosition>
+    {
+        public int Line { get; }
+        public int Character { get; }
+
+        public LinePosition(int line, int character)
+        {
+            Line = line;
+            Character = character;
+        }
+
+        public CodeAnalysis.Text.LinePosition AsCodeAnalysisLinePosition()
+        {
+            return new CodeAnalysis.Text.LinePosition(Line, Character);
+        }
+
+        public LinePosition SubtractLineOffset(LinePosition offset)
+        {
+            return new LinePosition(Line - offset.Line, Character);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as LinePosition);
+        }
+
+        public bool Equals(LinePosition other)
+        {
+            return other is { } && this == other;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Line, Character);
+        }
+
+        public static bool operator ==(LinePosition a, LinePosition b)
+        {
+            if (a is null && b is null)
+            {
+                return true;
+            }
+
+            if (a is null || b is null)
+            {
+                return false;
+            }
+
+            return a.Line == b.Line
+                && a.Character == b.Character;
+        }
+
+        public static bool operator !=(LinePosition a, LinePosition b)
+        {
+            return !(a == b);
+        }
+
+        public static LinePosition FromCodeAnalysisLinePosition(CodeAnalysis.Text.LinePosition linePosition)
+        {
+            return new LinePosition(linePosition.Line, linePosition.Character);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Interactive/LinePosition.cs
+++ b/src/Microsoft.DotNet.Interactive/LinePosition.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Interactive
             Character = character;
         }
 
-        public CodeAnalysis.Text.LinePosition AsCodeAnalysisLinePosition()
+        public CodeAnalysis.Text.LinePosition ToCodeAnalysisLinePosition()
         {
             return new CodeAnalysis.Text.LinePosition(Line, Character);
         }

--- a/src/Microsoft.DotNet.Interactive/LinePositionSpan.cs
+++ b/src/Microsoft.DotNet.Interactive/LinePositionSpan.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.DotNet.Interactive
+{
+    public class LinePositionSpan : IEquatable<LinePositionSpan>
+    {
+        public LinePosition Start { get; }
+        public LinePosition End { get; }
+
+        public LinePositionSpan(LinePosition start, LinePosition end)
+        {
+            Start = start;
+            End = end;
+        }
+
+        public LinePositionSpan SubtractLineOffset(LinePosition offset)
+        {
+            return new LinePositionSpan(
+                Start.SubtractLineOffset(offset),
+                End.SubtractLineOffset(offset));
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as LinePositionSpan);
+        }
+
+        public bool Equals(LinePositionSpan other)
+        {
+            return other is { } && this == other;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Start, End);
+        }
+
+        public static bool operator ==(LinePositionSpan a, LinePositionSpan b)
+        {
+            if (a is null && b is null)
+            {
+                return true;
+            }
+
+            if (a is null || b is null)
+            {
+                return false;
+            }
+
+            return a.Start == b.Start
+                && a.End == b.End;
+        }
+
+        public static bool operator !=(LinePositionSpan a, LinePositionSpan b)
+        {
+            return !(a == b);
+        }
+
+        public static LinePositionSpan FromCodeAnalysisLinePositionSpan(CodeAnalysis.Text.LinePositionSpan linePositionSpan)
+        {
+            return new LinePositionSpan(LinePosition.FromCodeAnalysisLinePosition(linePositionSpan.Start), LinePosition.FromCodeAnalysisLinePosition(linePositionSpan.End));
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Interactive/Parsing/PolyglotSyntaxTree.cs
+++ b/src/Microsoft.DotNet.Interactive/Parsing/PolyglotSyntaxTree.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Interactive.Parsing
 
         public int GetAbsolutePosition(LinePosition linePosition)
         {
-            return _sourceText.Lines.GetPosition(linePosition.AsCodeAnalysisLinePosition());
+            return _sourceText.Lines.GetPosition(linePosition.ToCodeAnalysisLinePosition());
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive/Parsing/PolyglotSyntaxTree.cs
+++ b/src/Microsoft.DotNet.Interactive/Parsing/PolyglotSyntaxTree.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Interactive.Parsing
 
         public int GetAbsolutePosition(LinePosition linePosition)
         {
-            return _sourceText.Lines.GetPosition(linePosition);
+            return _sourceText.Lines.GetPosition(linePosition.AsCodeAnalysisLinePosition());
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive/Utility/SourceUtilities.cs
+++ b/src/Microsoft.DotNet.Interactive/Utility/SourceUtilities.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Text.RegularExpressions;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.DotNet.Interactive.Utility
 {

--- a/src/dotnet-interactive.Profiler/Program.cs
+++ b/src/dotnet-interactive.Profiler/Program.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Threading.Tasks;
 using JetBrains.Profiler.Api;
-using Microsoft.CodeAnalysis.Text;
-using Microsoft.DotNet.Interactive.App;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.CSharp;
 using Microsoft.DotNet.Interactive.FSharp;

--- a/src/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
+++ b/src/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
@@ -15,6 +15,7 @@ using Microsoft.DotNet.Interactive.App.Commands;
 using Microsoft.DotNet.Interactive.Http;
 using Microsoft.DotNet.Interactive.Server;
 using Microsoft.DotNet.Interactive.Telemetry;
+using Microsoft.DotNet.Interactive.Tests.Utility;
 using Microsoft.DotNet.Interactive.Utility;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -116,7 +117,7 @@ namespace Microsoft.DotNet.Interactive.App.Tests.CommandLine
             options
                 .HttpPortRange
                 .Should()
-                .BeEquivalentTo(new HttpPortRange(3000, 4000));
+                .BeEquivalentToRespectingRuntimeTypes(new HttpPortRange(3000, 4000));
         }
 
         [Fact]
@@ -165,7 +166,7 @@ namespace Microsoft.DotNet.Interactive.App.Tests.CommandLine
             options
                 .HttpPortRange
                 .Should()
-                .BeEquivalentTo(new HttpPortRange(3000, 4000));
+                .BeEquivalentToRespectingRuntimeTypes(new HttpPortRange(3000, 4000));
         }
 
         [Fact]

--- a/src/interface-generator/InterfaceGenerator.cs
+++ b/src/interface-generator/InterfaceGenerator.cs
@@ -36,6 +36,8 @@ namespace Microsoft.DotNet.Interactive.InterfaceGen.App
 
         private static readonly HashSet<string> OptionalFields = new HashSet<string>
         {
+            $"{nameof(CompletionsProduced)}.{nameof(CompletionsProduced.LinePositionSpan)}",
+            $"{nameof(HoverTextProduced)}.{nameof(HoverTextProduced.LinePositionSpan)}",
             $"{nameof(KernelCommand)}.{nameof(KernelCommand.TargetKernelName)}",
             $"{nameof(SubmitCode)}.{nameof(SubmitCode.SubmissionType)}"
         };


### PR DESCRIPTION
This fixes an issue where System.Text.Json can't deserialize a struct by replacing those types with our own.  This also uncovered an issue where the deep object inspection was defaulting to compile time types instead of runtime.  A helper was added to do the correct deep inspection and all existing calls to `BeEquivalentTo()` were audited and updated if necessary.

Without this change, the `LinePosition` and `LinePositionSpan` structs are always deserialized to `default`, e.g., `null`/`0` which means all language service commands were reporting for line 0, character 0, regardless of where the actual request took place.