### PR TITLE
Displaying bitmap?

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
@@ -12,6 +12,7 @@ using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
 using static Microsoft.DotNet.Interactive.Formatting.Tests.Tags;
+using System.Drawing;
 
 namespace Microsoft.DotNet.Interactive.Formatting.Tests
 {
@@ -72,6 +73,14 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
     <tbody><tr><td>{PlainTextBegin}2{PlainTextEnd}</td><td>{PlainTextBegin}socks{PlainTextEnd}</td></tr>
     </tbody>
 </table>");
+            }
+
+            [Fact]
+            public void Formatter_kdjfdkjfksdjf()
+            {
+                //var formatter = HtmlFormatter.GetPreferredFormatterFor<Bitmap>();
+                var output = new Bitmap("D:/tmp/duck.png").ToDisplayString("text/html");
+                Console.WriteLine();
             }
 
             [Fact]

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/Microsoft.DotNet.Interactive.Formatting.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/Microsoft.DotNet.Interactive.Formatting.Tests.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Assent" Version="1.7.0" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Interactive.Formatting/DefaultHtmlFormatterSet.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/DefaultHtmlFormatterSet.cs
@@ -10,6 +10,7 @@ using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Html;
 using static Microsoft.DotNet.Interactive.Formatting.PocketViewTags;
 using System.Numerics;
+using System.Drawing;
 
 namespace Microsoft.DotNet.Interactive.Formatting
 {
@@ -160,6 +161,17 @@ namespace Microsoft.DotNet.Interactive.Formatting
                 new HtmlFormatter<BigInteger>((context, value, writer) =>
                 {
                     HtmlFormatter.FormatObjectAsPlainText(context, value, writer);
+                    return true;
+                }),
+
+                new HtmlFormatter<Bitmap>((context, value, writer) =>
+                {
+                    System.IO.MemoryStream stream = new System.IO.MemoryStream();
+                    value.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
+                    byte[] imageBytes = stream.ToArray();
+                    var base64 = Convert.ToBase64String(imageBytes);
+                    var img = @$"<img src='data:image/png;base64, {base64}' />";
+                    writer.Write(img);
                     return true;
                 }),
 

--- a/src/Microsoft.DotNet.Interactive.Formatting/Microsoft.DotNet.Interactive.Formatting.csproj
+++ b/src/Microsoft.DotNet.Interactive.Formatting/Microsoft.DotNet.Interactive.Formatting.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="2.2.0" />
     <PackageReference Include="microsoft.csharp" Version="4.7.0" />
     <PackageReference Include="System.CommandLine.Rendering" Version="0.3.0-alpha.20427.1" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
     <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>


### PR DESCRIPTION
It's an experiment. Do **NOT** look at the code now (you will want to ban me after looking at it). But here's the thought: what if we can display bitmap via base64 encoding? Here is the result of what I just did:
![image](https://user-images.githubusercontent.com/31178401/115446259-9b697e00-a21f-11eb-9290-03caab693696.png)

So to sum up: we create a default html formatter for bitmap, which would convert a bitmap into bytes, then into base64, and thanks to html we can store it right in the notebook. And display it.