### PR TITLE
use different extension version numbers for stable/insiders

### DIFF
--- a/eng/package/PackVSCodeExtension.ps1
+++ b/eng/package/PackVSCodeExtension.ps1
@@ -46,10 +46,10 @@ function Build-Extension([string] $packageDirectory, [string] $packageVersionNum
 }
 
 try {
-    $stablePackageVersion = "${stableToolVersionNumber}00"
-    $insidersPackageVersion = "${stableToolVersionNumber}01"
-    Build-Extension -packageDirectory "stable" -packageVersionNumber $stableToolVersionNumber -kernelVersionNumber $stableToolVersionNumber
-    Build-Extension -packageDirectory "insiders" -packageVersionNumber $stableToolVersionNumber -kernelVersionNumber $stableToolVersionNumber
+    $stablePackageVersion = "${stableToolVersionNumber}0"
+    $insidersPackageVersion = "${stableToolVersionNumber}1"
+    Build-Extension -packageDirectory "stable" -packageVersionNumber $stablePackageVersion -kernelVersionNumber $stableToolVersionNumber
+    Build-Extension -packageDirectory "insiders" -packageVersionNumber $insidersPackageVersion -kernelVersionNumber $stableToolVersionNumber
 }
 catch {
     Write-Host $_


### PR DESCRIPTION
Extension publish to only insiders was successful, so now we need to produce different version numbers during each build.  This is accomplished by appending `0` to stable builds and `1` to insider builds.

Once this is in, we can now publish the insider version of the extension at any time and not affect users on stable.  When we need to release a new version of stable, we must then immediately release the corresponding `1` insider release, too, to maintain proper extension updating behavior.  The dual-shipping will be handled by the release pipeline.

After this is merged, the stable release pipeline will need one more update to pick up the extension from the correct directory.

~~Marked as draft until the [internal build](https://dev.azure.com/dnceng/internal/_build/results?buildId=1028425&view=results) can be manually verified.~~ Internal build is good.