### PR TITLE
handle different cell apis in stable/insiders

### DIFF
--- a/src/dotnet-interactive-vscode/common/vscode/commands.ts
+++ b/src/dotnet-interactive-vscode/common/vscode/commands.ts
@@ -13,6 +13,7 @@ import { DotNetPathManager } from './extension';
 import { computeToolInstallArguments, executeSafe, executeSafeAndLog } from '../utilities';
 
 import * as jupyter from './jupyter';
+import * as versionSpecificFunctions from '../../versionSpecificFunctions';
 import { ReportChannel } from '../interfaces/vscode-like';
 
 export function registerAcquisitionCommands(context: vscode.ExtensionContext, diagnosticChannel: ReportChannel) {
@@ -108,7 +109,7 @@ export function registerKernelCommands(context: vscode.ExtensionContext, clientM
         }
 
         if (document) {
-            for (const cell of document.cells) {
+            for (const cell of versionSpecificFunctions.getCells(document)) {
                 endExecution(cell, false);
             }
 

--- a/src/dotnet-interactive-vscode/common/vscode/extension.ts
+++ b/src/dotnet-interactive-vscode/common/vscode/extension.ts
@@ -197,7 +197,7 @@ async function waitForSdkInstall(requiredSdkVersion: string): Promise<void> {
 async function updateNotebookCellLanguageInMetadata(candidateNotebookCellDocument: vscode.TextDocument) {
     const notebook = candidateNotebookCellDocument.notebook;
     if (notebook && isDotnetInteractiveLanguage(candidateNotebookCellDocument.languageId)) {
-        const cell = notebook.cells.find(c => c.document === candidateNotebookCellDocument);
+        const cell = versionSpecificFunctions.getCells(notebook).find(c => c.document === candidateNotebookCellDocument);
         if (cell) {
             const newMetadata = cell.metadata.with({
                 custom: {

--- a/src/dotnet-interactive-vscode/common/vscode/languageProvider.ts
+++ b/src/dotnet-interactive-vscode/common/vscode/languageProvider.ts
@@ -9,6 +9,7 @@ import { notebookCellLanguages, getSimpleLanguage, notebookCellChanged } from '.
 import { convertToRange, toVsCodeDiagnostic } from './vscodeUtilities';
 import { getDiagnosticCollection } from './diagnostics';
 import { provideSignatureHelp } from './../languageServices/signatureHelp';
+import * as versionSpecificFunctions from '../../versionSpecificFunctions';
 
 export class CompletionItemProvider implements vscode.CompletionItemProvider {
     static readonly triggerCharacters = ['.'];
@@ -131,7 +132,7 @@ export function registerLanguageProviders(clientMapper: ClientMapper, diagnostic
     disposables.push(vscode.languages.registerSignatureHelpProvider(languages, new SignatureHelpProvider(clientMapper), ...SignatureHelpProvider.triggerCharacters));
     disposables.push(vscode.workspace.onDidChangeTextDocument(e => {
         if (vscode.languages.match(notebookCellLanguages, e.document)) {
-            const cell = vscode.window.activeNotebookEditor?.document.cells.find(cell => cell.document === e.document);
+            const cell = versionSpecificFunctions.getCells(vscode.window.activeNotebookEditor?.document).find(cell => cell.document === e.document);
             if (cell) {
                 notebookCellChanged(clientMapper, e.document, getSimpleLanguage(cell.document.languageId), diagnosticDelay, diagnostics => {
                     const collection = getDiagnosticCollection(e.document.uri);

--- a/src/dotnet-interactive-vscode/common/vscode/notebookContentProvider.ts
+++ b/src/dotnet-interactive-vscode/common/vscode/notebookContentProvider.ts
@@ -9,6 +9,7 @@ import { getSimpleLanguage, getNotebookSpecificLanguage, languageToCellKind, bac
 import { Eol } from '../interfaces';
 import { NotebookCell, NotebookCellDisplayOutput, NotebookCellErrorOutput, NotebookCellOutput, NotebookDocument } from '../interfaces/contracts';
 import * as utilities from '../interfaces/utilities';
+import * as versionSpecificFunctions from '../../versionSpecificFunctions';
 import * as vscodeLike from '../interfaces/vscode-like';
 import { configureWebViewMessaging, getEol, isUnsavedNotebook } from './vscodeUtilities';
 
@@ -119,7 +120,7 @@ function toVsCodeNotebookCellData(cell: NotebookCell): vscode.NotebookCellData {
 
 export function toNotebookDocument(document: vscode.NotebookDocument): NotebookDocument {
     return {
-        cells: document.cells.map(toNotebookCell)
+        cells: versionSpecificFunctions.getCells(document).map(toNotebookCell)
     };
 }
 

--- a/src/dotnet-interactive-vscode/insiders/.eslintrc.json
+++ b/src/dotnet-interactive-vscode/insiders/.eslintrc.json
@@ -3,15 +3,18 @@
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
         "ecmaVersion": 6,
+        "project": "./tsconfig.json",
         "sourceType": "module"
     },
     "plugins": [
-        "@typescript-eslint"
+        "@typescript-eslint",
+        "deprecation"
     ],
     "rules": {
         "@typescript-eslint/class-name-casing": "warn",
         "@typescript-eslint/semi": "warn",
         "curly": "warn",
+        "deprecation/deprecation": "warn",
         "eqeqeq": "warn",
         "no-throw-literal": "warn",
         "semi": "off"

--- a/src/dotnet-interactive-vscode/insiders/package-lock.json
+++ b/src/dotnet-interactive-vscode/insiders/package-lock.json
@@ -1022,6 +1022,17 @@
         }
       }
     },
+    "eslint-plugin-deprecation": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-deprecation/-/eslint-plugin-deprecation-1.2.0.tgz",
+      "integrity": "sha512-SrZqomFYofRbxJ9dlAcu526/tiZoWoZgHdZWKHjrRT/uLfTtTTjdVf0gdy0AZxK8nH5ri0fukgwS28llUueitA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^2.19.2 || ^3.0.0",
+        "tslib": "^1.10.0",
+        "tsutils": "^3.0.0"
+      }
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",

--- a/src/dotnet-interactive-vscode/insiders/package.json
+++ b/src/dotnet-interactive-vscode/insiders/package.json
@@ -103,7 +103,7 @@
         },
         "dotnet-interactive.minimumInteractiveToolVersion": {
           "type": "string",
-          "default": "1.0.217604",
+          "default": "1.0.220104",
           "description": "The minimum required version of the .NET Interactive tool."
         }
       }
@@ -338,7 +338,7 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
-    "compile": "tsc -p ./",
+    "compile": "npm run lint && tsc -p ./",
     "lint": "eslint src --ext ts",
     "watch": "tsc -watch -p ./",
     "integration-test": "node ./out/tests/integration/runTest.js",
@@ -365,6 +365,7 @@
     "chai-fs": "2.0.0",
     "del-cli": "^3.0.1",
     "eslint": "6.8.0",
+    "eslint-plugin-deprecation": "^1.2.0",
     "glob": "7.1.6",
     "mocha": "7.1.1",
     "mocha-multi-reporters": "1.1.7",

--- a/src/dotnet-interactive-vscode/insiders/src/versionSpecificFunctions.ts
+++ b/src/dotnet-interactive-vscode/insiders/src/versionSpecificFunctions.ts
@@ -14,3 +14,19 @@ import * as vscodeUtilities from './common/vscode/vscodeUtilities';
 export function registerAdditionalContentProvider(context: vscode.ExtensionContext, contentProvider: vscode.NotebookContentProvider) {
     // empty for insiders
 }
+
+export function cellAt(document: vscode.NotebookDocument, index: number): vscode.NotebookCell {
+    return document.cellAt(index);
+}
+
+export function cellCount(document: vscode.NotebookDocument): number {
+    return document.cellCount;
+}
+
+export function getCells(document: vscode.NotebookDocument | undefined): Array<vscode.NotebookCell> {
+    if (document) {
+        return [...document.getCells()];
+    }
+
+    return [];
+}

--- a/src/dotnet-interactive-vscode/insiders/src/vscode.d.ts
+++ b/src/dotnet-interactive-vscode/insiders/src/vscode.d.ts
@@ -2158,10 +2158,33 @@ declare module 'vscode' {
 	}
 
 	/**
+	 * The reason why code actions were requested.
+	 */
+	export enum CodeActionTriggerKind {
+		/**
+		 * Code actions were explicitly requested by the user or by an extension.
+		 */
+		Invoke = 1,
+
+		/**
+		 * Code actions were requested automatically.
+		 *
+		 * This typically happens when current selection in a file changes, but can
+		 * also be triggered when file content changes.
+		 */
+		Automatic = 2,
+	}
+
+	/**
 	 * Contains additional diagnostic information about the context in which
 	 * a [code action](#CodeActionProvider.provideCodeActions) is run.
 	 */
 	export interface CodeActionContext {
+		/**
+		 * The reason why code actions were requested.
+		 */
+		readonly triggerKind: CodeActionTriggerKind;
+
 		/**
 		 * An array of diagnostics.
 		 */
@@ -2419,13 +2442,13 @@ declare module 'vscode' {
 	/**
 	 * Information about where a symbol is defined.
 	 *
-	 * Provides additional metadata over normal [location](#Location) definitions, including the range of
+	 * Provides additional metadata over normal {@link Location location} definitions, including the range of
 	 * the defining symbol
 	 */
 	export type DefinitionLink = LocationLink;
 
 	/**
-	 * The definition of a symbol represented as one or many [locations](#Location).
+	 * The definition of a symbol represented as one or many {@link Location locations}.
 	 * For most programming languages there is only one location at which a symbol is
 	 * defined.
 	 */

--- a/src/dotnet-interactive-vscode/insiders/src/vscode.proposed.d.ts
+++ b/src/dotnet-interactive-vscode/insiders/src/vscode.proposed.d.ts
@@ -812,6 +812,30 @@ declare module 'vscode' {
 
 	//#endregion
 
+	//#region Terminal initial text https://github.com/microsoft/vscode/issues/120368
+
+	export interface TerminalOptions {
+		/**
+		 * Initial text to write to the terminal, note that this is not sent to the process but
+		 * rather written directly to the terminal. This supports escape sequences such a setting
+		 * text style.
+		 */
+		readonly initialText?: string;
+	}
+
+	//#endregion
+
+	//#region Terminal icon https://github.com/microsoft/vscode/issues/120538
+
+	export interface TerminalOptions {
+		/**
+		 * A codicon ID to associate with this terminal.
+		 */
+		readonly icon?: string;
+	}
+
+	//#endregion
+
 	// eslint-disable-next-line vscode-dts-region-comments
 	//#region @jrieken -> exclusive document filters
 
@@ -1048,17 +1072,49 @@ declare module 'vscode' {
 		readonly uri: Uri;
 		readonly version: number;
 
+		/** @deprecated Use `uri` instead */
 		// todo@API don't have this...
 		readonly fileName: string;
 
 		readonly isDirty: boolean;
 		readonly isUntitled: boolean;
-		readonly cells: ReadonlyArray<NotebookCell>;
+
+		/**
+		 * `true` if the notebook has been closed. A closed notebook isn't synchronized anymore
+		 * and won't be re-used when the same resource is opened again.
+		 */
+		readonly isClosed: boolean;
 
 		readonly metadata: NotebookDocumentMetadata;
 
 		// todo@API should we really expose this?
 		readonly viewType: string;
+
+		// todo@API cellsAt(range)? getCell(index>)?
+		/** @deprecated Use `getCells(<...>) instead */
+		readonly cells: ReadonlyArray<NotebookCell>;
+
+		/**
+		 * The number of cells in the notebook document.
+		 */
+		readonly cellCount: number;
+
+		/**
+		 * Return the cell at the specified index. The index will be adjusted to the notebook.
+		 *
+		 * @param index - The index of the cell to retrieve.
+		 * @return A [cell](#NotebookCell).
+		 */
+		cellAt(index: number): NotebookCell;
+
+		/**
+		 * Get the cells of this notebook. A subset can be retrieved by providing
+		 * a range. The range will be adjuset to the notebook.
+		 *
+		 * @param range A notebook range.
+		 * @returns The cells contained by the range or all cells.
+		 */
+		getCells(range?: NotebookCellRange): ReadonlyArray<NotebookCell>;
 
 		/**
 		 * Save the document. The saving will be handled by the corresponding content provider
@@ -1070,6 +1126,7 @@ declare module 'vscode' {
 		save(): Thenable<boolean>;
 	}
 
+	// todo@API RENAME to NotebookRange
 	// todo@API maybe have a NotebookCellPosition sibling
 	export class NotebookCellRange {
 		readonly start: number;
@@ -1081,6 +1138,8 @@ declare module 'vscode' {
 		readonly isEmpty: boolean;
 
 		constructor(start: number, end: number);
+
+		with(change: { start?: number, end?: number }): NotebookCellRange;
 	}
 
 	export enum NotebookEditorRevealType {
@@ -1435,13 +1494,6 @@ declare module 'vscode' {
 		readonly options?: NotebookDocumentContentOptions;
 		readonly onDidChangeNotebookContentOptions?: Event<NotebookDocumentContentOptions>;
 
-		// todo@API remove! against separation of data provider and renderer
-		/**
-		 * @deprecated
-		 */
-		// eslint-disable-next-line vscode-dts-cancellation
-		resolveNotebook(document: NotebookDocument, webview: NotebookCommunication): Thenable<void>;
-
 		/**
 		 * Content providers should always use [file system providers](#FileSystemProvider) to
 		 * resolve the raw content for `uri` as the resouce is not necessarily a file on disk.
@@ -1590,6 +1642,14 @@ declare module 'vscode' {
 		viewType?: string | string[];
 		filenamePattern?: NotebookFilenamePattern;
 	}
+
+	// export interface NotebookFilter {
+	// 	readonly viewType?: string;
+	// 	readonly scheme?: string;
+	// 	readonly pattern?: GlobPattern;
+	// }
+
+	// export type NotebookSelector = NotebookFilter | string | ReadonlyArray<NotebookFilter | string>;
 
 	// todo@API very unclear, provider MUST not return alive object but only data object
 	// todo@API unclear how the flow goes
@@ -2056,7 +2116,7 @@ declare module 'vscode' {
 	*/
 	export namespace test {
 		/**
-		 * Registers a provider that discovers and runs tests.
+		 * Registers a provider that discovers tests in workspaces and documents.
 		 */
 		export function registerTestProvider<T extends TestItem>(testProvider: TestProvider<T>): Disposable;
 
@@ -2066,7 +2126,7 @@ declare module 'vscode' {
 		 * that "run" is called, all tests given in the run have their state
 		 * automatically set to {@link TestRunState.Queued}.
 		 */
-		export function runTests<T extends TestItem>(run: TestRunOptions<T>, cancellationToken?: CancellationToken): Thenable<void>;
+		export function runTests<T extends TestItem>(run: TestRunRequest<T>, token?: CancellationToken): Thenable<void>;
 
 		/**
 		 * Returns an observer that retrieves tests in the given workspace folder.
@@ -2092,13 +2152,13 @@ declare module 'vscode' {
 		 * @param persist whether the test results should be saved by VS Code
 		 * and persisted across reloads. Defaults to true.
 		 */
-		export function publishTestResult(results: TestResults, persist?: boolean): void;
+		export function publishTestResult(results: TestRunResult, persist?: boolean): void;
 
 		/**
 		* List of test results stored by VS Code, sorted in descnding
 		* order by their `completedAt` time.
 		*/
-		export const testResults: ReadonlyArray<TestResults>;
+		export const testResults: ReadonlyArray<TestRunResult>;
 
 		/**
 		* Event that fires when the {@link testResults} array is updated.
@@ -2117,7 +2177,7 @@ declare module 'vscode' {
 		 * null if a top-level test was added or removed. When fired, the consumer
 		 * should check the test item and all its children for changes.
 		 */
-		readonly onDidChangeTest: Event<TestChangeEvent>;
+		readonly onDidChangeTest: Event<TestsChangeEvent>;
 
 		/**
 		 * An event that fires when all test providers have signalled that the tests
@@ -2136,7 +2196,7 @@ declare module 'vscode' {
 		dispose(): void;
 	}
 
-	export interface TestChangeEvent {
+	export interface TestsChangeEvent {
 		/**
 		 * List of all tests that are newly added.
 		 */
@@ -2154,18 +2214,6 @@ declare module 'vscode' {
 	}
 
 	/**
-	 * Tree of tests returned from the provide methods in the {@link TestProvider}.
-	 */
-	export interface TestHierarchy<T extends TestItem> {
-		/**
-		 * Root node for tests. The root instance must not be replaced over
-		 * the lifespan of the TestHierarchy, since you will need to reference it
-		 * in {@link onDidChangeTest} when a test is added or removed.
-		 */
-		readonly root: T;
-	}
-
-	/**
 	 * Discovers and provides tests.
 	 *
 	 * Additionally, the UI may request it to discover tests for the workspace
@@ -2180,7 +2228,7 @@ declare module 'vscode' {
 		 * when the user opens the test explorer.
 		 *
 		 * It's guaranteed that this method will not be called again while
-		 * there is a previous uncancelled hierarchy for the given workspace folder.
+		 * there is a previous uncancelled call for the given workspace folder.
 		 *
 		 * @param workspace The workspace in which to observe tests
 		 * @param cancellationToken Token that signals the used asked to abort the test run.
@@ -2217,13 +2265,13 @@ declare module 'vscode' {
 		 * @param cancellationToken Token that signals the used asked to abort the test run.
 		 */
 		// eslint-disable-next-line vscode-dts-provider-naming
-		runTests(options: TestRun<T>, token: CancellationToken): ProviderResult<void>;
+		runTests(options: TestRunOptions<T>, token: CancellationToken): ProviderResult<void>;
 	}
 
 	/**
 	 * Options given to {@link test.runTests}.
 	 */
-	export interface TestRunOptions<T extends TestItem = TestItem> {
+	export interface TestRunRequest<T extends TestItem = TestItem> {
 		/**
 		 * Array of specific tests to run. The {@link TestProvider.testRoot} may
 		 * be provided as an indication to run all tests.
@@ -2244,20 +2292,40 @@ declare module 'vscode' {
 	}
 
 	/**
-	 * Options given to `TestProvider.runTests`
+	 * Options given to {@link TestProvider.runTests}
 	 */
-	export interface TestRun<T extends TestItem = TestItem> extends TestRunOptions<T> {
+	export interface TestRunOptions<T extends TestItem = TestItem> extends TestRunRequest<T> {
 		/**
 		 * Updates the state of the test in the run. By default, all tests involved
 		 * in the run will have a "queued" state until they are updated by this method.
 		 *
-		 * Calling with method with nodes outside the {@link tests} or in the
-		 * {@link exclude} array will no-op.
+		 * Calling with method with nodes outside the {@link TestRunRequesttests}
+		 * or in the {@link TestRunRequestexclude} array will no-op.
 		 *
 		 * @param test The test to update
 		 * @param state The state to assign to the test
+		 * @param duration Optionally sets how long the test took to run
 		 */
-		setState(test: T, state: TestState): void;
+		setState(test: T, state: TestResultState, duration?: number): void;
+
+		/**
+		 * Appends a message, such as an assertion error, to the test item.
+		 *
+		 * Calling with method with nodes outside the {@link TestRunRequesttests}
+		 * or in the {@link TestRunRequestexclude} array will no-op.
+		 *
+		 * @param test The test to update
+		 * @param state The state to assign to the test
+		 *
+		 */
+		appendMessage(test: T, message: TestMessage): void;
+
+		/**
+		 * Appends raw output from the test runner. On the user's request, the
+		 * output will be displayed in a terminal. ANSI escape sequences,
+		 * such as colors and text styles, are supported.
+		 */
+		appendOutput(output: string): void;
 	}
 
 	export interface TestChildrenCollection<T> extends Iterable<T> {
@@ -2304,7 +2372,7 @@ declare module 'vscode' {
 		readonly id: string;
 
 		/**
-		 * URI this TestItem is associated with. May be a file or file.
+		 * URI this TestItem is associated with. May be a file or directory.
 		 */
 		readonly uri: Uri;
 
@@ -2331,25 +2399,21 @@ declare module 'vscode' {
 		range?: Range;
 
 		/**
-		 * Whether this test item can be run individually, defaults to `true`.
-		 *
-		 * In some cases, like Go's tests, test can have children but these
-		 * children cannot be run independently.
+		 * Whether this test item can be run by providing it in the
+		 * {@link TestRunRequest.tests} array. Defaults to `true`.
 		 */
 		runnable: boolean;
 
 		/**
-		 * Whether this test item can be debugged individually, defaults to `false`.
-		 *
-		 * In some cases, like Go's tests, test can have children but these
-		 * children cannot be run independently.
+		 * Whether this test item can be debugged by providing it in the
+		 * {@link TestRunRequest.tests} array. Defaults to `false`.
 		 */
 		debuggable: boolean;
 
 		/**
 		 * Whether this test item can be expanded in the tree view, implying it
-		 * has (or may have) children. If this is given, the item may be
-		 * passed to the {@link TestHierarchy.getChildren} method.
+		 * has (or may have) children. If this is true, VS Code may call
+		 * the {@link TestItem.discoverChildren} method.
 		 */
 		expandable: boolean;
 
@@ -2358,15 +2422,14 @@ declare module 'vscode' {
 		 * @param id Value of the "id" property
 		 * @param label Value of the "label" property.
 		 * @param uri Value of the "uri" property.
-		 * @param parent Parent of this item. This should only be defined for the
-		 * test root.
+		 * @param expandable Value of the "expandable" property.
 		 */
 		constructor(id: string, label: string, uri: Uri, expandable: boolean);
 
 		/**
 		 * Marks the test as outdated. This can happen as a result of file changes,
 		 * for example. In "auto run" mode, tests that are outdated will be
-		 * automatically re-run after a short delay. Invoking this on a
+		 * automatically rerun after a short delay. Invoking this on a
 		 * test with children will mark the entire subtree as outdated.
 		 *
 		 * Extensions should generally not override this method.
@@ -2400,7 +2463,7 @@ declare module 'vscode' {
 	/**
 	 * Possible states of tests in a test run.
 	 */
-	export enum TestResult {
+	export enum TestResultState {
 		// Initial state
 		Unset = 0,
 		// Test will be run, but is not currently running.
@@ -2415,32 +2478,6 @@ declare module 'vscode' {
 		Skipped = 5,
 		// Test run failed for some other reason (compilation error, timeout, etc)
 		Errored = 6
-	}
-
-	/**
-	 * TestState associated with a test in its results.
-	 */
-	export class TestState {
-		/**
-		 * Current state of the test.
-		 */
-		readonly state: TestResult;
-
-		/**
-		 * Optional duration of the test run, in milliseconds.
-		 */
-		duration?: number;
-
-		/**
-		 * Associated test run message. Can, for example, contain assertion
-		 * failure information if the test fails.
-		 */
-		messages: TestMessage[];
-
-		/**
-		 * Creates a new TestState instance.
-		 */
-		constructor(state: TestResult);
 	}
 
 	/**
@@ -2499,18 +2536,19 @@ declare module 'vscode' {
 	}
 
 	/**
-	 * TestResults can be provided to VS Code, or read from it.
+	 * TestResults can be provided to VS Code in {@link test.publishTestResult},
+	 * or read from it in {@link test.testResults}.
 	 *
 	 * The results contain a 'snapshot' of the tests at the point when the test
-	 * run is complete. Therefore, information such as {@link Location} instances
-	 * may be out of date. If the test still exists in the workspace, consumers
-	 * can use its `id` to correlate the result instance with the living test.
+	 * run is complete. Therefore, information such as its {@link Range} may be
+	 * out of date. If the test still exists in the workspace, consumers can use
+	 * its `id` to correlate the result instance with the living test.
 	 *
 	 * @todo coverage and other info may eventually be provided here
 	 */
-	export interface TestResults {
+	export interface TestRunResult {
 		/**
-		 * Unix milliseconds timestamp at which the tests were completed.
+		 * Unix milliseconds timestamp at which the test run was completed.
 		 */
 		completedAt: number;
 
@@ -2557,7 +2595,19 @@ declare module 'vscode' {
 		/**
 		 * Current result of the test.
 		 */
-		readonly result: TestState;
+		readonly state: TestResultState;
+
+		/**
+		 * The number of milliseconds the test took to run. This is set once the
+		 * `state` is `Passed`, `Failed`, or `Errored`.
+		 */
+		readonly duration?: number;
+
+		/**
+		 * Associated test run message. Can, for example, contain assertion
+		 * failure information if the test fails.
+		 */
+		readonly messages: ReadonlyArray<TestMessage>;
 
 		/**
 		 * Optional list of nested tests for this item.
@@ -2742,7 +2792,7 @@ declare module 'vscode' {
 
 	//#endregion
 
-	//#region https://github.com/microsoft/vscode/issues/106488
+	//#region https://github.com/microsoft/vscode/issues/120173
 
 	export enum WorkspaceTrustState {
 		/**
@@ -2760,22 +2810,19 @@ declare module 'vscode' {
 		 *
 		 * If trust will be required, users will be prompted to make a choice.
 		 */
-		Unknown = 2
+		Unspecified = 2
 	}
 
 	/**
-	 * The event data that is fired when the trust state of the workspace changes
+	 * The event data that is fired when the trust state of the workspace changes.
+	 * When trust is revoked, the workspace will be reloaded. Therefore, extensions are
+	 * not expected to handle transitions out of a trusted state.
 	 */
 	export interface WorkspaceTrustStateChangeEvent {
 		/**
-		 * Previous trust state of the workspace
+		 * New trust state of the workspace
 		 */
-		previousTrustState: WorkspaceTrustState;
-
-		/**
-		 * Current trust state of the workspace
-		 */
-		currentTrustState: WorkspaceTrustState;
+		readonly newTrustState: WorkspaceTrustState;
 	}
 
 	/**
@@ -2786,7 +2833,7 @@ declare module 'vscode' {
 		 * When true, a modal dialog will be used to request workspace trust.
 		 * When false, a badge will be displayed on the Setting activity bar item
 		 */
-		modal: boolean;
+		readonly modal: boolean;
 	}
 
 	export namespace workspace {
@@ -2800,7 +2847,7 @@ declare module 'vscode' {
 		 * @param options Optional object describing the properties of the
 		 * workspace trust request
 		 */
-		export function requireWorkspaceTrust(options?: WorkspaceTrustRequestOptions): Thenable<WorkspaceTrustState>;
+		export function requestWorkspaceTrust(options?: WorkspaceTrustRequestOptions): Thenable<WorkspaceTrustState | undefined>;
 
 		/**
 		 * Event that fires when the trust state of the current workspace changes
@@ -2810,32 +2857,25 @@ declare module 'vscode' {
 
 	//#endregion
 
-	//#region https://github.com/microsoft/vscode/issues/118084
+	//#region https://github.com/microsoft/vscode/issues/115807
 
-	/**
-	 * The reason why code actions were requested.
-	 */
-	export enum CodeActionTriggerKind {
+	export interface Webview {
 		/**
-		 * Code actions were explicitly requested by the user or by an extension.
-		 */
-		Invoke = 1,
-
-		/**
-		 * Code actions were requested automatically.
+		 * @param message A json serializable message to send to the webview.
 		 *
-		 * This typically happens when current selection in a file changes, but can
-		 * also be triggered when file content changes.
+		 *   For older versions of vscode, if an `ArrayBuffer` is included in `message`,
+		 *   it will not be serialized properly and will not be received by the webview.
+		 *   Similarly any TypedArrays, such as a `Uint8Array`, will be very inefficiently
+		 *   serialized and will also not be recreated as a typed array inside the webview.
+		 *
+		 *   However if your extension targets vscode 1.56+ in the `engines` field of its
+		 *   `package.json` any `ArrayBuffer` values that appear in `message` will be more
+		 *   efficiently transferred to the webview and will also be recreated inside of
+		 *   the webview.
 		 */
-		Automatic = 2,
+		postMessage(message: any): Thenable<boolean>;
 	}
 
-	export interface CodeActionContext {
-		/**
-		 * The reason why code actions were requested.
-		 */
-		readonly triggerKind: CodeActionTriggerKind;
-	}
 	//#endregion
 
 	//#region https://github.com/microsoft/vscode/issues/115616 @alexr00

--- a/src/dotnet-interactive-vscode/stable/.eslintrc.json
+++ b/src/dotnet-interactive-vscode/stable/.eslintrc.json
@@ -3,15 +3,18 @@
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
         "ecmaVersion": 6,
+        "project": "./tsconfig.json",
         "sourceType": "module"
     },
     "plugins": [
-        "@typescript-eslint"
+        "@typescript-eslint",
+        "deprecation"
     ],
     "rules": {
         "@typescript-eslint/class-name-casing": "warn",
         "@typescript-eslint/semi": "warn",
         "curly": "warn",
+        "deprecation/deprecation": "warn",
         "eqeqeq": "warn",
         "no-throw-literal": "warn",
         "semi": "off"

--- a/src/dotnet-interactive-vscode/stable/package-lock.json
+++ b/src/dotnet-interactive-vscode/stable/package-lock.json
@@ -1022,6 +1022,17 @@
         }
       }
     },
+    "eslint-plugin-deprecation": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-deprecation/-/eslint-plugin-deprecation-1.2.0.tgz",
+      "integrity": "sha512-SrZqomFYofRbxJ9dlAcu526/tiZoWoZgHdZWKHjrRT/uLfTtTTjdVf0gdy0AZxK8nH5ri0fukgwS28llUueitA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^2.19.2 || ^3.0.0",
+        "tslib": "^1.10.0",
+        "tsutils": "^3.0.0"
+      }
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",

--- a/src/dotnet-interactive-vscode/stable/package.json
+++ b/src/dotnet-interactive-vscode/stable/package.json
@@ -112,7 +112,7 @@
         },
         "dotnet-interactive.minimumInteractiveToolVersion": {
           "type": "string",
-          "default": "1.0.217604",
+          "default": "1.0.220104",
           "description": "The minimum required version of the .NET Interactive tool."
         },
         "dotnet-interactive.useDotNetInteractiveExtensionForIpynbFiles": {
@@ -352,7 +352,7 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
-    "compile": "tsc -p ./",
+    "compile": "npm run lint && tsc -p ./",
     "lint": "eslint src --ext ts",
     "watch": "tsc -watch -p ./",
     "integration-test": "node ./out/tests/integration/runTest.js",
@@ -379,6 +379,7 @@
     "chai-fs": "2.0.0",
     "del-cli": "^3.0.1",
     "eslint": "6.8.0",
+    "eslint-plugin-deprecation": "^1.2.0",
     "glob": "7.1.6",
     "mocha": "7.1.1",
     "mocha-multi-reporters": "1.1.7",

--- a/src/dotnet-interactive-vscode/stable/src/versionSpecificFunctions.ts
+++ b/src/dotnet-interactive-vscode/stable/src/versionSpecificFunctions.ts
@@ -14,3 +14,19 @@ import * as vscodeUtilities from './common/vscode/vscodeUtilities';
 export function registerAdditionalContentProvider(context: vscode.ExtensionContext, contentProvider: vscode.NotebookContentProvider) {
     context.subscriptions.push(vscode.notebook.registerNotebookContentProvider('dotnet-interactive-jupyter', contentProvider));
 }
+
+export function cellAt(document: vscode.NotebookDocument, index: number): vscode.NotebookCell {
+    return document.cells[index];
+}
+
+export function cellCount(document: vscode.NotebookDocument): number {
+    return document.cells.length;
+}
+
+export function getCells(document: vscode.NotebookDocument | undefined): Array<vscode.NotebookCell> {
+    if (document) {
+        return [...document.cells];
+    }
+
+    return [];
+}


### PR DESCRIPTION
According to [this comment](https://github.com/microsoft/vscode/issues/93265#issuecomment-813989752) the notebook cell apis are changing.  The `cells: NotebookCell[]` property is getting replaced with `getCells(): NotebookCell[]`/`cellCount: number`/`cellAt(index: number): NotebookCell`.

This behavior was abstracted out to `versionSpecificFunctions.ts` since stable and insiders now have different methods of getting cell information.