### PR TITLE
ensure at least one cell is present in a notebook

### DIFF
--- a/src/dotnet-interactive-vscode/common/interactiveNotebook.ts
+++ b/src/dotnet-interactive-vscode/common/interactiveNotebook.ts
@@ -17,6 +17,8 @@ export const notebookCellLanguages: Array<string> = [
     'dotnet-interactive.sql'
 ];
 
+export const defaultNotebookCellLanguage = notebookCellLanguages[0];
+
 const notebookLanguagePrefix = 'dotnet-interactive.';
 
 export function getSimpleLanguage(language: string): string {

--- a/src/dotnet-interactive-vscode/common/vscode/notebookContentProvider.ts
+++ b/src/dotnet-interactive-vscode/common/vscode/notebookContentProvider.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { ClientMapper } from '../clientMapper';
-import { getSimpleLanguage, getNotebookSpecificLanguage, languageToCellKind, backupNotebook } from '../interactiveNotebook';
+import { getSimpleLanguage, getNotebookSpecificLanguage, languageToCellKind, backupNotebook, defaultNotebookCellLanguage } from '../interactiveNotebook';
 import { Eol } from '../interfaces';
 import { NotebookCell, NotebookCellDisplayOutput, NotebookCellErrorOutput, NotebookCellOutput, NotebookDocument } from '../interfaces/contracts';
 import * as utilities from '../interfaces/utilities';
@@ -49,6 +49,15 @@ export class DotNetInteractiveNotebookContentProvider implements vscode.Notebook
             }
         } else {
             // new empty/blank notebook, nothing to do
+        }
+
+        if (notebookCells.length === 0) {
+            // ensure at least one cell
+            notebookCells.push({
+                language: defaultNotebookCellLanguage,
+                contents: '',
+                outputs: [],
+            });
         }
 
         const notebookData = this.createNotebookData(notebookCells);


### PR DESCRIPTION
When the Jupyter extension isn't present and our extension is in charge of opening an empty notebook or creating a new blank one, we didn't create any cells so the VS Code notebook engine created one for us with the default language of Plain Text which isn't useful for us.  The fix is to simply ensure there's at least one cell present with a reasonable language.