### PR TITLE
bring back powershell packing

### DIFF
--- a/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -34,6 +34,39 @@
     	CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(NCrunch)' != '1'">
+    <Content Include="$(PkgPackageManagement)\**"
+             Exclude="$(PkgPackageManagement)\**\*.nupkg;$(PkgPackageManagement)\**\*.nuspec;$(PkgPackageManagement)\**\*.sha512;$(PkgPackageManagement)\**\fullclr\**"
+             Link="Modules\PackageManagement\%(RecursiveDir)%(FileName)%(Extension)"
+             PackagePath="contentFiles/any/any/Modules/PackageManagement"
+             PackageCopyToOutput="true"
+             CopyToOutputDirectory="PreserveNewest" 
+             Condition="'$(PkgPackageManagement)' != ''" />
+
+    <Content Include="$(PkgPowerShellGet)\**"
+             Exclude="$(PkgPowerShellGet)\**\*.nupkg;$(PkgPowerShellGet)\**\*.nuspec;$(PkgPowerShellGet)\**\*.sha512"
+             Link="Modules\PowerShellGet\%(RecursiveDir)%(FileName)%(Extension)"
+             PackagePath="contentFiles/any/any/Modules/PowerShellGet"
+             PackageCopyToOutput="true"
+             CopyToOutputDirectory="PreserveNewest" 
+             Condition="'$(PkgPowerShellGet)' != ''" />
+
+    <Content Include="$(PkgMicrosoft_PowerShell_Archive)\**"
+             Exclude="$(PkgMicrosoft_PowerShell_Archive)\**\*.nupkg;$(PkgMicrosoft_PowerShell_Archive)\**\*.nuspec;$(PkgMicrosoft_PowerShell_Archive)\**\*.sha512"
+             Link="Modules\Microsoft.PowerShell.Archive\%(RecursiveDir)%(FileName)%(Extension)"
+             PackagePath="contentFiles/any/any/Modules/Microsoft.PowerShell.Archive"
+             PackageCopyToOutput="true"
+             CopyToOutputDirectory="PreserveNewest" 
+             Condition="'$(PkgMicrosoft_PowerShell_Archive)' != ''" />
+
+    <Content Include="$(PkgThreadJob)\**"
+             Exclude="$(PkgThreadJob)\**\*.nupkg;$(PkgThreadJob)\**\*.nuspec;$(PkgThreadJob)\**\*.sha512"
+             Link="Modules\ThreadJob\%(RecursiveDir)%(FileName)%(Extension)"
+             PackagePath="contentFiles/any/any/Modules/ThreadJob"
+             PackageCopyToOutput="true"
+             CopyToOutputDirectory="PreserveNewest" 
+             Condition="'$(PkgThreadJob)' != ''" />
+  </ItemGroup>
 
   <!-- The dependencies for this project -->
   <ItemGroup>


### PR DESCRIPTION
PowerShell packing was accidentally removed [here](https://github.com/dotnet/interactive/commit/dda65675c5e8f116285022c2a16f976dce00b7a9#diff-48939ec201aa4085dc7937728cec5ebf6e387c69ba2d5747bbd55dc4e3bf949d) and this simply brings it back, but behind the `DisableArcade` flag.