### PR TITLE
revert dependency on sdk acquisition and cache location of dotnet tool

### DIFF
--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -50,7 +50,7 @@
   ],
   "main": "./out/vscode/extension.js",
   "extensionDependencies": [
-    "ms-dotnettools.vscode-dotnet-sdk"
+    "ms-dotnettools.vscode-dotnet-runtime"
   ],
   "contributes": {
     "notebookProvider": [

--- a/src/dotnet-interactive-vscode/src/tests/unit/acquisition.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/acquisition.test.ts
@@ -9,6 +9,7 @@ use(require('chai-fs'));
 
 import { acquireDotnetInteractive } from '../../acquisition';
 import { InstallInteractiveArgs } from '../../interfaces';
+import { computeToolInstallArguments } from '../../utilities';
 import { withFakeGlobalStorageLocation } from './utilities';
 
 describe('Acquisition tests', () => {
@@ -322,6 +323,33 @@ describe('Acquisition tests', () => {
                 expect(globalStoragePath).to.be.a.directory();
                 resolve();
             });
+        });
+    });
+
+    it('install arguments are computed from `undefined`', () => {
+        const installArgs = computeToolInstallArguments(undefined);
+        expect(installArgs).to.deep.equal({
+            dotnetPath: 'dotnet',
+            toolVersion: undefined,
+        });
+    });
+
+    it('install arguments are computed from `string`', () => {
+        const installArgs = computeToolInstallArguments('some/path/to/dotnet');
+        expect(installArgs).to.deep.equal({
+            dotnetPath: 'some/path/to/dotnet',
+            toolVersion: undefined,
+        });
+    });
+
+    it('install arguments are computed from an existing install arguments object', () => {
+        const installArgs = computeToolInstallArguments({
+            dotnetPath: 'some/path/to/dotnet',
+            toolVersion: 'some-tool-version',
+        });
+        expect(installArgs).to.deep.equal({
+            dotnetPath: 'some/path/to/dotnet',
+            toolVersion: 'some-tool-version',
         });
     });
 });

--- a/src/dotnet-interactive-vscode/src/tests/unit/client.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/client.test.ts
@@ -398,7 +398,7 @@ describe('InteractiveClient tests', () => {
         let transportCreated = false;
         const clientMapper = new ClientMapper(async (_notebookPath) => {
             if (transportCreated) {
-                throw 'transport already created; this function should not have been called again';
+                throw new Error('transport already created; this function should not have been called again');
             }
 
             transportCreated = true;

--- a/src/dotnet-interactive-vscode/src/utilities.ts
+++ b/src/dotnet-interactive-vscode/src/utilities.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import * as path from 'path';
-import { ProcessStart } from "./interfaces";
+import { InstallInteractiveArgs, ProcessStart } from "./interfaces";
 import { Uri } from 'dotnet-interactive-vscode-interfaces/out/notebook';
 
 export function processArguments(template: { args: Array<string>, workingDirectory: string }, notebookPath: string, fallbackWorkingDirectory: string, dotnetPath: string, globalStoragePath: string): ProcessStart {
@@ -140,4 +140,19 @@ export function isDotNetKernelPreferred(filename: string, fileMetadata: any): bo
         default:
             return false;
     }
+}
+
+export function computeToolInstallArguments(args: InstallInteractiveArgs | string | undefined): InstallInteractiveArgs {
+    let installArgs: InstallInteractiveArgs = {
+        dotnetPath: 'dotnet', // if nothing is specified, we have to fall back to _something_
+        toolVersion: undefined,
+    };
+
+    if (typeof args === 'string') {
+        installArgs.dotnetPath = args;
+    } else if (typeof args === 'object' && typeof args.dotnetPath === 'string') {
+        installArgs = args;
+    }
+
+    return installArgs;
 }

--- a/src/dotnet-interactive-vscode/src/vscode/commands.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/commands.ts
@@ -10,6 +10,8 @@ import { ClientMapper } from '../clientMapper';
 import { getEol, isUnsavedNotebook } from './vscodeUtilities';
 import { toNotebookDocument } from './notebookContentProvider';
 import { KernelId, updateCellMetadata } from './notebookKernel';
+import { setGlobalDotnetPath } from './extension';
+import { computeToolInstallArguments } from '../utilities';
 
 export function registerAcquisitionCommands(context: vscode.ExtensionContext) {
     const config = vscode.workspace.getConfiguration('dotnet-interactive');
@@ -17,20 +19,11 @@ export function registerAcquisitionCommands(context: vscode.ExtensionContext) {
     const interactiveToolSource = config.get<string>('interactiveToolSource');
 
     context.subscriptions.push(vscode.commands.registerCommand('dotnet-interactive.acquire', async (args?: InstallInteractiveArgs | string | undefined): Promise<InteractiveLaunchOptions> => {
-        if (!args) {
-            // unspecified; the best we can do is hope it's on the path
-            args = 'dotnet';
-        }
-
-        if (typeof args === 'string') {
-            args = {
-                dotnetPath: args,
-                toolVersion: undefined,
-            };
-        }
+        const installArgs = computeToolInstallArguments(args);
+        setGlobalDotnetPath(installArgs.dotnetPath);
 
         const launchOptions = await acquireDotnetInteractive(
-            args,
+            installArgs,
             minDotNetInteractiveVersion!,
             context.globalStorageUri.fsPath,
             getInteractiveVersion,


### PR DESCRIPTION
Revert #1088 because it's not as useful as we'd hope.

Also cache the location of the `dotnet` tool that was found _including_ if it was passed to our acquire command.  This means that if any other extension calls our `dotnet-interactive.acquire` command, whatever path they gave us for `dotnet`, we will save and use from then on forward.