### PR TITLE
offer to re-open .net .ipynb notebooks in our own editor

### DIFF
--- a/src/dotnet-interactive-vscode/common/utilities.ts
+++ b/src/dotnet-interactive-vscode/common/utilities.ts
@@ -234,6 +234,10 @@ export function stringify(value: any): string {
     });
 }
 
+export function isDotnetKernel(kernelspecName: any): boolean {
+    return typeof kernelspecName === 'string' && kernelspecName.toLowerCase().startsWith('.net-');
+}
+
 export function isDotNetKernelPreferred(filename: string, fileMetadata: any): boolean {
     const extension = path.extname(filename);
     switch (extension) {
@@ -244,10 +248,9 @@ export function isDotNetKernelPreferred(filename: string, fileMetadata: any): bo
         // maybe preferred if the kernelspec data matches
         case '.ipynb':
             const kernelName = fileMetadata?.custom?.metadata?.kernelspec?.name;
-            const isDotnetKernel = typeof kernelName === 'string' && kernelName.toLowerCase().startsWith('.net-');
             const languageInfo = fileMetadata?.custom?.metadata?.language_info?.name;
             const isDotnetLanguageInfo = typeof languageInfo === 'string' && isDotnetInteractiveLanguage(languageInfo);
-            return isDotnetKernel || isDotnetLanguageInfo;
+            return isDotnetKernel(kernelName) || isDotnetLanguageInfo;
         // never preferred if it's an unknown extension
         default:
             return false;

--- a/src/dotnet-interactive-vscode/common/vscode/vscodeUtilities.ts
+++ b/src/dotnet-interactive-vscode/common/vscode/vscodeUtilities.ts
@@ -7,6 +7,10 @@ import { Eol, WindowsEol, NonWindowsEol } from "../interfaces";
 import { Diagnostic, DiagnosticSeverity, LinePosition, LinePositionSpan } from '../interfaces/contracts';
 import { ClientMapper } from '../clientMapper';
 
+export function isStableBuild(): boolean {
+    return !isInsidersBuild();
+}
+
 export function isInsidersBuild(): boolean {
     return vscode.version.indexOf('-insider') >= 0;
 }

--- a/src/dotnet-interactive-vscode/stable/package.json
+++ b/src/dotnet-interactive-vscode/stable/package.json
@@ -118,7 +118,7 @@
         },
         "dotnet-interactive.useDotNetInteractiveExtensionForIpynbFiles": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "(LEGACY) Use the .NET Interactive extension to handle .ipynb files (requires restart)."
         }
       }


### PR DESCRIPTION
If a .NET Interactive `.ipynb` notebook was opened with another editor (e.g., the Jupyter extension), prompt the user to re-open with us so we can properly maintain cell language metadata.

![image](https://user-images.githubusercontent.com/926281/115476378-98a66300-a1f6-11eb-91f7-e5336695ea4a.png)
