### PR TITLE
retarget extension for stable vscode

### DIFF
--- a/src/dotnet-interactive-vscode/README.md
+++ b/src/dotnet-interactive-vscode/README.md
@@ -1,4 +1,4 @@
-This extension is currently **_in preview_**. [Visual Studio Code Insiders](https://code.visualstudio.com/insiders/)  is required.
+This extension is currently **_in preview_**.
 _The Visual Studio Code notebook support that this extension uses is also in preview and design is ongoing, so the extension might not work._
 ---
 
@@ -8,18 +8,18 @@ This extension adds support for using .NET Interactive in a Visual Studio Code n
 
 ## Getting Started
 
-1.  Install the latest [Visual Studio Code Insiders](https://code.visualstudio.com/insiders/).
+1.  Install the latest [Visual Studio Code](https://code.visualstudio.com/).
 
-2.  Install the latest [.NET 5 SDK](https://dotnet.microsoft.com/download/dotnet/5.0) 
+2.  Install the latest [.NET 5 SDK](https://dotnet.microsoft.com/download/dotnet/5.0)
 
 3.  Install the .NET Interactive Notebooks extension from the [marketplace](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode).
 
 ## Opening and Creating notebooks
 
-To open an existing .NET notebook, bring up the Command Palette(`Ctrl+Shift+P`) and select **Open notebook**.  Now, navigate to a local `.ipynb` file. 
+To open an existing .NET notebook, bring up the Command Palette(`Ctrl+Shift+P`) and select **.NET Interactive: Open notebook**.  Now, navigate to a local `.ipynb` file.
 
 ![opennotebook](https://user-images.githubusercontent.com/2546640/94441970-67d6e180-0171-11eb-8319-c12ba82c3d30.gif)
 
-To create a new notebook, open the Command Palette(`Ctrl+Shift+P`), and select **Create new blank notebook**. You can also create a new notebook with `Ctrl+Shift+Alt+N` key combination. 
+To create a new notebook, open the Command Palette(`Ctrl+Shift+P`), and select **.NET Interactive: Create new blank notebook**. You can also create a new notebook with `Ctrl+Shift+Alt+N` key combination.
 
 ![newnotebook](https://user-images.githubusercontent.com/2546640/94438730-833fed80-016d-11eb-94e6-da7b51abf58a.gif)

--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -12,7 +12,7 @@
   "//version": "The version '42.42.42' is auto-set during CI package creation.",
   "version": "42.42.42",
   "engines": {
-    "vscode": "^1.46.0"
+    "vscode": "^1.53.0"
   },
   "bugs": {
     "url": "https://github.com/dotnet/interactive/issues"
@@ -41,6 +41,7 @@
   ],
   "activationEvents": [
     "onNotebook:dotnet-interactive",
+    "onNotebook:dotnet-interactive-jupyter",
     "onNotebook:*",
     "onCommand:dotnet-interactive.acquire",
     "onCommand:dotnet-interactive.newNotebook",
@@ -49,8 +50,7 @@
   ],
   "main": "./out/vscode/extension.js",
   "extensionDependencies": [
-    "ms-dotnettools.vscode-dotnet-runtime",
-    "ms-toolsai.jupyter"
+    "ms-dotnettools.vscode-dotnet-runtime"
   ],
   "contributes": {
     "notebookProvider": [
@@ -62,6 +62,16 @@
             "filenamePattern": "*.{dib,dotnet-interactive}"
           }
         ]
+      },
+      {
+        "viewType": "dotnet-interactive-jupyter",
+        "displayName": ".NET Interactive for Jupyter Notebooks",
+        "selector": [
+          {
+            "filenamePattern": "*.ipynb"
+          }
+        ],
+        "priority": "option"
       }
     ],
     "configuration": {
@@ -104,8 +114,13 @@
         },
         "dotnet-interactive.minimumInteractiveToolVersion": {
           "type": "string",
-          "default": "1.0.207101",
+          "default": "1.0.210401",
           "description": "The minimum required version of the .NET Interactive tool."
+        },
+        "dotnet-interactive.useJupyterExtensionForIpynbFiles": {
+          "type": "boolean",
+          "default": false,
+          "description": "(EXPERIMENTAL) Use the Jupyter extension to handle .ipynb notebook files if possible (requries restart)."
         }
       }
     },

--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -65,7 +65,7 @@
       },
       {
         "viewType": "dotnet-interactive-jupyter",
-        "displayName": ".NET Interactive for Jupyter Notebooks",
+        "displayName": ".NET Interactive for Jupyter",
         "selector": [
           {
             "filenamePattern": "*.ipynb"
@@ -120,7 +120,7 @@
         "dotnet-interactive.useJupyterExtensionForIpynbFiles": {
           "type": "boolean",
           "default": false,
-          "description": "(EXPERIMENTAL) Use the Jupyter extension to handle .ipynb notebook files if possible (requries restart)."
+          "description": "(EXPERIMENTAL) Use the Jupyter extension to handle .ipynb files if possible (requires restart)."
         }
       }
     },

--- a/src/dotnet-interactive-vscode/src/ipynbUtilities.ts
+++ b/src/dotnet-interactive-vscode/src/ipynbUtilities.ts
@@ -117,7 +117,6 @@ export interface KernelspecMetadata {
     readonly display_name: string,
     readonly language: string,
     readonly name: string,
-    readonly [key: string]: any,
 }
 
 export const requiredKernelspecData: KernelspecMetadata = {
@@ -137,12 +136,8 @@ export function withDotNetKernelMetadata(metadata: { [key: string]: any } | unde
 
     result.custom ||= {};
     result.custom.metadata ||= {};
-    result.custom.metadata.kernelspec ||= {};
 
     // always set kernelspec data so that this notebook can be opened in Jupyter Lab
-    for (const key in requiredKernelspecData) {
-        result.custom.metadata.kernelspec[key] = requiredKernelspecData[key];
-    }
-
+    result.custom.metadata.kernelspec = { ...result.custom.metadata.kernelspec, ...requiredKernelspecData };
     return result;
 }

--- a/src/dotnet-interactive-vscode/src/ipynbUtilities.ts
+++ b/src/dotnet-interactive-vscode/src/ipynbUtilities.ts
@@ -124,14 +124,17 @@ export function withDotNetKernelMetadata(metadata: { [key: string]: any } | unde
 
     result.custom ||= {};
     result.custom.metadata ||= {};
+    result.custom.metadata.kernelspec ||= {};
 
-    // set kernelspec only if there's nothing present
-    if (!result.custom.metadata.kernelspec) {
-        result.custom.metadata.kernelspec = {
-            display_name: '.NET (C#)',
-            language: 'C#',
-            name: '.net-csharp',
-        };
+    const requiredKernelspecData: { [key: string]: any } = {
+        display_name: '.NET (C#)',
+        language: 'C#',
+        name: '.net-csharp',
+    };
+
+    // always set kernelspec data so that this notebook can be opened in Jupyter Lab
+    for (const key in requiredKernelspecData) {
+        result.custom.metadata.kernelspec[key] = requiredKernelspecData[key];
     }
 
     return result;

--- a/src/dotnet-interactive-vscode/src/ipynbUtilities.ts
+++ b/src/dotnet-interactive-vscode/src/ipynbUtilities.ts
@@ -113,6 +113,19 @@ export function getCellLanguage(cellText: string, cellMetadata: DotNetCellMetada
     return getNotebookSpecificLanguage(cellLanguageSpecifier || cellMetadata.language || documentMetadata.name || fallbackLanguage);
 }
 
+export interface KernelspecMetadata {
+    readonly display_name: string,
+    readonly language: string,
+    readonly name: string,
+    readonly [key: string]: any,
+}
+
+export const requiredKernelspecData: KernelspecMetadata = {
+    display_name: '.NET (C#)',
+    language: 'C#',
+    name: '.net-csharp',
+};
+
 export function withDotNetKernelMetadata(metadata: { [key: string]: any } | undefined): any | undefined {
     // clone the existing metadata
     let result: { [key: string]: any } = {};
@@ -125,12 +138,6 @@ export function withDotNetKernelMetadata(metadata: { [key: string]: any } | unde
     result.custom ||= {};
     result.custom.metadata ||= {};
     result.custom.metadata.kernelspec ||= {};
-
-    const requiredKernelspecData: { [key: string]: any } = {
-        display_name: '.NET (C#)',
-        language: 'C#',
-        name: '.net-csharp',
-    };
 
     // always set kernelspec data so that this notebook can be opened in Jupyter Lab
     for (const key in requiredKernelspecData) {

--- a/src/dotnet-interactive-vscode/src/tests/unit/ipynbMetadata.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/ipynbMetadata.test.ts
@@ -233,6 +233,7 @@ describe('ipynb metadata tests', () => {
                 custom: {
                     metadata: {
                         kernelspec: {
+                            name: 'this will be overwritten',
                             some_existing_key: 'some existing value'
                         },
                         some_custom_metadata: {

--- a/src/dotnet-interactive-vscode/src/tests/unit/ipynbMetadata.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/ipynbMetadata.test.ts
@@ -170,7 +170,7 @@ describe('ipynb metadata tests', () => {
             });
         });
 
-        it(`doesn't set kernelspec data when already present`, () => {
+        it(`merges kernelspec data with existing`, () => {
             const documentMetadata = {
                 custom: {
                     metadata: {
@@ -185,7 +185,10 @@ describe('ipynb metadata tests', () => {
                 custom: {
                     metadata: {
                         kernelspec: {
-                            some_existing_key: 'some existing value'
+                            display_name: '.NET (C#)',
+                            language: 'C#',
+                            name: '.net-csharp',
+                            some_existing_key: 'some existing value',
                         }
                     }
                 }
@@ -246,6 +249,9 @@ describe('ipynb metadata tests', () => {
                 custom: {
                     metadata: {
                         kernelspec: {
+                            display_name: '.NET (C#)',
+                            language: 'C#',
+                            name: '.net-csharp',
                             some_existing_key: 'some existing value'
                         },
                         some_custom_metadata: {

--- a/src/dotnet-interactive-vscode/src/tests/unit/misc.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/misc.test.ts
@@ -4,9 +4,61 @@
 import { expect } from 'chai';
 import { NotebookCellDisplayOutput, NotebookCellErrorOutput, NotebookCellTextOutput } from '../../contracts';
 
-import { debounce, isDisplayOutput, isErrorOutput, isTextOutput, parse, processArguments, stringify } from '../../utilities';
+import { debounce, isDisplayOutput, isErrorOutput, isTextOutput, mergeObjects, parse, processArguments, stringify } from '../../utilities';
 
 describe('Miscellaneous tests', () => {
+    describe('JSON object merging', () => {
+        it(`two JSON objects can be merged`, () => {
+            const baseObject = {
+                key1: {
+                    key2: 'value 2'
+                },
+                key3: 1
+            };
+            const additionalData = {
+                key3: 3
+            };
+            const result = mergeObjects(baseObject, additionalData);
+            expect(result).to.deep.equal({
+                key1: {
+                    key2: 'value 2'
+                },
+                key3: 3
+            });
+        });
+
+        it(`objects can be merged if first is undefined`, () => {
+            const baseObject = undefined;
+            const additionalData = {
+                key3: 3
+            };
+            const result = mergeObjects(baseObject, additionalData);
+            expect(result).to.deep.equal({
+                key3: 3
+            });
+        });
+
+        it(`objects can be merged if second is undefined`, () => {
+            const baseObject = {
+                key1: {
+                    key2: 'value 2'
+                }
+            };
+            const additionalData = undefined;
+            const result = mergeObjects(baseObject, additionalData);
+            expect(result).to.deep.equal({
+                key1: {
+                    key2: 'value 2'
+                }
+            });
+        });
+
+        it(`objects can be merged if both are undefined`, () => {
+            const result = mergeObjects(undefined, undefined);
+            expect(result).to.deep.equal({});
+        });
+    });
+
     it(`verify command and argument replacement is as expected`, () => {
         let template = {
             args: [

--- a/src/dotnet-interactive-vscode/src/tests/unit/misc.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/misc.test.ts
@@ -32,6 +32,70 @@ describe('Miscellaneous tests', () => {
             expect(isDotNetKernelPreferred(filename, fileMetadata)).is.true;
         });
 
+        it(`.ipynb file extension is preferred for F# kernelspec`, () => {
+            const filename = 'notebook.ipynb';
+            const fileMetadata = {
+                custom: {
+                    metadata: {
+                        kernelspec: {
+                            display_name: '.NET (F#)',
+                            language: 'F#',
+                            name: '.net-fsharp',
+                        }
+                    }
+                }
+            };
+            expect(isDotNetKernelPreferred(filename, fileMetadata)).is.true;
+        });
+
+        it(`.ipynb file extension is preferred improperly-cased kernelspec`, () => {
+            const filename = 'notebook.ipynb';
+            const fileMetadata = {
+                custom: {
+                    metadata: {
+                        kernelspec: {
+                            display_name: '.NET (C#)',
+                            language: 'C#',
+                            name: '.NET-CSHARP',
+                        }
+                    }
+                }
+            };
+            expect(isDotNetKernelPreferred(filename, fileMetadata)).is.true;
+        });
+
+        it(`.ipynb file extension is preferred for alternate F# kernelspec`, () => {
+            const filename = 'notebook.ipynb';
+            const fileMetadata = {
+                custom: {
+                    metadata: {
+                        kernelspec: {
+                            display_name: '.NET (F#) (dev)',
+                            language: 'F#',
+                            name: '.net-fsharp-dev',
+                        }
+                    }
+                }
+            };
+            expect(isDotNetKernelPreferred(filename, fileMetadata)).is.true;
+        });
+
+        it(`.ipynb file extension is preferred for PowerShell kernelspec`, () => {
+            const filename = 'notebook.ipynb';
+            const fileMetadata = {
+                custom: {
+                    metadata: {
+                        kernelspec: {
+                            display_name: '.NET (PowerShell)',
+                            language: 'pwsh',
+                            name: '.net-powershell',
+                        }
+                    }
+                }
+            };
+            expect(isDotNetKernelPreferred(filename, fileMetadata)).is.true;
+        });
+
         it(`.ipynb file extension is not preferred if metadata kernelspec doesn't match`, () => {
             const filename = 'notebook.ipynb';
             const fileMetadata = {

--- a/src/dotnet-interactive-vscode/src/tests/unit/misc.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/misc.test.ts
@@ -4,7 +4,7 @@
 import { expect } from 'chai';
 import { NotebookCellDisplayOutput, NotebookCellErrorOutput, NotebookCellTextOutput } from '../../contracts';
 import { requiredKernelspecData } from '../../ipynbUtilities';
-import { debounce, isDisplayOutput, isDotNetKernelPreferred, isErrorOutput, isTextOutput, mergeObjects, parse, processArguments, stringify } from '../../utilities';
+import { debounce, isDisplayOutput, isDotNetKernelPreferred, isErrorOutput, isTextOutput, parse, processArguments, stringify } from '../../utilities';
 
 describe('Miscellaneous tests', () => {
     describe('preferred kernel selection', () => {
@@ -128,58 +128,6 @@ describe('Miscellaneous tests', () => {
                 }
             };
             expect(isDotNetKernelPreferred(filename, fileMetadata)).is.false;
-        });
-    });
-
-    describe('JSON object merging', () => {
-        it(`two JSON objects can be merged`, () => {
-            const baseObject = {
-                key1: {
-                    key2: 'value 2'
-                },
-                key3: 1
-            };
-            const additionalData = {
-                key3: 3
-            };
-            const result = mergeObjects(baseObject, additionalData);
-            expect(result).to.deep.equal({
-                key1: {
-                    key2: 'value 2'
-                },
-                key3: 3
-            });
-        });
-
-        it(`objects can be merged if first is undefined`, () => {
-            const baseObject = undefined;
-            const additionalData = {
-                key3: 3
-            };
-            const result = mergeObjects(baseObject, additionalData);
-            expect(result).to.deep.equal({
-                key3: 3
-            });
-        });
-
-        it(`objects can be merged if second is undefined`, () => {
-            const baseObject = {
-                key1: {
-                    key2: 'value 2'
-                }
-            };
-            const additionalData = undefined;
-            const result = mergeObjects(baseObject, additionalData);
-            expect(result).to.deep.equal({
-                key1: {
-                    key2: 'value 2'
-                }
-            });
-        });
-
-        it(`objects can be merged if both are undefined`, () => {
-            const result = mergeObjects(undefined, undefined);
-            expect(result).to.deep.equal({});
         });
     });
 

--- a/src/dotnet-interactive-vscode/src/utilities.ts
+++ b/src/dotnet-interactive-vscode/src/utilities.ts
@@ -125,6 +125,23 @@ export function stringify(value: any): string {
     });
 }
 
+export function mergeObjects(baseObject: { [key: string]: any } | undefined, additionalData: { [key: string]: any } | undefined): any {
+    let result: { [key: string]: any } = {};
+    if (baseObject) {
+        for (const key in baseObject) {
+            result[key] = baseObject[key];
+        }
+    }
+
+    if (additionalData) {
+        for (const key in additionalData) {
+            result[key] = additionalData[key];
+        }
+    }
+
+    return result;
+}
+
 export function isErrorOutput(arg: any): arg is NotebookCellErrorOutput {
     return arg
         && typeof arg.errorName === 'string'

--- a/src/dotnet-interactive-vscode/src/utilities.ts
+++ b/src/dotnet-interactive-vscode/src/utilities.ts
@@ -4,7 +4,6 @@
 import * as path from 'path';
 import { NotebookCellDisplayOutput, NotebookCellErrorOutput, NotebookCellTextOutput } from "./contracts";
 import { ProcessStart } from "./interfaces";
-import { requiredKernelspecData } from './ipynbUtilities';
 import { Uri } from './interfaces/vscode';
 
 export function processArguments(template: { args: Array<string>, workingDirectory: string }, notebookPath: string, fallbackWorkingDirectory: string, dotnetPath: string, globalStoragePath: string): ProcessStart {
@@ -124,23 +123,6 @@ export function stringify(value: any): string {
 
         return value;
     });
-}
-
-export function mergeObjects(baseObject: { [key: string]: any } | undefined, additionalData: { [key: string]: any } | undefined): any {
-    let result: { [key: string]: any } = {};
-    if (baseObject) {
-        for (const key in baseObject) {
-            result[key] = baseObject[key];
-        }
-    }
-
-    if (additionalData) {
-        for (const key in additionalData) {
-            result[key] = additionalData[key];
-        }
-    }
-
-    return result;
 }
 
 export function isDotNetKernelPreferred(filename: string, fileMetadata: any): boolean {

--- a/src/dotnet-interactive-vscode/src/utilities.ts
+++ b/src/dotnet-interactive-vscode/src/utilities.ts
@@ -152,18 +152,9 @@ export function isDotNetKernelPreferred(filename: string, fileMetadata: any): bo
             return true;
         // maybe preferred if the kernelspec data matches
         case '.ipynb':
-            const kernelspec = fileMetadata?.custom?.metadata?.kernelspec;
-            if (kernelspec) {
-                for (const key in requiredKernelspecData) {
-                    if (kernelspec[key] !== requiredKernelspecData[key]) {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            return false;
+            const kernelName = fileMetadata?.custom?.metadata?.kernelspec?.name;
+            return typeof kernelName === 'string'
+                && kernelName.toLowerCase().startsWith('.net-');
         // never preferred if it's an unknown extension
         default:
             return false;

--- a/src/dotnet-interactive-vscode/src/vscode/commands.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/commands.ts
@@ -3,10 +3,11 @@
 
 import * as vscode from 'vscode';
 import * as cp from 'child_process';
+import * as path from 'path';
 import { acquireDotnetInteractive } from '../acquisition';
 import { InstallInteractiveArgs, InteractiveLaunchOptions } from '../interfaces';
 import { ClientMapper } from '../clientMapper';
-import { getEol } from './vscodeUtilities';
+import { getEol, isUnsavedNotebook } from './vscodeUtilities';
 import { toNotebookDocument } from './notebookContentProvider';
 import { KernelId, updateCellMetadata } from './notebookKernel';
 
@@ -117,7 +118,7 @@ export function registerKernelCommands(context: vscode.ExtensionContext, clientM
     }));
 }
 
-export function registerFileCommands(context: vscode.ExtensionContext, clientMapper: ClientMapper) {
+export function registerFileCommands(context: vscode.ExtensionContext, clientMapper: ClientMapper, useJupyterExtension: boolean) {
 
     const eol = getEol();
 
@@ -126,9 +127,35 @@ export function registerFileCommands(context: vscode.ExtensionContext, clientMap
         '.NET Interactive Notebooks': ['dib', 'dotnet-interactive']
     };
 
+    function workspaceHasUnsavedNotebookWithName(fileName: string): boolean {
+        return vscode.workspace.textDocuments.findIndex(textDocument => {
+            if (textDocument.notebook) {
+                const notebookUri = textDocument.notebook.uri;
+                return isUnsavedNotebook(notebookUri) && path.basename(notebookUri.fsPath) === fileName;
+            }
+
+            return false;
+        }) >= 0;
+    }
+
+    function getNewNotebookName(): string {
+        let suffix = 1;
+        while (workspaceHasUnsavedNotebookWithName(`Untitled-${suffix}.ipynb`)) {
+            suffix++;
+        }
+
+        return `Untitled-${suffix}.ipynb`;
+    }
+
     context.subscriptions.push(vscode.commands.registerCommand('dotnet-interactive.newNotebook', async () => {
-        await vscode.commands.executeCommand('jupyter.createnewnotebook');
-        await switchToInteractiveKernel();
+        if (useJupyterExtension) {
+            await vscode.commands.executeCommand('jupyter.createnewnotebook');
+            await switchToInteractiveKernel();
+        } else {
+            const fileName = getNewNotebookName();
+            const newUri = vscode.Uri.file(fileName).with({ scheme: 'untitled', path: fileName });
+            await vscode.commands.executeCommand('vscode.openWith', newUri, 'dotnet-interactive-jupyter');
+        }
     }));
 
     context.subscriptions.push(vscode.commands.registerCommand('dotnet-interactive.openNotebook', async (notebookUri: vscode.Uri | undefined) => {
@@ -148,8 +175,12 @@ export function registerFileCommands(context: vscode.ExtensionContext, clientMap
             }
         }
 
-        await vscode.commands.executeCommand('vscode.openWith', notebookUri, 'jupyter-notebook');
-        await switchToInteractiveKernel();
+        if (useJupyterExtension) {
+            await vscode.commands.executeCommand('vscode.openWith', notebookUri, 'jupyter-notebook');
+            await switchToInteractiveKernel();
+        } else {
+            await vscode.commands.executeCommand('vscode.openWith', notebookUri, 'dotnet-interactive-jupyter');
+        }
     }));
 
     context.subscriptions.push(vscode.commands.registerCommand('dotnet-interactive.saveAsNotebook', async () => {

--- a/src/dotnet-interactive-vscode/src/vscode/extension.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/extension.ts
@@ -66,27 +66,47 @@ export async function activate(context: vscode.ExtensionContext) {
     });
 
     registerKernelCommands(context, clientMapper);
-    registerFileCommands(context, clientMapper);
+
+    const isInsidersBuild = vscode.version.indexOf('-insider') >= 0;
+    const jupyterExtensionIsPresent = vscode.extensions.getExtension('ms-toolsai.jupyter') !== undefined;
+    const useJupyterExtension = isInsidersBuild && jupyterExtensionIsPresent && (config.get<boolean>('useJupyterExtensionForIpynbFiles') || false);
+    registerFileCommands(context, clientMapper, useJupyterExtension);
 
     const diagnosticDelay = config.get<number>('liveDiagnosticDelay') || 500; // fall back to something reasonable
     const selectorDib = {
         viewType: ['dotnet-interactive'],
         filenamePattern: '*.{dib,dotnet-interactive}'
     };
-    const selectorJupyter = {
+    const selectorIpynbWithJupyter = {
         viewType: ['jupyter-notebook'],
         filenamePattern: '*.ipynb'
     };
+    const selectorIpynbWithDotNetInteractive = {
+        viewType: ['dotnet-interactive-jupyter'],
+        filenamePatter: '*.ipynb'
+    };
     const notebookContentProvider = new DotNetInteractiveNotebookContentProvider(clientMapper);
+
+    // notebook content
+    context.subscriptions.push(vscode.notebook.registerNotebookContentProvider('dotnet-interactive', notebookContentProvider));
+    context.subscriptions.push(vscode.notebook.registerNotebookContentProvider('dotnet-interactive-jupyter', notebookContentProvider));
+
+    // notebook kernels
     const apiBootstrapperUri = vscode.Uri.file(path.join(context.extensionPath, 'resources', 'kernelHttpApiBootstrapper.js'));
     const notebookKernel = new DotNetInteractiveNotebookKernel(clientMapper, apiBootstrapperUri);
     const notebookKernelProvider = new DotNetInteractiveNotebookKernelProvider(notebookKernel, clientMapper);
-    context.subscriptions.push(vscode.notebook.registerNotebookContentProvider('dotnet-interactive', notebookContentProvider));
     context.subscriptions.push(vscode.notebook.registerNotebookKernelProvider(selectorDib, notebookKernelProvider));
-    context.subscriptions.push(vscode.notebook.registerNotebookKernelProvider(selectorJupyter, notebookKernelProvider));
+    if (useJupyterExtension) {
+        context.subscriptions.push(vscode.notebook.registerNotebookKernelProvider(selectorIpynbWithJupyter, notebookKernelProvider));
+    } else {
+        context.subscriptions.push(vscode.notebook.registerNotebookKernelProvider(selectorIpynbWithDotNetInteractive, notebookKernelProvider));
+    }
+
     context.subscriptions.push(vscode.notebook.onDidChangeActiveNotebookKernel(async e => await updateDocumentMetadata(e, clientMapper)));
-    context.subscriptions.push(vscode.notebook.onDidChangeCellLanguage(async e => await updateCellLanguageInMetadata(e)));
     context.subscriptions.push(vscode.notebook.onDidCloseNotebookDocument(notebookDocument => clientMapper.closeClient(notebookDocument.uri)));
+
+    // language registration
+    context.subscriptions.push(vscode.notebook.onDidChangeCellLanguage(async e => await updateCellLanguageInMetadata(e)));
     context.subscriptions.push(registerLanguageProviders(clientMapper, diagnosticDelay));
 }
 

--- a/src/dotnet-interactive-vscode/src/vscode/extension.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/extension.ts
@@ -18,7 +18,7 @@ import compareVersions = require("compare-versions");
 import { DotNetCellMetadata, withDotNetMetadata } from '../ipynbUtilities';
 import { processArguments } from '../utilities';
 import { OutputChannelAdapter } from './OutputChannelAdapter';
-import { DotNetInteractiveNotebookKernel, KernelId, updateCellLanguages, updateDocumentKernelspecMetadata } from './notebookKernel';
+import { KernelId, updateCellLanguages, updateDocumentKernelspecMetadata } from './notebookKernel';
 import { DotNetInteractiveNotebookKernelProvider } from './notebookKernelProvider';
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -93,8 +93,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // notebook kernels
     const apiBootstrapperUri = vscode.Uri.file(path.join(context.extensionPath, 'resources', 'kernelHttpApiBootstrapper.js'));
-    const notebookKernel = new DotNetInteractiveNotebookKernel(clientMapper, apiBootstrapperUri);
-    const notebookKernelProvider = new DotNetInteractiveNotebookKernelProvider(notebookKernel, clientMapper);
+    const notebookKernelProvider = new DotNetInteractiveNotebookKernelProvider(apiBootstrapperUri, clientMapper);
     context.subscriptions.push(vscode.notebook.registerNotebookKernelProvider(selectorDib, notebookKernelProvider));
     if (useJupyterExtension) {
         context.subscriptions.push(vscode.notebook.registerNotebookKernelProvider(selectorIpynbWithJupyter, notebookKernelProvider));

--- a/src/dotnet-interactive-vscode/src/vscode/notebookKernel.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/notebookKernel.ts
@@ -10,6 +10,7 @@ import { getDiagnosticCollection } from './diagnostics';
 import { getSimpleLanguage } from "../interactiveNotebook";
 import { Diagnostic, DiagnosticSeverity } from "../contracts";
 import { getCellLanguage, getDotNetMetadata, getLanguageInfoMetadata, withDotNetKernelMetadata } from '../ipynbUtilities';
+import { mergeObjects } from '../utilities';
 
 export const KernelId: string = 'dotnet-interactive';
 
@@ -78,8 +79,9 @@ export class DotNetInteractiveNotebookKernel implements vscode.NotebookKernel {
 export async function updateCellMetadata(document: vscode.NotebookDocument, cell: vscode.NotebookCell, metadata: vscode.NotebookCellMetadata): Promise<void> {
     const cellIndex = document.cells.findIndex(c => c === cell);
     if (cellIndex >= 0) {
+        const newMetadata = mergeObjects(cell.metadata, metadata);
         const edit = new vscode.WorkspaceEdit();
-        edit.replaceNotebookCellMetadata(document.uri, cellIndex, metadata);
+        edit.replaceNotebookCellMetadata(document.uri, cellIndex, newMetadata);
         await vscode.workspace.applyEdit(edit);
     }
 }
@@ -96,7 +98,23 @@ export async function updateCellOutputs(document: vscode.NotebookDocument, cell:
 export async function updateDocumentKernelspecMetadata(document: vscode.NotebookDocument): Promise<void> {
     const edit = new vscode.WorkspaceEdit();
     const documentKernelMetadata = withDotNetKernelMetadata(document.metadata);
+
+    // workaround for https://github.com/microsoft/vscode/issues/115912; capture all cell data so we can re-apply it at the end
+    const cellData: Array<vscode.NotebookCellData> = document.cells.map(c => {
+        return {
+            cellKind: c.cellKind,
+            source: c.document.getText(),
+            language: c.language,
+            outputs: c.outputs,
+            metadata: c.metadata
+        };
+    });
+
     edit.replaceNotebookMetadata(document.uri, documentKernelMetadata);
+
+    // this is the re-application for the workaround mentioned above
+    edit.replaceNotebookCells(document.uri, 0, document.cells.length - 1, cellData);
+
     await vscode.workspace.applyEdit(edit);
 }
 

--- a/src/dotnet-interactive-vscode/src/vscode/notebookKernel.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/notebookKernel.ts
@@ -19,12 +19,13 @@ export class DotNetInteractiveNotebookKernel implements vscode.NotebookKernel {
     label: string;
     description?: string | undefined;
     detail?: string | undefined;
-    isPreferred: boolean = true;
+    isPreferred: boolean;
     preloads?: vscode.Uri[] | undefined;
 
-    constructor(readonly clientMapper: ClientMapper, apiBootstrapperUri: vscode.Uri) {
+    constructor(readonly clientMapper: ClientMapper, apiBootstrapperUri: vscode.Uri, isPreferred: boolean) {
         this.label = ".NET Interactive";
         this.preloads = [apiBootstrapperUri];
+        this.isPreferred = isPreferred;
     }
 
     async executeAllCells(document: vscode.NotebookDocument): Promise<void> {
@@ -113,7 +114,7 @@ export async function updateDocumentKernelspecMetadata(document: vscode.Notebook
     edit.replaceNotebookMetadata(document.uri, documentKernelMetadata);
 
     // this is the re-application for the workaround mentioned above
-    edit.replaceNotebookCells(document.uri, 0, document.cells.length - 1, cellData);
+    edit.replaceNotebookCells(document.uri, 0, document.cells.length, cellData);
 
     await vscode.workspace.applyEdit(edit);
 }

--- a/src/dotnet-interactive-vscode/src/vscode/notebookKernel.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/notebookKernel.ts
@@ -10,7 +10,6 @@ import { getDiagnosticCollection } from './diagnostics';
 import { getSimpleLanguage } from "../interactiveNotebook";
 import { Diagnostic, DiagnosticSeverity } from "../contracts";
 import { getCellLanguage, getDotNetMetadata, getLanguageInfoMetadata, withDotNetKernelMetadata } from '../ipynbUtilities';
-import { mergeObjects } from '../utilities';
 
 export const KernelId: string = 'dotnet-interactive';
 
@@ -80,7 +79,7 @@ export class DotNetInteractiveNotebookKernel implements vscode.NotebookKernel {
 export async function updateCellMetadata(document: vscode.NotebookDocument, cell: vscode.NotebookCell, metadata: vscode.NotebookCellMetadata): Promise<void> {
     const cellIndex = document.cells.findIndex(c => c === cell);
     if (cellIndex >= 0) {
-        const newMetadata = mergeObjects(cell.metadata, metadata);
+        const newMetadata = { ...cell.metadata, ...metadata };
         const edit = new vscode.WorkspaceEdit();
         edit.replaceNotebookCellMetadata(document.uri, cellIndex, newMetadata);
         await vscode.workspace.applyEdit(edit);

--- a/src/dotnet-interactive-vscode/src/vscode/vscode.d.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/vscode.d.ts
@@ -1451,6 +1451,21 @@ declare module 'vscode' {
 	}
 
 	/**
+	 * An error type that should be used to signal cancellation of an operation.
+	 *
+	 * This type can be used in response to a [cancellation token](#CancellationToken)
+	 * being cancelled or when an operation is being cancelled by the
+	 * executor of that operation.
+	 */
+	export class CancellationError extends Error {
+
+		/**
+		 * Creates a new cancellation error.
+		 */
+		constructor();
+	}
+
+	/**
 	 * Represents a type which can release resources, such
 	 * as event listening or a timer.
 	 */
@@ -4683,6 +4698,10 @@ declare module 'vscode' {
 		 */
 		afterText?: RegExp;
 		/**
+		 * This rule will only execute if the text above the current line matches this regular expression.
+		 */
+		previousLineText?: RegExp;
+		/**
 		 * The action to execute.
 		 */
 		action: EnterAction;
@@ -5807,6 +5826,11 @@ declare module 'vscode' {
 		};
 
 		/**
+		 * A storage utility for secrets.
+		 */
+		readonly secrets: SecretStorage;
+
+		/**
 		 * The uri of the directory containing the extension.
 		 */
 		readonly extensionUri: Uri;
@@ -5941,6 +5965,48 @@ declare module 'vscode' {
 		 * @param value A value. MUST not contain cyclic references.
 		 */
 		update(key: string, value: any): Thenable<void>;
+	}
+
+	/**
+	 * The event data that is fired when a secret is added or removed.
+	 */
+	export interface SecretStorageChangeEvent {
+		/**
+		 * The key of the secret that has changed.
+		 */
+		readonly key: string;
+	}
+
+	/**
+	 * Represents a storage utility for secrets, information that is
+	 * sensitive.
+	 */
+	export interface SecretStorage {
+		/**
+		 * Retrieve a secret that was stored with key. Returns undefined if there
+		 * is no password matching that key.
+		 * @param key The key the secret was stored under.
+		 * @returns The stored value or `undefined`.
+		 */
+		get(key: string): Thenable<string | undefined>;
+
+		/**
+		 * Store a secret under a given key.
+		 * @param key The key to store the secret under.
+		 * @param value The secret.
+		 */
+		store(key: string, value: string): Thenable<void>;
+
+		/**
+		 * Remove a secret from storage.
+		 * @param key The key the secret was stored under.
+		 */
+		delete(key: string): Thenable<void>;
+
+		/**
+		 * Fires when a secret is stored or deleted.
+		 */
+		onDidChange: Event<SecretStorageChangeEvent>;
 	}
 
 	/**
@@ -8880,13 +8946,13 @@ declare module 'vscode' {
 		 * Because of that, no property that changes the presentation (label, description, etc.)
 		 * can be changed.
 		 *
-		 * @param element The object associated with the TreeItem
 		 * @param item Undefined properties of `item` should be set then `item` should be returned.
+		 * @param element The object associated with the TreeItem.
+		 * @param token A cancellation token.
 		 * @return The resolved tree item or a thenable that resolves to such. It is OK to return the given
 		 * `item`. When no result is returned, the given `item` will be used.
 		 */
-		// eslint-disable-next-line vscode-dts-cancellation
-		resolveTreeItem?(item: TreeItem, element: T): ProviderResult<TreeItem>;
+		resolveTreeItem?(item: TreeItem, element: T, token: CancellationToken): ProviderResult<TreeItem>;
 	}
 
 	export class TreeItem {
@@ -9207,7 +9273,7 @@ declare module 'vscode' {
 		 * Implement to handle when the number of rows and columns that fit into the terminal panel
 		 * changes, for example when font size changes or when the panel is resized. The initial
 		 * state of a terminal's dimensions should be treated as `undefined` until this is triggered
-		 * as the size of a terminal isn't know until it shows up in the user interface.
+		 * as the size of a terminal isn't known until it shows up in the user interface.
 		 *
 		 * When dimensions are overridden by
 		 * [onDidOverrideDimensions](#Pseudoterminal.onDidOverrideDimensions), `setDimensions` will
@@ -11878,8 +11944,6 @@ declare module 'vscode' {
 		export const onDidChange: Event<void>;
 	}
 
-	//#region Comments
-
 	/**
 	 * Collapsible state of a [comment thread](#CommentThread)
 	 */
@@ -12146,7 +12210,7 @@ declare module 'vscode' {
 		/**
 		 * Optional reaction handler for creating and deleting reactions on a [comment](#Comment).
 		 */
-		reactionHandler?: (comment: Comment, reaction: CommentReaction) => Promise<void>;
+		reactionHandler?: (comment: Comment, reaction: CommentReaction) => Thenable<void>;
 
 		/**
 		 * Dispose this comment controller.

--- a/src/dotnet-interactive-vscode/src/vscode/vscode.proposed.d.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/vscode.proposed.d.ts
@@ -16,26 +16,7 @@
 
 declare module 'vscode' {
 
-	//#region https://github.com/microsoft/vscode/issues/93686
-
-	/**
-	 * An error type should be used to signal cancellation of an operation.
-	 *
-	 * This type can be used in response to a cancellation token or when an
-	 * operation is being cancelled by the executor of that operation.
-	 */
-	export class CancellationError extends Error {
-
-		/**
-		 * Creates a new cancellation error.
-		 */
-		constructor();
-	}
-
-
-	//#endregion
-
-	// #region auth provider: https://github.com/microsoft/vscode/issues/88309
+	//#region auth provider: https://github.com/microsoft/vscode/issues/88309
 
 	/**
 	 * An [event](#Event) which fires when an [AuthenticationProvider](#AuthenticationProvider) is added or removed.
@@ -73,28 +54,9 @@ declare module 'vscode' {
 	}
 
 	/**
-	 * **WARNING** When writing an AuthenticationProvider, `id` should be treated as part of your extension's
-	 * API, changing it is a breaking change for all extensions relying on the provider. The id is
-	 * treated case-sensitively.
+	 * A provider for performing authentication to a service.
 	 */
 	export interface AuthenticationProvider {
-		/**
-		 * Used as an identifier for extensions trying to work with a particular
-		 * provider: 'microsoft', 'github', etc. id must be unique, registering
-		 * another provider with the same id will fail.
-		 */
-		readonly id: string;
-
-		/**
-		 * The human-readable name of the provider.
-		 */
-		readonly label: string;
-
-		/**
-		 * Whether it is possible to be signed into multiple accounts at once with this provider
-		*/
-		readonly supportsMultipleAccounts: boolean;
-
 		/**
 		 * An [event](#Event) which fires when the array of sessions has changed, or data
 		 * within a session has changed.
@@ -121,17 +83,31 @@ declare module 'vscode' {
 		logout(sessionId: string): Thenable<void>;
 	}
 
+	/**
+	 * Options for creating an [AuthenticationProvider](#AuthentcationProvider).
+	 */
+	export interface AuthenticationProviderOptions {
+		/**
+		 * Whether it is possible to be signed into multiple accounts at once with this provider.
+		 * If not specified, will default to false.
+		*/
+		readonly supportsMultipleAccounts?: boolean;
+	}
+
 	export namespace authentication {
 		/**
 		 * Register an authentication provider.
 		 *
 		 * There can only be one provider per id and an error is being thrown when an id
-		 * has already been used by another provider.
+		 * has already been used by another provider. Ids are case-sensitive.
 		 *
+		 * @param id The unique identifier of the provider.
+		 * @param label The human-readable name of the provider.
 		 * @param provider The authentication provider provider.
+		 * @params options Additional options for the provider.
 		 * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
 		 */
-		export function registerAuthenticationProvider(provider: AuthenticationProvider): Disposable;
+		export function registerAuthenticationProvider(id: string, label: string, provider: AuthenticationProvider, options?: AuthenticationProviderOptions): Disposable;
 
 		/**
 		 * @deprecated - getSession should now trigger extension activation.
@@ -155,7 +131,15 @@ declare module 'vscode' {
 
 	//#endregion
 
+	// eslint-disable-next-line vscode-dts-region-comments
 	//#region @alexdima - resolvers
+
+	export interface MessageOptions {
+		/**
+		 * Do not render a native message box.
+		 */
+		useCustom?: boolean;
+	}
 
 	export interface RemoteAuthorityResolverContext {
 		resolveAttempt: number;
@@ -178,12 +162,14 @@ declare module 'vscode' {
 		// The desired local port. If this port can't be used, then another will be chosen.
 		localAddressPort?: number;
 		label?: string;
+		public?: boolean;
 	}
 
 	export interface TunnelDescription {
 		remoteAddress: { port: number, host: string; };
 		//The complete local address(ex. localhost:1234)
 		localAddress: { port: number, host: string; } | string;
+		public?: boolean;
 	}
 
 	export interface Tunnel extends TunnelDescription {
@@ -245,6 +231,7 @@ declare module 'vscode' {
 		 */
 		tunnelFeatures?: {
 			elevation: boolean;
+			public: boolean;
 		};
 	}
 
@@ -742,6 +729,7 @@ declare module 'vscode' {
 
 	//#endregion
 
+	// eslint-disable-next-line vscode-dts-region-comments
 	//#region debug
 
 	/**
@@ -762,8 +750,7 @@ declare module 'vscode' {
 
 	//#endregion
 
-
-
+	// eslint-disable-next-line vscode-dts-region-comments
 	//#region @joaomoreno: SCM validation
 
 	/**
@@ -814,6 +801,7 @@ declare module 'vscode' {
 
 	//#endregion
 
+	// eslint-disable-next-line vscode-dts-region-comments
 	//#region @joaomoreno: SCM selected provider
 
 	export interface SourceControl {
@@ -889,6 +877,7 @@ declare module 'vscode' {
 
 	//#endregion
 
+	// eslint-disable-next-line vscode-dts-region-comments
 	//#region @jrieken -> exclusive document filters
 
 	export interface DocumentFilter {
@@ -897,26 +886,11 @@ declare module 'vscode' {
 
 	//#endregion
 
-	//#region @alexdima - OnEnter enhancement
-	export interface OnEnterRule {
-		/**
-		 * This rule will only execute if the text above the this line matches this regular expression.
-		 */
-		oneLineAboveText?: RegExp;
-	}
-	//#endregion
-
 	//#region Tree View: https://github.com/microsoft/vscode/issues/61313 @alexr00
 	export interface TreeView<T> extends Disposable {
-		reveal(element: T | undefined, options?: { select?: boolean, focus?: boolean, expand?: boolean | number }): Thenable<void>;
+		reveal(element: T | undefined, options?: { select?: boolean, focus?: boolean, expand?: boolean | number; }): Thenable<void>;
 	}
 	//#endregion
-
-	//#region Tree data provider: https://github.com/microsoft/vscode/issues/111614 @alexr00
-	export interface TreeDataProvider<T> {
-		resolveTreeItem?(item: TreeItem, element: T, token: CancellationToken): ProviderResult<TreeItem>;
-	}
-	////#endregion
 
 	//#region Task presentation group: https://github.com/microsoft/vscode/issues/47265
 	export interface TaskPresentationOptions {
@@ -1015,7 +989,7 @@ declare module 'vscode' {
 
 	//#endregion
 
-	//#region @rebornix: Notebook
+	//#region notebook https://github.com/microsoft/vscode/issues/106744
 
 	export enum CellKind {
 		Markdown = 1,
@@ -1053,7 +1027,7 @@ declare module 'vscode' {
 		/**
 		 * Additional attributes of a cell metadata.
 		 */
-		custom?: { [key: string]: any };
+		custom?: { [key: string]: any; };
 	}
 
 	export interface CellDisplayOutput {
@@ -1177,7 +1151,7 @@ declare module 'vscode' {
 		/**
 		 * Additional attributes of a cell metadata.
 		 */
-		custom?: { [key: string]: any };
+		custom?: { [key: string]: any; };
 	}
 
 	export interface NotebookCell {
@@ -1227,7 +1201,7 @@ declare module 'vscode' {
 		/**
 		 * Additional attributes of the document metadata.
 		 */
-		custom?: { [key: string]: any };
+		custom?: { [key: string]: any; };
 
 		/**
 		 * The document's current run state
@@ -1239,6 +1213,11 @@ declare module 'vscode' {
 		 * When false, insecure outputs like HTML, JavaScript, SVG will not be rendered.
 		 */
 		trusted?: boolean;
+
+		/**
+		 * Languages the document supports
+		 */
+		languages?: string[];
 	}
 
 	export interface NotebookDocumentContentOptions {
@@ -1284,7 +1263,7 @@ declare module 'vscode' {
 
 		locationAt(positionOrRange: Position | Range): Location;
 		positionAt(location: Location): Position;
-		contains(uri: Uri): boolean
+		contains(uri: Uri): boolean;
 	}
 
 	export interface WorkspaceEdit {
@@ -1318,11 +1297,17 @@ declare module 'vscode' {
 		 * The range will always be revealed in the center of the viewport.
 		 */
 		InCenter = 1,
+
 		/**
 		 * If the range is outside the viewport, it will be revealed in the center of the viewport.
 		 * Otherwise, it will be revealed with as little scrolling as possible.
 		 */
 		InCenterIfOutsideViewport = 2,
+
+		/**
+		 * The range will always be revealed at the top of the viewport.
+		 */
+		AtTop = 3
 	}
 
 	export interface NotebookEditor {
@@ -1588,16 +1573,16 @@ declare module 'vscode' {
 		 * resolve the raw content for `uri` as the resouce is not necessarily a file on disk.
 		 */
 		// eslint-disable-next-line vscode-dts-provider-naming
-		openNotebook(uri: Uri, openContext: NotebookDocumentOpenContext): NotebookData | Promise<NotebookData>;
+		openNotebook(uri: Uri, openContext: NotebookDocumentOpenContext): NotebookData | Thenable<NotebookData>;
 		// eslint-disable-next-line vscode-dts-provider-naming
 		// eslint-disable-next-line vscode-dts-cancellation
-		resolveNotebook(document: NotebookDocument, webview: NotebookCommunication): Promise<void>;
+		resolveNotebook(document: NotebookDocument, webview: NotebookCommunication): Thenable<void>;
 		// eslint-disable-next-line vscode-dts-provider-naming
-		saveNotebook(document: NotebookDocument, cancellation: CancellationToken): Promise<void>;
+		saveNotebook(document: NotebookDocument, cancellation: CancellationToken): Thenable<void>;
 		// eslint-disable-next-line vscode-dts-provider-naming
-		saveNotebookAs(targetResource: Uri, document: NotebookDocument, cancellation: CancellationToken): Promise<void>;
+		saveNotebookAs(targetResource: Uri, document: NotebookDocument, cancellation: CancellationToken): Thenable<void>;
 		// eslint-disable-next-line vscode-dts-provider-naming
-		backupNotebook(document: NotebookDocument, context: NotebookDocumentBackupContext, cancellation: CancellationToken): Promise<NotebookDocumentBackup>;
+		backupNotebook(document: NotebookDocument, context: NotebookDocumentBackupContext, cancellation: CancellationToken): Thenable<NotebookDocumentBackup>;
 	}
 
 	export interface NotebookKernel {
@@ -1613,7 +1598,7 @@ declare module 'vscode' {
 		cancelAllCellsExecution(document: NotebookDocument): void;
 	}
 
-	export type NotebookFilenamePattern = GlobPattern | { include: GlobPattern; exclude: GlobPattern };
+	export type NotebookFilenamePattern = GlobPattern | { include: GlobPattern; exclude: GlobPattern; };
 
 	export interface NotebookDocumentFilter {
 		viewType?: string | string[];
@@ -1696,7 +1681,7 @@ declare module 'vscode' {
 		): Disposable;
 
 		export function createNotebookEditorDecorationType(options: NotebookDecorationRenderOptions): NotebookEditorDecorationType;
-		export function openNotebookDocument(uri: Uri, viewType?: string): Promise<NotebookDocument>;
+		export function openNotebookDocument(uri: Uri, viewType?: string): Thenable<NotebookDocument>;
 		export const onDidOpenNotebookDocument: Event<NotebookDocument>;
 		export const onDidCloseNotebookDocument: Event<NotebookDocument>;
 		export const onDidSaveNotebookDocument: Event<NotebookDocument>;
@@ -1719,7 +1704,7 @@ declare module 'vscode' {
 		 */
 		export function createConcatTextDocument(notebook: NotebookDocument, selector?: DocumentSelector): NotebookConcatTextDocument;
 
-		export const onDidChangeActiveNotebookKernel: Event<{ document: NotebookDocument, kernel: NotebookKernel | undefined }>;
+		export const onDidChangeActiveNotebookKernel: Event<{ document: NotebookDocument, kernel: NotebookKernel | undefined; }>;
 
 		/**
 		 * Creates a notebook cell status bar [item](#NotebookCellStatusBarItem).
@@ -1740,7 +1725,7 @@ declare module 'vscode' {
 		export const onDidChangeActiveNotebookEditor: Event<NotebookEditor | undefined>;
 		export const onDidChangeNotebookEditorSelection: Event<NotebookEditorSelectionChangeEvent>;
 		export const onDidChangeNotebookEditorVisibleRanges: Event<NotebookEditorVisibleRangesChangeEvent>;
-		export function showNotebookDocument(document: NotebookDocument, options?: NotebookDocumentShowOptions): Promise<NotebookEditor>;
+		export function showNotebookDocument(document: NotebookDocument, options?: NotebookDocumentShowOptions): Thenable<NotebookEditor>;
 	}
 
 	//#endregion
@@ -1951,9 +1936,86 @@ declare module 'vscode' {
 	}
 
 	export namespace languages {
-		export function getTokenInformationAtPosition(document: TextDocument, position: Position): Promise<TokenInformation>;
+		export function getTokenInformationAtPosition(document: TextDocument, position: Position): Thenable<TokenInformation>;
 	}
 
+	//#endregion
+
+	//#region https://github.com/microsoft/vscode/issues/16221
+
+	export namespace languages {
+		/**
+		 * Register a inline hints provider.
+		 *
+		 * Multiple providers can be registered for a language. In that case providers are asked in
+		 * parallel and the results are merged. A failing provider (rejected promise or exception) will
+		 * not cause a failure of the whole operation.
+		 *
+		 * @param selector A selector that defines the documents this provider is applicable to.
+		 * @param provider An inline hints provider.
+		 * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
+		 */
+		export function registerInlineHintsProvider(selector: DocumentSelector, provider: InlineHintsProvider): Disposable;
+	}
+
+	/**
+	 * Inline hint information.
+	 */
+	export class InlineHint {
+		/**
+		 * The text of the hint.
+		 */
+		text: string;
+		/**
+		 * The range of the hint.
+		 */
+		range: Range;
+		/**
+		 * Tooltip when hover on the hint.
+		 */
+		description?: string | MarkdownString;
+		/**
+		 * Whitespace before the hint.
+		 */
+		whitespaceBefore?: boolean;
+		/**
+		 * Whitespace after the hint.
+		 */
+		whitespaceAfter?: boolean;
+
+		/**
+		 * Creates a new inline hint information object.
+		 *
+		 * @param text The text of the hint.
+		 * @param range The range of the hint.
+		 * @param hoverMessage Tooltip when hover on the hint.
+		 * @param whitespaceBefore Whitespace before the hint.
+		 * @param whitespaceAfter TWhitespace after the hint.
+		 */
+		constructor(text: string, range: Range, description?: string | MarkdownString, whitespaceBefore?: boolean, whitespaceAfter?: boolean);
+	}
+
+	/**
+	 * The inline hints provider interface defines the contract between extensions and
+	 * the inline hints feature.
+	 */
+	export interface InlineHintsProvider {
+
+		/**
+		 * An optional event to signal that inline hints have changed.
+		 * @see [EventEmitter](#EventEmitter)
+		 */
+		onDidChangeInlineHints?: Event<void>;
+
+		/**
+		 * @param model The document in which the command was invoked.
+		 * @param range The range for which line hints should be computed.
+		 * @param token A cancellation token.
+		 *
+		 * @return A list of arguments labels or a thenable that resolves to such.
+		 */
+		provideInlineHints(model: TextDocument, range: Range, token: CancellationToken): ProviderResult<InlineHint[]>;
+	}
 	//#endregion
 
 	//#region https://github.com/microsoft/vscode/issues/104436
@@ -1974,7 +2036,6 @@ declare module 'vscode' {
 	}
 
 	//#endregion
-
 
 	//#region https://github.com/microsoft/vscode/issues/102091
 
@@ -2019,13 +2080,31 @@ declare module 'vscode' {
 		 * Returns an observer that retrieves tests in the given text document.
 		 */
 		export function createDocumentTestObserver(document: TextDocument): TestObserver;
+
+		/**
+		 * The last or selected test run. Cleared when a new test run starts.
+		 */
+		export const testResults: TestResults | undefined;
+
+		/**
+		 * Event that fires when the testResults are updated.
+		 */
+		export const onDidChangeTestResults: Event<void>;
+	}
+
+	export interface TestResults {
+		/**
+		 * The results from the latest test run. The array contains a snapshot of
+		 * all tests involved in the run at the moment when it completed.
+		 */
+		readonly tests: ReadonlyArray<RequiredTestItem> | undefined;
 	}
 
 	export interface TestObserver {
 		/**
 		 * List of tests returned by test provider for files in the workspace.
 		 */
-		readonly tests: ReadonlyArray<TestItem>;
+		readonly tests: ReadonlyArray<RequiredTestItem>;
 
 		/**
 		 * An event that fires when an existing test in the collection changes, or
@@ -2055,23 +2134,23 @@ declare module 'vscode' {
 		/**
 		 * List of all tests that are newly added.
 		 */
-		readonly added: ReadonlyArray<TestItem>;
+		readonly added: ReadonlyArray<RequiredTestItem>;
 
 		/**
 		 * List of existing tests that have updated.
 		 */
-		readonly updated: ReadonlyArray<TestItem>;
+		readonly updated: ReadonlyArray<RequiredTestItem>;
 
 		/**
 		 * List of existing tests that have been removed.
 		 */
-		readonly removed: ReadonlyArray<TestItem>;
+		readonly removed: ReadonlyArray<RequiredTestItem>;
 
 		/**
 		 * Highest node in the test tree under which changes were made. This can
 		 * be easily plugged into events like the TreeDataProvider update event.
 		 */
-		readonly commonChangeAncestor: TestItem | null;
+		readonly commonChangeAncestor: RequiredTestItem | null;
 	}
 
 	/**
@@ -2178,6 +2257,16 @@ declare module 'vscode' {
 		label: string;
 
 		/**
+		 * Optional unique identifier for the TestItem. This is used to correlate
+		 * test results and tests in the document with those in the workspace
+		 * (test explorer). This must not change for the lifetime of a test item.
+		 *
+		 * If the ID is not provided, it defaults to the concatenation of the
+		 * item's label and its parent's ID, if any.
+		 */
+		readonly id?: string;
+
+		/**
 		 * Optional description that appears next to the label.
 		 */
 		description?: string;
@@ -2212,6 +2301,15 @@ declare module 'vscode' {
 		 */
 		state: TestState;
 	}
+
+	/**
+	 * A {@link TestItem} with its defaults filled in.
+	 */
+	export type RequiredTestItem = {
+		[K in keyof Required<TestItem>]: K extends 'children'
+		? RequiredTestItem[]
+		: (K extends 'description' | 'location' ? TestItem[K] : Required<TestItem>[K])
+	};
 
 	export enum TestRunState {
 		// Initial state
@@ -2302,44 +2400,127 @@ declare module 'vscode' {
 		location?: Location;
 	}
 
-	/**
-	 * Additional metadata about the uri being opened
-	 */
-	interface OpenExternalUriContext {
-
-	}
-
 	//#endregion
 
 	//#region Opener service (https://github.com/microsoft/vscode/issues/109277)
 
 	/**
-	 * Handles opening external uris.
+	 * Details if an `ExternalUriOpener` can open a uri.
 	 *
-	 * An extension can use this to open a `http` link to a webserver inside of VS Code instead of
-	 * having the link be opened by the webbrowser.
+	 * The priority is also used to rank multiple openers against each other and determine
+	 * if an opener should be selected automatically or if the user should be prompted to
+	 * select an opener.
+	 *
+	 * VS Code will try to use the best available opener, as sorted by `ExternalUriOpenerPriority`.
+	 * If there are multiple potential "best" openers for a URI, then the user will be prompted
+	 * to select an opener.
+	 */
+	export enum ExternalUriOpenerPriority {
+		/**
+		 * The opener is disabled and will never be shown to users.
+		 *
+		 * Note that the opener can still be used if the user specifically
+		 * configures it in their settings.
+		 */
+		None = 0,
+
+		/**
+		 * The opener can open the uri but will not cause a prompt on its own
+		 * since VS Code always contributes a built-in `Default` opener.
+		 */
+		Option = 1,
+
+		/**
+		 * The opener can open the uri.
+		 *
+		 * VS Code's built-in opener has `Default` priority. This means that any additional `Default`
+		 * openers will cause the user to be prompted to select from a list of all potential openers.
+		 */
+		Default = 2,
+
+		/**
+		 * The opener can open the uri and should be automatically selected over any
+		 * default openers, include the built-in one from VS Code.
+		 *
+		 * A preferred opener will be automatically selected if no other preferred openers
+		 * are available. If multiple preferred openers are available, then the user
+		 * is shown a prompt with all potential openers (not just preferred openers).
+		 */
+		Preferred = 3,
+	}
+
+	/**
+	 * Handles opening uris to external resources, such as http(s) links.
+	 *
+	 * Extensions can implement an `ExternalUriOpener` to open `http` links to a webserver
+	 * inside of VS Code instead of having the link be opened by the web browser.
 	 *
 	 * Currently openers may only be registered for `http` and `https` uris.
 	 */
 	export interface ExternalUriOpener {
 
 		/**
-		 * Try to open a given uri.
+		 * Check if the opener can open a uri.
 		 *
-		 * @param uri The uri to open. This uri may have been transformed by port forwarding. To access
-		 * the original uri that triggered the open, use `ctx.original`.
-		 * @param ctx Additional metadata about the triggered open.
-		 * @param token Cancellation token.
+		 * @param uri The uri being opened. This is the uri that the user clicked on. It has
+		 * not yet gone through port forwarding.
+		 * @param token Cancellation token indicating that the result is no longer needed.
 		 *
-		 * @return Optional command that opens the uri. If no command is returned, VS Code will
-		 * continue checking to see if any other openers are available.
-		 *
-		 * This command is given the resolved uri to open. This may be different from the original `uri` due
-		 * to port forwarding.
-		 *
-		 * If multiple openers are available for a given uri, then the `Command.title` is shown in the UI.
+		 * @return Priority indicating if the opener can open the external uri.
 		 */
-		openExternalUri(uri: Uri, ctx: OpenExternalUriContext, token: CancellationToken): ProviderResult<Command>;
+		canOpenExternalUri(uri: Uri, token: CancellationToken): ExternalUriOpenerPriority | Thenable<ExternalUriOpenerPriority>;
+
+		/**
+		 * Open a uri.
+		 *
+		 * This is invoked when:
+		 *
+		 * - The user clicks a link which does not have an assigned opener. In this case, first `canOpenExternalUri`
+		 *   is called and if the user selects this opener, then `openExternalUri` is called.
+		 * - The user sets the default opener for a link in their settings and then visits a link.
+		 *
+		 * @param resolvedUri The uri to open. This uri may have been transformed by port forwarding, so it
+		 * may not match the original uri passed to `canOpenExternalUri`. Use `ctx.originalUri` to check the
+		 * original uri.
+		 * @param ctx Additional information about the uri being opened.
+		 * @param token Cancellation token indicating that opening has been canceled.
+		 *
+		 * @return Thenable indicating that the opening has completed.
+		 */
+		openExternalUri(resolvedUri: Uri, ctx: OpenExternalUriContext, token: CancellationToken): Thenable<void> | void;
+	}
+
+	/**
+	 * Additional information about the uri being opened.
+	 */
+	interface OpenExternalUriContext {
+		/**
+		 * The uri that triggered the open.
+		 *
+		 * This is the original uri that the user clicked on or that was passed to `openExternal.`
+		 * Due to port forwarding, this may not match the `resolvedUri` passed to `openExternalUri`.
+		 */
+		readonly sourceUri: Uri;
+	}
+
+	/**
+	 * Additional metadata about a registered `ExternalUriOpener`.
+	 */
+	interface ExternalUriOpenerMetadata {
+
+		/**
+		 * List of uri schemes the opener is triggered for.
+		 *
+		 * Currently only `http` and `https` are supported.
+		 */
+		readonly schemes: readonly string[]
+
+		/**
+		 * Text displayed to the user that explains what the opener does.
+		 *
+		 * For example, 'Open in browser preview'
+		 */
+		readonly label: string;
 	}
 
 	namespace window {
@@ -2348,50 +2529,51 @@ declare module 'vscode' {
 		 *
 		 * When a uri is about to be opened, an `onUriOpen:SCHEME` activation event is fired.
 		 *
-		 * @param schemes List of uri schemes the opener is triggered for. Currently only `http`
-		 * and `https` are supported.
+		 * @param id Unique id of the opener, such as `myExtension.browserPreview`. This is used in settings
+		 *   and commands to identify the opener.
 		 * @param opener Opener to register.
+		 * @param metadata Additional information about the opener.
 		 *
 		* @returns Disposable that unregisters the opener.
+		*/
+		export function registerExternalUriOpener(id: string, opener: ExternalUriOpener, metadata: ExternalUriOpenerMetadata): Disposable;
+	}
+
+	interface OpenExternalOptions {
+		/**
+		 * Allows using openers contributed by extensions through  `registerExternalUriOpener`
+		 * when opening the resource.
+		 *
+		 * If `true`, VS Code will check if any contributed openers can handle the
+		 * uri, and fallback to the default opener behavior.
+		 *
+		 * If it is string, this specifies the id of the `ExternalUriOpener`
+		 * that should be used if it is available. Use `'default'` to force VS Code's
+		 * standard external opener to be used.
 		 */
-		export function registerExternalUriOpener(schemes: readonly string[], opener: ExternalUriOpener,): Disposable;
+		readonly allowContributedOpeners?: boolean | string;
+	}
+
+	namespace env {
+		export function openExternal(target: Uri, options?: OpenExternalOptions): Thenable<boolean>;
+	}
+
+	//endregionn
+
+	//#region https://github.com/Microsoft/vscode/issues/15178
+
+	// TODO@API must be a class
+	export interface OpenEditorInfo {
+		name: string;
+		resource: Uri;
+	}
+
+	export namespace window {
+		export const openEditors: ReadonlyArray<OpenEditorInfo>;
+
+		// todo@API proper event type
+		export const onDidChangeOpenEditors: Event<void>;
 	}
 
 	//#endregion
-
-	/**
-	 * Represents a storage utility for secrets, information that is
-	 * sensitive.
-	 */
-	export interface SecretStorage {
-		/**
-		 * Retrieve a secret that was stored with key. Returns undefined if there
-		 * is no password matching that key.
-		 * @param key The key the password was stored under.
-		 * @returns The stored value or `undefined`.
-		 */
-		get(key: string): Thenable<string | undefined>;
-
-		/**
-		 * Store a secret under a given key.
-		 * @param key The key to store the password under.
-		 * @param value The password.
-		 */
-		set(key: string, value: string): Thenable<void>;
-
-		/**
-		 * Remove a secret from storage.
-		 * @param key The key the password was stored under.
-		 */
-		delete(key: string): Thenable<void>;
-
-		/**
-		 * Fires when a secret is set or deleted.
-		 */
-		onDidChange: Event<void>;
-	}
-
-	export interface ExtensionContext {
-		secrets: SecretStorage;
-	}
 }

--- a/src/dotnet-interactive-vscode/update-proposed-api.ps1
+++ b/src/dotnet-interactive-vscode/update-proposed-api.ps1
@@ -1,2 +1,4 @@
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/microsoft/vscode/master/src/vs/vscode.d.ts" -OutFile "$PSScriptRoot\src\vscode\vscode.d.ts"
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/microsoft/vscode/master/src/vs/vscode.proposed.d.ts" -OutFile "$PSScriptRoot\src\vscode\vscode.proposed.d.ts"
+$branchName = "release/1.53"
+
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/microsoft/vscode/$branchName/src/vs/vscode.d.ts" -OutFile "$PSScriptRoot\src\vscode\vscode.d.ts"
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/microsoft/vscode/$branchName/src/vs/vscode.proposed.d.ts" -OutFile "$PSScriptRoot\src\vscode\vscode.proposed.d.ts"


### PR DESCRIPTION
Purely by accident, our extension works on stable VS Code instead of Insiders like we advertise.  This PR simply makes that official by pulling in the appropriate *.d.ts files from VS Code.

In the future we'll split out a separate Insiders-only version of the extension for rapid development, but that will require figuring out some infrastructure trickery, so in the meantime I've made it so that by default our extension provides support for our own .ipynb files, _but_ if (1) the extension is running an insiders build, (2) the Jupyter extension is installed, and (3) a new option is checked (default `false`), then we'll allow the Jupyter extension to handle the .ipynb file format for us.  This buys us some time until we figure out how to properly split the extension.

There are also some additional changes that recently popped up, including:

1. When our kernel is selected for a given notebook, always set the document metadata to contain our Jupyter kernelspec settings to allow that notebook to be directly opened in Jupyter Lab.
2. When a .ipynb is opened with the Jupyter extension (following the strict options set above), we sniff out the kernelspec data and if it looks like it's probably one of ours, we say that our kernel is the preferred one.  This will make the scenario where a user is given a notebook from a Jupyter Lab user and they open it on a machine with only VS Code installed, then we will be appropriately selected as the kernel.  If we don't see the appropriate metadata, we'll still return a non-preferred version of our kernel so it can always be manually selected.

Future work to be done includes:
1. When we're using the Jupyter extension to handle the file and a new notebook is created, when the notebook is eventually saved we have no way of reassociating `Untitled-1.ipynb` to `C:\MyNotebook.ipynb`.