### PR TITLE
auto-acquire an sdk if it's not found

### DIFF
--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -50,7 +50,7 @@
   ],
   "main": "./out/vscode/extension.js",
   "extensionDependencies": [
-    "ms-dotnettools.vscode-dotnet-runtime"
+    "ms-dotnettools.vscode-dotnet-sdk"
   ],
   "contributes": {
     "notebookProvider": [

--- a/src/dotnet-interactive-vscode/src/vscode/extension.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/extension.ts
@@ -164,7 +164,7 @@ async function getDotnetPath(outputChannel: OutputChannelAdapter): Promise<strin
     if (await isDotnetUpToDate(minDotNetSdkVersion!)) {
         dotnetPath = 'dotnet';
     } else {
-        const commandResult = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', { version: minDotNetSdkVersion, requestingExtensionId: 'ms-dotnettools.dotnet-interactive-vscode' });
+        const commandResult = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet-sdk.acquire', { version: minDotNetSdkVersion, requestingExtensionId: 'ms-dotnettools.dotnet-interactive-vscode' });
         dotnetPath = commandResult!.dotnetPath;
     }
 


### PR DESCRIPTION
If the command `dotnet` isn't present or it's not an appropriate version, auto-acquire an SDK and use that.

We would previously acquire a runtime, because that's all we had access to.  Most scenarios would work _except_ `#r "nuget:..."` because that uses the full SDK, but now that we acquire an SDK, all NuGet scenarios will work, even if there's no SDK installed on the machine.