### PR TITLE
better handle when the kernel server is unexpectedly gone

### DIFF
--- a/src/dotnet-interactive-vscode/package-lock.json
+++ b/src/dotnet-interactive-vscode/package-lock.json
@@ -62,6 +62,15 @@
       "integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==",
       "dev": true
     },
+    "@types/chai-as-promised": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.3.tgz",
+      "integrity": "sha512-FQnh1ohPXJELpKhzjuDkPLR2BZCAqed+a6xV4MI/T3XzHfd2FlarfUGUdZYgqYe8oxkYn0fchHEeHfHqdZ96sg==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*"
+      }
+    },
     "@types/chai-fs": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/chai-fs/-/chai-fs-2.0.2.tgz",
@@ -478,6 +487,15 @@
         "get-func-name": "^2.0.0",
         "pathval": "^1.1.0",
         "type-detect": "^4.0.5"
+      }
+    },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "^1.0.2"
       }
     },
     "chai-fs": {

--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -280,6 +280,7 @@
   },
   "devDependencies": {
     "@types/chai": "4.2.11",
+    "@types/chai-as-promised": "^7.1.3",
     "@types/chai-fs": "2.0.2",
     "@types/glob": "7.1.1",
     "@types/mocha": "7.0.2",
@@ -290,6 +291,7 @@
     "@typescript-eslint/eslint-plugin": "2.26.0",
     "@typescript-eslint/parser": "2.26.0",
     "chai": "4.2.0",
+    "chai-as-promised": "^7.1.1",
     "chai-fs": "2.0.0",
     "del-cli": "^3.0.1",
     "eslint": "6.8.0",

--- a/src/dotnet-interactive-vscode/src/stdioKernelTransport.ts
+++ b/src/dotnet-interactive-vscode/src/stdioKernelTransport.ts
@@ -49,7 +49,6 @@ export class StdioKernelTransport implements KernelTransport {
             this.diagnosticChannel.appendLine(`Kernel started with pid ${childProcess.pid}.`);
 
             childProcess.on('exit', (code: number, signal: string) => {
-
                 let message = `Kernel pid ${childProcess.pid} ended`;
                 let messageCodeSuffix = (code && code !== 0)
                     ? ` with code ${code}`
@@ -153,8 +152,6 @@ export class StdioKernelTransport implements KernelTransport {
         });
     }
 
-
-
     private handleLine(line: string) {
         let obj = parse(line);
         let envelope = <KernelEventEnvelope>obj;
@@ -195,13 +192,16 @@ export class StdioKernelTransport implements KernelTransport {
 
             let str = stringify(submit);
             if (isNotNull(this.childProcess)) {
-                this.childProcess.stdin.write(str);
-                this.childProcess.stdin.write('\n');
-
-                resolve();
+                try {
+                    this.childProcess.stdin.write(str);
+                    this.childProcess.stdin.write('\n');
+                    resolve();
+                } catch (e) {
+                    reject(e);
+                }
             }
             else {
-                reject();
+                reject('Kernel process is `null`.');
             }
         });
     }

--- a/src/dotnet-interactive-vscode/src/tests/unit/callbackTestKernelTransport.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/callbackTestKernelTransport.ts
@@ -1,0 +1,54 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { KernelCommand, KernelCommandType, KernelEventEnvelopeObserver, DisposableSubscription, KernelCommandEnvelopeObserver, KernelEventEnvelope, KernelTransport } from 'dotnet-interactive-vscode-interfaces/out/contracts';
+
+// executes the given callback for the specified commands
+export class CallbackTestKernelTransport implements KernelTransport {
+    private theObserver: KernelEventEnvelopeObserver | undefined;
+
+    constructor(readonly fakedCommandCallbacks: { [key: string]: () => KernelEventEnvelope }) {
+    }
+
+    subscribeToKernelEvents(observer: KernelEventEnvelopeObserver): DisposableSubscription {
+        this.theObserver = observer;
+        return {
+            dispose: () => { }
+        };
+    }
+
+    subscribeToCommands(observer: KernelCommandEnvelopeObserver): DisposableSubscription {
+        // Currently, the back channel for client-side kernels is only implemented by the SignalR
+        // transport, so tests in this project don't call this.
+        throw new Error("Stdio channel doesn't currently support a back channel");
+    }
+
+    async submitCommand(command: KernelCommand, commandType: KernelCommandType, token: string): Promise<void> {
+        return new Promise((resolve, reject) => {
+            const commandCallback = this.fakedCommandCallbacks[commandType];
+            if (!commandCallback) {
+                reject(`No callback specified for command '${commandType}'`);
+                return;
+            }
+
+            const eventEnvelope = commandCallback();
+            if (this.theObserver) {
+                this.theObserver(eventEnvelope);
+            }
+
+            resolve();
+        });
+    }
+
+    publishKernelEvent(eventEnvelope: KernelEventEnvelope): Promise<void> {
+        throw new Error("Stdio channel doesn't currently support a back channel");
+    }
+
+    waitForReady(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    dispose() {
+        // noop
+    }
+}

--- a/src/dotnet-interactive-vscode/src/vscode/notebookKernel.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/notebookKernel.ts
@@ -57,18 +57,18 @@ export class DotNetInteractiveNotebookKernel implements vscode.NotebookKernel {
             diagnosticCollection.set(cell.uri, diags.filter(d => d.severity !== DiagnosticSeverity.Hidden).map(toVsCodeDiagnostic));
         }
 
-        return client.execute(source, getSimpleLanguage(cell.language), outputObserver, diagnosticObserver, { id: document.uri.toString() }).then(async () => {
-            await updateCellMetadata(document, cell, {
+        return client.execute(source, getSimpleLanguage(cell.language), outputObserver, diagnosticObserver, { id: document.uri.toString() }).then(() => {
+            return updateCellMetadata(document, cell, {
                 runState: vscode.NotebookCellRunState.Success,
                 lastRunDuration: Date.now() - startTime,
             });
-        }).catch(async () => {
-            await updateCellMetadata(document, cell, {
+        }).catch(() => {
+            return updateCellMetadata(document, cell, {
                 runState: vscode.NotebookCellRunState.Error,
                 lastRunDuration: Date.now() - startTime,
             });
-        }).then(async () => {
-            await updateCellLanguages(document);
+        }).then(() => {
+            return updateCellLanguages(document);
         });
     }
 


### PR DESCRIPTION
There are two major changes in this PR:

1. Properly reject all promises in the case of command execution failure.  There was an improper mix of both `async/await` and `resolve/reject` that could result in an exception filtering too high in the stack and throwing somewhere in the VS Code host which could then mess up the host and get the user into a state where the notebook would stop responding, sometimes to the point that the editor couldn't be closed.
2. Detect when the kernel process has exited (e.g., crash or the user killed it with the Task Manager) and remove it from the client map.  This means that subsequent commands will start a new client instead of inappropriately trying to communicate with a dead process.

User-facing scenarios covered:

1. Open notebook, kill kernel server via Task Manager, execute a cell.  Before: cell would show as executing forever and never finish.  After: the kernel server restarts and performs the requested action.
2. Open notebook, kill kernel server via Task Manager, hover over an identifier.  Before: nothing would happen, but then the notebook could never be closed.  After: the kernel server restarts and performs the requested action.