### PR TITLE
initialise signalr connection on extension load

### DIFF
--- a/src/dotnet-interactive-vscode/resources/kernelHttpApiBootstrapper.js
+++ b/src/dotnet-interactive-vscode/resources/kernelHttpApiBootstrapper.js
@@ -65,9 +65,19 @@
                     ],
                         function (dotnet) {
                             dotnet.init(global);
+                            dotnet.createDotnetInteractiveClient(uri)
+                                .then(client => {
+                                    global.interactiveClientInstance = client;
+                                    console.log('dotnet-interactive client connection established');
+                                })
+                                .catch(error => {
+                                    console.log('dotnet-interactive client connection cannot be established');
+                                    console.log(error);
+                                });
                             console.log('dotnet-interactive js api initialised');
                         },
                         function (error) {
+                            console.log('dotnet-interactive js api initialisation failure');
                             console.log(error);
                         }
                     );

--- a/src/dotnet-interactive/build-and-install-dotnet-interactive.ps1
+++ b/src/dotnet-interactive/build-and-install-dotnet-interactive.ps1
@@ -4,7 +4,7 @@ $ErrorActionPreference = "Stop"
 $thisDir = Split-Path -Parent $PSCommandPath
 $toolLocation = ""
 $toolVersion = ""
-dotnet run -p (Join-Path -Path $thisDir ".." "interface-generator") --out-file (Join-Path $thisDir ".." "dotnet-interactive-vscode" "src" "contracts.ts")
+dotnet run -p (Join-Path -Path $thisDir ".." "interface-generator") --out-file (Join-Path $thisDir ".." "dotnet-interactive-vscode" "src" "interfaces" "src" "contracts.ts")
 
 dotnet run -p (Join-Path -Path $thisDir ".." "interface-generator") --out-file (Join-Path $thisDir ".." "Microsoft.DotNet.Interactive.Js" "src" "dotnet-interactive" "contracts.ts")
 


### PR DESCRIPTION
In a notebook without any js cell the signalr hub would not initialise.
This pr ensure that when the vscode extension is loaded and fully configured a client connection is established. This makes the  clientside kernel work in all scenarios