### PR TITLE
[release/hotfix] Port fixes to stable

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,9 +2,11 @@
 trigger:
 - main
 - feature/*
+- release/*
 pr:
 - main
 - feature/*
+- release/*
 
 # Variables
 variables:

--- a/src/dotnet-interactive-vscode/package-lock.json
+++ b/src/dotnet-interactive-vscode/package-lock.json
@@ -2152,6 +2152,14 @@
       "requires": {
         "uuid": "^3.3.2",
         "xmlbuilder": "^13.0.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "normalize-package-data": {
@@ -3029,10 +3037,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.1.0",

--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -319,6 +319,7 @@
   "dependencies": {
     "compare-versions": "3.6.0",
     "node-fetch": "^2.6.1",
+    "uuid": "^8.3.2",
     "dotnet-interactive-vscode-insiders": "file:src/vscode/insiders/dotnet-interactive-vscode-insiders-1.0.0.tgz",
     "dotnet-interactive-vscode-interfaces": "file:src/interfaces/dotnet-interactive-vscode-interfaces-1.0.0.tgz",
     "dotnet-interactive-vscode-stable": "file:src/vscode/stable/dotnet-interactive-vscode-stable-1.0.0.tgz"

--- a/src/dotnet-interactive-vscode/src/interactiveNotebook.ts
+++ b/src/dotnet-interactive-vscode/src/interactiveNotebook.ts
@@ -17,6 +17,8 @@ export const notebookCellLanguages: Array<string> = [
     'dotnet-interactive.sql'
 ];
 
+export const defaultNotebookCellLanguage = notebookCellLanguages[0];
+
 const notebookLanguagePrefix = 'dotnet-interactive.';
 
 export function getSimpleLanguage(language: string): string {

--- a/src/dotnet-interactive-vscode/src/tests/unit/client.test.ts
+++ b/src/dotnet-interactive-vscode/src/tests/unit/client.test.ts
@@ -479,4 +479,11 @@ describe('InteractiveClient tests', () => {
         });
     });
 
+    it('exception creating kernel transport gracefully fails', done => {
+        const clientMapper = new ClientMapper(async _notebookPath => {
+            throw new Error('simulated error during transport creation');
+        });
+        expect(clientMapper.getOrAddClient({ fsPath: 'fake-notebook' })).eventually.rejectedWith('simulated error during transport creation').notify(done);
+    });
+
 });

--- a/src/dotnet-interactive-vscode/src/vscode/OutputChannelAdapter.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/OutputChannelAdapter.ts
@@ -10,7 +10,7 @@ export class OutputChannelAdapter implements ReportChannel {
     }
 
     getName(): string {
-        return this.clear.name;
+        return this.channel.name;
     }
 
     append(value: string): void {

--- a/src/dotnet-interactive-vscode/src/vscode/notebookContentProvider.ts
+++ b/src/dotnet-interactive-vscode/src/vscode/notebookContentProvider.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { ClientMapper } from '../clientMapper';
-import { getSimpleLanguage, getNotebookSpecificLanguage, languageToCellKind, backupNotebook } from '../interactiveNotebook';
+import { getSimpleLanguage, getNotebookSpecificLanguage, languageToCellKind, backupNotebook, defaultNotebookCellLanguage } from '../interactiveNotebook';
 import { Eol } from '../interfaces';
 import { NotebookCell, NotebookCellOutput, NotebookDocument } from 'dotnet-interactive-vscode-interfaces/out/contracts';
 import { configureWebViewMessaging, getEol, isInsidersBuild, isUnsavedNotebook } from './vscodeUtilities';
@@ -48,6 +48,15 @@ export class DotNetInteractiveNotebookContentProvider implements vscode.Notebook
             }
         } else {
             // new empty/blank notebook, nothing to do
+        }
+
+        if (notebookCells.length === 0) {
+            // ensure at least one cell
+            notebookCells.push({
+                language: defaultNotebookCellLanguage,
+                contents: '',
+                outputs: [],
+            });
         }
 
         const notebookData = this.createNotebookData(notebookCells);


### PR DESCRIPTION
This PR adds 2 fixes to the current stable extension:

- #1140 - "log all tool acquisition failures to diagnostics channel" via cherry-pick.  The next commit cbd4dba3d29a6e0772bc93afb8b134a733a42d57 also corresponds to this fix.  This is in response to #1137 to make acquisition errors easier to diagngose.  
- #1154 - "ensure at least one cell is present in a notebook" via manual application; unable to cherry-pick due to the structure of the repo changing.  This fixes the issue where blank/empty notebooks were getting their initial cell language set to "Plain Text" instead of "C# (.NET Interactive)".