### PR TITLE
Fast path scheduling for language service commands

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/Microsoft.DotNet.Interactive.ExtensionLab.Tests.v3.ncrunchproject
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/Microsoft.DotNet.Interactive.ExtensionLab.Tests.v3.ncrunchproject
@@ -1,3 +1,27 @@
 ﻿<ProjectConfiguration>
-  <Settings />
+  <Settings>
+    <IgnoredTests>
+      <NamedTestSelector>
+        <TestName>Microsoft.DotNet.Interactive.ExtensionLab.Tests.InspectTests.inspect_with_complex_source_and_release_settings_calls_inspector_and_produces_output</TestName>
+      </NamedTestSelector>
+      <NamedTestSelector>
+        <TestName>Microsoft.DotNet.Interactive.ExtensionLab.Tests.InspectTests.inspect_with_configuration_settings_calls_inspector_and_produces_output("Debug")</TestName>
+      </NamedTestSelector>
+      <NamedTestSelector>
+        <TestName>Microsoft.DotNet.Interactive.ExtensionLab.Tests.InspectTests.inspect_with_configuration_settings_calls_inspector_and_produces_output("Release")</TestName>
+      </NamedTestSelector>
+      <NamedTestSelector>
+        <TestName>Microsoft.DotNet.Interactive.ExtensionLab.Tests.InspectTests.inspect_with_default_settings_calls_inspector_and_produces_output</TestName>
+      </NamedTestSelector>
+      <NamedTestSelector>
+        <TestName>Microsoft.DotNet.Interactive.ExtensionLab.Tests.InspectTests.inspect_with_default_settings_produces_proper_js_and_css</TestName>
+      </NamedTestSelector>
+      <NamedTestSelector>
+        <TestName>Microsoft.DotNet.Interactive.ExtensionLab.Tests.InspectTests.inspect_with_kind_settings_calls_inspector_and_produces_output("Regular")</TestName>
+      </NamedTestSelector>
+      <NamedTestSelector>
+        <TestName>Microsoft.DotNet.Interactive.ExtensionLab.Tests.InspectTests.inspect_with_kind_settings_calls_inspector_and_produces_output("Script")</TestName>
+      </NamedTestSelector>
+    </IgnoredTests>
+  </Settings>
 </ProjectConfiguration>

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/NteractKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/NteractKernelExtension.cs
@@ -30,7 +30,6 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
     <img src=""https://user-images.githubusercontent.com/547415/109559345-621e5880-7a8f-11eb-8b98-d4feeaac116f.png"" width=""75%"">
     </details>"),
                 "text/html");
-
             return Task.CompletedTask;
         }
 

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -34,40 +34,6 @@
     	CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(NCrunch)' != '1'">
-    <Content Include="$(PkgPackageManagement)\**"
-             Exclude="$(PkgPackageManagement)\**\*.nupkg;$(PkgPackageManagement)\**\*.nuspec;$(PkgPackageManagement)\**\*.sha512;$(PkgPackageManagement)\**\fullclr\**"
-             Link="Modules\PackageManagement\%(RecursiveDir)%(FileName)%(Extension)"
-             PackagePath="contentFiles/any/any/Modules/PackageManagement"
-             PackageCopyToOutput="true"
-             CopyToOutputDirectory="PreserveNewest" 
-             Condition="'$(PkgPackageManagement)' != ''" />
-
-    <Content Include="$(PkgPowerShellGet)\**"
-             Exclude="$(PkgPowerShellGet)\**\*.nupkg;$(PkgPowerShellGet)\**\*.nuspec;$(PkgPowerShellGet)\**\*.sha512"
-             Link="Modules\PowerShellGet\%(RecursiveDir)%(FileName)%(Extension)"
-             PackagePath="contentFiles/any/any/Modules/PowerShellGet"
-             PackageCopyToOutput="true"
-             CopyToOutputDirectory="PreserveNewest" 
-             Condition="'$(PkgPowerShellGet)' != ''" />
-
-    <Content Include="$(PkgMicrosoft_PowerShell_Archive)\**"
-             Exclude="$(PkgMicrosoft_PowerShell_Archive)\**\*.nupkg;$(PkgMicrosoft_PowerShell_Archive)\**\*.nuspec;$(PkgMicrosoft_PowerShell_Archive)\**\*.sha512"
-             Link="Modules\Microsoft.PowerShell.Archive\%(RecursiveDir)%(FileName)%(Extension)"
-             PackagePath="contentFiles/any/any/Modules/Microsoft.PowerShell.Archive"
-             PackageCopyToOutput="true"
-             CopyToOutputDirectory="PreserveNewest" 
-             Condition="'$(PkgMicrosoft_PowerShell_Archive)' != ''" />
-
-    <Content Include="$(PkgThreadJob)\**"
-             Exclude="$(PkgThreadJob)\**\*.nupkg;$(PkgThreadJob)\**\*.nuspec;$(PkgThreadJob)\**\*.sha512"
-             Link="Modules\ThreadJob\%(RecursiveDir)%(FileName)%(Extension)"
-             PackagePath="contentFiles/any/any/Modules/ThreadJob"
-             PackageCopyToOutput="true"
-             CopyToOutputDirectory="PreserveNewest" 
-             Condition="'$(PkgThreadJob)' != ''" />
-  </ItemGroup>
-
   <!-- The dependencies for this project -->
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.Interactive.Formatting\Microsoft.DotNet.Interactive.Formatting.csproj" />

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -34,6 +34,40 @@
     	CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(NCrunch)' != '1'">
+    <Content Include="$(PkgPackageManagement)\**"
+             Exclude="$(PkgPackageManagement)\**\*.nupkg;$(PkgPackageManagement)\**\*.nuspec;$(PkgPackageManagement)\**\*.sha512;$(PkgPackageManagement)\**\fullclr\**"
+             Link="Modules\PackageManagement\%(RecursiveDir)%(FileName)%(Extension)"
+             PackagePath="contentFiles/any/any/Modules/PackageManagement"
+             PackageCopyToOutput="true"
+             CopyToOutputDirectory="PreserveNewest" 
+             Condition="'$(PkgPackageManagement)' != ''" />
+
+    <Content Include="$(PkgPowerShellGet)\**"
+             Exclude="$(PkgPowerShellGet)\**\*.nupkg;$(PkgPowerShellGet)\**\*.nuspec;$(PkgPowerShellGet)\**\*.sha512"
+             Link="Modules\PowerShellGet\%(RecursiveDir)%(FileName)%(Extension)"
+             PackagePath="contentFiles/any/any/Modules/PowerShellGet"
+             PackageCopyToOutput="true"
+             CopyToOutputDirectory="PreserveNewest" 
+             Condition="'$(PkgPowerShellGet)' != ''" />
+
+    <Content Include="$(PkgMicrosoft_PowerShell_Archive)\**"
+             Exclude="$(PkgMicrosoft_PowerShell_Archive)\**\*.nupkg;$(PkgMicrosoft_PowerShell_Archive)\**\*.nuspec;$(PkgMicrosoft_PowerShell_Archive)\**\*.sha512"
+             Link="Modules\Microsoft.PowerShell.Archive\%(RecursiveDir)%(FileName)%(Extension)"
+             PackagePath="contentFiles/any/any/Modules/Microsoft.PowerShell.Archive"
+             PackageCopyToOutput="true"
+             CopyToOutputDirectory="PreserveNewest" 
+             Condition="'$(PkgMicrosoft_PowerShell_Archive)' != ''" />
+
+    <Content Include="$(PkgThreadJob)\**"
+             Exclude="$(PkgThreadJob)\**\*.nupkg;$(PkgThreadJob)\**\*.nuspec;$(PkgThreadJob)\**\*.sha512"
+             Link="Modules\ThreadJob\%(RecursiveDir)%(FileName)%(Extension)"
+             PackagePath="contentFiles/any/any/Modules/ThreadJob"
+             PackageCopyToOutput="true"
+             CopyToOutputDirectory="PreserveNewest" 
+             Condition="'$(PkgThreadJob)' != ''" />
+  </ItemGroup>
+
   <!-- The dependencies for this project -->
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.Interactive.Formatting\Microsoft.DotNet.Interactive.Formatting.csproj" />

--- a/src/Microsoft.DotNet.Interactive.Tests/KernelSchedulerTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/KernelSchedulerTests.cs
@@ -102,7 +102,7 @@ namespace Microsoft.DotNet.Interactive.Tests
 
             using var scheduler = new KernelScheduler<int, int>();
             scheduler.RegisterDeferredOperationSource(
-                (v, _) => Enumerable.Repeat(v * 10, v), PerformWork);
+                (v, _) => Enumerable.Repeat(v * 10, v).ToList(), PerformWork);
 
             for (var i = 1; i <= 3; i++)
             {
@@ -332,7 +332,7 @@ namespace Microsoft.DotNet.Interactive.Tests
 
             using var scheduler = new KernelScheduler<int, int>();
             scheduler.RegisterDeferredOperationSource(
-                (v, scope) => scope == "scope2" ? Enumerable.Repeat(v * 10, v) : Enumerable.Empty<int>(), PerformWork);
+                (v, scope) => scope == "scope2" ? Enumerable.Repeat(v * 10, v).ToList() : Enumerable.Empty<int>().ToList(), PerformWork);
 
             for (var i = 1; i <= 3; i++)
             {

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
@@ -1134,11 +1134,11 @@ Console.Write(2);
             await kernel.SendAsync(new RequestCompletions("al", new LinePosition(0, 2)));
 
             KernelEvents
-                        .OfType<CompletionsProduced>()
-                        .Single()
-                        .Completions
-                        .Should()
-                        .Contain(i => i.DisplayText == "alpha");
+                .OfType<CompletionsProduced>()
+                .Single()
+                .Completions
+                .Should()
+                .Contain(i => i.DisplayText == "alpha");
         }
 
         [Fact]

--- a/src/Microsoft.DotNet.Interactive/IKernelScheduler.cs
+++ b/src/Microsoft.DotNet.Interactive/IKernelScheduler.cs
@@ -16,13 +16,4 @@ namespace Microsoft.DotNet.Interactive
             string scope = "default",
             CancellationToken cancellationToken = default);
     }
-
-    internal class ImmediateScheduler<T, TResult> : IKernelScheduler<T, TResult>
-    {
-        public Task<TResult> RunAsync(T value, KernelSchedulerDelegate<T, TResult> onExecuteAsync, string scope = "default",
-            CancellationToken cancellationToken = default)
-        {
-            return onExecuteAsync(value);
-        }
-    }
 }

--- a/src/Microsoft.DotNet.Interactive/IKernelScheduler.cs
+++ b/src/Microsoft.DotNet.Interactive/IKernelScheduler.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Interactive
             CancellationToken cancellationToken = default);
     }
 
-    public class SchedulerToDoStuff<T, TResult> : IKernelScheduler<T, TResult>
+    internal class ImmediateScheduler<T, TResult> : IKernelScheduler<T, TResult>
     {
         public Task<TResult> RunAsync(T value, KernelSchedulerDelegate<T, TResult> onExecuteAsync, string scope = "default",
             CancellationToken cancellationToken = default)

--- a/src/Microsoft.DotNet.Interactive/IKernelScheduler.cs
+++ b/src/Microsoft.DotNet.Interactive/IKernelScheduler.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Interactive
+{
+    public delegate Task<TResult> KernelSchedulerDelegate<in T, TResult>(T value);
+
+    public interface IKernelScheduler<T, TResult>
+    {
+        Task<TResult> RunAsync(
+            T value,
+            KernelSchedulerDelegate<T,TResult> onExecuteAsync,
+            string scope = "default",
+            CancellationToken cancellationToken = default);
+    }
+
+    public class SchedulerToDoStuff<T, TResult> : IKernelScheduler<T, TResult>
+    {
+        public Task<TResult> RunAsync(T value, KernelSchedulerDelegate<T, TResult> onExecuteAsync, string scope = "default",
+            CancellationToken cancellationToken = default)
+        {
+            return onExecuteAsync(value);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Interactive/ImmediateScheduler.cs
+++ b/src/Microsoft.DotNet.Interactive/ImmediateScheduler.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Interactive
+{
+    internal class ImmediateScheduler<T, TResult> : IKernelScheduler<T, TResult>
+    {
+        public Task<TResult> RunAsync(T value, KernelSchedulerDelegate<T, TResult> onExecuteAsync, string scope = "default",
+            CancellationToken cancellationToken = default)
+        {
+            return onExecuteAsync(value);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Interactive/Kernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Kernel.cs
@@ -271,6 +271,9 @@ namespace Microsoft.DotNet.Interactive
                                 break;
 
                             case RequestDiagnostics _:
+                            case RequestHoverText _:
+                            case RequestCompletions _:
+                            case RequestSignatureHelp _:
                                 // FIX: (SendAsync) 
                                 await context.HandlingKernel.FastPathScheduler.RunAsync(
                                     c,

--- a/src/Microsoft.DotNet.Interactive/Kernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Kernel.cs
@@ -270,9 +270,10 @@ namespace Microsoft.DotNet.Interactive
                                 await InvokePipelineAndCommandHandler(cancel);
                                 break;
 
-                            case RequestDiagnostics requestDiagnostics:
+                            case RequestDiagnostics _:
+                            case LanguageServiceCommand _:
                                 // FIX: (SendAsync) 
-                                 await context.HandlingKernel.FastPathScheduler.RunAsync(
+                                await context.HandlingKernel.FastPathScheduler.RunAsync(
                                     c,
                                     InvokePipelineAndCommandHandler,
                                     c.KernelUri.ToString(),

--- a/src/Microsoft.DotNet.Interactive/Kernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Kernel.cs
@@ -251,6 +251,8 @@ namespace Microsoft.DotNet.Interactive
             {
                 if (TryPreprocessCommands(command, context, out var commands))
                 {
+                    SetHandlingKernel(command, context);
+
                     foreach (var c in commands)
                     {
                         switch (c)
@@ -270,7 +272,7 @@ namespace Microsoft.DotNet.Interactive
 
                             case RequestDiagnostics requestDiagnostics:
                                 // FIX: (SendAsync) 
-                                 await FastPathScheduler.RunAsync(
+                                 await context.HandlingKernel.FastPathScheduler.RunAsync(
                                     c,
                                     InvokePipelineAndCommandHandler,
                                     c.KernelUri.ToString(),
@@ -317,8 +319,6 @@ namespace Microsoft.DotNet.Interactive
 
             try
             {
-                SetHandlingKernel(command, context);
-
                 await Pipeline.SendAsync(command, context);
 
                 if (command != context.Command)

--- a/src/Microsoft.DotNet.Interactive/Kernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Kernel.cs
@@ -271,7 +271,6 @@ namespace Microsoft.DotNet.Interactive
                                 break;
 
                             case RequestDiagnostics _:
-                            case LanguageServiceCommand _:
                                 // FIX: (SendAsync) 
                                 await context.HandlingKernel.FastPathScheduler.RunAsync(
                                     c,
@@ -320,6 +319,8 @@ namespace Microsoft.DotNet.Interactive
 
             try
             {
+                SetHandlingKernel(command, context);
+
                 await Pipeline.SendAsync(command, context);
 
                 if (command != context.Command)

--- a/src/Microsoft.DotNet.Interactive/Kernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Kernel.cs
@@ -328,7 +328,7 @@ namespace Microsoft.DotNet.Interactive
                     await SendAsync(
                         new AnonymousKernelCommand((_, _) => Task.CompletedTask, invocationContext.HandlingKernel.Name,
                             invocationContext.Command), invocationContext.CancellationToken);
-                    _fastPathScheduler = new SchedulerToDoStuff<KernelCommand, KernelCommandResult>();
+                    _fastPathScheduler = new ImmediateScheduler<KernelCommand, KernelCommandResult>();
 
                 }
             }

--- a/src/dotnet-interactive/Properties/launchSettings.json
+++ b/src/dotnet-interactive/Properties/launchSettings.json
@@ -3,8 +3,8 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:56581/",
-      "sslPort": 0
+      "applicationUrl": "http://localhost:49380/",
+      "sslPort": 44320
     }
   },
   "profiles": {


### PR DESCRIPTION
The goal here is to improve UI responsiveness by allowing language service (and other) commands that don't change the state of the kernel to be scheduled in parallel to commands, like `SubmitCode`, that do. 