### PR TITLE
Minor fixes of languages and versions for Jupyter

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Jupyter/Protocol/LanguageInfo.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/Protocol/LanguageInfo.cs
@@ -64,14 +64,14 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Protocol
 
     public class CSharpLanguageInfo : LanguageInfo
     {
-        public CSharpLanguageInfo(string version = "8.0") : base("C#", version, "text/x-csharp", ".cs", pygmentsLexer: "csharp")
+        public CSharpLanguageInfo(string version = "9.0") : base("C#", version, "text/x-csharp", ".cs", pygmentsLexer: "csharp")
         {
         }
     }
 
     public class FSharpLanguageInfo : LanguageInfo
     {
-        public FSharpLanguageInfo(string version = "4.5") : base("F#", version, "text/x-fsharp", ".fs", pygmentsLexer: "fsharp")
+        public FSharpLanguageInfo(string version = "5.0") : base("F#", version, "text/x-fsharp", ".fs", pygmentsLexer: "fsharp")
         {
            
         }

--- a/src/Microsoft.DotNet.Interactive.Jupyter/Protocol/LanguageInfo.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/Protocol/LanguageInfo.cs
@@ -71,7 +71,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Protocol
 
     public class FSharpLanguageInfo : LanguageInfo
     {
-        public FSharpLanguageInfo(string version = "4.5") : base("C#", version, "text/x-fsharp", ".fs", pygmentsLexer: "fsharp")
+        public FSharpLanguageInfo(string version = "4.5") : base("F#", version, "text/x-fsharp", ".fs", pygmentsLexer: "fsharp")
         {
            
         }
@@ -87,7 +87,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Protocol
 
     public class VBnetLanguageInfo : LanguageInfo
     {
-        public VBnetLanguageInfo(string version = "15.0") : base("C#", version, "text/x-vbnet", ".vb", pygmentsLexer: "vbnet")
+        public VBnetLanguageInfo(string version = "15.0") : base("VB.NET", version, "text/x-vbnet", ".vb", pygmentsLexer: "vbnet")
         {
         }
     }

--- a/src/Microsoft.DotNet.Interactive.Jupyter/Protocol/LanguageInfo.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/Protocol/LanguageInfo.cs
@@ -84,11 +84,4 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Protocol
            
         }
     }
-
-    public class VBnetLanguageInfo : LanguageInfo
-    {
-        public VBnetLanguageInfo(string version = "15.0") : base("VB.NET", version, "text/x-vbnet", ".vb", pygmentsLexer: "vbnet")
-        {
-        }
-    }
 }


### PR DESCRIPTION
~~I do **not** know whether I will succeed at adding it XD. Let's see.~~

~~#847~~

- [x] Minor fix to languages names (so that you can see proper buttons in File>Download as)
As far as I could understand, it might also make sense to make the default language versions to 9.0 and 5.0 for C# and F# respectively. At least, that's the languages which work. Did I do it right?
~~- [ ] Exporting a notebook into `html` to ~a temporary file~ to a variable.~~
~~This command~~
~~```~~
~~jupyter-nbconvert CSharpTest.ipynb --output-dir=. --stdout~~
~~```~~
~~will return an `html` code.~~
~~- [ ] Converting the exported html ~file~ code into pdf~~
~~

Alright, this PR only performs minor changes to versions and language mismatch. 

**Why this PR doesn't close 847**: there are outside tools which already do it for any ipynb notebook, so no need to add it to dotnet interactive explicitly. It might be also added as a frontend extension to Jupyter lab, but it will be still a separate tool.