### PR TITLE
don't crash the extension if the notebook couldn't be read or didn't exist

### DIFF
--- a/src/dotnet-interactive-vscode/src/vscode/extension.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/extension.ts
@@ -102,7 +102,7 @@ export async function activate(context: vscode.ExtensionContext) {
         viewType: ['dotnet-interactive-jupyter'],
         filenamePatter: '*.ipynb'
     };
-    const notebookContentProvider = new DotNetInteractiveNotebookContentProvider(clientMapper);
+    const notebookContentProvider = new DotNetInteractiveNotebookContentProvider(diagnosticsChannel, clientMapper);
 
     // notebook content
     context.subscriptions.push(vscode.notebook.registerNotebookContentProvider('dotnet-interactive', notebookContentProvider));


### PR DESCRIPTION
This works around the following failure scenario:

1. Create a new blank .NET Interactive notebook.  It should open with the Jupyter extension.
2. Reopen the notebook with the .NET Interactive for Jupyter editor.
3. Crash because the extension of the file `\Untitled-1.ipynb-6122c466-6a34-4518-9ea5-92b98cf9b2df` was not supported.

The file URI given to us doesn't exist and the extension is incorrect.  While the issue lies somewhere within VS Code itself, we still shouldn't crash.

The fix is two-fold:

1. Don't actually try to read a file's contents unless that file exists on disk.
2. Increase the scope of the `try/catch` and report all failures to our output channel.