### PR TITLE
Extend support

### DIFF
--- a/samples/ExtensionLab/ExtensionLab-SandDance.ipynb
+++ b/samples/ExtensionLab/ExtensionLab-SandDance.ipynb
@@ -1,0 +1,99 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "dotnet_interactive": {
+          "language": "csharp"
+        }
+      },
+      "source": [
+        "#i \"nuget:c:\\temp\""
+      ],
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "dotnet_interactive": {
+          "language": "csharp"
+        }
+      },
+      "source": [
+        "#r \"nuget:Microsoft.DotNet.Interactive.ExtensionLab,*-*\""
+      ],
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "dotnet_interactive": {
+          "language": "csharp"
+        }
+      },
+      "source": [
+        "using System.IO;\n",
+        "using System.Net.Http;\n",
+        "string housingPath = \"housing.csv\";\n",
+        "\n",
+        "if (!File.Exists(housingPath))\n",
+        "{\n",
+        "    var contents = await new HttpClient()\n",
+        "        .GetStringAsync(\"https://raw.githubusercontent.com/ageron/handson-ml2/master/datasets/housing/housing.csv\");\n",
+        "        \n",
+        "    File.WriteAllText(\"housing.csv\", contents);\n",
+        "}"
+      ],
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "dotnet_interactive": {
+          "language": "csharp"
+        }
+      },
+      "source": [
+        "using Microsoft.Data.Analysis;\n",
+        "using Microsoft.DotNet.Interactive.ExtensionLab;\n",
+        "using Microsoft.ML;\n",
+        "\n",
+        "var housingData = DataFrame.LoadCsv(housingPath);"
+      ],
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "dotnet_interactive": {
+          "language": "csharp"
+        }
+      },
+      "source": [
+        "housingData.ExploreWithSandDance();"
+      ],
+      "outputs": []
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".NET (C#)",
+      "language": "C#",
+      "name": ".net-csharp"
+    },
+    "language_info": {
+      "file_extension": ".cs",
+      "mimetype": "text/x-csharp",
+      "name": "C#",
+      "pygments_lexer": "csharp",
+      "version": "8.0"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 4
+}

--- a/samples/ExtensionLab/ExtensionLab-SandDance.ipynb
+++ b/samples/ExtensionLab/ExtensionLab-SandDance.ipynb
@@ -9,19 +9,9 @@
         }
       },
       "source": [
-        "#i \"nuget:c:\\temp\""
-      ],
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {
-        "dotnet_interactive": {
-          "language": "csharp"
-        }
-      },
-      "source": [
+        "#i \"nuget:https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json\" \n",
+        "#i \"nuget:https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json\" \n",
+        "\n",
         "#r \"nuget:Microsoft.DotNet.Interactive.ExtensionLab,*-*\""
       ],
       "outputs": []
@@ -75,7 +65,7 @@
         }
       },
       "source": [
-        "housingData.ExploreWithSandDance();"
+        "housingData.ExploreWithSandDance()"
       ],
       "outputs": []
     }

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/SandDanceKernelExtensionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/SandDanceKernelExtensionTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab.Tests
 
             var formatted = data.ExploreWithSandDance().ToDisplayString(HtmlFormatter.MimeType);
 
-            formatted.Should().Contain("configureRequireFromExtension('SandDance','1.0.0')(['sandDance/sanddanceapi'], (sandDance) => {");
+            formatted.Should().Contain("configureRequireFromExtension('SandDance','1.0.0')(['SandDance/sanddanceapi'], (sandDance) => {");
         }
 
         [Fact]

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/DataFrameKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/DataFrameKernelExtension.cs
@@ -14,6 +14,7 @@ using Microsoft.Data.Analysis;
 using Microsoft.DotNet.Interactive;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.CSharp;
+using Microsoft.DotNet.Interactive.ExtensionLab;
 using Microsoft.DotNet.Interactive.Formatting;
 using Microsoft.ML;
 
@@ -158,6 +159,13 @@ namespace Microsoft.ML
             KernelInvocationContext.Current.Display(
                 source.ToTabularJsonString(),
                 HtmlFormatter.MimeType);
+        }
+
+        public static SandDanceExplorer ExploreWithSandDance(this IDataView source)
+        {
+            var explorer = new SandDanceExplorer();
+            explorer.LoadData(source.ToTabularJsonString());
+            return explorer;
         }
 
         private static T GetValue<T>(ValueGetter<T> valueGetter)

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/SandDanceKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/SandDanceKernelExtension.cs
@@ -123,7 +123,7 @@ let {functionName} = () => {{");
             else
             {
                 code.AppendLine($@"
-    configureRequireFromExtension('SandDance','{context}')(['sandDance/sanddanceapi'], (sandDance) => {{");
+    configureRequireFromExtension('SandDance','{context}')(['SandDance/sanddanceapi'], (sandDance) => {{");
             }
 
             code.AppendLine($@"

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/SandDanceKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/SandDanceKernelExtension.cs
@@ -74,6 +74,13 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
             return explorer;
         }
 
+        public static SandDanceExplorer ExploreWithSandDance(this  TabularJsonString source)
+        {
+            var explorer = new SandDanceExplorer();
+            explorer.LoadData(source);
+            return explorer;
+        }
+
         private static HtmlString RenderSandDanceExplorer(this TabularJsonString data)
         {
             var divId = Guid.NewGuid().ToString("N");

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/SandDanceKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/SandDanceKernelExtension.cs
@@ -35,7 +35,12 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
     {
         internal void LoadData<T>(IEnumerable<T> source)
         {
-            TabularData = source.ToTabularJsonString();
+            LoadData(source.ToTabularJsonString());
+        }
+
+        internal void LoadData(TabularJsonString source)
+        {
+            TabularData = source;
         }
 
         internal TabularJsonString TabularData { get; set; }

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/SandDanceKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/SandDanceKernelExtension.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
             KernelInvocationContext.Current?.Display(
                 new HtmlString($@"<details><summary>Explore data visually using the <a href=""https://github.com/microsoft/SandDance"">SandDance Explorer</a>.</summary>
     <p>This extension adds the ability to sort, filter, and visualize data using the <a href=""https://github.com/microsoft/SandDance"">SandDance Explorer</a>. Use the <code>ExploreWithSandDance</code> extension method with variables of type <code>IEnumerable<T></code> or <code>IDataView</code> to render the data explorer.</p>
-    <img src=""https://user-images.githubusercontent.com/547415/109559345-621e5880-7a8f-11eb-8b98-d4feeaac116f.png"" width=""75%"">
+    <img src=""https://user-images.githubusercontent.com/11507384/54236654-52d42800-44d1-11e9-859e-6c5d297a46d2.gif"" width=""75%"">
     </details>"),
                 "text/html");
 

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/TabularDataFormatterTests.can_generate_tabular_json_when_non_numeric_literals_are_used.approved.json
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/TabularDataFormatterTests.can_generate_tabular_json_when_non_numeric_literals_are_used.approved.json
@@ -1,0 +1,46 @@
+{
+  "schema": {
+    "primaryKey": [],
+    "fields": [
+      {
+        "name": "Name",
+        "type": "string"
+      },
+      {
+        "name": "IsValid",
+        "type": "boolean"
+      },
+      {
+        "name": "Cost",
+        "type": "number"
+      }
+    ]
+  },
+  "data": [
+    {
+      "Name": "Q",
+      "IsValid": false,
+      "Cost": "NaN"
+    },
+    {
+      "Name": "U",
+      "IsValid": false,
+      "Cost": 5
+    },
+    {
+      "Name": "E",
+      "IsValid": true,
+      "Cost": "-Infinity"
+    },
+    {
+      "Name": "S",
+      "IsValid": false,
+      "Cost": 10
+    },
+    {
+      "Name": "T",
+      "IsValid": false,
+      "Cost": "Infinity"
+    }
+  ]
+}

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/TabularDataFormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/TabularDataFormatterTests.cs
@@ -21,6 +21,23 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
         }
 
         [Fact]
+        public void can_generate_tabular_json_when_non_numeric_literals_are_used()
+        {
+            var data = new[]
+            {
+                new { Name = "Q", IsValid = false, Cost = double.NaN },
+                new { Name = "U", IsValid = false, Cost = 5.0 },
+                new { Name = "E", IsValid = true, Cost = double.NegativeInfinity },
+                new { Name = "S", IsValid = false, Cost = 10.0 },
+                new { Name = "T", IsValid = false, Cost = double.PositiveInfinity }
+            };
+
+            var formattedData = data.ToDisplayString(TabularDataFormatter.MimeType);
+
+            this.Assent(formattedData, _configuration);
+        }
+
+        [Fact]
         public void can_generate_tabular_json_from_object_array()
         {
             var data = new[]

--- a/src/Microsoft.DotNet.Interactive.Formatting/JsonFormatter.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/JsonFormatter.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.DotNet.Interactive.Formatting
 {
@@ -14,6 +15,7 @@ namespace Microsoft.DotNet.Interactive.Formatting
             SerializerOptions = new JsonSerializerOptions{
                 WriteIndented = false,
                 IgnoreNullValues = true,
+                NumberHandling = JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.AllowNamedFloatingPointLiterals,
                 Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
             };
         }

--- a/src/Microsoft.DotNet.Interactive.Formatting/TabularDataSet.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/TabularDataSet.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.DotNet.Interactive.Formatting
 {
@@ -30,6 +31,7 @@ namespace Microsoft.DotNet.Interactive.Formatting
             return new TabularJsonString(JsonSerializer.Serialize(tabularData, new JsonSerializerOptions
             {
                 WriteIndented = true,
+                NumberHandling = JsonNumberHandling.AllowReadingFromString| JsonNumberHandling.AllowNamedFloatingPointLiterals,
                 Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
             }));
         }

--- a/src/Microsoft.DotNet.Interactive.SqlServer.Tests/MsSqlConnectionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer.Tests/MsSqlConnectionTests.cs
@@ -94,11 +94,13 @@ SELECT TOP 100 * FROM Person.Person
                 .NotContainErrors()
                 .And
                 .ContainSingle<DisplayedValueProduced>(e =>
-                    e.FormattedValues.Any(f => f.MimeType == "text/markdown"))
-                .Which.FormattedValues.Single(f => f.MimeType == "text/markdown")
+                    e.FormattedValues.Any(f => f.MimeType == "text/html"))
+                .Which.FormattedValues.Single(f => f.MimeType == "text/html")
                 .Value
                 .Should()
-                .Contain("- `#!sql-adventureworks`");
+                .Contain("#!sql-adventureworks")
+                .And
+                .Contain(" SELECT TOP * FROM");
 
         }
 

--- a/src/Microsoft.DotNet.Interactive/Server/Serializer.cs
+++ b/src/Microsoft.DotNet.Interactive/Server/Serializer.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.DotNet.Interactive.Notebook;
 
 namespace Microsoft.DotNet.Interactive.Server
@@ -15,6 +16,7 @@ namespace Microsoft.DotNet.Interactive.Server
             {
                 WriteIndented = false,
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                NumberHandling = JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.AllowNamedFloatingPointLiterals,
                 Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
             };
             JsonSerializerOptions.Converters.Add(new DataDictionaryConverter());


### PR DESCRIPTION
Add support for tabluar jason adn dataframe to be used as sources for SandDance explorer

![image](https://user-images.githubusercontent.com/375556/110127279-5d261580-7dbd-11eb-8bae-bc25a9abd8b1.png)
