### PR TITLE
remove noise in lock files for local packages

### DIFF
--- a/src/dotnet-interactive-vscode/Clear-PackageSha.ps1
+++ b/src/dotnet-interactive-vscode/Clear-PackageSha.ps1
@@ -1,0 +1,23 @@
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+[CmdletBinding(PositionalBinding=$false)]
+param (
+    [string]$projectJsonLockPath,
+    [string]$packageName
+)
+
+Set-StrictMode -version 2.0
+$ErrorActionPreference = "Stop"
+
+try {
+    $packageJsonLockContents = Get-Content $projectJsonLockPath | Out-String | ConvertFrom-Json
+    $packageJsonLockContents."dependencies"."$packageName".PSObject.Properties.Remove("integrity")
+    $packageJsonLockContents | ConvertTo-Json -depth 100 | Out-File $projectJsonLockPath
+}
+catch {
+    Write-Host $_
+    Write-Host $_.Exception
+    Write-Host $_.ScriptStackTrace
+    exit 1
+}

--- a/src/dotnet-interactive-vscode/build-deps.ps1
+++ b/src/dotnet-interactive-vscode/build-deps.ps1
@@ -4,26 +4,7 @@
 Set-StrictMode -version 2.0
 $ErrorActionPreference = "Stop"
 
-function Get-Integrity([string] $filePath) {
-    $hash = (Get-FileHash $filePath -Algorithm SHA512).Hash
-    $bytes = (0..($hash.Length / 2)) | ForEach-Object { [System.Convert]::ToByte($hash.Substring($_, 2), 16) }
-    return [System.Convert]::ToBase64String($bytes)
-}
-
-function Update-PackageSha([string] $projectJsonLockPath, [string] $packageName, [string] $packageTarball) {
-    $packageJsonLockContents = Get-Content $projectJsonLockPath | Out-String | ConvertFrom-Json
-    # TEMP: Don't compute integrity hash, just delete it
-    # $hash = Get-Integrity -filePath $packageTarball
-    # $packageJsonLockContents."dependencies"."$packageName"."integrity" = "sha512-$hash"
-    $packageJsonLockContents."dependencies"."$packageName".PSObject.Properties.Remove("integrity")
-    $packageJsonLockContents | ConvertTo-Json -depth 100 | Out-File $projectJsonLockPath
-}
-
 try {
-    $interfacesTarball = "$PSScriptRoot/src/interfaces/vscode-interfaces-1.0.0.tgz"
-    $insidersTarball = "$PSScriptRoot/src/vscode/insiders/vscode-insiders-1.0.0.tgz"
-    $stableTarball = "$PSScriptRoot/src/vscode/stable/vscode-stable-1.0.0.tgz"
-
     # Build-Interfaces
     Push-Location "$PSScriptRoot/src/interfaces"
     npm install; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
@@ -32,25 +13,25 @@ try {
     Pop-Location
 
     # Build insiders
-    Update-PackageSha -projectJsonLockPath "$PSScriptRoot/src/vscode/insiders/package-lock.json" -packageName "vscode-interfaces" -packageTarball $interfacesTarball
+    . "$PSScriptRoot/Clear-PackageSha.ps1" -projectJsonLockPath "$PSScriptRoot/src/vscode/insiders/package-lock.json" -packageName "vscode-interfaces"; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
     Push-Location "$PSScriptRoot/src/vscode/insiders"
     npm install; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
     npm run compile; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
     npm pack; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
     Pop-Location
+    . "$PSScriptRoot/Clear-PackageSha.ps1" -projectJsonLockPath "$PSScriptRoot/src/vscode/insiders/package-lock.json" -packageName "vscode-interfaces"; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     # Build stable
-    Update-PackageSha -projectJsonLockPath "$PSScriptRoot/src/vscode/stable/package-lock.json" -packageName "vscode-interfaces" -packageTarball $interfacesTarball
+    . "$PSScriptRoot/Clear-PackageSha.ps1" -projectJsonLockPath "$PSScriptRoot/src/vscode/stable/package-lock.json" -packageName "vscode-interfaces"; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
     Push-Location "$PSScriptRoot/src/vscode/stable"
     npm install; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
     npm run compile; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
     npm pack; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
     Pop-Location
+    . "$PSScriptRoot/Clear-PackageSha.ps1" -projectJsonLockPath "$PSScriptRoot/src/vscode/stable/package-lock.json" -packageName "vscode-interfaces"; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     # Root project
-    Update-PackageSha -projectJsonLockPath "$PSScriptRoot/package-lock.json" -packageName "vscode-interfaces" -packageTarball $interfacesTarball
-    Update-PackageSha -projectJsonLockPath "$PSScriptRoot/package-lock.json" -packageName "vscode-insiders" -packageTarball $insidersTarball
-    Update-PackageSha -projectJsonLockPath "$PSScriptRoot/package-lock.json" -packageName "vscode-stable" -packageTarball $stableTarball
+    ./clean-deps.ps1
 }
 catch {
     Write-Host $_

--- a/src/dotnet-interactive-vscode/clean-deps.ps1
+++ b/src/dotnet-interactive-vscode/clean-deps.ps1
@@ -1,0 +1,17 @@
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+Set-StrictMode -version 2.0
+$ErrorActionPreference = "Stop"
+
+try {
+    . "$PSScriptRoot/Clear-PackageSha.ps1" -projectJsonLockPath "$PSScriptRoot/package-lock.json" -packageName "vscode-interfaces"; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    . "$PSScriptRoot/Clear-PackageSha.ps1" -projectJsonLockPath "$PSScriptRoot/package-lock.json" -packageName "vscode-insiders"; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    . "$PSScriptRoot/Clear-PackageSha.ps1" -projectJsonLockPath "$PSScriptRoot/package-lock.json" -packageName "vscode-stable"; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+}
+catch {
+    Write-Host $_
+    Write-Host $_.Exception
+    Write-Host $_.ScriptStackTrace
+    exit 1
+}

--- a/src/dotnet-interactive-vscode/package-lock.json
+++ b/src/dotnet-interactive-vscode/package-lock.json
@@ -3064,14 +3064,12 @@
     },
     "vscode-insiders": {
       "version": "file:src/vscode/insiders/vscode-insiders-1.0.0.tgz",
-      "integrity": "sha512-KLKMWlk5dsPXtHR/vkAaMOJCa+crzGGxtjg3asBdiFRWrnV89UZiLHyx2CRjFMNINtCbmikIAeYQD0VELa1BYA==",
       "requires": {
         "vscode-interfaces": "file:src/interfaces/vscode-interfaces-1.0.0.tgz"
       }
     },
     "vscode-interfaces": {
-      "version": "file:src/interfaces/vscode-interfaces-1.0.0.tgz",
-      "integrity": "sha512-1FXFs67tzEyl4pt2u/GJ+mQ0UOzwaVlL2aoAz3uyWZcMpGxxA60nTS7gJXhdfOfiOWlmbFlx7jD6uEJ9Nl2HXg=="
+      "version": "file:src/interfaces/vscode-interfaces-1.0.0.tgz"
     },
     "vscode-oniguruma": {
       "version": "1.3.1",
@@ -3081,7 +3079,6 @@
     },
     "vscode-stable": {
       "version": "file:src/vscode/stable/vscode-stable-1.0.0.tgz",
-      "integrity": "sha512-BrWYk6QqZNXAcji3mkYX77zWfdGyi/bteFwZiF+p5MET4JZglOCGgg/Fr5fVrnSTTjdrF4hZIQ9fDu6IZM0IcQ==",
       "requires": {
         "vscode-interfaces": "file:src/interfaces/vscode-interfaces-1.0.0.tgz"
       }

--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -262,8 +262,8 @@
   "scripts": {
     "clean-packages": "npx del-cli --force \"node_modules/**/vscode-*-1.0.0.tgz\"",
     "vscode:prepublish": "npm run compile && npm run clean-packages",
-    "build-deps": "pwsh ./build-deps.ps1",
-    "preinstall": "npm run build-deps",
+    "preinstall": "pwsh ./build-deps.ps1",
+    "postshrinkwrap": "pwsh ./clean-deps.ps1",
     "compile": "tsc -p ./",
     "lint:interfaces": "npm --prefix ./src/interfaces run lint",
     "lint:insiders": "npm --prefix ./src/vscode/insiders run lint",

--- a/src/dotnet-interactive-vscode/src/vscode/insiders/package-lock.json
+++ b/src/dotnet-interactive-vscode/src/vscode/insiders/package-lock.json
@@ -1186,8 +1186,7 @@
       "dev": true
     },
     "vscode-interfaces": {
-      "version": "file:../../interfaces/vscode-interfaces-1.0.0.tgz",
-      "integrity": "sha512-1FXFs67tzEyl4pt2u/GJ+mQ0UOzwaVlL2aoAz3uyWZcMpGxxA60nTS7gJXhdfOfiOWlmbFlx7jD6uEJ9Nl2HXg=="
+      "version": "file:../../interfaces/vscode-interfaces-1.0.0.tgz"
     },
     "which": {
       "version": "1.3.1",

--- a/src/dotnet-interactive-vscode/src/vscode/stable/package-lock.json
+++ b/src/dotnet-interactive-vscode/src/vscode/stable/package-lock.json
@@ -1186,8 +1186,7 @@
       "dev": true
     },
     "vscode-interfaces": {
-      "version": "file:../../interfaces/vscode-interfaces-1.0.0.tgz",
-      "integrity": "sha512-1FXFs67tzEyl4pt2u/GJ+mQ0UOzwaVlL2aoAz3uyWZcMpGxxA60nTS7gJXhdfOfiOWlmbFlx7jD6uEJ9Nl2HXg=="
+      "version": "file:../../interfaces/vscode-interfaces-1.0.0.tgz"
     },
     "which": {
       "version": "1.3.1",


### PR DESCRIPTION
Slightly refactor our building of sub-projects to reduce the churn in the package-lock files for the locally produced packages.