### PR TITLE
text fixes during extension loading

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/SQLiteConnectionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/SQLiteConnectionTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab.Tests
     {
 
         [Fact]
-        public async Task SQLKernel_will_suggests_sqllite_connection_when_statements_are_submitted_to_it()
+        public async Task SQLKernel_suggests_SQLite_connection_when_statements_are_submitted_to_it()
         {
             using var kernel = new CompositeKernel
             {
@@ -47,12 +47,12 @@ SELECT * FROM fruit
 
             events.Should().NotContainErrors();
             events.Should()
-                .ContainSingle<DisplayedValueProduced>()
-                .Which
-                .Value
-                .As<string>()
-                .Should()
-                .Contain("- `#!sql-mydb`");
+                  .ContainSingle<DisplayedValueProduced>()
+                  .Which
+                  .FormattedValues
+                  .Should()
+                  .ContainSingle(v => v.Value.Contains("#!sql-mydb") &&
+                                      v.MimeType == "text/html");
         }
 
         [Fact]

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/DataFrameKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/DataFrameKernelExtension.cs
@@ -76,7 +76,7 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
 
             KernelInvocationContext.Current?.Display(
                 new HtmlString($@"<details><summary>Create strongly-typed dataframes using<code>#!linqify</code>.</summary>
-    <p>The `#!linqify` magic command replaces a <a href=""https://www.nuget.org/packages/Microsoft.Data.Analysis/""><code>Microsoft.Data.Analysis.DataFrame</code></a> variable with a generated, strongly-typed data frame, allowing the use of LINQ operations over the contained data.</p>
+    <p>The <code>#!linqify</code> magic command replaces a <a href=""https://www.nuget.org/packages/Microsoft.Data.Analysis/""><code>Microsoft.Data.Analysis.DataFrame</code></a> variable with a generated, strongly-typed data frame, allowing the use of LINQ operations over the contained data.</p>
     </details>"),
                 "text/html");
 

--- a/src/Microsoft.DotNet.Interactive/Extensions/AssemblyBasedExtensionLoader.cs
+++ b/src/Microsoft.DotNet.Interactive/Extensions/AssemblyBasedExtensionLoader.cs
@@ -118,11 +118,14 @@ namespace Microsoft.DotNet.Interactive.Extensions
                                      .Where(t => t.CanBeInstantiated() && typeof(IKernelExtension).IsAssignableFrom(t))
                                      .ToArray();
 
+                if (extensionTypes.Any())
+                {
+                    context.Display($"Loading extensions from `{assemblyFile.Name}`", "text/markdown");
+                }
+
                 foreach (var extensionType in extensionTypes)
                 {
                     var extension = (IKernelExtension) Activator.CreateInstance(extensionType);
-
-                    context.Display($"Loading extensions from `{extensionType.FullName}`", "text/markdown");
 
                     try
                     {

--- a/src/Microsoft.DotNet.Interactive/Extensions/AssemblyBasedExtensionLoader.cs
+++ b/src/Microsoft.DotNet.Interactive/Extensions/AssemblyBasedExtensionLoader.cs
@@ -122,6 +122,8 @@ namespace Microsoft.DotNet.Interactive.Extensions
                 {
                     var extension = (IKernelExtension) Activator.CreateInstance(extensionType);
 
+                    context.Display($"Loading extensions from `{extensionType.FullName}`", "text/markdown");
+
                     try
                     {
                         await extension.OnLoadAsync(kernel);

--- a/src/Microsoft.DotNet.Interactive/SqlKernel.cs
+++ b/src/Microsoft.DotNet.Interactive/SqlKernel.cs
@@ -71,7 +71,7 @@ Now, you can connect to a Microsoft SQL Server database by running the following
 </code>
 "), "text/html");
             }
-            else if (!string.IsNullOrWhiteSpace(command.Code))
+            else
             {
                 PocketView view =
                     div(


### PR DESCRIPTION
This tweaks a few of the messages from extensions.

I'm trying to make it a little clearer which extensions came from which assemblies:

![image](https://user-images.githubusercontent.com/547415/109861371-177a1900-7c14-11eb-8799-5230b88ad1b1.png)
![image](https://user-images.githubusercontent.com/547415/109863887-054daa00-7c17-11eb-9320-daa7fd9b940a.png)
