### PR TITLE
require dotnet sdk to already be on the machine

### DIFF
--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -49,9 +49,7 @@
     "onCommand:dotnet-interactive.saveAsNotebook"
   ],
   "main": "./out/vscode/extension.js",
-  "extensionDependencies": [
-    "ms-dotnettools.vscode-dotnet-runtime"
-  ],
+  "extensionDependencies": [],
   "contributes": {
     "notebookProvider": [
       {

--- a/src/dotnet-interactive-vscode/src/clientMapper.ts
+++ b/src/dotnet-interactive-vscode/src/clientMapper.ts
@@ -20,16 +20,20 @@ export class ClientMapper {
         let key = ClientMapper.keyFromUri(uri);
         let clientPromise = this.clientMap.get(key);
         if (clientPromise === undefined) {
-            clientPromise = new Promise<InteractiveClient>(async resolve => {
-                const transport = await this.kernelTransportCreator(uri.fsPath);
-                const client = new InteractiveClient(transport);
+            clientPromise = new Promise<InteractiveClient>(async (resolve, reject) => {
+                try {
+                    const transport = await this.kernelTransportCreator(uri.fsPath);
+                    const client = new InteractiveClient(transport);
 
-                let onCreate = this.clientCreationCallbackMap.get(key);
-                if (onCreate) {
-                    await onCreate(client);
+                    let onCreate = this.clientCreationCallbackMap.get(key);
+                    if (onCreate) {
+                        await onCreate(client);
+                    }
+
+                    resolve(client);
+                } catch (err) {
+                    reject(err);
                 }
-
-                resolve(client);
             });
             this.clientMap.set(key, clientPromise);
         }

--- a/src/dotnet-interactive-vscode/src/interfaces/src/dotnet.ts
+++ b/src/dotnet-interactive-vscode/src/interfaces/src/dotnet.ts
@@ -1,8 +1,0 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
-// interface acquired from https://github.com/dotnet/vscode-dotnet-runtime/blob/6331b67af2689ba353a1a793eeb1e00131cec46b/vscode-dotnet-runtime-library/src/IDotnetAcquireResult.ts
-
-export interface IDotnetAcquireResult {
-    dotnetPath: string;
-}

--- a/src/dotnet-interactive-vscode/src/tests/unit/misc.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/misc.test.ts
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import { NotebookCellDisplayOutput, NotebookCellErrorOutput, NotebookCellTextOutput } from 'dotnet-interactive-vscode-interfaces/out/contracts';
 import { isDisplayOutput, isErrorOutput, isTextOutput, reshapeOutputValueForVsCode } from 'dotnet-interactive-vscode-interfaces/out/utilities';
 import { requiredKernelspecData } from '../../ipynbUtilities';
-import { debounce, executeSafe, isDotNetKernelPreferred, parse, processArguments, stringify } from '../../utilities';
+import { debounce, executeSafe, isDotNetKernelPreferred, isDotNetUpToDate, parse, processArguments, stringify } from '../../utilities';
 
 import * as notebook from 'dotnet-interactive-vscode-interfaces/out/notebook';
 
@@ -303,6 +303,28 @@ describe('Miscellaneous tests', () => {
             code: -1,
             output: '',
             error: 'Error: spawn this-is-a-command-that-will-fail ENOENT',
+        });
+    });
+
+    describe('dotnet version sufficiency tests', () => {
+        it('supported version is allowed', () => {
+            const isSupported = isDotNetUpToDate('5.0', { code: 0, output: '5.0.101' });
+            expect(isSupported).to.be.true;
+        });
+
+        it(`version number acquisition passes, but version isn't sufficient`, () => {
+            const isSupported = isDotNetUpToDate('5.0', { code: 0, output: '3.1.403' });
+            expect(isSupported).to.be.false;
+        });
+
+        it(`version number looks good, but return code wasn't`, () => {
+            const isSupported = isDotNetUpToDate('5.0', { code: 1, output: '5.0.101' });
+            expect(isSupported).to.be.false;
+        });
+
+        it('version number check crashed', () => {
+            const isSupported = isDotNetUpToDate('5.0', { code: -1, output: '' });
+            expect(isSupported).to.be.false;
         });
     });
 });

--- a/src/dotnet-interactive-vscode/src/utilities.ts
+++ b/src/dotnet-interactive-vscode/src/utilities.ts
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+import * as compareVersions from 'compare-versions';
 import * as cp from 'child_process';
 import * as path from 'path';
 import { InstallInteractiveArgs, ProcessStart } from "./interfaces";
@@ -40,6 +41,10 @@ export function executeSafe(command: string, args: Array<string>, workingDirecto
             });
         }
     });
+}
+
+export function isDotNetUpToDate(minVersion: string, commandResult: { code: number, output: string }): boolean {
+    return commandResult.code === 0 && compareVersions.compare(commandResult.output, minVersion, '>=');
 }
 
 export function processArguments(template: { args: Array<string>, workingDirectory: string }, notebookPath: string, fallbackWorkingDirectory: string, dotnetPath: string, globalStoragePath: string): ProcessStart {


### PR DESCRIPTION
Turns out trying to use a .NET runtime doesn't work at all; we require a full SDK to properly function.

This removes the runtime requirement and fails with (hopefully helpful) error messages if `dotnet` wasn't found.  We'll need to have some discussions around what the error message should say and how we direct the user down the path of success, but the basic shape is still ready for review.