### PR TITLE
default to our own editor

### DIFF
--- a/src/dotnet-interactive-vscode/src/vscode/extension.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/extension.ts
@@ -126,8 +126,14 @@ export async function activate(context: vscode.ExtensionContext) {
 
     let jupyterApi: jupyter.IJupyterExtensionApi | undefined = undefined;
     if (useJupyterExtension) {
-        jupyterApi = <jupyter.IJupyterExtensionApi>await jupyterExtension!.activate();
-        jupyterApi.registerNewNotebookContent({ defaultCellLanguage: 'dotnet-interactive.csharp' });
+        try {
+            jupyterApi = <jupyter.IJupyterExtensionApi>await jupyterExtension!.activate();
+            jupyterApi.registerNewNotebookContent({ defaultCellLanguage: 'dotnet-interactive.csharp' });
+        } catch (err) {
+            diagnosticsChannel.appendLine(`Error activating and registering with Jupyter extension: ${err}.  Defaulting to local file handling.`);
+            useJupyterExtension = false;
+            jupyterApi = undefined;
+        }
     }
 
     const diagnosticDelay = config.get<number>('liveDiagnosticDelay') || 500; // fall back to something reasonable


### PR DESCRIPTION
If we've determined we're going to use the Jupyter extension for .ipynb handling and it fails for any reason, clear some variables so we'll safely fall back to our own.