### PR TITLE
cache interactive client for vscode

### DIFF
--- a/src/dotnet-interactive-vscode/resources/kernelHttpApiBootstrapper.js
+++ b/src/dotnet-interactive-vscode/resources/kernelHttpApiBootstrapper.js
@@ -67,7 +67,7 @@
                             dotnet.init(global);
                             dotnet.createDotnetInteractiveClient(uri)
                                 .then(client => {
-                                    global.interactiveClientInstance = client;
+                                    global.createDotnetInteractiveClient = function () { return Promise.resolve(client); }
                                     console.log('dotnet-interactive client connection established');
                                 })
                                 .catch(error => {

--- a/src/dotnet-interactive.Tests/FormatterConfigurationTests.cs
+++ b/src/dotnet-interactive.Tests/FormatterConfigurationTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.Interactive.App.Tests
                           .EnforceNewLine()
                           .Should()
                           .Be(@"<script type=""text/javascript"">if (typeof window.createDotnetInteractiveClient === typeof Function) {
-createDotnetInteractiveClient('http://12.12.12.12:4242/').then(function (interactive) {
+createDotnetInteractiveClient('http://12.12.12.12:4242/').then(async function (interactive) {
 let notebookScope = getDotnetInteractiveScope('http://12.12.12.12:4242/');
 alert('hello');
 });

--- a/src/dotnet-interactive/CommandLine/CommandLineParser.cs
+++ b/src/dotnet-interactive/CommandLine/CommandLineParser.cs
@@ -550,7 +550,7 @@ namespace Microsoft.DotNet.Interactive.App.CommandLine
                                 var apiUri = await frontedEnvironment.GetApiUriAsync();
                                 var fullCode =
                                     $@"if (typeof window.createDotnetInteractiveClient === typeof Function) {{
-createDotnetInteractiveClient('{apiUri.AbsoluteUri}').then(function (interactive) {{
+createDotnetInteractiveClient('{apiUri.AbsoluteUri}').then(async function (interactive) {{
 let notebookScope = getDotnetInteractiveScope('{apiUri.AbsoluteUri}');
 {script.ScriptValue}
 }});


### PR DESCRIPTION
Also let all JS content be async.  This means this:

``` javascript
interactive.csharp.getVariable("myVariable").then(value => {
    document.getElementById("output").innerText = `The value is ${value}`;
});
```

can now be expressed as:

``` javascript
const value = await interactive.csharp.getVariable("myVariable");
document.getElementById("output").innerText = `The value is ${value}`;
```

(but the old method still works)