### PR TITLE
Fix MsSqlConnectionTests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -167,8 +167,12 @@ stages:
       jobs:
       - job: Linux
         pool:
-          name: NetCorePublic-Pool
-          queue: BuildPool.Ubuntu.1604.amd64.Open
+          ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+            name: NetCorePublic-Pool
+            queue: BuildPool.Ubuntu.1604.amd64.Open
+          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+            name: NetCoreInternal-Pool
+            queue: BuildPool.Ubuntu.1604.amd64
         variables:
         # Enable signing for internal, non-PR builds
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/src/Microsoft.DotNet.Interactive.SqlServer.Tests/MsSqlConnectionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer.Tests/MsSqlConnectionTests.cs
@@ -55,19 +55,11 @@ SELECT TOP 100 * FROM Person.Person
 
             events.Should().NotContainErrors();
 
-            events.Should()
-                .Contain(e => e is DisplayedValueProduced && e.As<DisplayedValueProduced>()
-                .FormattedValues
-                .First()
-                .MimeType
-                .Equals(PlainTextFormatter.MimeType));
+            events.Should().ContainSingle<DisplayedValueProduced>(e => e.FormattedValues.Any(f => f.MimeType == PlainTextFormatter.MimeType))
+            .Which.FormattedValues.Should().ContainSingle(f => f.MimeType == PlainTextFormatter.MimeType)
 
-            events.Should()
-                .Contain(e => e is DisplayedValueProduced && e.As<DisplayedValueProduced>()
-                .FormattedValues
-                .First()
-                .MimeType
-                .Equals(HtmlFormatter.MimeType));
+            events.Should().ContainSingle<DisplayedValueProduced>(e => e.FormattedValues.Any(f => f.MimeType == HtmlFormatter.MimeType))
+            .Which.FormattedValues.Should().ContainSingle(f => f.MimeType == HtmlFormatter.MimeType);
         }
 
         [MsSqlFact]
@@ -119,15 +111,10 @@ select * from sys.databases
             var events = result.KernelEvents.ToSubscribedList();
 
             events.Should().NotContainErrors();
-
-            var value = events.Where(e => e is DisplayedValueProduced && e.As<DisplayedValueProduced>()
-                .FormattedValues
-                .First()
-                .MimeType
-                .Equals(HtmlFormatter.MimeType))
-                .First()
-                .As<DisplayedValueProduced>();
-
+                
+            var value = events.Should()
+                .ContainSingle<DisplayedValueProduced>(e => e.FormattedValues.Any(f => f.MimeType == HtmlFormatter.MimeType))
+                .Which;
 
             var tables = (IEnumerable<IEnumerable<IEnumerable<(string, object)>>>) value.Value;
 
@@ -163,18 +150,9 @@ drop table dbo.EmptyTable;
             var events = result.KernelEvents.ToSubscribedList();
 
             events.Should().NotContainErrors();
-
-            var value = events.Where(e => e is DisplayedValueProduced && e.As<DisplayedValueProduced>()
-                .FormattedValues
-                .First()
-                .MimeType
-                .Equals(PlainTextFormatter.MimeType))
-                .Last()
-                .As<DisplayedValueProduced>();
-
-            var message = (string) value.Value;
-            message.Should().StartWith("Info");
-            message.Should().NotContain("Error");
+                
+            events.Should()
+                .ContainSingle<DisplayedValueProduced>(e => e.FormattedValues.Any(f => f.Value == "Info: No rows were returned for query 0 in batch 0."));
         }
     }
 }


### PR DESCRIPTION
Fix tests that were broken by displaying SQL Server messages. (Now there are two DisplayedValueProduced events)