### PR TITLE
log all tool acquisition failures to diagnostics channel

### DIFF
--- a/src/dotnet-interactive-vscode/src/tests/unit/client.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/client.test.ts
@@ -479,4 +479,11 @@ describe('InteractiveClient tests', () => {
         });
     });
 
+    it('exception creating kernel transport gracefully fails', done => {
+        const clientMapper = new ClientMapper(async _notebookPath => {
+            throw new Error('simulated error during transport creation');
+        });
+        expect(clientMapper.getOrAddClient({ fsPath: 'fake-notebook' })).eventually.rejectedWith('simulated error during transport creation').notify(done);
+    });
+
 });

--- a/src/dotnet-interactive-vscode/src/utilities.ts
+++ b/src/dotnet-interactive-vscode/src/utilities.ts
@@ -5,7 +5,7 @@ import * as compareVersions from 'compare-versions';
 import * as cp from 'child_process';
 import * as path from 'path';
 import { InstallInteractiveArgs, ProcessStart } from "./interfaces";
-import { Uri } from 'dotnet-interactive-vscode-interfaces/out/notebook';
+import { ReportChannel, Uri } from 'dotnet-interactive-vscode-interfaces/out/notebook';
 
 export function executeSafe(command: string, args: Array<string>, workingDirectory?: string | undefined): Promise<{ code: number, output: string, error: string }> {
     return new Promise<{ code: number, output: string, error: string }>(resolve => {
@@ -41,6 +41,23 @@ export function executeSafe(command: string, args: Array<string>, workingDirecto
             });
         }
     });
+}
+
+export async function executeSafeAndLog(outputChannel: ReportChannel, operationName: string, command: string, args: Array<string>, workingDirectory?: string): Promise<{ code: number, output: string, error: string }> {
+    outputChannel.appendLine(`${operationName}: Executing [${command} ${args.join(' ')}] in '${workingDirectory}'.`);
+    const result = await executeSafe(command, args, workingDirectory);
+    outputChannel.appendLine(`${operationName}: Finished with code ${result.code}.`);
+    if (result.output.length > 0) {
+        outputChannel.appendLine(`${operationName}: STDOUT:`);
+        outputChannel.appendLine(result.output);
+    }
+
+    if (result.error.length > 0) {
+        outputChannel.appendLine(`${operationName}: STDERR:`);
+        outputChannel.appendLine(result.error);
+    }
+
+    return result;
 }
 
 export function isDotNetUpToDate(minVersion: string, commandResult: { code: number, output: string }): boolean {

--- a/src/dotnet-interactive-vscode/src/utilities.ts
+++ b/src/dotnet-interactive-vscode/src/utilities.ts
@@ -4,8 +4,9 @@
 import * as compareVersions from 'compare-versions';
 import * as cp from 'child_process';
 import * as path from 'path';
+import { v4 as uuid } from 'uuid';
 import { InstallInteractiveArgs, ProcessStart } from "./interfaces";
-import { ReportChannel, Uri } from 'dotnet-interactive-vscode-interfaces/out/notebook';
+import { ErrorOutputMimeType, NotebookCellOutput, NotebookCellOutputItem, ReportChannel, Uri } from 'dotnet-interactive-vscode-interfaces/out/notebook';
 
 export function executeSafe(command: string, args: Array<string>, workingDirectory?: string | undefined): Promise<{ code: number, output: string, error: string }> {
     return new Promise<{ code: number, output: string, error: string }>(resolve => {
@@ -58,6 +59,27 @@ export async function executeSafeAndLog(outputChannel: ReportChannel, operationN
     }
 
     return result;
+}
+
+export function createOutput(outputItems: Array<NotebookCellOutputItem>, outputId?: string): NotebookCellOutput {
+    if (!outputId) {
+        outputId = uuid();
+    }
+
+    const output: NotebookCellOutput = {
+        id: outputId,
+        outputs: outputItems,
+    };
+    return output;
+}
+
+export function createErrorOutput(message: string, outputId?: string): NotebookCellOutput {
+    const outputItem: NotebookCellOutputItem = {
+        mime: ErrorOutputMimeType,
+        value: message,
+    };
+    const output = createOutput([outputItem], outputId);
+    return output;
 }
 
 export function isDotNetUpToDate(minVersion: string, commandResult: { code: number, output: string }): boolean {

--- a/src/dotnet-interactive-vscode/src/vscode/OutputChannelAdapter.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/OutputChannelAdapter.ts
@@ -10,7 +10,7 @@ export class OutputChannelAdapter implements ReportChannel {
     }
 
     getName(): string {
-        return this.clear.name;
+        return this.channel.name;
     }
 
     append(value: string): void {

--- a/src/dotnet-interactive-vscode/src/vscode/commands.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/commands.ts
@@ -13,8 +13,9 @@ import { DotNetPathManager } from './extension';
 import { computeToolInstallArguments, executeSafe } from '../utilities';
 
 import * as jupyter from './jupyter';
+import { ReportChannel } from 'dotnet-interactive-vscode-interfaces/out/notebook';
 
-export function registerAcquisitionCommands(context: vscode.ExtensionContext) {
+export function registerAcquisitionCommands(context: vscode.ExtensionContext, diagnosticChannel: ReportChannel) {
     const config = vscode.workspace.getConfiguration('dotnet-interactive');
     const minDotNetInteractiveVersion = config.get<string>('minimumInteractiveToolVersion');
     const interactiveToolSource = config.get<string>('interactiveToolSource');
@@ -35,7 +36,7 @@ export function registerAcquisitionCommands(context: vscode.ExtensionContext) {
                 async () => { await vscode.window.showInformationMessage('.NET Interactive installation complete.'); });
             return launchOptions;
         } catch (err) {
-            console.error(`Error acquiring dotnet-interactive tool: ${err}`);
+            diagnosticChannel.appendLine(`Error acquiring dotnet-interactive tool: ${err}`);
         }
     }));
 

--- a/src/dotnet-interactive-vscode/src/vscode/extension.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/extension.ts
@@ -48,12 +48,12 @@ export class CachedDotNetPathManager {
 export const DotNetPathManager = new CachedDotNetPathManager();
 
 export async function activate(context: vscode.ExtensionContext) {
-    // this must happen first, because some following functions use the acquisition command
-    registerAcquisitionCommands(context);
-
     const config = vscode.workspace.getConfiguration('dotnet-interactive');
     const diagnosticsChannel = new OutputChannelAdapter(vscode.window.createOutputChannel('.NET Interactive : diagnostics'));
     DotNetPathManager.setOutputChannelAdapter(diagnosticsChannel);
+
+    // this must happen early, because some following functions use the acquisition command
+    registerAcquisitionCommands(context, diagnosticsChannel);
 
     // register with VS Code
     const clientMapper = new ClientMapper(async (notebookPath) => {
@@ -66,7 +66,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
         const launchOptions = await getInteractiveLaunchOptions();
         if (!launchOptions) {
-            throw new Error('Unable to get interactive launch options; .NET SDK must be installed first.');
+            throw new Error(`Unable to get interactive launch options.  Please see the '${diagnosticsChannel.getName()}' output window for details.`);
         }
 
         // prepare kernel transport launch arguments and working directory using a fresh config item so we don't get cached values
@@ -188,12 +188,16 @@ async function updateCellLanguageInMetadata(languageChangeEvent: { cell: vscode.
 
 async function updateDocumentMetadata(e: { document: vscode.NotebookDocument, kernel: vscode.NotebookKernel | undefined }, clientMapper: ClientMapper) {
     if (e.kernel?.id === KernelId) {
-        // update various metadata
-        await updateDocumentKernelspecMetadata(e.document);
-        await updateCellLanguages(e.document);
+        try {
+            // update various metadata
+            await updateDocumentKernelspecMetadata(e.document);
+            await updateCellLanguages(e.document);
 
-        // force creation of the client so we don't have to wait for the user to execute a cell to get the tool
-        await clientMapper.getOrAddClient(e.document.uri);
+            // force creation of the client so we don't have to wait for the user to execute a cell to get the tool
+            await clientMapper.getOrAddClient(e.document.uri);
+        } catch (err) {
+            vscode.window.showErrorMessage(`Failed to set document metadata for '${e.document.uri}': ${err}`);
+        }
     }
 }
 

--- a/src/dotnet-interactive-vscode/src/vscode/extension.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/extension.ts
@@ -33,7 +33,7 @@ export class CachedDotNetPathManager {
 
     setDotNetPath(dotNetPath: string) {
         if (this.dotNetPath !== dotNetPath) {
-            this.dotNetPath = dotNetPath
+            this.dotNetPath = dotNetPath;
             if (this.outputChannelAdapter) {
                 this.outputChannelAdapter.appendLine(`dotnet path set to '${this.dotNetPath}'`);
             }


### PR DESCRIPTION
As part of investigating #1137, be explicit about logging tool acquisition failures to the diagnostics output pane.

I injected fake failures at all 3 tool acquisition failure points; checking the existing tool version, creating a tool manifest, installing the tool.  All three errors appear in essentially the same way.

![image](https://user-images.githubusercontent.com/926281/110178389-3b2b9380-7dbb-11eb-99ff-4ff3680adcc9.png)

![image](https://user-images.githubusercontent.com/926281/110178405-41217480-7dbb-11eb-93f0-3bc1f137744d.png)

![image](https://user-images.githubusercontent.com/926281/110178419-467ebf00-7dbb-11eb-991b-fe01428d9690.png)
