### PR TITLE
publish npm package to specified feed

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -395,3 +395,15 @@ stages:
       enableSymbolValidation: false
       # SourceLink improperly looks for generated files.  See https://github.com/dotnet/arcade/issues/3069
       enableSourceLinkValidation: false
+
+#---------------------------------------------------------------------------------------------------------------------#
+#                                                    NPM Publish                                                      #
+#---------------------------------------------------------------------------------------------------------------------#
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - template: eng/publish/publish-npm.yml
+    parameters:
+      packageName: microsoft-dotnet-interactive-*.tgz
+      registryUrl: pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/npm/registry/
+      registryUser: dnceng
+      registryEmail: dnceng@microsoft.com
+      publishingBranch: main

--- a/eng/package/PackNpmPackage.ps1
+++ b/eng/package/PackNpmPackage.ps1
@@ -18,14 +18,15 @@ function Build-NpmPackage() {
     # pack
     Write-Host "Packing package"
     npm pack
-    Copy-Item -Path (Join-Path (Get-Location) "dotnet-interactive-$packageVersionNumber.tgz") -Destination $outDir
+    Copy-Item -Path (Join-Path (Get-Location) "microsoft-dotnet-interactive-$packageVersionNumber.tgz") -Destination $outDir
 }
 
 try {
     . "$PSScriptRoot\PackUtilities.ps1"
 
-    # create destination
+    # copy publish scripts
     EnsureCleanDirectory -location $outDir
+    Copy-Item -Path $PSScriptRoot\..\publish\* -Destination $outDir -Recurse
 
     Build-NpmPackage
 }

--- a/eng/publish/PublishNPMPackage.ps1
+++ b/eng/publish/PublishNPMPackage.ps1
@@ -1,0 +1,47 @@
+[CmdletBinding(PositionalBinding = $false)]
+param (
+    [string]$packageName,
+    [string]$registryUrl,
+    [string]$registryUser,
+    [string]$registryEmail,
+    [string]$currentBranch,
+    [string]$publishingBranch,
+    [string]$artifactDirectory,
+    [string]$registryPublishToken
+)
+
+Set-StrictMode -version 2.0
+$ErrorActionPreference = "Stop"
+
+try {
+    # create .npmrc with package feed
+    $registryPublishTokenBase64 = [Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($registryPublishToken))
+    $npmrcContents = "
+; begin auth token
+registry=https://$registryUrl
+username=$registryUser
+email=$registryEmail
+_password=$registryPublishTokenBase64
+_accessToken=$registryPublishToken
+; end auth token"
+    $npmrcContents | Out-File "$artifactDirectory/.npmrc"
+
+    # publish to feed
+    if (($currentBranch -Eq $publishingBranch) -Or ($currentBranch -Eq "refs/heads/$publishingBranch")) {
+        $singlePackageName = Get-ChildItem "$artifactDirectory/$packageName" | Select-Object -First 1
+        Write-Host "Publishing $singlePackageName to $registryUrl"
+        npm publish "$singlePackageName" --access public
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
+    }
+    else {
+        Write-Host "Branch '$currentBranch' does not match publishing branch '$publishingBranch', skipping publish."
+    }
+}
+catch {
+    Write-Host $_
+    Write-Host $_.Exception
+    Write-Host $_.ScriptStackTrace
+    exit 1
+}

--- a/eng/publish/publish-npm.yml
+++ b/eng/publish/publish-npm.yml
@@ -1,0 +1,39 @@
+parameters:
+  packageName: ''
+  registryUrl: ''
+  publishingBranch: ''
+  registryUser: ''
+  registryEmail: ''
+
+stages:
+- stage: publish
+  dependsOn: build
+  displayName: Publish NPM package to feed
+  jobs:
+  - job: Publish_NPM
+    pool:
+      vmImage: windows-latest
+    variables:
+    - group: AzureDevOps-Artifact-Feeds-Pats
+    - name: NodeJSVersion
+      value: '12.16.1'
+    steps:
+    - task: NodeTool@0
+      displayName: Add NodeJS/npm
+      inputs:
+        versionSpec: $(NodeJSVersion)
+    - task: DownloadBuildArtifacts@0
+      displayName: Download build NPM artifacts
+      inputs:
+        buildType: current
+        artifactName: npm
+        downloadPath: $(Build.ArtifactStagingDirectory)
+    - task: PowerShell@2
+      displayName: Publish NPM package
+      inputs:
+        filePath: $(Build.SourcesDirectory)/eng/publish/PublishNPMPackage.ps1
+        arguments: -packageName "${{ parameters.packageName }}" -registryUrl "${{ parameters.registryUrl }}" -currentBranch "$env:BUILD_SOURCEBRANCH" -publishingBranch "${{ parameters.publishingBranch }}" -artifactDirectory "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/npm" -registryPublishToken "$env:PUBLISH_TOKEN" -registryUser "${{ parameters.registryUser }}" -registryEmail "${{ parameters.registryEmail }}"
+        workingDirectory: '$(Build.ArtifactStagingDirectory)/npm'
+        pwsh: true
+      env:
+        PUBLISH_TOKEN: $(dn-bot-all-orgs-artifact-feeds-rw)

--- a/src/dotnet-interactive-npm/.gitignore
+++ b/src/dotnet-interactive-npm/.gitignore
@@ -1,4 +1,4 @@
 dist/
 node_modules/
 
-dotnet-interactive-*.tgz
+microsoft-dotnet-interactive-*.tgz

--- a/src/dotnet-interactive-npm/package.json
+++ b/src/dotnet-interactive-npm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dotnet-interactive",
+  "name": "@microsoft/dotnet-interactive",
   "displayName": ".NET Interactive Notebooks",
   "//description": "During build, the description gets the git SHA appended to it.",
   "description": ".NET Interactive Notebook APIs for NodeJS.",


### PR DESCRIPTION
Sample run of this against internal build is [here](https://dev.azure.com/dnceng/internal/_build/results?buildId=1046778&view=results) and resultant package is [here](https://dev.azure.com/dnceng/public/_packaging?_a=package&feed=dotnet-tools&package=%40microsoft%2Fdotnet-interactive&protocolType=Npm&version=1.0.216814).  The internal feed with this package is [here](https://dev.azure.com/dnceng/public/_packaging?_a=feed&feed=dotnet-tools) and has connection instructions there.

Every build of `main` will publish a new package to the feed.  The publishing branch is controlled by the bottom of `azure-pipelines.yml` with the `publishingBranch` parameter.

![image](https://user-images.githubusercontent.com/926281/111727157-959b0a00-8827-11eb-9f23-14013555418c.png)

The actual publishing of the package is handled via the new `PublishNPMPackage.ps1` which should be able to be used to publish to npmjs.com when the time arises.
