### PR TITLE
allow tests to be skipped in signed build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ stages:
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
             name: NetCoreInternal-Pool
             queue: buildpool.windows.10.amd64.vs2019
-        timeoutInMinutes: 300
+        timeoutInMinutes: 90
         variables:
         # Enable signing for internal, non-PR builds
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -76,6 +76,10 @@ stages:
             value: Test
           - name: _BuildArgs
             value: /p:SignType=$(_SignType)
+        # SkipTests
+        - ${{ if ne(variables['SkipTests'], 'true') }}:
+          - name: _TestArgs
+            value: -test
         steps:
         - script: git config --global core.longpaths true
           displayName: Enable `git clean` to handle long paths
@@ -110,7 +114,7 @@ stages:
             -configuration $(_BuildConfig)
             -prepareMachine
             -sign
-            -test
+            $(_TestArgs)
             $(_BuildArgs)
           displayName: Build / Test
           env:
@@ -119,6 +123,7 @@ stages:
         - script: npm run ciTest
           displayName: NPM tests
           workingDirectory: "$(Build.SourcesDirectory)/src/Microsoft.DotNet.Interactive.Js"
+          condition: ne(variables['SkipTests'], 'true')
 
         # build and test VS Code extension
         - script: npm install
@@ -128,6 +133,7 @@ stages:
         - script: npm run ciTest
           displayName: npm test (VS Code stable)
           workingDirectory: "$(Build.SourcesDirectory)/src/dotnet-interactive-vscode/stable"
+          condition: ne(variables['SkipTests'], 'true')
 
         - script: npm install
           displayName: npm install (VS Code insiders)
@@ -136,6 +142,7 @@ stages:
         - script: npm run ciTest
           displayName: npm test (VS Code insiders)
           workingDirectory: "$(Build.SourcesDirectory)/src/dotnet-interactive-vscode/insiders"
+          condition: ne(variables['SkipTests'], 'true')
 
         # build and test npm package
         - script: npm install
@@ -145,6 +152,7 @@ stages:
         - script: npm run ciTest
           displayName: npm test (npm package)
           workingDirectory: "$(Build.SourcesDirectory)/src/dotnet-interactive-npm"
+          condition: ne(variables['SkipTests'], 'true')
 
         # publish VS Code and npm test results
         - task: PublishTestResults@2
@@ -231,6 +239,10 @@ stages:
             value: Test
           - name: _BuildArgs
             value: /p:SignType=$(_SignType)
+        # SkipTests
+        - ${{ if ne(variables['SkipTests'], 'true') }}:
+          - name: _TestArgs
+            value: --test
         steps:
         - script: git config --global core.longpaths true
           displayName: Enable `git clean` to handle long paths
@@ -258,7 +270,7 @@ stages:
         - script: ./eng/cibuild.sh
             --configuration $(_BuildConfig)
             --prepareMachine
-            --test
+            $(_TestArgs)
           displayName: Build / Test
           env:
             TRYDOTNET_PACKAGES_PATH: $(TryDotNetPackagesPath)
@@ -266,6 +278,7 @@ stages:
         - script: npm run ciTest
           displayName: NPM tests
           workingDirectory: "$(Build.SourcesDirectory)/src/Microsoft.DotNet.Interactive.Js"
+          condition: ne(variables['SkipTests'], 'true')
 
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
@@ -321,7 +334,7 @@ stages:
       jobs:
       - job: IntegrationTest
         dependsOn: Windows_NT
-        condition: succeeded()
+        condition: and(succeeded(), ne(variables['SkipTests'], 'true'))
         pool:
           vmImage: ubuntu-latest
         variables:


### PR DESCRIPTION
To make testing build changes faster, I added a variable `SkipTests` to the signed build definition that defaults to `false`.  If set to `true` the obvious will happen.  This PR is to ensure I didn't break PR builds.

The behavior of `SkipTests=false` being the default instead of `RunTests=true` is because the PR build doesn't define that variable and I want the skipping of tests to be very explicit.  If instead the condition was (pseudo) `if $(RunTests) == 'true' ...` then if the variable was ever removed or renamed, tests would never be run.  I'd rather err on the side of running tests.

Marked as draft until internal builds (one with `SkipTests` as default `false`, one with `true`) finish with expected results.

I also dropped the Windows leg timeout down to 90 minutes; 5 hours was too much given the hanging tests we're dealing with, but 90 minutes should give us plenty of time to finish, even if it's a slow run.

Edit:
Internal builds behaved as expected.