### PR TITLE
ensure a non-existant dotnet always returns something actionable

### DIFF
--- a/src/dotnet-interactive-vscode/.vscode/tasks.json
+++ b/src/dotnet-interactive-vscode/.vscode/tasks.json
@@ -1,20 +1,26 @@
 // See https://go.microsoft.com/fwlink/?LinkId=733558
 // for the documentation about the tasks.json format
 {
-	"version": "2.0.0",
-	"tasks": [
-		{
-			"type": "npm",
-			"script": "watch",
-			"problemMatcher": "$tsc-watch",
-			"isBackground": true,
-			"presentation": {
-				"reveal": "never"
-			},
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			}
-		}
-	]
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "watch",
+      "problemMatcher": "$tsc-watch",
+      "isBackground": true,
+      "presentation": {
+        "reveal": "never"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "run tests",
+      "type": "npm",
+      "script": "test",
+      "group": "test"
+    }
+  ]
 }

--- a/src/dotnet-interactive-vscode/src/tests/unit/misc.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/misc.test.ts
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import { NotebookCellDisplayOutput, NotebookCellErrorOutput, NotebookCellTextOutput } from 'dotnet-interactive-vscode-interfaces/out/contracts';
 import { isDisplayOutput, isErrorOutput, isTextOutput, reshapeOutputValueForVsCode } from 'dotnet-interactive-vscode-interfaces/out/utilities';
 import { requiredKernelspecData } from '../../ipynbUtilities';
-import { debounce, isDotNetKernelPreferred, parse, processArguments, stringify } from '../../utilities';
+import { debounce, executeSafe, isDotNetKernelPreferred, parse, processArguments, stringify } from '../../utilities';
 
 import * as notebook from 'dotnet-interactive-vscode-interfaces/out/notebook';
 
@@ -294,6 +294,15 @@ describe('Miscellaneous tests', () => {
         it(`non-error mime type doesn't reshape output`, () => {
             const reshaped = reshapeOutputValueForVsCode('text/plain', 'some error message');
             expect(reshaped).to.equal('some error message');
+        });
+    });
+
+    it('executing a non-existant process still returns', async () => {
+        const result = await executeSafe('this-is-a-command-that-will-fail', []);
+        expect(result).to.deep.equal({
+            code: -1,
+            output: '',
+            error: 'Error: spawn this-is-a-command-that-will-fail ENOENT',
         });
     });
 });

--- a/src/dotnet-interactive-vscode/src/tests/unit/misc.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/misc.test.ts
@@ -297,7 +297,7 @@ describe('Miscellaneous tests', () => {
         });
     });
 
-    it('executing a non-existant process still returns', async () => {
+    it('executing a non-existent process still returns', async () => {
         const result = await executeSafe('this-is-a-command-that-will-fail', []);
         expect(result).to.deep.equal({
             code: -1,


### PR DESCRIPTION
While testing something else I discovered that if `dotnet.exe` is _completely_ missing from the machine, then our up-to-date check never returns and we'll spin forever.  The fix was to also listen to the spawned process's `'error'` event.  I also moved the function to a common location so I could add a test.