### PR TITLE
Typo in an md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Contributing
 Please read [.NET Core Guidelines](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/contributing.md) for more general information about coding styles, source structure, making pull requests, and more.
 While this project is in the early phases of development, some of the guidelines in this document -- such as API reviews -- do not yet apply as strongly.
 
-That said, please use open a GitHub to discuss first any API renames or changes before submitting PRs.
+That said, please open a GitHub issue to discuss any API renames or changes before submitting PRs.
 
 ## Developer guide
 


### PR DESCRIPTION
But why you don't have the developer guide in this file as well? I think it might be more convenient and consistent.