### PR TITLE
pass reference assemblies to interactive workspace to enable bcl doc comments

### DIFF
--- a/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
@@ -420,6 +420,11 @@ namespace Microsoft.DotNet.Interactive.CSharp
                              .Select(r => CachingMetadataResolver.ResolveReferenceWithXmlDocumentationProvider(r))
                              .ToArray();
 
+            foreach (var reference in references)
+            {
+                _workspace.AddPackageManagerReference(reference);
+            }
+
             ScriptOptions = ScriptOptions.AddReferences(references);
         }
 

--- a/src/Microsoft.DotNet.Interactive.CSharp/InteractiveWorkspace.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/InteractiveWorkspace.cs
@@ -119,7 +119,7 @@ namespace Microsoft.DotNet.Interactive.CSharp
             return solution;
         }
 
-        private IEnumerable<MetadataReference> GetReferenceSet(Compilation compilation)
+        private IReadOnlyCollection<MetadataReference> GetReferenceSet(Compilation compilation)
         {
             var references =
                 _referenceAssemblies

--- a/src/Microsoft.DotNet.Interactive.CSharp/InteractiveWorkspace.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/InteractiveWorkspace.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Reactive.Disposables;
 
 using Microsoft.CodeAnalysis;
@@ -21,6 +24,8 @@ namespace Microsoft.DotNet.Interactive.CSharp
         private readonly CSharpParseOptions _parseOptions;
         private Compilation _currentCompilation;
         private DocumentId _workingDocumentId;
+        private readonly IReadOnlyCollection<MetadataReference> _referenceAssemblies;
+        private readonly List<MetadataReference> _packageManagerReferences = new List<MetadataReference>();
 
         public InteractiveWorkspace() : base(MefHostServices.DefaultHost, WorkspaceKind.Interactive)
         {
@@ -29,10 +34,65 @@ namespace Microsoft.DotNet.Interactive.CSharp
                 DocumentationMode.Parse,
                 SourceCodeKind.Script);
 
+            _referenceAssemblies = ResolveRefAssemblies();
+
             _disposables.Add(Disposable.Create(() =>
             {
                 _currentCompilation = null;
             }));
+        }
+
+        private static string ResolveRefAssemblyPath()
+        {
+            var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+            var refAssemblyDir = runtimeDir; // if any of the below path probing fails, fall back to the runtime so we can still run
+
+            // e.g., will transform
+            //   `C:\Program Files\dotnet\shared\Microsoft.NETCore.App\5.0.3`
+            // to
+            //   `C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0\ref\net5.0`
+            if (Version.TryParse(Path.GetFileName(runtimeDir), out var runtimeVersion))
+            {
+                var appRefDir = Path.Combine(runtimeDir, "..", "..", "..", "packs", "Microsoft.NETCore.App.Ref");
+                if (Directory.Exists(appRefDir))
+                {
+                    var latestRuntimeDirAndVersion =
+                        Directory.GetDirectories(appRefDir)
+                        .Select(dir => Path.GetFileName(dir))
+                        .Select(dir => new { Directory = dir, Version = Version.TryParse(dir, out var version) ? version : new Version() })
+                        .OrderBy(dirPair => dirPair.Version)
+                        .Where(dirPair => dirPair.Version <= runtimeVersion)
+                        .LastOrDefault();
+                    if (latestRuntimeDirAndVersion is { })
+                    {
+                        var refVersion = latestRuntimeDirAndVersion.Directory; // e.g., `5.0.0`
+                        var tfmName = $"net{latestRuntimeDirAndVersion.Version.Major}.{latestRuntimeDirAndVersion.Version.Minor}"; // e.g., `net5.0`
+                        refAssemblyDir = Path.Combine(appRefDir, refVersion, "ref", tfmName);
+                    }
+                }
+            }
+
+            return refAssemblyDir;
+        }
+
+        private static IReadOnlyCollection<MetadataReference> ResolveRefAssemblies()
+        {
+            var assemblyRefs = new List<MetadataReference>();
+            foreach (var assemblyRef in Directory.EnumerateFiles(ResolveRefAssemblyPath(), "*.dll"))
+            {
+                try
+                {
+                    var resolved = CachingMetadataResolver.ResolveReferenceWithXmlDocumentationProvider(assemblyRef, MetadataReferenceProperties.Assembly);
+                    assemblyRefs.Add(resolved);
+                }
+                catch (Exception ex) when (ex is ArgumentNullException || ex is ArgumentException || ex is IOException)
+                {
+                    // the only exceptions that can be thrown by `ResolveReferenceWithXmlDocumentationProvider` which
+                    // internally calls `XmlDocumentationProvider.CreateFromFile`
+                }
+            }
+
+            return assemblyRefs;
         }
 
         public void UpdateWorkspace(ScriptState scriptState)
@@ -59,6 +119,16 @@ namespace Microsoft.DotNet.Interactive.CSharp
             return solution;
         }
 
+        private IEnumerable<MetadataReference> GetReferenceSet(Compilation compilation)
+        {
+            var references =
+                _referenceAssemblies
+                .Concat(_packageManagerReferences)
+                .Concat(compilation.DirectiveReferences)
+                .ToArray();
+            return references;
+        }
+
         private (ProjectId projectId, DocumentId workingDocumentId) AddNewWorkingProjectToSolution(Compilation previousCompilation, ProjectId projectReferenceProjectId)
         {
             var solution = CurrentSolution;
@@ -67,12 +137,15 @@ namespace Microsoft.DotNet.Interactive.CSharp
 
             var projectId = ProjectId.CreateNewId(debugName: $"workingProject{assemblyName}");
 
+            var references = GetReferenceSet(previousCompilation);
+
             solution = CreateProjectAndAddToSolution(
-                projectId, 
-                assemblyName, 
-                compilationOptions, 
+                projectId,
+                assemblyName,
+                compilationOptions,
                 solution,
-                projectReferenceProjectId);
+                projectReferenceProjectId,
+                references);
 
             var workingDocumentId = DocumentId.CreateNewId(
                 projectId);
@@ -140,13 +213,15 @@ namespace Microsoft.DotNet.Interactive.CSharp
                 projectId = ProjectId.CreateNewId(debugName: debugName);
             }
 
+            var references = GetReferenceSet(compilation);
+
             solution = CreateProjectAndAddToSolution(
-                projectId, 
-                assemblyName, 
-                compilationOptions, 
+                projectId,
+                assemblyName,
+                compilationOptions,
                 solution,
-                projectReferenceProjectId, 
-                compilation.References);
+                projectReferenceProjectId,
+                references);
 
             var currentSubmissionDocumentId = DocumentId.CreateNewId(
                 projectId,
@@ -186,6 +261,11 @@ namespace Microsoft.DotNet.Interactive.CSharp
             SetCurrentSolution(solution);
             return workingDocument;
 
+        }
+
+        public void AddPackageManagerReference(MetadataReference reference)
+        {
+            _packageManagerReferences.Add(reference);
         }
 
         protected override void Dispose(bool finalize)

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/CompletionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/CompletionTests.cs
@@ -318,6 +318,24 @@ var y = x + 2;
         }
 
         [Theory]
+        [InlineData(Language.CSharp, "System.Environment.Command$$Line", "Gets the command line for this process.")]
+        public async Task completion_doc_comments_can_be_loaded_from_bcl_types(Language language, string markupCode, string expectedCompletionSubstring)
+        {
+            using var kernel = CreateKernel(language);
+
+            MarkupTestFile.GetLineAndColumn(markupCode, out var code, out var line, out var character);
+            await kernel.SendAsync(new RequestCompletions(code, new LinePosition(line, character)));
+
+            KernelEvents
+                .Should()
+                .ContainSingle<CompletionsProduced>()
+                .Which
+                .Completions
+                .Should()
+                .ContainSingle(ci => ci.Documentation != null && ci.Documentation.Contains(expectedCompletionSubstring));
+        }
+
+        [Theory]
         [InlineData(Language.CSharp, "/// <summary>Adds two numbers.</summary>\nint Add(int a, int b) => a + b;", "Ad$$", "Adds two numbers.")]
         [InlineData(Language.FSharp, "/// Adds two numbers.\nlet add a b = a + b", "ad$$", "Adds two numbers.")]
         public async Task completion_doc_comments_can_be_loaded_from_source_in_a_previous_submission(Language language, string previousSubmission, string markupCode, string expectedCompletionSubString)


### PR DESCRIPTION
The `CSharpScript` object only tracks runtime assemblies, so passing those to the interactive workspace meant that any types that get forwarded to `System.Private.CoreLib.dll` (e.g., `System.Environment` defined in `System.Runtime.dll`/`System.Runtime.xml` is implemented in `System.Private.CoreLib.dll` which doesn't have a corresponding `System.Private.CoreLib.xml` file) won't have proper doc comments, because the defining ref assembly and the xml doc comment file names don't match.

The fix was to:

1. **Find and enumerate all reference assemblies and use those for the workspace.**  The reference assembly location is computed from the runtime location.  This same path calculation is used internally in F# and if at any point the path calculation fails, the runtime assemblies will be used.  In this scenario, doc comments won't be loaded, but the end user will still get parameter names and basic signature help, so they're not left completely in the cold.
2. **Combine the assemblies from (1) with anything referenced via explicit `#r "path/to/assembly.dll"`**, and
3. **all references from NuGet packages.**

Fixes #1072.