### PR TITLE
use latest ubuntu for most linux runs, but internal hosted pool for official

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -167,7 +167,8 @@ stages:
       jobs:
       - job: Linux
         pool:
-          vmImage: ubuntu-16.04
+          name: NetCorePublic-Pool
+          queue: BuildPool.Ubuntu.1604.amd64.Open
         variables:
         # Enable signing for internal, non-PR builds
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -227,7 +228,7 @@ stages:
       jobs:
       - job: Dockerfile_official_image
         pool:
-          vmImage: ubuntu-16.04
+          vmImage: ubuntu-latest
         steps:
         - checkout: self
           clean: true
@@ -243,7 +244,7 @@ stages:
       jobs:
       - job: Dockerfile_Main
         pool:
-          vmImage: ubuntu-16.04
+          vmImage: ubuntu-latest
         steps:
         - checkout: self
           clean: true
@@ -259,7 +260,7 @@ stages:
       jobs:
       - job: Dockerfile_Binder_Dependency
         pool:
-          vmImage: ubuntu-16.04
+          vmImage: ubuntu-latest
         steps:
         - checkout: self
           clean: true
@@ -277,7 +278,7 @@ stages:
         dependsOn: Windows_NT
         condition: succeeded()
         pool:
-          vmImage: ubuntu-16.04
+          vmImage: ubuntu-latest
         variables:
         - name: DOTNET_INTERACTIVE_CLI_TELEMETRY_OPTOUT
           value: 1


### PR DESCRIPTION
This is an attempt to try to get rid of the Linux build timeouts that keep happening by migrating to the internally hosted Ubuntu pool for that run.  Also update our other Linux runs to not depend on a specific build.

Marked as draft because I plan on running it repeatedly.

Run 1: pass
Run 2: pass
Run 3: pass
Run 4: pass
Run 5: pass
Run 6: pass
Run 7: pass
Run 8: pass
Run 9: pass
Run 10: pass

Ten runs in a row passed which makes me feel pretty good about this.  There was one run that took ~1 hour to acquire a hosted Linux VM, but it _did_ pass which is arguably better than the failures we've been seeing.