### PR TITLE
fix kernel restart loop due to races

### DIFF
--- a/src/dotnet-interactive-vscode/resources/kernelHttpApiBootstrapper.js
+++ b/src/dotnet-interactive-vscode/resources/kernelHttpApiBootstrapper.js
@@ -74,10 +74,10 @@
                                     console.log('dotnet-interactive client connection cannot be established');
                                     console.log(error);
                                 });
-                            console.log('dotnet-interactive js api initialised');
+                            console.log(`dotnet-interactive js api initialised for ${uri}`);
                         },
                         function (error) {
-                            console.log('dotnet-interactive js api initialisation failure');
+                            console.log(`dotnet-interactive js api initialisation failed for ${uri}`);
                             console.log(error);
                         }
                     );

--- a/src/dotnet-interactive-vscode/src/vscode/vscodeUtilities.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/vscodeUtilities.ts
@@ -73,14 +73,16 @@ export function configureWebViewMessaging(webview: vscode.NotebookCommunication,
     webview.onDidReceiveMessage(async (message) => {
         switch (message.command) {
             case "getHttpApiEndpoint":
-                const client = await clientMapper.getOrAddClient(documentUri);
-                const uri = client.tryGetProperty<vscode.Uri>("externalUri");
-                webview.postMessage({ command: "configureFactories", endpointUri: uri?.toString() });
-
-                clientMapper.onClientCreate(documentUri, async (client) => {
+                const client = await clientMapper.tryGetClient(documentUri);
+                if (client) {
                     const uri = client.tryGetProperty<vscode.Uri>("externalUri");
-                    await webview.postMessage({ command: "resetFactories", endpointUri: uri?.toString() });
-                });
+                    webview.postMessage({ command: "configureFactories", endpointUri: uri?.toString() });
+
+                    clientMapper.onClientCreate(documentUri, async (client) => {
+                        const uri = client.tryGetProperty<vscode.Uri>("externalUri");
+                        await webview.postMessage({ command: "resetFactories", endpointUri: uri?.toString() });
+                    });
+                }
                 break;
         }
     });


### PR DESCRIPTION
There was a race condition in the `processExited` handler on `StdioKernelTransport` that would cause the client
mapper to remove a tracked client _after_ it had already been restarted, which would then kick off a kernel restart
loop where it was constantly killing itself after it had started.  This was sometimes exacerbated by the bootstrap
API listener that was too eagerly grabbing a client.

The fix was threefold:

1. Don't fire the `processExited` event when the transport was explicitly shutdown, only when it died unexpectedly.
2. When the process _did_ exit unexpectedly, don't resolve its client just to shut it down; this could spawn extra
   processes that were never tracked.
3. Make the bootstrap API less eager and only act if a client had already been created.

Fixes #1135