### PR TITLE
default to using the jupyter extension

### DIFF
--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -117,10 +117,10 @@
           "default": "1.0.211604",
           "description": "The minimum required version of the .NET Interactive tool."
         },
-        "dotnet-interactive.useJupyterExtensionForIpynbFiles": {
+        "dotnet-interactive.useDotNetInteractiveExtensionForIpynbFiles": {
           "type": "boolean",
           "default": false,
-          "description": "(EXPERIMENTAL) Use the Jupyter extension to handle .ipynb files if possible (requires restart)."
+          "description": "(LEGACY) Use the .NET Interactive extension to handle .ipynb files (requires restart)."
         }
       }
     },

--- a/src/dotnet-interactive-vscode/src/vscode/extension.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/extension.ts
@@ -72,8 +72,15 @@ export async function activate(context: vscode.ExtensionContext) {
     const hostVersionSuffix = isInsidersBuild() ? 'Insiders' : 'Stable';
     diagnosticsChannel.appendLine(`Extension started for VS Code ${hostVersionSuffix}.`);
 
+    // Default to using the Jupyter extension for .ipynb handling if the extension is present, unless the user has
+    // specified otherwise.
     const jupyterExtensionIsPresent = vscode.extensions.getExtension('ms-toolsai.jupyter') !== undefined;
-    const useJupyterExtension = isInsidersBuild() && jupyterExtensionIsPresent && (config.get<boolean>('useJupyterExtensionForIpynbFiles') || false);
+    let useJupyterExtension = jupyterExtensionIsPresent;
+    const forceDotNetIpynbHandling = config.get<boolean>('useDotNetInteractiveExtensionForIpynbFiles') || false;
+    if (forceDotNetIpynbHandling) {
+        useJupyterExtension = false;
+    }
+
     registerFileCommands(context, clientMapper, useJupyterExtension);
 
     const diagnosticDelay = config.get<number>('liveDiagnosticDelay') || 500; // fall back to something reasonable


### PR DESCRIPTION
This switches to using the Jupyter extension by default in both stable and insiders and allows an explicit override to force our own handling via an option.

I have not yet added a direct dependency on the Jupyter extension because there are currently some broken APIs when using that against insiders that prevent our extension from properly registering, so I'm leaving open the fallback of disabling the Jupyter extension and allowing our own ipynb handling to be used.  Once the Jupyter extension has been updated to work on insiders again, I'll come back and directly add our dependency on it via `package.json`.

Fixes #1060.