### PR TITLE
load doc comments from xml files when available

### DIFF
--- a/src/Microsoft.DotNet.Interactive.CSharp/CompletionExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/CompletionExtensions.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Tags;
 using Microsoft.DotNet.Interactive.Events;
+using RoslynCompletionDescription = Microsoft.CodeAnalysis.Completion.CompletionDescription;
 using RoslynCompletionItem = Microsoft.CodeAnalysis.Completion.CompletionItem;
 
 namespace Microsoft.DotNet.Interactive.CSharp
@@ -50,14 +49,15 @@ namespace Microsoft.DotNet.Interactive.CSharp
             return null;
         }
 
-        public static CompletionItem ToModel(this RoslynCompletionItem item)
+        public static CompletionItem ToModel(this RoslynCompletionItem item, RoslynCompletionDescription description)
         {
             return new CompletionItem(
                 displayText: item.DisplayText,
                 kind: item.GetKind(),
                 filterText: item.FilterText,
                 sortText: item.SortText,
-                insertText: item.FilterText);
+                insertText: item.FilterText,
+                documentation: description.Text);
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/CompletionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/CompletionTests.cs
@@ -316,5 +316,130 @@ var y = x + 2;
                 .Should()
                 .Be(new LinePositionSpan(new LinePosition(line, 0), new LinePosition(line, 3)));
         }
+
+        [Theory]
+        [InlineData(Language.CSharp, "/// <summary>Adds two numbers.</summary>\nint Add(int a, int b) => a + b;", "Ad$$", "Adds two numbers.")]
+        [InlineData(Language.FSharp, "/// Adds two numbers.\nlet add a b = a + b", "ad$$", "Adds two numbers.")]
+        public async Task completion_doc_comments_can_be_loaded_from_source_in_a_previous_submission(Language language, string previousSubmission, string markupCode, string expectedCompletionSubString)
+        {
+            using var kernel = CreateKernel(language);
+
+            await SubmitCode(kernel, previousSubmission);
+
+            MarkupTestFile.GetLineAndColumn(markupCode, out var code, out var line, out var character);
+            await kernel.SendAsync(new RequestCompletions(code, new LinePosition(line, character)));
+
+            KernelEvents
+                .Should()
+                .ContainSingle<CompletionsProduced>()
+                .Which
+                .Completions
+                .Should()
+                .ContainSingle(ci => ci.Documentation != null && ci.Documentation.Contains(expectedCompletionSubString));
+        }
+
+        [Theory]
+        [InlineData(Language.CSharp)]
+        [InlineData(Language.FSharp)]
+        public async Task completion_contains_doc_comments_from_individually_referenced_assemblies_with_xml_files(Language language)
+        {
+            using var assembly = new TestAssemblyReference("Project", "netstandard2.0", "Program.cs", @"
+public class C
+{
+    /// <summary>This is the answer.</summary>
+    public static int TheAnswer => 42;
+}
+");
+            var assemblyPath = await assembly.BuildAndGetPathToAssembly();
+
+            var assemblyReferencePath = language switch
+            {
+                Language.CSharp => assemblyPath,
+                Language.FSharp => assemblyPath.Replace("\\", "\\\\")
+            };
+
+            using var kernel = CreateKernel(language);
+
+            await SubmitCode(kernel, $"#r \"{assemblyReferencePath}\"");
+
+            var markupCode = "C.TheAns$$";
+
+            MarkupTestFile.GetLineAndColumn(markupCode, out var code, out var line, out var character);
+            await kernel.SendAsync(new RequestCompletions(code, new LinePosition(line, character)));
+
+            KernelEvents
+                .Should()
+                .ContainSingle<CompletionsProduced>()
+                .Which
+                .Completions
+                .Should()
+                .ContainSingle(ci => ci.Documentation != null && ci.Documentation.Contains("This is the answer."));
+        }
+
+        [Fact]
+        public async Task csharp_completions_can_read_doc_comments_from_nuget_packages_after_forcing_the_assembly_to_load()
+        {
+            using var kernel = CreateKernel(Language.CSharp);
+
+            await SubmitCode(kernel, "#r \"nuget: Newtonsoft.Json, 12.0.3\"");
+
+            // The following line forces the assembly and the doc comments to be loaded
+            await SubmitCode(kernel, "var _unused = Newtonsoft.Json.JsonConvert.Null;");
+
+            var markupCode = "Newtonsoft.Json.JsonConvert.Nu$$";
+
+            MarkupTestFile.GetLineAndColumn(markupCode, out var code, out var line, out var character);
+            await kernel.SendAsync(new RequestCompletions(code, new LinePosition(line, character)));
+
+            KernelEvents
+                .Should()
+                .ContainSingle<CompletionsProduced>()
+                .Which
+                .Completions
+                .Should()
+                .ContainSingle(ci => ci.Documentation != null && ci.Documentation.Contains("Represents JavaScript's null as a string. This field is read-only."));
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/interactive/issues/1071  N.b., the preceeding test can be deleted when this one is fixed.")]
+        public async Task csharp_completions_can_read_doc_comments_from_nuget_packages()
+        {
+            using var kernel = CreateKernel(Language.CSharp);
+
+            await SubmitCode(kernel, "#r \"nuget: Newtonsoft.Json, 12.0.3\"");
+
+            var markupCode = "Newtonsoft.Json.JsonConvert.Nu$$";
+
+            MarkupTestFile.GetLineAndColumn(markupCode, out var code, out var line, out var character);
+            await kernel.SendAsync(new RequestCompletions(code, new LinePosition(line, character)));
+
+            KernelEvents
+                .Should()
+                .ContainSingle<CompletionsProduced>()
+                .Which
+                .Completions
+                .Should()
+                .ContainSingle(ci => ci.Documentation != null && ci.Documentation.Contains("Represents JavaScript's null as a string. This field is read-only."));
+        }
+
+        [Fact]
+        public async Task fsharp_completions_can_read_doc_comments_from_nuget_packages()
+        {
+            using var kernel = CreateKernel(Language.FSharp);
+
+            await SubmitCode(kernel, "#r \"nuget: Newtonsoft.Json, 12.0.3\"");
+
+            var markupCode = "Newtonsoft.Json.JsonConvert.Nu$$";
+
+            MarkupTestFile.GetLineAndColumn(markupCode, out var code, out var line, out var character);
+            await kernel.SendAsync(new RequestCompletions(code, new LinePosition(line, character)));
+
+            KernelEvents
+                .Should()
+                .ContainSingle<CompletionsProduced>()
+                .Which
+                .Completions
+                .Should()
+                .ContainSingle(ci => ci.Documentation != null && ci.Documentation.Contains("Represents JavaScript's null as a string. This field is read-only."));
+        }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/SignatureHelpTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/SignatureHelpTests.cs
@@ -149,7 +149,7 @@ public class SampleClass
         }
 
         [Fact]
-        public async Task csharp_signature_hep_can_read_doc_comments_from_nuget_packages_after_forcing_the_assembly_to_load()
+        public async Task csharp_signature_help_can_read_doc_comments_from_nuget_packages_after_forcing_the_assembly_to_load()
         {
             using var kernel = CreateKernel(Language.CSharp);
 

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/SignatureHelpTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/SignatureHelpTests.cs
@@ -173,7 +173,7 @@ public class SampleClass
         }
 
         [Fact(Skip = "https://github.com/dotnet/interactive/issues/1071  N.b., the preceeding test can be deleted when this one is fixed.")]
-        public async Task csharp_signature_hep_can_read_doc_comments_from_nuget_packages()
+        public async Task csharp_signature_help_can_read_doc_comments_from_nuget_packages()
         {
             using var kernel = CreateKernel(Language.CSharp);
 

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/SignatureHelpTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/SignatureHelpTests.cs
@@ -9,6 +9,7 @@ using Microsoft.DotNet.Interactive.Tests.Utility;
 using Xunit;
 using Xunit.Abstractions;
 
+#pragma warning disable 8509
 namespace Microsoft.DotNet.Interactive.Tests.LanguageServices
 {
     public class SignatureHelpTests : LanguageKernelTestBase
@@ -114,6 +115,82 @@ namespace Microsoft.DotNet.Interactive.Tests.LanguageServices
                 .Documentation.Value
                 .Should()
                 .Be(expectedMethodDocumentation);
+        }
+
+        [Fact]
+        public async Task csharp_signature_help_contains_doc_comments_from_individually_referenced_assemblies_with_xml_files()
+        {
+            using var assembly = new TestAssemblyReference("Project", "netstandard2.0", "Program.cs", @"
+public class SampleClass
+{
+    /// <summary>A sample class constructor.</summary>
+    public SampleClass() { }
+}
+");
+            var assemblyPath = await assembly.BuildAndGetPathToAssembly();
+
+            using var kernel = CreateKernel(Language.CSharp);
+
+            await SubmitCode(kernel, $"#r \"{assemblyPath}\"");
+
+            var markupCode = "new SampleClass($$";
+
+            MarkupTestFile.GetLineAndColumn(markupCode, out var code, out var line, out var column);
+
+            await kernel.SendAsync(new RequestSignatureHelp(code, new LinePosition(line, column)));
+
+            KernelEvents
+                .Should()
+                .ContainSingle<SignatureHelpProduced>()
+                .Which
+                .Signatures
+                .Should()
+                .ContainSingle(sh => sh.Documentation.Value.Contains("A sample class constructor."));
+        }
+
+        [Fact]
+        public async Task csharp_signature_hep_can_read_doc_comments_from_nuget_packages_after_forcing_the_assembly_to_load()
+        {
+            using var kernel = CreateKernel(Language.CSharp);
+
+            await SubmitCode(kernel, "#r \"nuget: Newtonsoft.Json, 12.0.3\"");
+
+            // The following line forces the assembly and the doc comments to be loaded
+            await SubmitCode(kernel, "var _unused = Newtonsoft.Json.JsonConvert.Null;");
+
+            var markupCode = "Newtonsoft.Json.JsonConvert.DeserializeObject($$";
+
+            MarkupTestFile.GetLineAndColumn(markupCode, out var code, out var line, out var character);
+            await kernel.SendAsync(new RequestSignatureHelp(code, new LinePosition(line, character)));
+
+            KernelEvents
+                .Should()
+                .ContainSingle<SignatureHelpProduced>()
+                .Which
+                .Signatures
+                .Should()
+                .ContainSingle(sh => sh.Documentation.Value.Contains("Deserializes the JSON to a .NET object."));
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/interactive/issues/1071  N.b., the preceeding test can be deleted when this one is fixed.")]
+        public async Task csharp_signature_hep_can_read_doc_comments_from_nuget_packages()
+        {
+            using var kernel = CreateKernel(Language.CSharp);
+
+            await SubmitCode(kernel, "#r \"nuget: Newtonsoft.Json, 12.0.3\"");
+
+            var markupCode = "Newtonsoft.Json.JsonConvert.DeserializeObject($$";
+
+            MarkupTestFile.GetLineAndColumn(markupCode, out var code, out var line, out var character);
+            await kernel.SendAsync(new RequestSignatureHelp(code, new LinePosition(line, character)));
+
+            KernelEvents
+                .Should()
+                .ContainSingle<SignatureHelpProduced>()
+                .Which
+                .Signatures
+                .Should()
+                .ContainSingle(sh => sh.Documentation.Value.Contains("Deserializes the JSON to a .NET object."));
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Tests/Utility/TemporaryDirectory.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Utility/TemporaryDirectory.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+
+namespace Microsoft.DotNet.Interactive.Tests.Utility
+{
+    public class TemporaryDirectory : IDisposable
+    {
+        public DirectoryInfo Directory { get; }
+
+        public TemporaryDirectory(params (string relativePath, string content)[] contents)
+        {
+            var tempPath = Path.GetTempPath();
+            var dirName = Guid.NewGuid().ToString();
+            var fullPath = Path.Combine(tempPath, dirName);
+            var parentDirectory = new DirectoryInfo(fullPath);
+            Directory = DirectoryUtility.CreateDirectory(parentDirectory: parentDirectory);
+            DirectoryUtility.Populate(Directory, contents);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Interactive.Tests/Utility/TestAssemblyReference.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Utility/TestAssemblyReference.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Interactive.Utility;
+
+namespace Microsoft.DotNet.Interactive.Tests.Utility
+{
+    public class TestAssemblyReference : IDisposable
+    {
+        public string ProjectName { get; }
+        public string TargetFramework { get; }
+        public TemporaryDirectory Directory { get; }
+
+        public TestAssemblyReference(string projectName, string targetFramework, string sourceFileName, string sourceFileContents)
+        {
+            ProjectName = projectName;
+            TargetFramework = targetFramework;
+            Directory = new TemporaryDirectory(
+                ($"{ProjectName}.csproj", $@"
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>{TargetFramework}</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+</Project>"),
+                (sourceFileName, sourceFileContents)
+            );
+        }
+
+        public async Task<string> BuildAndGetPathToAssembly()
+        {
+            var dotnet = new Dotnet(Directory.Directory);
+            var result = await dotnet.Build();
+            result.ThrowOnFailure("Failed to build sample assembly");
+            var assemblyPath = Path.Combine(Directory.Directory.FullName, "bin", "Debug", TargetFramework, $"{ProjectName}.dll");
+            if (!File.Exists(assemblyPath))
+            {
+                throw new Exception($"The expected assembly was not found at path '{assemblyPath}'.");
+            }
+
+            return assemblyPath;
+        }
+
+        public void Dispose()
+        {
+            Directory.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
This loads doc comments from `.xml` files that are next to `.dll` files and ensures that data is passed through to the events.

For all the currently supported language services (completion, hover, sighelp) I've added tests that cover retrieving doc comments from (source, assembly reference, NuGet package).

Filed issue #1071 to track some edge cases around NuGet and C# doc comments.
Filed issue #1072 to track loading doc comments from BCL/Framework types.

Fixes #626 (added test).
Fixes #628 (added test).
Fixes #727 (added test).