### PR TITLE
BigInteger should be displayed as plain text

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Dynamic;
 using System.IO;
 using System.Linq;
+using System.Numerics;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
@@ -305,7 +306,21 @@ string";
                           $"{PlainTextBegin}{instance.HtmlEncode()}{PlainTextEnd}");
             }
 
+            [Fact]
+            public void It_does_not_affect_BigInteger()
+            {
+                var formatter = HtmlFormatter.GetPreferredFormatterFor(typeof(BigInteger));
 
+                var writer = new StringWriter();
+
+                var instance = BigInteger.Parse("78923589327589332402359");
+
+                formatter.Format(instance, writer);
+
+                writer.ToString()
+                    .Should()
+                    .Be("<div class=\"dni-plaintext\">78923589327589332402359</div>");
+            }
         }
         public class Sequences : FormatterTestBase
         {

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
@@ -15,11 +15,10 @@ using static Microsoft.DotNet.Interactive.Formatting.Tests.Tags;
 
 namespace Microsoft.DotNet.Interactive.Formatting.Tests
 {
-    public class Tags
+    public static class Tags
     {
         public const string PlainTextBegin = "<div class=\"dni-plaintext\">";
         public const string PlainTextEnd = "</div>";
-
     }
     public class HtmlFormatterTests : FormatterTestBase
     {
@@ -307,7 +306,7 @@ string";
             }
 
             [Fact]
-            public void It_does_not_affect_BigInteger()
+            public void HtmlFormatter_returns_plain_for_BigInteger()
             {
                 var formatter = HtmlFormatter.GetPreferredFormatterFor(typeof(BigInteger));
 
@@ -319,9 +318,26 @@ string";
 
                 writer.ToString()
                     .Should()
-                    .Be("<div class=\"dni-plaintext\">78923589327589332402359</div>");
+                    .Be($"{PlainTextBegin}78923589327589332402359{PlainTextEnd}");
+            }
+
+            [Fact]
+            public void PlainTextFormatter_returns_plain_for_BigInteger()
+            {
+                var formatter = PlainTextFormatter.GetPreferredFormatterFor(typeof(BigInteger));
+
+                var writer = new StringWriter();
+
+                var instance = BigInteger.Parse("78923589327589332402359");
+
+                formatter.Format(instance, writer);
+
+                writer.ToString()
+                    .Should()
+                    .Be($"{PlainTextBegin}78923589327589332402359{PlainTextEnd}");
             }
         }
+
         public class Sequences : FormatterTestBase
         {
             [Fact]

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
@@ -334,7 +334,7 @@ string";
 
                 writer.ToString()
                     .Should()
-                    .Be($"{PlainTextBegin}78923589327589332402359{PlainTextEnd}");
+                    .Be("78923589327589332402359");
             }
         }
 

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
@@ -320,22 +320,6 @@ string";
                     .Should()
                     .Be($"{PlainTextBegin}78923589327589332402359{PlainTextEnd}");
             }
-
-            [Fact]
-            public void PlainTextFormatter_returns_plain_for_BigInteger()
-            {
-                var formatter = PlainTextFormatter.GetPreferredFormatterFor(typeof(BigInteger));
-
-                var writer = new StringWriter();
-
-                var instance = BigInteger.Parse("78923589327589332402359");
-
-                formatter.Format(instance, writer);
-
-                writer.ToString()
-                    .Should()
-                    .Be("78923589327589332402359");
-            }
         }
 
         public class Sequences : FormatterTestBase

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/PlainTextFormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/PlainTextFormatterTests.cs
@@ -9,6 +9,7 @@ using FluentAssertions;
 using System.Linq;
 using FluentAssertions.Extensions;
 using Xunit;
+using System.Numerics;
 
 namespace Microsoft.DotNet.Interactive.Formatting.Tests
 {
@@ -343,6 +344,22 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
                 formatter.Format(timespan, writer);
 
                 writer.ToString().Should().Be(timespan.ToString());
+            }
+
+            [Fact]
+            public void PlainTextFormatter_returns_plain_for_BigInteger()
+            {
+                var formatter = PlainTextFormatter.GetPreferredFormatterFor(typeof(BigInteger));
+
+                var writer = new StringWriter();
+
+                var instance = BigInteger.Parse("78923589327589332402359");
+
+                formatter.Format(instance, writer);
+
+                writer.ToString()
+                    .Should()
+                    .Be("78923589327589332402359");
             }
         }
 

--- a/src/Microsoft.DotNet.Interactive.Formatting/DefaultHtmlFormatterSet.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/DefaultHtmlFormatterSet.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Html;
 using static Microsoft.DotNet.Interactive.Formatting.PocketViewTags;
+using System.Numerics;
 
 namespace Microsoft.DotNet.Interactive.Formatting
 {
@@ -156,9 +157,9 @@ namespace Microsoft.DotNet.Interactive.Formatting
                 }),
 
                 // BigInteger should be displayed as plain text
-                new HtmlFormatter<System.Numerics.BigInteger>((context, value, writer) =>
+                new HtmlFormatter<BigInteger>((context, value, writer) =>
                 {
-                    HtmlFormatter.FormatStringAsPlainText(value.ToString(), writer);
+                    value.FormatTo(writer, PlainTextFormatter.MimeType);
                     return true;
                 }),
 

--- a/src/Microsoft.DotNet.Interactive.Formatting/DefaultHtmlFormatterSet.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/DefaultHtmlFormatterSet.cs
@@ -155,6 +155,13 @@ namespace Microsoft.DotNet.Interactive.Formatting
                     return formatter.Format(context, value, writer);
                 }),
 
+                // BigInteger should be displayed as plain text
+                new HtmlFormatter<System.Numerics.BigInteger>((context, value, writer) =>
+                {
+                    HtmlFormatter.FormatStringAsPlainText(value.ToString(), writer);
+                    return true;
+                }),
+
                 // Try to display object results as tables. This will return false for nested tables.
                 new HtmlFormatter<object>((context, value, writer) =>
                 {

--- a/src/Microsoft.DotNet.Interactive.Formatting/DefaultHtmlFormatterSet.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/DefaultHtmlFormatterSet.cs
@@ -159,7 +159,7 @@ namespace Microsoft.DotNet.Interactive.Formatting
                 // BigInteger should be displayed as plain text
                 new HtmlFormatter<BigInteger>((context, value, writer) =>
                 {
-                    value.FormatTo(writer, PlainTextFormatter.MimeType);
+                    HtmlFormatter.FormatObjectAsPlainText(context, value, writer);
                     return true;
                 }),
 

--- a/src/Microsoft.DotNet.Interactive.Formatting/DefaultPlainTextFormatterSet.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/DefaultPlainTextFormatterSet.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.CommandLine.Rendering;
 using System.Dynamic;
 using System.Linq;
+using System.Numerics;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using Microsoft.AspNetCore.Html;
@@ -125,6 +126,13 @@ namespace Microsoft.DotNet.Interactive.Formatting
                     var type = obj.GetType();
                     var formatter = PlainTextFormatter.GetDefaultFormatterForAnyEnumerable(type);
                     return formatter.Format(context, obj, writer);
+                }),
+
+                // BigInteger should be displayed as plain text
+                new PlainTextFormatter<BigInteger>((context, value, writer) =>
+                {
+                    value.FormatTo(writer, PlainTextFormatter.MimeType);
+                    return true;
                 }),
 
                 // Fallback for any object

--- a/src/Microsoft.DotNet.Interactive.Formatting/Formatter.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/Formatter.cs
@@ -499,18 +499,12 @@ namespace Microsoft.DotNet.Interactive.Formatting
         internal static ITypeFormatter InferPreferredFormatter(Type actualType, string mimeType)
         {
             // Try to find a user-specified type formatter, use the most specific type with a matching mime type
-            var userFormatter = TryInferPreferredFormatter(actualType, mimeType, _typeFormatters);
-            if (userFormatter != null)
-            {
+            if (TryInferPreferredFormatter(actualType, mimeType, _typeFormatters) is { } userFormatter)
                 return userFormatter;
-            }
 
             // Try to find a default built-in type formatter, use the most specific type with a matching mime type
-            var defaultFormatter = TryInferPreferredFormatter(actualType, mimeType, _defaultTypeFormatters);
-            if (defaultFormatter != null)
-            {
+            if (TryInferPreferredFormatter(actualType, mimeType, _defaultTypeFormatters) is { } defaultFormatter)
                 return defaultFormatter;
-            }
 
             // Last resort backup 
             return new AnonymousTypeFormatter<object>((context, obj, writer) =>

--- a/src/Microsoft.DotNet.Interactive/Notebook/NotebookCellOutputConverter.cs
+++ b/src/Microsoft.DotNet.Interactive/Notebook/NotebookCellOutputConverter.cs
@@ -39,7 +39,6 @@ namespace Microsoft.DotNet.Interactive.Notebook
                             if (reader.Read() && reader.TokenType == JsonTokenType.String)
                             {
                                 errorName = reader.GetString();
-
                             }
                             break;
                         case "errorValue":


### PR DESCRIPTION
Unlike what we see in https://github.com/dotnet/interactive/issues/1096

Before:
![image](https://user-images.githubusercontent.com/31178401/114775412-f0b61300-9d79-11eb-9d9f-4f5a2fc24467.png)

After:
![image](https://user-images.githubusercontent.com/31178401/114775446-fc093e80-9d79-11eb-8286-690b98a9df19.png)
