### PR TITLE
switch build pool on ci location

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -167,8 +167,12 @@ stages:
       jobs:
       - job: Linux
         pool:
-          name: NetCorePublic-Pool
-          queue: BuildPool.Ubuntu.1604.amd64.Open
+          ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+            name: NetCorePublic-Pool
+            queue: BuildPool.Ubuntu.1604.amd64.Open
+          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+            name: NetCoreInternal-Pool
+            queue: BuildPool.Ubuntu.1604.amd64
         variables:
         # Enable signing for internal, non-PR builds
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
The internal CI has a slightly different build pool name.  ~~Internal test build is [here](https://dev.azure.com/dnceng/internal/_build/results?buildId=1011993&view=results).~~ Internal Linux leg has passed.