### PR TITLE
allow publishing multiple extensions with one invocation

### DIFF
--- a/eng/publish/PublishVSCodeExtension.ps1
+++ b/eng/publish/PublishVSCodeExtension.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding(PositionalBinding = $false)]
 param (
     [string]$artifactsPath,
-    [string]$vscodeTarget,
+    [string[]]$vscodeTargets,
     [string]$publishToken
 )
 
@@ -9,18 +9,26 @@ Set-StrictMode -version 2.0
 $ErrorActionPreference = "Stop"
 
 try {
-    # find extension vsix
-    $extension = Get-ChildItem "$artifactsPath\$vscodeTarget\dotnet-interactive-vscode-*.vsix" | Select-Object -First 1
-
-    # verify
-    . "$PSScriptRoot\VerifyVSCodeExtension.ps1" -extensionPath $extension
+    npm install -g vsce
     if ($LASTEXITCODE -ne 0) {
         exit $LASTEXITCODE
     }
 
-    # publish
-    npm install -g vsce
-    vsce publish --packagePath $extension --pat $publishToken --noVerify
+    $vscodeTargets | ForEach-Object {
+        $vscodeTarget = $_
+
+        # find extension vsix
+        $extension = Get-ChildItem "$artifactsPath\$vscodeTarget\dotnet-interactive-vscode-*.vsix" | Select-Object -First 1
+
+        # verify
+        . "$PSScriptRoot\VerifyVSCodeExtension.ps1" -extensionPath $extension
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
+
+        # publish
+        vsce publish --packagePath $extension --pat $publishToken --noVerify
+    }
 }
 catch {
     Write-Host $_


### PR DESCRIPTION
Just a cleanup of the publish script so that we only have to invoke it once.  Once this is merged the release pipelines will need to be updated with the following change(s):

``` diff
// stable publish
-.\PublishVSCodeExtension.ps1 ... -vscodeTarget "stable" ...
-.\PublishVSCodeExtension.ps1 ... -vscodeTarget "insiders" ...
+.\PublishVSCodeExtension.ps1 ... -vscodeTargets "stable","insiders" ...

// insiders publish
-.\PublishVSCodeExtension.ps1 ... -vscodeTarget "insiders" ...
+.\PublishVSCodeExtension.ps1 ... -vscodeTargets "insiders" ...
```