### PR TITLE
broaden preferred kernel detection

### DIFF
--- a/src/dotnet-interactive-vscode/common/tests/unit/misc.test.ts
+++ b/src/dotnet-interactive-vscode/common/tests/unit/misc.test.ts
@@ -121,6 +121,34 @@ describe('Miscellaneous tests', () => {
             expect(isDotNetKernelPreferred(filename, fileMetadata)).is.false;
         });
 
+        it(`.ipynb file extension is preferred if metadata contains an acceptable language_info value`, () => {
+            const filename = 'notebook.ipynb';
+            const fileMetadata = {
+                custom: {
+                    metadata: {
+                        language_info: {
+                            name: 'dotnet-interactive.fsharp'
+                        }
+                    }
+                }
+            };
+            expect(isDotNetKernelPreferred(filename, fileMetadata)).is.true;
+        });
+
+        it(`.ipynb file extension is not preferred if metadata contains an unacceptable language_info value`, () => {
+            const filename = 'notebook.ipynb';
+            const fileMetadata = {
+                custom: {
+                    metadata: {
+                        language_info: {
+                            name: 'python'
+                        }
+                    }
+                }
+            };
+            expect(isDotNetKernelPreferred(filename, fileMetadata)).is.false;
+        });
+
         it(`unsupported file extension is not preferred even if metadata matches`, () => {
             const filename = 'notebook.not-a-notebook-we-know-about';
             const fileMetadata = {

--- a/src/dotnet-interactive-vscode/common/utilities.ts
+++ b/src/dotnet-interactive-vscode/common/utilities.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 import { v4 as uuid } from 'uuid';
 import { InstallInteractiveArgs, ProcessStart } from "./interfaces";
 import { ErrorOutputMimeType, NotebookCellOutput, NotebookCellOutputItem, ReportChannel, Uri } from './interfaces/vscode-like';
+import { isDotnetInteractiveLanguage } from './interactiveNotebook';
 
 export function executeSafe(command: string, args: Array<string>, workingDirectory?: string | undefined): Promise<{ code: number, output: string, error: string }> {
     return new Promise<{ code: number, output: string, error: string }>(resolve => {
@@ -215,8 +216,10 @@ export function isDotNetKernelPreferred(filename: string, fileMetadata: any): bo
         // maybe preferred if the kernelspec data matches
         case '.ipynb':
             const kernelName = fileMetadata?.custom?.metadata?.kernelspec?.name;
-            return typeof kernelName === 'string'
-                && kernelName.toLowerCase().startsWith('.net-');
+            const isDotnetKernel = typeof kernelName === 'string' && kernelName.toLowerCase().startsWith('.net-');
+            const languageInfo = fileMetadata?.custom?.metadata?.language_info?.name;
+            const isDotnetLanguageInfo = typeof languageInfo === 'string' && isDotnetInteractiveLanguage(languageInfo);
+            return isDotnetKernel || isDotnetLanguageInfo;
         // never preferred if it's an unknown extension
         default:
             return false;


### PR DESCRIPTION
Currently when a `.ipynb` file is opened if we find the following metadata we report that our kernel is preferred:

``` json
"metadata": {
  "kernelspec": {
    "name": ".net-csharp"
  }
}
```

This PR also broadens the possible shapes of preferred metadata to this:

``` json
"metadata": {
  "language_info": {
    "name": "dotnet-interactive.csharp"
  }
}
```

This is to help with the scenario where the user has the Jupyter extension installed and they create a new notebook, that's the document metadata that's currently applied.