### PR TITLE
fix poundi results display

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
@@ -428,7 +428,7 @@ Formatter.Register<DataFrame>((df, writer) =>
             await kernel.SubmitCodeAsync(@"#i ""nuget:https://completelyFakerestoreSource""");
 
             events.Should()
-                  .ContainSingle<DisplayedValueProduced>()
+                  .ContainSingle<DisplayedValueUpdated>()
                   .Which
                   .FormattedValues
                   .Should()

--- a/src/Microsoft.DotNet.Interactive/KernelSupportsNugetExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelSupportsNugetExtensions.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
+using Microsoft.DotNet.Interactive.Formatting;
 using static Microsoft.DotNet.Interactive.Formatting.PocketViewTags;
 
 namespace Microsoft.DotNet.Interactive
@@ -46,13 +47,12 @@ namespace Microsoft.DotNet.Interactive
                 if (context.HandlingKernel is ISupportNuget kernel)
                 {
                     kernel.AddRestoreSource(source.Replace("nuget:", ""));
-
                     IHtmlContent content = div(
                         strong("Restore sources"),
-                        ul(kernel.RestoreSources
-                                 .Select(s => li(span(s)))));
+                        ul(kernel.RestoreSources.Select(s => li(span(s)))));
 
-                    context.Display(content);
+                    var displayed = new DisplayedValue("displayedValueRestoreSources" + context.GetHashCode().ToString(), HtmlFormatter.MimeType, context);
+                    displayed.Update(content);
                 }
             });
             return iDirective;


### PR DESCRIPTION
Fixes: #https://github.com/dotnet/interactive/issues/1174

notebooks is very chatty when notifying the host of restore sources.  It displays the whole list again every time a new restore source is added.

This PR reduces that by updating the message each time a source is added.
![image](https://user-images.githubusercontent.com/5175830/114494540-67fc7300-9bd1-11eb-84ca-abf56a46e2bb.png)

This PR includes
