### PR TITLE
wrap js in function constructor to properly report syntax errors that prevent compilation

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Http/HtmlNotebookFrontendEnvironment.cs
+++ b/src/Microsoft.DotNet.Interactive.Http/HtmlNotebookFrontendEnvironment.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using System.Web;
 using Microsoft.AspNetCore.Html;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
@@ -60,8 +61,17 @@ if (typeof window.createDotnetInteractiveClient === typeof Function) {{
         const notebookScope = getDotnetInteractiveScope('{apiUri.AbsoluteUri}');
         try {{
 
-".Replace("\r\n", "\n");
-            var codePostlude = $@"
+await Object.getPrototypeOf(async function() {{}}).constructor(
+    ""interactive"",
+    ""console"",
+    ""notebookScope"",
+    """.Replace("\r\n", "\n");
+            var codePostlude = $@"""
+)(
+    interactive,
+    console,
+    notebookScope
+);
 
         }} catch (err) {{
             interactive.failCommand(err, '{commandToken}');
@@ -72,7 +82,7 @@ if (typeof window.createDotnetInteractiveClient === typeof Function) {{
     }});
 }}
 ".Replace("\r\n", "\n");
-            var wrappedCode = $"{codePrelude}{code}{codePostlude}";
+            var wrappedCode = $"{codePrelude}{HttpUtility.JavaScriptStringEncode(code)}{codePostlude}";
             var executionCompletionSource = new TaskCompletionSource();
             _tokenToInvocationContext[commandToken] = (context, executionCompletionSource);
             IHtmlContent content = PocketViewTags.script[type: "text/javascript"](wrappedCode.ToHtmlContent());

--- a/src/dotnet-interactive.Tests/FrontendEnvironmentHandlingTests.cs
+++ b/src/dotnet-interactive.Tests/FrontendEnvironmentHandlingTests.cs
@@ -49,7 +49,16 @@ if (typeof window.createDotnetInteractiveClient === typeof Function) {
         const notebookScope = getDotnetInteractiveScope('http://12.12.12.12:4242/');
         try {
 
-console.log('test');
+await Object.getPrototypeOf(async function() {}).constructor(
+    ""interactive"",
+    ""console"",
+    ""notebookScope"",
+    ""console.log(\u0027test\u0027);""
+)(
+    interactive,
+    console,
+    notebookScope
+);
 
         } catch (err) {
             interactive.failCommand(err, 'token-abcd');
@@ -102,7 +111,7 @@ console.log('test');
                 .Should()
                 .ContainAll(
                     "http://test-uri",
-                    "console.log('test');"
+                    @"console.log(\u0027test\u0027);"
                 );
         }
 


### PR DESCRIPTION
Before we would simply inline the user's JS code, but if there was a syntax error, or more nevariously, if they had an unclosed multiline string or comment (e.g., a rogue `/*`), then the rest of the emitted JS wasn't correct.  Execution would fail but wouldn't be caught by our wrapper so it would look like the JS was running forever.

![image](https://user-images.githubusercontent.com/926281/112371825-4aa44b00-8c9c-11eb-9667-98310594be47.png)

This change creates a new async function object with the escaped string of their code and explicitly passes in the variables we want in their scope.  This has the added benefit of invalid code will result in a 'compile' error and throw from the function ctor and get caught by our regular handling and more appropriately report the error.

![image](https://user-images.githubusercontent.com/926281/112371976-71fb1800-8c9c-11eb-858e-13a6e4d145e2.png)
