### PR TITLE
don't crash when required ipynb fields are missing

### DIFF
--- a/src/Microsoft.DotNet.Interactive/Notebook/NullableJsonElementExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/Notebook/NullableJsonElementExtensions.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Microsoft.DotNet.Interactive.Notebook
+{
+    internal static class NullableJsonElementExtensions
+    {
+        public static IEnumerable<JsonElement> EnumerateArray(this JsonElement? jsonElement)
+        {
+            return (jsonElement?.EnumerateArray() as IEnumerable<JsonElement>) ?? Array.Empty<JsonElement>();
+        }
+
+        public static string GetRawText(this JsonElement? jsonElement)
+        {
+            return jsonElement?.GetRawText() ?? "{}";
+        }
+
+        public static string GetString(this JsonElement? jsonElement)
+        {
+            return jsonElement?.GetString();
+        }
+    }
+}


### PR DESCRIPTION
When parsing a Jupyter notebook (.ipynb) if there are missing fields, System.Text.Json will throw where Newtonsoft.Json would return `null`.  This adds tests for those missing cases and removes all calls to `.GetProperty()` with a safe variant that we already had.  Some convenience extension methods were added for `Nullable<JsonElement>`.

Fixes #1039.