### PR TITLE
update insiders kernel execution model

### DIFF
--- a/src/dotnet-interactive-vscode/common/vscode/commands.ts
+++ b/src/dotnet-interactive-vscode/common/vscode/commands.ts
@@ -8,9 +8,10 @@ import { InstallInteractiveArgs, InteractiveLaunchOptions } from '../interfaces'
 import { ClientMapper } from '../clientMapper';
 import { getEol, isUnsavedNotebook } from './vscodeUtilities';
 import { toNotebookDocument } from './notebookContentProvider';
-import { KernelId, updateCellMetadata } from './notebookKernel';
+import { KernelId } from './notebookKernel';
 import { DotNetPathManager } from './extension';
 import { computeToolInstallArguments, executeSafe, executeSafeAndLog } from '../utilities';
+import * as versionSpecificFunctions from '../../versionSpecificFunctions';
 
 import * as jupyter from './jupyter';
 import { ReportChannel } from '../interfaces/vscode-like';
@@ -108,10 +109,9 @@ export function registerKernelCommands(context: vscode.ExtensionContext, clientM
         }
 
         if (document) {
-            const d = document;
-            document.cells.forEach(async cell => {
-                await updateCellMetadata(d, cell, { runState: vscode.NotebookCellRunState.Idle });
-            });
+            for (const cell of document.cells) {
+                await versionSpecificFunctions.markCellIdle(document, cell);
+            }
 
             clientMapper.closeClient(document.uri);
         }

--- a/src/dotnet-interactive-vscode/common/vscode/extension.ts
+++ b/src/dotnet-interactive-vscode/common/vscode/extension.ts
@@ -179,15 +179,14 @@ export function deactivate() {
 async function updateNotebookCellLanguageInMetadata(candidateNotebookCellDocument: vscode.TextDocument) {
     const notebook = candidateNotebookCellDocument.notebook;
     if (notebook && isDotnetInteractiveLanguage(candidateNotebookCellDocument.languageId)) {
-        const cellIndex = notebook.cells.findIndex(c => c.document === candidateNotebookCellDocument);
-        if (cellIndex >= 0) {
-            const cell = notebook.cells[cellIndex];
+        const cell = notebook.cells.find(c => c.document === candidateNotebookCellDocument);
+        if (cell) {
             const edit = new vscode.WorkspaceEdit();
             const cellMetadata: DotNetCellMetadata = {
                 language: getSimpleLanguage(candidateNotebookCellDocument.languageId),
             };
             const metadata = withDotNetMetadata(cell.metadata, cellMetadata);
-            edit.replaceNotebookCellMetadata(candidateNotebookCellDocument.uri, cellIndex, metadata);
+            edit.replaceNotebookCellMetadata(candidateNotebookCellDocument.uri, cell.index, metadata);
             await vscode.workspace.applyEdit(edit);
         }
     }

--- a/src/dotnet-interactive-vscode/insiders/package.json
+++ b/src/dotnet-interactive-vscode/insiders/package.json
@@ -112,7 +112,7 @@
         },
         "dotnet-interactive.minimumInteractiveToolVersion": {
           "type": "string",
-          "default": "1.0.216815",
+          "default": "1.0.217001",
           "description": "The minimum required version of the .NET Interactive tool."
         },
         "dotnet-interactive.useDotNetInteractiveExtensionForIpynbFiles": {

--- a/src/dotnet-interactive-vscode/insiders/src/versionSpecificFunctions.ts
+++ b/src/dotnet-interactive-vscode/insiders/src/versionSpecificFunctions.ts
@@ -4,8 +4,14 @@
 import * as vscode from 'vscode';
 import * as contracts from './common/interfaces/contracts';
 import * as vscodeLike from './common/interfaces/vscode-like';
-import * as utilities from './common/interfaces/utilities';
-import { contractCellOutputToVsCodeCellOutput } from './common/vscode/notebookContentProvider';
+import * as interactiveNotebook from './common/interactiveNotebook';
+import * as utilities from './common/utilities';
+import * as notebookContentProvider from './common/vscode/notebookContentProvider';
+import * as notebookKernel from './common/vscode/notebookKernel';
+import * as diagnostics from './common/vscode/diagnostics';
+import * as vscodeUtilities from './common/vscode/vscodeUtilities';
+
+import { ClientMapper } from './common/clientMapper';
 
 export function getCellKind(cell: vscode.NotebookCell): vscode.NotebookCellKind {
     return cell.kind;
@@ -16,7 +22,70 @@ export function createVsCodeNotebookCellData(cellData: { cellKind: vscodeLike.No
         cellData.cellKind,
         cellData.source,
         cellData.language,
-        cellData.outputs.map(contractCellOutputToVsCodeCellOutput),
+        cellData.outputs.map(notebookContentProvider.contractCellOutputToVsCodeCellOutput),
         cellData.metadata,
     );
+}
+
+const executionTasks: Map<vscode.Uri, vscode.NotebookCellExecutionTask> = new Map();
+
+export async function executeCell(document: vscode.NotebookDocument, cell: vscode.NotebookCell, clientMapper: ClientMapper): Promise<void> {
+    const startTime = Date.now();
+    const executionTask = vscode.notebook.createNotebookCellExecutionTask(document.uri, cell.index, notebookKernel.KernelId);
+    if (executionTask) {
+        executionTasks.set(cell.document.uri, executionTask);
+        try {
+            executionTask.start({
+                startTime,
+            });
+            executionTask.clearOutput(cell.index);
+            const client = await clientMapper.getOrAddClient(document.uri);
+            const source = cell.document.getText();
+            function outputObserver(outputs: Array<vscodeLike.NotebookCellOutput>) {
+                updateCellOutputs(executionTask!, cell, outputs).then(() => { });
+            }
+
+            const diagnosticCollection = diagnostics.getDiagnosticCollection(cell.document.uri);
+
+            function diagnosticObserver(diags: Array<contracts.Diagnostic>) {
+                diagnosticCollection.set(cell.document.uri, diags.filter(d => d.severity !== contracts.DiagnosticSeverity.Hidden).map(vscodeUtilities.toVsCodeDiagnostic));
+            }
+
+            return client.execute(source, interactiveNotebook.getSimpleLanguage(cell.document.languageId), outputObserver, diagnosticObserver, { id: document.uri.toString() }).then(() =>
+                endExecution(cell, true, Date.now() - startTime)
+            ).catch(() => endExecution(cell, false, Date.now() - startTime)
+            ).then(() => {
+                return notebookKernel.updateCellLanguages(document);
+            });
+        } catch (err) {
+            const errorOutput = utilities.createErrorOutput(`Error executing cell: ${err}`);
+            await updateCellOutputs(executionTask, cell, [errorOutput]);
+            endExecution(cell, false, Date.now() - startTime);
+            throw err;
+        }
+    }
+}
+
+function endExecution(cell: vscode.NotebookCell, success: boolean, duration?: number) {
+    const executionTask = executionTasks.get(cell.document.uri);
+    if (executionTask) {
+        executionTasks.delete(cell.document.uri);
+        executionTask.end({
+            success,
+            duration,
+        });
+    }
+}
+
+export async function cancelCellExecution(document: vscode.NotebookDocument, cell: vscode.NotebookCell, clientMapper: ClientMapper): Promise<void> {
+    // only required for stable
+}
+
+export async function markCellIdle(document: vscode.NotebookDocument, cell: vscode.NotebookCell) {
+    endExecution(cell, false);
+}
+
+async function updateCellOutputs(executionTask: vscode.NotebookCellExecutionTask, cell: vscode.NotebookCell, outputs: Array<vscodeLike.NotebookCellOutput>): Promise<void> {
+    const reshapedOutputs = outputs.map(o => new vscode.NotebookCellOutput(o.outputs.map(oi => notebookContentProvider.generateVsCodeNotebookCellOutputItem(oi.mime, oi.value))));
+    await executionTask.replaceOutput(reshapedOutputs, cell.index);
 }

--- a/src/dotnet-interactive-vscode/insiders/src/vscode.d.ts
+++ b/src/dotnet-interactive-vscode/insiders/src/vscode.d.ts
@@ -6674,6 +6674,10 @@ declare module 'vscode' {
 		 * tasks are always fully resolved. A valid default implementation for the
 		 * `resolveTask` method is to return `undefined`.
 		 *
+		 * Note that when filling in the properties of `task`, you _must_ be sure to
+		 * use the exact same `TaskDefinition` and not create a new one. Other properties
+		 * may be changed.
+		 *
 		 * @param task The task to resolve.
 		 * @param token A cancellation token.
 		 * @return The resolved task

--- a/src/dotnet-interactive-vscode/insiders/src/vscode.proposed.d.ts
+++ b/src/dotnet-interactive-vscode/insiders/src/vscode.proposed.d.ts
@@ -963,18 +963,6 @@ declare module 'vscode' {
 		Code = 2
 	}
 
-	export enum NotebookCellRunState {
-		Running = 1,
-		Idle = 2,
-		Success = 3,
-		Error = 4
-	}
-
-	export enum NotebookRunState {
-		Running = 1,
-		Idle = 2
-	}
-
 	export class NotebookCellMetadata {
 		/**
 		 * Controls whether a cell's editor is editable/readonly.
@@ -1003,14 +991,16 @@ declare module 'vscode' {
 
 		// run related API, will be removed
 		readonly hasExecutionOrder?: boolean;
-		readonly executionOrder?: number;
-		readonly runState?: NotebookCellRunState;
-		readonly runStartTime?: number;
-		readonly lastRunDuration?: number;
 
-		constructor(editable?: boolean, breakpointMargin?: boolean, hasExecutionOrder?: boolean, executionOrder?: number, runState?: NotebookCellRunState, runStartTime?: number, statusMessage?: string, lastRunDuration?: number, inputCollapsed?: boolean, outputCollapsed?: boolean, custom?: Record<string, any>)
+		constructor(editable?: boolean, breakpointMargin?: boolean, hasExecutionOrder?: boolean, statusMessage?: string, lastRunDuration?: number, inputCollapsed?: boolean, outputCollapsed?: boolean, custom?: Record<string, any>)
 
-		with(change: { editable?: boolean | null, breakpointMargin?: boolean | null, hasExecutionOrder?: boolean | null, executionOrder?: number | null, runState?: NotebookCellRunState | null, runStartTime?: number | null, statusMessage?: string | null, lastRunDuration?: number | null, inputCollapsed?: boolean | null, outputCollapsed?: boolean | null, custom?: Record<string, any> | null, }): NotebookCellMetadata;
+		with(change: { editable?: boolean | null, breakpointMargin?: boolean | null, hasExecutionOrder?: boolean | null, statusMessage?: string | null, lastRunDuration?: number | null, inputCollapsed?: boolean | null, outputCollapsed?: boolean | null, custom?: Record<string, any> | null, }): NotebookCellMetadata;
+	}
+
+	export interface NotebookCellExecutionSummary {
+		executionOrder?: number;
+		success?: boolean;
+		duration?: number;
 	}
 
 	// todo@API support ids https://github.com/jupyter/enhancement-proposals/blob/master/62-cell-id/cell-id.md
@@ -1021,6 +1011,7 @@ declare module 'vscode' {
 		readonly document: TextDocument;
 		readonly metadata: NotebookCellMetadata
 		readonly outputs: ReadonlyArray<NotebookCellOutput>;
+		readonly latestExecutionSummary: NotebookCellExecutionSummary | undefined;
 	}
 
 	export class NotebookDocumentMetadata {
@@ -1048,12 +1039,9 @@ declare module 'vscode' {
 		// todo@API is this a kernel property?
 		readonly cellHasExecutionOrder: boolean;
 
-		// todo@API remove
-		readonly runState: NotebookRunState;
+		constructor(editable?: boolean, cellEditable?: boolean, cellHasExecutionOrder?: boolean, custom?: { [key: string]: any; }, trusted?: boolean);
 
-		constructor(editable?: boolean, cellEditable?: boolean, cellHasExecutionOrder?: boolean, custom?: { [key: string]: any; }, runState?: NotebookRunState, trusted?: boolean);
-
-		with(change: { editable?: boolean | null, cellEditable?: boolean | null, cellHasExecutionOrder?: boolean | null, custom?: { [key: string]: any; } | null, runState?: NotebookRunState | null, trusted?: boolean | null, }): NotebookDocumentMetadata
+		with(change: { editable?: boolean | null, cellEditable?: boolean | null, cellHasExecutionOrder?: boolean | null, custom?: { [key: string]: any; } | null, trusted?: boolean | null, }): NotebookDocumentMetadata
 	}
 
 	export interface NotebookDocumentContentOptions {
@@ -1227,6 +1215,12 @@ declare module 'vscode' {
 		readonly visibleRanges: ReadonlyArray<NotebookCellRange>;
 	}
 
+	export interface NotebookCellExecutionStateChangeEvent {
+		readonly document: NotebookDocument;
+		readonly cell: NotebookCell;
+		readonly executionState: NotebookCellExecutionState;
+	}
+
 	// todo@API support ids https://github.com/jupyter/enhancement-proposals/blob/master/62-cell-id/cell-id.md
 	export class NotebookCellData {
 		kind: NotebookCellKind;
@@ -1236,7 +1230,8 @@ declare module 'vscode' {
 		language: string;
 		outputs?: NotebookCellOutput[];
 		metadata?: NotebookCellMetadata;
-		constructor(kind: NotebookCellKind, source: string, language: string, outputs?: NotebookCellOutput[], metadata?: NotebookCellMetadata)
+		latestExecutionSummary?: NotebookCellExecutionSummary;
+		constructor(kind: NotebookCellKind, source: string, language: string, outputs?: NotebookCellOutput[], metadata?: NotebookCellMetadata, latestExecutionSummary?: NotebookCellExecutionSummary);
 	}
 
 	export class NotebookData {
@@ -1402,7 +1397,24 @@ declare module 'vscode' {
 
 	//#endregion
 
+	//#region https://github.com/microsoft/vscode/issues/106744, NotebookSerializer
+
+	export interface NotebookSerializer {
+		dataToNotebook(data: Uint8Array): NotebookData | Thenable<NotebookData>;
+		notebookToData(data: NotebookData): Uint8Array | Thenable<Uint8Array>;
+	}
+
+	export namespace notebook {
+
+		// TODO@api use NotebookDocumentFilter instead of just notebookType:string?
+		// TODO@API options duplicates the more powerful variant on NotebookContentProvider
+		export function registerNotebookSerializer(notebookType: string, provider: NotebookSerializer, options?: NotebookDocumentContentOptions): Disposable;
+	}
+
+	//#endregion
+
 	//#region https://github.com/microsoft/vscode/issues/106744, NotebookContentProvider
+
 
 	interface NotebookDocumentBackup {
 		/**
@@ -1479,27 +1491,6 @@ declare module 'vscode' {
 
 	//#region https://github.com/microsoft/vscode/issues/106744, NotebookKernel
 
-	// todo@API use the NotebookCellExecution-object as a container to model and enforce
-	// the flow of a cell execution
-
-	// kernel -> execute_info
-	// ext -> createNotebookCellExecution(cell)
-	// kernel -> done
-	// exec.dispose();
-
-	// export interface NotebookCellExecution {
-	// 	dispose(): void;
-	// 	clearOutput(): void;
-	// 	appendOutput(out: NotebookCellOutput): void;
-	// 	replaceOutput(out: NotebookCellOutput): void;
-	//  appendOutputItems(output:string, items: NotebookCellOutputItem[]):void;
-	//  replaceOutputItems(output:string, items: NotebookCellOutputItem[]):void;
-	// }
-
-	// export function createNotebookCellExecution(cell: NotebookCell, startTime?: number): NotebookCellExecution;
-	// export const onDidStartNotebookCellExecution: Event<any>;
-	// export const onDidStopNotebookCellExecution: Event<any>;
-
 	export interface NotebookKernel {
 
 		// todo@API make this mandatory?
@@ -1524,14 +1515,86 @@ declare module 'vscode' {
 		// fired when properties like the supported languages etc change
 		// onDidChangeProperties?: Event<void>
 
-		// @roblourens
-		// todo@API change to `executeCells(document: NotebookDocument, cells: NotebookCellRange[], context:{isWholeNotebooke: boolean}, token: CancelationToken): void;`
-		// todo@API interrupt vs cancellation, https://github.com/microsoft/vscode/issues/106741
-		// interrupt?():void;
-		executeCell(document: NotebookDocument, cell: NotebookCell): void;
-		cancelCellExecution(document: NotebookDocument, cell: NotebookCell): void;
-		executeAllCells(document: NotebookDocument): void;
-		cancelAllCellsExecution(document: NotebookDocument): void;
+		/**
+		 * A kernel can optionally implement this which will be called when any "cancel" button is clicked in the document.
+		 */
+		interrupt?(document: NotebookDocument): void;
+
+		/**
+		 * Called when the user triggers execution of a cell by clicking the run button for a cell, multiple cells,
+		 * or full notebook. The cell will be put into the Pending state when this method is called. If
+		 * createNotebookCellExecutionTask has not been called by the time the promise returned by this method is
+		 * resolved, the cell will be put back into the Idle state.
+		 */
+		executeCellsRequest(document: NotebookDocument, ranges: NotebookCellRange[]): Thenable<void>;
+	}
+
+	export interface NotebookCellExecuteStartContext {
+		// TODO@roblou are we concerned about clock issues with this absolute time?
+		/**
+		 * The time that execution began, in milliseconds in the Unix epoch. Used to drive the clock
+		 * that shows for how long a cell has been running. If not given, the clock won't be shown.
+		 */
+		startTime?: number;
+	}
+
+	export interface NotebookCellExecuteEndContext {
+		/**
+		 * If true, a green check is shown on the cell status bar.
+		 * If false, a red X is shown.
+		 */
+		success?: boolean;
+
+		/**
+		 * The total execution time in milliseconds.
+		 */
+		duration?: number;
+	}
+
+	/**
+	 * A NotebookCellExecutionTask is how the kernel modifies a notebook cell as it is executing. When
+	 * [`createNotebookCellExecutionTask`](#notebook.createNotebookCellExecutionTask) is called, the cell
+	 * enters the Pending state. When `start()` is called on the execution task, it enters the Executing state. When
+	 * `end()` is called, it enters the Idle state. While in the Executing state, cell outputs can be
+	 * modified with the methods on the run task.
+	 *
+	 * All outputs methods operate on this NotebookCellExecutionTask's cell by default. They optionally take
+	 * a cellIndex parameter that allows them to modify the outputs of other cells. `appendOutputItems` and
+	 * `replaceOutputItems` operate on the output with the given ID, which can be an output on any cell. They
+	 * all resolve once the output edit has been applied.
+	 */
+	export interface NotebookCellExecutionTask {
+		readonly document: NotebookDocument;
+		readonly cell: NotebookCell;
+
+		start(context?: NotebookCellExecuteStartContext): void;
+		executionOrder: number | undefined;
+		end(result?: NotebookCellExecuteEndContext): void;
+		readonly token: CancellationToken;
+
+		clearOutput(cellIndex?: number): Thenable<void>;
+		appendOutput(out: NotebookCellOutput[], cellIndex?: number): Thenable<void>;
+		replaceOutput(out: NotebookCellOutput[], cellIndex?: number): Thenable<void>;
+		appendOutputItems(items: NotebookCellOutputItem[], outputId: string): Thenable<void>;
+		replaceOutputItems(items: NotebookCellOutputItem[], outputId: string): Thenable<void>;
+	}
+
+	export enum NotebookCellExecutionState {
+		Idle = 1,
+		Pending = 2,
+		Executing = 3,
+	}
+
+	export namespace notebook {
+		/**
+		 * Creates a [`NotebookCellExecutionTask`](#NotebookCellExecutionTask). Should only be called by a kernel. Returns undefined unless requested by the active kernel.
+		 * @param uri The [uri](#Uri) of the notebook document.
+		 * @param index The index of the cell.
+		 * @param kernelId The id of the kernel requesting this run task. If this kernel is not the current active kernel, `undefined` is returned.
+		 */
+		export function createNotebookCellExecutionTask(uri: Uri, index: number, kernelId: string): NotebookCellExecutionTask | undefined;
+
+		export const onDidChangeCellExecutionState: Event<NotebookCellExecutionStateChangeEvent>;
 	}
 
 	export type NotebookFilenamePattern = GlobPattern | { include: GlobPattern; exclude: GlobPattern; };
@@ -2122,33 +2185,6 @@ declare module 'vscode' {
 		 * in {@link onDidChangeTest} when a test is added or removed.
 		 */
 		readonly root: T;
-
-		/**
-		 * An event that fires when an existing test `root` changes.  This can be
-		 * a result of a property update, or an update to its children. Changes
-		 * made to tests will not be visible to {@link TestObserver} instances
-		 * until this event is fired.
-		 *
-		 * When a change is signalled, VS Code will check for any new or removed
-		 * direct children of the changed ite, For example, firing the event with
-		 * the {@link testRoot} will detect any new children in `root.children`.
-		 */
-		readonly onDidChangeTest: Event<T>;
-
-		/**
-		 * Promise that should be resolved when all tests that are initially
-		 * defined have been discovered. The provider should continue to watch for
-		 * changes and fire `onDidChangeTest` until the hierarchy is disposed.
-		 */
-		readonly discoveredInitialTests?: Thenable<unknown>;
-
-		/**
-		 * An event that fires when a test becomes outdated, as a result of
-		 * file changes, for example. In "auto run" mode, tests that are outdated
-		 * will be automatically re-run after a short delay. Firing a test
-		 * with children will mark the entire subtree as outdated.
-		 */
-		readonly onDidInvalidateTest?: Event<T>;
 	}
 
 	/**
@@ -2170,8 +2206,9 @@ declare module 'vscode' {
 		 *
 		 * @param workspace The workspace in which to observe tests
 		 * @param cancellationToken Token that signals the used asked to abort the test run.
+		 * @returns the root test item for the workspace
 		 */
-		provideWorkspaceTestHierarchy(workspace: WorkspaceFolder, token: CancellationToken): ProviderResult<TestHierarchy<T>>;
+		provideWorkspaceTestRoot(workspace: WorkspaceFolder, token: CancellationToken): ProviderResult<T>;
 
 		/**
 		 * Requests that tests be provided for the given document. This will be
@@ -2183,18 +2220,21 @@ declare module 'vscode' {
 		 * saved, if possible.
 		 *
 		 * If the test system is not able to provide or estimate for tests on a
-		 * per-file basis, this method may not be implemented. In that case, VS
-		 * Code will request and use the information from the workspace hierarchy.
+		 * per-file basis, this method may not be implemented. In that case, the
+		 * editor will request and use the information from the workspace tree.
 		 *
 		 * @param document The document in which to observe tests
 		 * @param cancellationToken Token that signals the used asked to abort the test run.
+		 * @returns the root test item for the workspace
 		 */
-		provideDocumentTestHierarchy?(document: TextDocument, token: CancellationToken): ProviderResult<TestHierarchy<T>>;
+		provideDocumentTestRoot?(document: TextDocument, token: CancellationToken): ProviderResult<T>;
 
 		/**
+		 * @todo this will move out of the provider soon
+		 * @todo this will eventually need to be able to return a summary report, coverage for example.
+		 *
 		 * Starts a test run. This should cause {@link onDidChangeTest} to
 		 * fire with update test states during the run.
-		 * @todo this will eventually need to be able to return a summary report, coverage for example.
 		 * @param options Options for this test run
 		 * @param cancellationToken Token that signals the used asked to abort the test run.
 		 */
@@ -2242,17 +2282,54 @@ declare module 'vscode' {
 		setState(test: T, state: TestState): void;
 	}
 
+	export interface TestChildrenCollection<T> extends Iterable<T> {
+		/**
+		 * Gets the number of children in the collection.
+		 */
+		readonly size: number;
+
+		/**
+		 * Gets an existing TestItem by its ID, if it exists.
+		 * @param id ID of the test.
+		 * @returns the TestItem instance if it exists.
+		 */
+		get(id: string): T | undefined;
+
+		/**
+		 * Adds a new child test item. No-ops if the test was already a child.
+		 * @param child The test item to add.
+		 */
+		add(child: T): void;
+
+		/**
+		 * Removes the child test item by reference or ID from the collection.
+		 * @param child Child ID or instance to remove.
+		 */
+		delete(child: T | string): void;
+
+		/**
+		 * Removes all children from the collection.
+		 */
+		clear(): void;
+	}
+
 	/**
 	 * A test item is an item shown in the "test explorer" view. It encompasses
 	 * both a suite and a test, since they have almost or identical capabilities.
 	 */
-	export class TestItem {
+	export class TestItem<TChildren = any> {
 		/**
 		 * Unique identifier for the TestItem. This is used to correlate
 		 * test results and tests in the document with those in the workspace
 		 * (test explorer). This must not change for the lifetime of the TestItem.
 		 */
 		readonly id: string;
+
+		/**
+		 * A set of children this item has. You can add new children to it, which
+		 * will propagate to the editor UI.
+		 */
+		readonly children: TestChildrenCollection<TChildren>;
 
 		/**
 		 * Display name describing the test case.
@@ -2263,6 +2340,12 @@ declare module 'vscode' {
 		 * Optional description that appears next to the label.
 		 */
 		description?: string;
+
+		/**
+		 * Location of the test in the workspace. This is used to show line
+		 * decorations and code lenses for the test.
+		 */
+		location?: Location;
 
 		/**
 		 * Whether this test item can be run individually, defaults to `true`.
@@ -2281,22 +2364,53 @@ declare module 'vscode' {
 		debuggable: boolean;
 
 		/**
-		 * Location of the test in the workspace. This is used to show line
-		 * decorations and code lenses for the test.
+		 * Whether this test item can be expanded in the tree view, implying it
+		 * has (or may have) children. If this is given, the item may be
+		 * passed to the {@link TestHierarchy.getChildren} method.
 		 */
-		location?: Location;
-
-		/**
-		 * Optional list of nested tests for this item.
-		 */
-		children: TestItem[];
+		expandable: boolean;
 
 		/**
 		 * Creates a new TestItem instance.
 		 * @param id Value of the "id" property
 		 * @param label Value of the "label" property.
+		 * @param parent Parent of this item. This should only be defined for the
+		 * test root.
 		 */
-		constructor(id: string, label: string);
+		constructor(id: string, label: string, expandable: boolean);
+
+		/**
+		 * Marks the test as outdated. This can happen as a result of file changes,
+		 * for example. In "auto run" mode, tests that are outdated will be
+		 * automatically re-run after a short delay. Invoking this on a
+		 * test with children will mark the entire subtree as outdated.
+		 *
+		 * Extensions should generally not override this method.
+		 */
+		invalidate(): void;
+
+		/**
+		 * Requests the children of the test item. Extensions should override this
+		 * method for any test that can discover children.
+		 *
+		 * When called, the item should discover tests and update its's `children`.
+		 * The provider will be marked as 'busy' when this method is called, and
+		 * the provider should report `{ busy: false }` to {@link Progress.report}
+		 * once discovery is complete.
+		 *
+		 * The item should continue watching for changes to the children and
+		 * firing updates until the token is cancelled. The process of watching
+		 * the tests may involve creating a file watcher, for example.
+		 *
+		 * The editor will only call this method when it's interested in refreshing
+		 * the children of the item, and will not call it again while there's an
+		 * existing, uncancelled discovery for an item.
+		 *
+		 * @param token Cancellation for the request. Cancellation will be
+		 * requested if the test changes before the previous call completes.
+		 * @returns a provider result of child test items
+		 */
+		discoverChildren(progress: Progress<{ busy: boolean }>, token: CancellationToken): void;
 	}
 
 	/**
@@ -2420,23 +2534,46 @@ declare module 'vscode' {
 		 * List of test results. The items in this array are the items that
 		 * were passed in the {@link test.runTests} method.
 		 */
-		results: ReadonlyArray<Readonly<TestItemWithResults>>;
+		results: ReadonlyArray<Readonly<TestResultSnapshot>>;
 	}
 
 	/**
-	 * A {@link TestItem} with an associated result, which appear or can be
-	 * provided in {@link TestResult} interfaces.
+	 * A {@link TestItem}-like interface with an associated result, which appear
+	 * or can be provided in {@link TestResult} interfaces.
 	 */
-	export interface TestItemWithResults extends TestItem {
+	export interface TestResultSnapshot {
+		/**
+		 * Unique identifier that matches that of the associated TestItem.
+		 * This is used to correlate test results and tests in the document with
+		 * those in the workspace (test explorer).
+		 */
+		readonly id: string;
+
+		/**
+		 * Display name describing the test case.
+		 */
+		readonly label: string;
+
+		/**
+		 * Optional description that appears next to the label.
+		 */
+		readonly description?: string;
+
+		/**
+		 * Location of the test in the workspace. This is used to show line
+		 * decorations and code lenses for the test.
+		 */
+		readonly location?: Location;
+
 		/**
 		 * Current result of the test.
 		 */
-		result: TestState;
+		readonly result: TestState;
 
 		/**
 		 * Optional list of nested tests for this item.
 		 */
-		children: Readonly<TestItemWithResults>[];
+		readonly children: Readonly<TestResultSnapshot>[];
 	}
 
 	//#endregion

--- a/src/dotnet-interactive-vscode/stable/package.json
+++ b/src/dotnet-interactive-vscode/stable/package.json
@@ -112,7 +112,7 @@
         },
         "dotnet-interactive.minimumInteractiveToolVersion": {
           "type": "string",
-          "default": "1.0.216815",
+          "default": "1.0.217001",
           "description": "The minimum required version of the .NET Interactive tool."
         },
         "dotnet-interactive.useDotNetInteractiveExtensionForIpynbFiles": {

--- a/src/dotnet-interactive-vscode/stable/src/versionSpecificFunctions.ts
+++ b/src/dotnet-interactive-vscode/stable/src/versionSpecificFunctions.ts
@@ -4,8 +4,14 @@
 import * as vscode from 'vscode';
 import * as contracts from './common/interfaces/contracts';
 import * as vscodeLike from './common/interfaces/vscode-like';
-import * as utilities from './common/interfaces/utilities';
-import { contractCellOutputToVsCodeCellOutput } from './common/vscode/notebookContentProvider';
+import * as utilities from './common/utilities';
+import * as notebookContentProvider from './common/vscode/notebookContentProvider';
+import * as notebookKernel from './common/vscode/notebookKernel';
+import * as interactiveNotebook from './common/interactiveNotebook';
+import * as diagnostics from './common/vscode/diagnostics';
+import * as vscodeUtilities from './common/vscode/vscodeUtilities';
+
+import { ClientMapper } from './common/clientMapper';
 
 export function getCellKind(cell: vscode.NotebookCell): vscode.NotebookCellKind {
     return cell.cellKind;
@@ -16,7 +22,86 @@ export function createVsCodeNotebookCellData(cellData: { cellKind: vscodeLike.No
         cellKind: cellData.cellKind,
         source: cellData.source,
         language: cellData.language,
-        outputs: cellData.outputs.map(contractCellOutputToVsCodeCellOutput),
+        outputs: cellData.outputs.map(notebookContentProvider.contractCellOutputToVsCodeCellOutput),
         metadata: cellData.metadata,
     };
+}
+
+export async function executeCell(document: vscode.NotebookDocument, cell: vscode.NotebookCell, clientMapper: ClientMapper): Promise<void> {
+    const startTime = Date.now();
+    try {
+        await updateCellMetadata(document, cell, {
+            runStartTime: startTime,
+            runState: vscode.NotebookCellRunState.Running,
+        });
+        await updateCellOutputs(document, cell, []);
+        let client = await clientMapper.getOrAddClient(document.uri);
+        let source = cell.document.getText();
+        function outputObserver(outputs: Array<vscodeLike.NotebookCellOutput>) {
+            updateCellOutputs(document, cell, outputs).then(() => { });
+        }
+
+        let diagnosticCollection = diagnostics.getDiagnosticCollection(cell.document.uri);
+
+        function diagnosticObserver(diags: Array<contracts.Diagnostic>) {
+            diagnosticCollection.set(cell.document.uri, diags.filter(d => d.severity !== contracts.DiagnosticSeverity.Hidden).map(vscodeUtilities.toVsCodeDiagnostic));
+        }
+
+        return client.execute(source, interactiveNotebook.getSimpleLanguage(cell.document.languageId), outputObserver, diagnosticObserver, { id: document.uri.toString() }).then(() =>
+            updateCellMetadata(document, cell, {
+                runState: vscode.NotebookCellRunState.Success,
+                lastRunDuration: Date.now() - startTime,
+            })
+        ).catch(() => setCellErrorState(document, cell, startTime)).then(() => {
+            return notebookKernel.updateCellLanguages(document);
+        });
+    } catch (err) {
+        const errorOutput = utilities.createErrorOutput(`Error executing cell: ${err}`);
+        await updateCellOutputs(document, cell, [errorOutput]);
+        await setCellErrorState(document, cell, startTime);
+        throw err;
+    }
+}
+
+export async function cancelCellExecution(document: vscode.NotebookDocument, cell: vscode.NotebookCell, clientMapper: ClientMapper): Promise<void> {
+    const startTime = cell.metadata.runStartTime || Date.now();
+    const duration = Date.now() - startTime;
+    return clientMapper.getOrAddClient(document.uri).then(client => {
+        const errorOutput = utilities.createErrorOutput("Cell execution cancelled by user");
+        const resultPromise = () => updateCellOutputs(document, cell, [...cell.outputs, errorOutput])
+            .then(() => setCellErrorState(document, cell, startTime));
+        client.cancel()
+            .then(resultPromise)
+            .catch(resultPromise);
+    }).catch((err) => {
+        const errorOutput = utilities.createErrorOutput(`Error cancelling cell: ${err}`);
+        return updateCellOutputs(document, cell, [errorOutput]).then(() =>
+            setCellErrorState(document, cell, startTime));
+    });
+}
+
+export function markCellIdle(document: vscode.NotebookDocument, cell: vscode.NotebookCell): Promise<void> {
+    return updateCellMetadata(document, cell, { runState: vscode.NotebookCellRunState.Idle });
+}
+
+function setCellErrorState(document: vscode.NotebookDocument, cell: vscode.NotebookCell, startTime: number): Promise<void> {
+    return updateCellMetadata(document, cell, {
+        runState: vscode.NotebookCellRunState.Error,
+        lastRunDuration: Date.now() - startTime,
+    });
+}
+
+async function updateCellMetadata(document: vscode.NotebookDocument, cell: vscode.NotebookCell, metadata: vscodeLike.NotebookCellMetadata): Promise<void> {
+    const newMetadata = cell.metadata.with(metadata);
+    const edit = new vscode.WorkspaceEdit();
+    edit.replaceNotebookCellMetadata(document.uri, cell.index, newMetadata);
+    await vscode.workspace.applyEdit(edit);
+}
+
+async function updateCellOutputs(document: vscode.NotebookDocument, cell: vscode.NotebookCell, outputs: Array<vscodeLike.NotebookCellOutput>): Promise<void> {
+    const edit = new vscode.WorkspaceEdit();
+    edit.replaceNotebookCellOutput(document.uri, cell.index, outputs.map(o => {
+        return new vscode.NotebookCellOutput(o.outputs.map(oi => notebookContentProvider.generateVsCodeNotebookCellOutputItem(oi.mime, oi.value)));
+    }));
+    await vscode.workspace.applyEdit(edit);
 }


### PR DESCRIPTION
VS Code Insiders just updated with breaking changes to notebook kernel execution.  This PR separates the two different execution models (stable vs. insiders) into the two `versionSpecificFunctions.ts` files and makes `notebookKernel.ts` a thin wrapper around these version-specific functions.  Stable is unchanged, just rearranged; Insiders is very different regarding starting and stopping execution as well as setting outputs.

Scenarios covered in both Stable and Insiders:

1. Execute a cell that produces regular output.
2. Execute a cell that updates output (e.g., NuGet package restore.)
3. Execute a cell that produces errors (e.g., compilation failure).
4. Execute a long-running cell then restart the kernel; verify the cell's state is no longer executing.

Notably broken in this PR is execution cancellation in Insiders.  That will be addressed next.