### PR TITLE
Improve language service performance

### DIFF
--- a/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
@@ -147,7 +147,7 @@ namespace Microsoft.DotNet.Interactive.CSharp
 
             using var _ = new GCPressure(1024 * 1024);
 
-            var document = _workspace.UpdateWorkingDocument(command.Code);
+            var document = _workspace.ForkDocumentForLanguageServices(command.Code);
             var text = await document.GetTextAsync();
             var cursorPosition = text.Lines.GetPosition(command.LinePosition.ToCodeAnalysisLinePosition());
             var service = QuickInfoService.GetService(document);
@@ -176,7 +176,7 @@ namespace Microsoft.DotNet.Interactive.CSharp
         {
             await EnsureWorkspaceIsInitializedAsync(context);
 
-            var document = _workspace.UpdateWorkingDocument(command.Code); 
+            var document = _workspace.ForkDocumentForLanguageServices(command.Code); 
             var signatureHelp = await SignatureHelpGenerator.GenerateSignatureInformation(document, command);
             if (signatureHelp is { })
             {
@@ -370,7 +370,7 @@ namespace Microsoft.DotNet.Interactive.CSharp
 
             using var _ = new GCPressure(1024 * 1024);
 
-            var document = _workspace.UpdateWorkingDocument(code);
+            var document = _workspace.ForkDocumentForLanguageServices(code);
             var service = CompletionService.GetService(document);
             var completionList = await service.GetCompletionsAsync(document, cursorPosition);
            
@@ -410,7 +410,7 @@ namespace Microsoft.DotNet.Interactive.CSharp
         {
             await EnsureWorkspaceIsInitializedAsync(context);
 
-            var document = _workspace.UpdateWorkingDocument(command.Code);
+            var document = _workspace.ForkDocumentForLanguageServices(command.Code);
             var semanticModel = await document.GetSemanticModelAsync();
             var diagnostics = semanticModel.GetDiagnostics();
             context.Publish(GetDiagnosticsProduced(command, diagnostics));

--- a/src/Microsoft.DotNet.Interactive.CSharp/InteractiveWorkspace.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/InteractiveWorkspace.cs
@@ -274,6 +274,30 @@ namespace Microsoft.DotNet.Interactive.CSharp
 
         }
 
+        public Document ForkDocumentForLanguageServices(string code)
+        {
+            var solution = CurrentSolution;
+
+                solution = solution.RemoveDocument(_workingDocumentId);
+
+                var documentDebugName = $"Working from #{_submissionCount}";
+
+                var workingDocumentId = DocumentId.CreateNewId(
+                    _workingProjectId,
+                    documentDebugName);
+
+                solution = solution.AddDocument(
+                    workingDocumentId,
+                    documentDebugName,
+                    SourceText.From(code)
+                );
+
+                var workingDocument = solution.GetDocument(workingDocumentId);
+
+                return workingDocument;
+
+        }
+
         public void AddPackageManagerReference(MetadataReference reference)
         {
             _packageManagerReferences.Add(reference);

--- a/src/Microsoft.DotNet.Interactive.CSharp/InteractiveWorkspace.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/InteractiveWorkspace.cs
@@ -242,38 +242,6 @@ namespace Microsoft.DotNet.Interactive.CSharp
             return projectId;
         }
 
-
-        public Document UpdateWorkingDocument(string code)
-        {
-            Document workingDocument;
-
-            lock (_workspaceLock)
-            {
-                var solution = CurrentSolution;
-
-                solution = solution.RemoveDocument(_workingDocumentId);
-
-                var documentDebugName = $"Working from #{_submissionCount}";
-
-                var workingDocumentId = DocumentId.CreateNewId(
-                    _workingProjectId,
-                    documentDebugName);
-
-                solution = solution.AddDocument(
-                    workingDocumentId,
-                    documentDebugName,
-                    SourceText.From(code)
-                );
-
-                workingDocument = solution.GetDocument(workingDocumentId);
-                _workingDocumentId = workingDocumentId;
-                SetCurrentSolution(solution);
-            }
-
-            return workingDocument;
-
-        }
-
         public Document ForkDocumentForLanguageServices(string code)
         {
             var solution = CurrentSolution;

--- a/src/Microsoft.DotNet.Interactive.CSharp/InteractiveWorkspace.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/InteractiveWorkspace.cs
@@ -246,23 +246,23 @@ namespace Microsoft.DotNet.Interactive.CSharp
         {
             var solution = CurrentSolution;
 
-                solution = solution.RemoveDocument(_workingDocumentId);
+            solution = solution.RemoveDocument(_workingDocumentId);
 
-                var documentDebugName = $"Working from #{_submissionCount}";
+            var documentDebugName = $"Working from #{_submissionCount}";
 
-                var workingDocumentId = DocumentId.CreateNewId(
-                    _workingProjectId,
-                    documentDebugName);
+            var workingDocumentId = DocumentId.CreateNewId(
+                _workingProjectId,
+                documentDebugName);
 
-                solution = solution.AddDocument(
-                    workingDocumentId,
-                    documentDebugName,
-                    SourceText.From(code)
-                );
+            solution = solution.AddDocument(
+                workingDocumentId,
+                documentDebugName,
+                SourceText.From(code)
+            );
 
-                var workingDocument = solution.GetDocument(workingDocumentId);
+            var workingDocument = solution.GetDocument(workingDocumentId);
 
-                return workingDocument;
+            return workingDocument;
 
         }
 

--- a/src/Microsoft.DotNet.Interactive.CSharp/SignatureHelp/SignatureHelpGenerator.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/SignatureHelp/SignatureHelpGenerator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -14,9 +15,10 @@ namespace Microsoft.DotNet.Interactive.CSharp.SignatureHelp
 {
     internal static class SignatureHelpGenerator
     {
-        public static async Task<SignatureHelpProduced> GenerateSignatureInformation(Document document, RequestSignatureHelp command)
+        public static async Task<SignatureHelpProduced> GenerateSignatureInformation(Document document,
+            RequestSignatureHelp command, CancellationToken cancellationToken)
         {
-            var invocation = await GetInvocation(document, command.LinePosition);
+            var invocation = await GetInvocation(document, command.LinePosition, cancellationToken);
             if (invocation is null)
             {
                 return null;
@@ -41,14 +43,12 @@ namespace Microsoft.DotNet.Interactive.CSharp.SignatureHelp
             var bestScoreIndex = 0;
 
             var types = invocation.ArgumentTypes;
-            ISymbol throughSymbol = null;
-            ISymbol throughType = null;
             var methodGroup = invocation.SemanticModel.GetMemberGroup(invocation.Receiver).OfType<IMethodSymbol>();
             if (invocation.Receiver is MemberAccessExpressionSyntax)
             {
                 var throughExpression = ((MemberAccessExpressionSyntax)invocation.Receiver).Expression;
-                throughSymbol = invocation.SemanticModel.GetSpeculativeSymbolInfo(invocation.Position, throughExpression, SpeculativeBindingOption.BindAsExpression).Symbol;
-                throughType = invocation.SemanticModel.GetSpeculativeTypeInfo(invocation.Position, throughExpression, SpeculativeBindingOption.BindAsTypeOrNamespace).Type;
+                var throughSymbol = invocation.SemanticModel.GetSpeculativeSymbolInfo(invocation.Position, throughExpression, SpeculativeBindingOption.BindAsExpression).Symbol;
+                ISymbol throughType = invocation.SemanticModel.GetSpeculativeTypeInfo(invocation.Position, throughExpression, SpeculativeBindingOption.BindAsTypeOrNamespace).Type;
                 var includeInstance = (throughSymbol != null && !(throughSymbol is ITypeSymbol)) ||
                     throughExpression is LiteralExpressionSyntax ||
                     throughExpression is TypeOfExpressionSyntax;
@@ -80,12 +80,13 @@ namespace Microsoft.DotNet.Interactive.CSharp.SignatureHelp
                 activeParameter);
         }
 
-        private static async Task<InvocationContext> GetInvocation(Document document, LinePosition linePosition)
+        private static async Task<InvocationContext> GetInvocation(Document document, LinePosition linePosition,
+            CancellationToken cancellationToken)
         {
-            var text = await document.GetTextAsync();
+            var text = await document.GetTextAsync(cancellationToken);
             var position = Math.Max(text.Lines.GetPosition(linePosition.ToCodeAnalysisLinePosition()) - 1, 0); // backtrack into the actual invocation
-            var tree = await document.GetSyntaxTreeAsync();
-            var root = await tree.GetRootAsync();
+            var tree = await document.GetSyntaxTreeAsync(cancellationToken);
+            var root = await tree.GetRootAsync(cancellationToken);
             var node = root.FindToken(position).Parent;
 
             // Walk up until we find a node that we're interested in.
@@ -93,19 +94,19 @@ namespace Microsoft.DotNet.Interactive.CSharp.SignatureHelp
             {
                 if (node is InvocationExpressionSyntax invocation && invocation.ArgumentList.Span.Contains(position))
                 {
-                    var semanticModel = await document.GetSemanticModelAsync();
+                    var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
                     return new InvocationContext(semanticModel, position, invocation.Expression, invocation.ArgumentList, invocation.IsInStaticContext());
                 }
 
                 if (node is ObjectCreationExpressionSyntax objectCreation && objectCreation.ArgumentList.Span.Contains(position))
                 {
-                    var semanticModel = await document.GetSemanticModelAsync();
+                    var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
                     return new InvocationContext(semanticModel, position, objectCreation, objectCreation.ArgumentList, objectCreation.IsInStaticContext());
                 }
 
                 if (node is AttributeSyntax attributeSyntax && attributeSyntax.ArgumentList.Span.Contains(position))
                 {
-                    var semanticModel = await document.GetSemanticModelAsync();
+                    var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
                     return new InvocationContext(semanticModel, position, attributeSyntax, attributeSyntax.ArgumentList, attributeSyntax.IsInStaticContext());
                 }
 

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
@@ -636,6 +636,7 @@ $${languageSpecificCode}
         [Theory]
         [InlineData(Language.CSharp)]
         [InlineData(Language.FSharp)]
+        [InlineData(Language.PowerShell)]
         public void when_a_sequence_of_diagnostics_requests_is_fired_diagnostics_are_produced_only_for_the_latest_request(Language language)
         {
             var kernel = CreateKernel(language);

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
@@ -638,17 +638,17 @@ $${languageSpecificCode}
         [InlineData(Language.CSharp)]
         [InlineData(Language.FSharp)]
         [InlineData(Language.PowerShell)]
-        public void when_a_sequence_of_diagnostics_requests_is_fired_diagnostics_are_produced_only_for_the_latest_request(Language language)
+        public async Task when_a_sequence_of_diagnostics_requests_is_fired_diagnostics_are_produced_only_for_the_latest_request(Language language)
         {
             var kernel = CreateKernel(language);
            
-            var results =  Task.WhenAll(
+            var results = await Task.WhenAll(
                 kernel.SendAsync(new RequestDiagnostics("C")),
                 kernel.SendAsync(new RequestDiagnostics("Co")),
                 kernel.SendAsync(new RequestDiagnostics("Con")),
                 kernel.SendAsync(new RequestDiagnostics("Cons")), 
                 kernel.SendAsync(new RequestDiagnostics("Conso"))
-            ).Result;
+            );
 
            var events = results.SelectMany(r => r.KernelEvents.ToSubscribedList()).ToList();
 
@@ -668,17 +668,17 @@ $${languageSpecificCode}
         [Theory]
         [InlineData(Language.CSharp)]
         [InlineData(Language.FSharp)]
-        public void RequestCompletions_prevents_RequestDiagnostics_from_producing_events(Language language)
+        public async Task RequestCompletions_prevents_RequestDiagnostics_from_producing_events(Language language)
         {
             var kernel = CreateKernel(language);
             MarkupTestFile.GetLineAndColumn("Console.$$", out var output, out var line, out var column);
 
             var requestDiagnosticsCommand = new RequestDiagnostics(output);
 
-            var results = Task.WhenAll(
+            var results = await  Task.WhenAll(
                 kernel.SendAsync(new RequestCompletions(output, new LinePosition(line,column))),
                 kernel.SendAsync(requestDiagnosticsCommand)
-            ).Result;
+            );
 
             var events = results.SelectMany(r => r.KernelEvents.ToSubscribedList()).ToList();
 

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
@@ -640,7 +640,8 @@ $${languageSpecificCode}
         public void when_a_sequence_of_diagnostics_requests_is_fired_diagnostics_are_produced_only_for_the_latest_request(Language language)
         {
             var kernel = CreateKernel(language);
-           var results =  Task.WhenAll(
+           
+            var results =  Task.WhenAll(
                 kernel.SendAsync(new RequestDiagnostics("C")),
                 kernel.SendAsync(new RequestDiagnostics("Co")),
                 kernel.SendAsync(new RequestDiagnostics("Con")),

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
@@ -633,10 +633,12 @@ $${languageSpecificCode}
                 .ContainSingle(diag => diag.LinePositionSpan.Start.Line == line);
         }
 
-        [Fact]
-        public void when_a_sequence_of_diagnostics_requests_is_fired_diagnostics_are_produced_only_for_the_latest_request()
+        [Theory]
+        [InlineData(Language.CSharp)]
+        [InlineData(Language.FSharp)]
+        public void when_a_sequence_of_diagnostics_requests_is_fired_diagnostics_are_produced_only_for_the_latest_request(Language language)
         {
-            var kernel = CreateKernel();
+            var kernel = CreateKernel(language);
            var results =  Task.WhenAll(
                 kernel.SendAsync(new RequestDiagnostics("C")),
                 kernel.SendAsync(new RequestDiagnostics("Co")),

--- a/src/Microsoft.DotNet.Interactive/ImmediateScheduler.cs
+++ b/src/Microsoft.DotNet.Interactive/ImmediateScheduler.cs
@@ -8,10 +8,11 @@ namespace Microsoft.DotNet.Interactive
 {
     internal class ImmediateScheduler<T, TResult> : IKernelScheduler<T, TResult>
     {
-        public Task<TResult> RunAsync(T value, KernelSchedulerDelegate<T, TResult> onExecuteAsync, string scope = "default",
+        public async Task<TResult> RunAsync(T value, KernelSchedulerDelegate<T, TResult> onExecuteAsync, string scope = "default",
             CancellationToken cancellationToken = default)
         {
-            return onExecuteAsync(value);
+            await Task.Yield();
+            return await onExecuteAsync(value);
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive/Kernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Kernel.cs
@@ -276,7 +276,8 @@ namespace Microsoft.DotNet.Interactive
                                 {
                                     if (_countOfLanguageServiceCommandsInFlight > 0)
                                     {
-                                        context.Complete(command);
+                                    
+                                        context.CancelWithSuccess();
                                         return context.Result;
                                     }
 
@@ -299,7 +300,7 @@ namespace Microsoft.DotNet.Interactive
                                 {
                                     if (_inFlightContext is { } inflight)
                                     {
-                                        inflight.Complete(inflight.Command);
+                                        inflight.CancelWithSuccess();
                                     }
 
                                     Interlocked.Increment(ref _countOfLanguageServiceCommandsInFlight);

--- a/src/Microsoft.DotNet.Interactive/Kernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Kernel.cs
@@ -427,7 +427,7 @@ namespace Microsoft.DotNet.Interactive
         private static readonly List<KernelCommand> EmptyCommandList = new(0);
         private readonly SemaphoreSlim _fastPathSchedulerLock = new(1);
         private KernelInvocationContext _inFlightContext;
-        private int _languageServiceCommandInFlight = 0;
+        private int _countOfLanguageServiceCommandsInFlight = 0;
 
 
         protected IReadOnlyList<KernelCommand> GetDeferredOperations(KernelCommand command, string scope)

--- a/src/Microsoft.DotNet.Interactive/Kernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Kernel.cs
@@ -288,7 +288,7 @@ namespace Microsoft.DotNet.Interactive
 
                                     _inFlightContext = context;
 
-                                    await RunOnFastPath(cancellationToken, context, c);
+                                    await RunOnFastPath(context, c, cancellationToken);
 
                                     _inFlightContext = null;
                                 }
@@ -305,7 +305,7 @@ namespace Microsoft.DotNet.Interactive
 
                                     Interlocked.Increment(ref _countOfLanguageServiceCommandsInFlight);
 
-                                    await RunOnFastPath(cancellationToken, context, c);
+                                    await RunOnFastPath(context, c, cancellationToken);
 
                                     Interlocked.Decrement(ref _countOfLanguageServiceCommandsInFlight);
                                 }
@@ -338,14 +338,14 @@ namespace Microsoft.DotNet.Interactive
             return context.Result;
         }
 
-        private async Task RunOnFastPath(CancellationToken cancellationToken, KernelInvocationContext context,
-            KernelCommand c)
+        private async Task RunOnFastPath(KernelInvocationContext context,
+            KernelCommand command, CancellationToken cancellationToken)
         {
             var fastPathScheduler = await context.HandlingKernel.GetFastPathSchedulerAsync(context);
             await fastPathScheduler.RunAsync(
-                    c,
+                    command,
                     InvokePipelineAndCommandHandler,
-                    c.KernelUri.ToString(),
+                    command.KernelUri.ToString(),
                     cancellationToken: cancellationToken)
                 .ContinueWith(t =>
                 {

--- a/src/Microsoft.DotNet.Interactive/Kernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Kernel.cs
@@ -281,8 +281,6 @@ namespace Microsoft.DotNet.Interactive
                                     context.Complete(command);
                                 }
 
-                               
-
                                 _inFlightDiagnosticsCommandInvocationContext?.Complete(_inFlightDiagnosticsCommandInvocationContext.Command);
                                 if (command is RequestDiagnostics)
                                 {

--- a/src/Microsoft.DotNet.Interactive/Kernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Kernel.cs
@@ -279,6 +279,7 @@ namespace Microsoft.DotNet.Interactive
                                 if (_languageServiceCommandInFlight > 0 && command is RequestDiagnostics)
                                 {
                                     context.Complete(command);
+                                    return context.Result;
                                 }
 
                                 _inFlightDiagnosticsCommandInvocationContext?.Complete(_inFlightDiagnosticsCommandInvocationContext.Command);

--- a/src/Microsoft.DotNet.Interactive/KernelInvocationContext.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelInvocationContext.cs
@@ -210,5 +210,11 @@ namespace Microsoft.DotNet.Interactive
             // This method is not async because it would prevent the setting of _current.Value to null from flowing up to the caller.
             return new ValueTask(Task.CompletedTask);
         }
+
+        internal void CancelWithSuccess()
+        {
+            Complete(Command);
+            TryCancel();
+        }
     }
 }

--- a/src/Microsoft.DotNet.Interactive/KernelInvocationContext.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelInvocationContext.cs
@@ -32,8 +32,8 @@ namespace Microsoft.DotNet.Interactive
         private KernelInvocationContext(KernelCommand command)
         {
             var operation = new OperationLogger(
-                args: new object[] { ("Start AsyncContext.Id", AsyncContext.Id), ("KernelCommand", command) },
-                exitArgs: () => new[] { ("End AsyncContext.Id", (object) AsyncContext.Id) },
+                args: new object[] { ("KernelCommand", command) },
+                exitArgs: () => new[] { ("KernelCommand", (object)command) },
                 category: nameof(KernelInvocationContext),
                 logOnStart: true);
 

--- a/src/Microsoft.DotNet.Interactive/Utility/ConsoleOutput.cs
+++ b/src/Microsoft.DotNet.Interactive/Utility/ConsoleOutput.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.IO;
-using Pocket;
-using CompositeDisposable = System.Reactive.Disposables.CompositeDisposable;
-using Disposable = System.Reactive.Disposables.Disposable;
+using System.Reactive.Disposables;
 
 namespace Microsoft.DotNet.Interactive.Utility
 {
@@ -19,22 +17,13 @@ namespace Microsoft.DotNet.Interactive.Utility
         private static TextWriter _originalErrorWriter;
 
         private static int _refCount = 0;
-
-        private static readonly Logger Log = new(nameof(ConsoleOutput));
+        
 
         public static IDisposable Subscribe(Func<ObservableConsole, IDisposable> subscribe)
         {
-            OperationLogger _operationLogger;
 
             lock (_systemConsoleSwapLock)
             {
-                _operationLogger = Log.OnEnterAndExit(
-                    $"Subscribe on AsyncContext.Id {AsyncContext.Id?.ToString() ?? "none"} with initial _refCount {_refCount}",
-                    exitArgs: () => new[]
-                    {
-                        ("AsyncContext.Id", (object) AsyncContext.Id),
-                        ("_refCount", _refCount),
-                    });
 
                 if (++_refCount == 1)
                 {
@@ -74,8 +63,7 @@ namespace Microsoft.DotNet.Interactive.Utility
                             _multiplexingErrorWriter = null;
                         }
                     }
-                }),
-                _operationLogger);
+                }));
         }
 
         public record ObservableConsole(

--- a/src/Microsoft.DotNet.Interactive/Utility/MultiplexingTextWriter.cs
+++ b/src/Microsoft.DotNet.Interactive/Utility/MultiplexingTextWriter.cs
@@ -59,26 +59,12 @@ namespace Microsoft.DotNet.Interactive.Utility
 
         private TextWriter GetCurrentWriter(bool forWrite = true)
         {
-            string readOrWrite;
-            if (forWrite)
-            {
-                readOrWrite = "write";
-            }
-            else
-            {
-                readOrWrite = "read";
-            }
 
             if (AsyncContext.Id is { } asyncContextId)
             {
-                // FIX: (GetCurrentWriter) remove debuggy stuff
                 var writer = _writers.GetOrAdd(
                     asyncContextId,
-                    _ =>
-                    {
-                        return _createTextWriter();
-                    });
-
+                    _ => _createTextWriter());
 
                 return writer;
             }

--- a/src/Microsoft.DotNet.Interactive/Utility/MultiplexingTextWriter.cs
+++ b/src/Microsoft.DotNet.Interactive/Utility/MultiplexingTextWriter.cs
@@ -57,7 +57,7 @@ namespace Microsoft.DotNet.Interactive.Utility
             });
         }
 
-        private TextWriter GetCurrentWriter(bool forWrite = true)
+        private TextWriter GetCurrentWriter()
         {
 
             if (AsyncContext.Id is { } asyncContextId)
@@ -74,7 +74,7 @@ namespace Microsoft.DotNet.Interactive.Utility
 
         public IObservable<string> GetObservable()
         {
-            if (GetCurrentWriter(false) is IObservable<string> observable)
+            if (GetCurrentWriter() is IObservable<string> observable)
             {
                 return observable;
             }
@@ -88,18 +88,7 @@ namespace Microsoft.DotNet.Interactive.Utility
             return Observable.Empty<string>();
         }
 
-        public override Encoding Encoding
-        {
-            get
-            {
-                if (_encoding == null)
-                {
-                    _encoding = new UnicodeEncoding(false, false);
-                }
-
-                return _encoding;
-            }
-        }
+        public override Encoding Encoding => _encoding ?? (_encoding = new UnicodeEncoding(false, false));
 
         public IEnumerable<TextWriter> Writers => _writers.Select(w => w.Value);
 

--- a/src/Microsoft.DotNet.Interactive/Utility/MultiplexingTextWriter.cs
+++ b/src/Microsoft.DotNet.Interactive/Utility/MultiplexingTextWriter.cs
@@ -7,12 +7,11 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Pocket;
-using static Pocket.Logger<Microsoft.DotNet.Interactive.Utility.MultiplexingTextWriter>;
 
 namespace Microsoft.DotNet.Interactive.Utility
 {
@@ -39,7 +38,7 @@ namespace Microsoft.DotNet.Interactive.Utility
 
         private TextWriter DefaultCreateTextWriter()
         {
-            return new ObservableStringWriter(_name + ":" + AsyncContext.Id);
+            return new ObservableStringWriter();
         }
 
         public IDisposable EnsureInitializedForCurrentAsyncContext()
@@ -54,12 +53,6 @@ namespace Microsoft.DotNet.Interactive.Utility
                 {
                     writer.Dispose();
                     _writers.TryRemove(id, out _);
-                }
-                else
-                {
-                    Log.Error(
-                        message: $"Couldn't find {{name}}:{GetHashCode()} on asyncContextId {{id}}",
-                        args: new object[] { _name, id });
                 }
             });
         }
@@ -83,11 +76,9 @@ namespace Microsoft.DotNet.Interactive.Utility
                     asyncContextId,
                     _ =>
                     {
-                        Log.Info($"Adding writer {{name}}:{GetHashCode()} on {{asyncContextId}} for {{readOrWrite}}", _name, asyncContextId, readOrWrite);
                         return _createTextWriter();
                     });
 
-                Log.Info($"Retrieving {{name}}:{GetHashCode()} on {{asyncContextId}} for {{readOrWrite}}. Writers: {{writers}}.", _name, asyncContextId, readOrWrite, _writers);
 
                 return writer;
             }
@@ -376,7 +367,6 @@ namespace Microsoft.DotNet.Interactive.Utility
             if (AsyncContext.Id is { } asyncContextId &&
                 _writers.TryGetValue(asyncContextId, out var writer))
             {
-                Log.Info($"ToString {{name}}:{GetHashCode()} on {{asyncContextId}}", _name, asyncContextId);
 
                 return writer.ToString();
             }


### PR DESCRIPTION
Prevent RequestDiagnostics from producing events when other language services are running
Produce diagnostics only on last command handling 