### PR TITLE
update to new apis

### DIFF
--- a/src/dotnet-interactive-vscode/common/ipynbUtilities.ts
+++ b/src/dotnet-interactive-vscode/common/ipynbUtilities.ts
@@ -19,7 +19,7 @@ function isDotNetCellMetadata(arg: any): arg is DotNetCellMetadata {
         && typeof arg.language === 'string';
 }
 
-export function getDotNetMetadata(metadata: CellMetadata | undefined): DotNetCellMetadata {
+export function getDotNetMetadata(metadata: any): DotNetCellMetadata {
     if (metadata &&
         metadata.custom &&
         metadata.custom.metadata &&
@@ -47,7 +47,7 @@ function isLanguageInfoMetadata(arg: any): arg is LanguageInfoMetadata {
         && typeof arg.name === 'string';
 }
 
-export function getLanguageInfoMetadata(metadata: DocumentMetadata | undefined): LanguageInfoMetadata {
+export function getLanguageInfoMetadata(metadata: any): LanguageInfoMetadata {
     let languageMetadata: LanguageInfoMetadata = {
         name: undefined,
     };

--- a/src/dotnet-interactive-vscode/common/vscode/commands.ts
+++ b/src/dotnet-interactive-vscode/common/vscode/commands.ts
@@ -6,10 +6,8 @@ import * as path from 'path';
 import { acquireDotnetInteractive } from '../acquisition';
 import { InstallInteractiveArgs, InteractiveLaunchOptions } from '../interfaces';
 import { ClientMapper } from '../clientMapper';
-import { getEol, isUnsavedNotebook } from './vscodeUtilities';
-import { toNotebookDocument } from './notebookContentProvider';
-import { KernelId, endExecution } from './notebookKernel';
-import { DotNetPathManager } from './extension';
+import { getEol, isUnsavedNotebook, toNotebookDocument } from './vscodeUtilities';
+import { DotNetPathManager, KernelId } from './extension';
 import { computeToolInstallArguments, executeSafe, executeSafeAndLog } from '../utilities';
 
 import * as jupyter from './jupyter';
@@ -124,7 +122,7 @@ export function registerKernelCommands(context: vscode.ExtensionContext, clientM
 
         if (document) {
             for (const cell of versionSpecificFunctions.getCells(document)) {
-                endExecution(cell, false);
+                versionSpecificFunctions.endExecution(cell, false);
             }
 
             clientMapper.closeClient(document.uri);

--- a/src/dotnet-interactive-vscode/insiders/package.json
+++ b/src/dotnet-interactive-vscode/insiders/package.json
@@ -104,7 +104,7 @@
         },
         "dotnet-interactive.minimumInteractiveToolVersion": {
           "type": "string",
-          "default": "1.0.221503",
+          "default": "1.0.222102",
           "description": "The minimum required version of the .NET Interactive tool."
         }
       }
@@ -343,7 +343,7 @@
     "lint": "eslint src --ext ts",
     "watch": "tsc -watch -p ./",
     "integration-test": "node ./out/tests/integration/runTest.js",
-    "pretest": "npm run compile && npm run lint",
+    "pretest": "npm run compile",
     "test": "mocha --opts mocha.opts",
     "ciTest": "npm test -- --reporter mocha-multi-reporters --reporter-options configFile=testConfig.json",
     "tdd": "npm test -- --watch",

--- a/src/dotnet-interactive-vscode/insiders/src/notebookControllers.ts
+++ b/src/dotnet-interactive-vscode/insiders/src/notebookControllers.ts
@@ -1,0 +1,239 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import * as vscode from 'vscode';
+import { ClientMapper } from './common/clientMapper';
+
+import * as contracts from './common/interfaces/contracts';
+import * as vscodeLike from './common/interfaces/vscode-like';
+import * as diagnostics from './common/vscode/diagnostics';
+import * as utilities from './common/utilities';
+import * as versionSpecificFunctions from './versionSpecificFunctions';
+import * as vscodeUtilities from './common/vscode/vscodeUtilities';
+import { getSimpleLanguage, notebookCellLanguages } from './common/interactiveNotebook';
+import { getCellLanguage, getDotNetMetadata, getLanguageInfoMetadata, withDotNetKernelMetadata } from './common/ipynbUtilities';
+import { reshapeOutputValueForVsCode } from './common/interfaces/utilities';
+import { isStableBuild } from './common/vscode/vscodeUtilities';
+
+const executionTasks: Map<vscode.Uri, vscode.NotebookCellExecutionTask> = new Map();
+
+export class DotNetNotebookKernel {
+
+    private disposables: { dispose(): void }[] = [];
+
+    constructor(private readonly clientMapper: ClientMapper, preloadUris: vscode.Uri[]) {
+        const preloads = preloadUris.map(uri => ({ uri }));
+
+        // .dib execution
+        const dibController = vscode.notebook.createNotebookController(
+            'dotnet-interactive',
+            { viewType: 'dotnet-interactive' },
+            '.NET Interactive',
+            this.executeHandler.bind(this),
+            preloads
+        );
+        dibController.isPreferred = true;
+        this.commonControllerInit(dibController);
+
+        // .ipynb execution via this extension
+        if (isStableBuild()) {
+            const ipynbController = vscode.notebook.createNotebookController(
+                'dotnet-interactive-jupyter',
+                { viewType: 'dotnet-interactive-jupyter' },
+                '.NET Interactive',
+                this.executeHandler.bind(this), // handler
+                preloads
+            );
+            ipynbController.isPreferred = false;
+            this.commonControllerInit(ipynbController);
+        }
+
+        // .ipynb execution via Jupyter extension
+        const jupyterController = vscode.notebook.createNotebookController(
+            'dotnet-interactive-for-jupyter',
+            { viewType: 'jupyter-notebook' },
+            '.NET Interactive',
+            this.executeHandler.bind(this),
+            preloads
+        );
+        jupyterController.isPreferred = false;
+        jupyterController.onDidChangeNotebookAssociation(async e => {
+            if (e.selected) {
+                try {
+                    // update various metadata
+                    await updateDocumentKernelspecMetadata(e.notebook);
+                    await updateCellLanguages(e.notebook);
+
+                    // force creation of the client so we don't have to wait for the user to execute a cell to get the tool
+                    await clientMapper.getOrAddClient(e.notebook.uri);
+                } catch (err) {
+                    vscode.window.showErrorMessage(`Failed to set document metadata for '${e.notebook.uri}': ${err}`);
+                }
+            } else if (isStableBuild()) {
+                // `e.notebook.metadata.custom` is deprecated but still used by the Jupyter extension; soon the metadata will change to something like this:
+                //    e.notebook.metadata['kernelspec']?.name;
+                const kernelspecName = e.notebook.metadata?.custom?.metadata?.kernelspec?.name;
+                await vscodeUtilities.offerToReOpen(e.notebook, kernelspecName);
+            }
+        });
+        this.commonControllerInit(jupyterController);
+    }
+
+    dispose(): void {
+        this.disposables.forEach(d => d.dispose());
+    }
+
+    private commonControllerInit(controller: vscode.NotebookController) {
+        controller.supportedLanguages = notebookCellLanguages;
+        this.disposables.push(controller.onDidReceiveMessage(e => {
+            const documentUri = e.editor.document.uri;
+            switch (e.message.command) {
+                case "getHttpApiEndpoint":
+                    this.clientMapper.tryGetClient(documentUri).then(client => {
+                        if (client) {
+                            const uri = client.tryGetProperty<vscode.Uri>("externalUri");
+                            controller.postMessage({ command: "configureFactories", endpointUri: uri?.toString() });
+
+                            this.clientMapper.onClientCreate(documentUri, async (client) => {
+                                const uri = client.tryGetProperty<vscode.Uri>("externalUri");
+                                await controller.postMessage({ command: "resetFactories", endpointUri: uri?.toString() });
+                            });
+                        }
+                    });
+                    break;
+            }
+        }));
+        this.disposables.push(controller);
+    }
+
+    private async executeHandler(cells: vscode.NotebookCell[], controller: vscode.NotebookController): Promise<void> {
+        for (const cell of cells) {
+            await this.executeCell(cell, controller);
+        }
+    }
+
+    private async executeCell(cell: vscode.NotebookCell, controller: vscode.NotebookController): Promise<void> {
+        const executionTask = controller.createNotebookCellExecutionTask(cell);
+        if (executionTask) {
+            executionTasks.set(cell.document.uri, executionTask);
+            try {
+                executionTask.start({
+                    startTime: Date.now(),
+                });
+                setCellLockState(cell, true);
+                executionTask.clearOutput(cell.index);
+                const client = await this.clientMapper.getOrAddClient(cell.notebook.uri);
+                executionTask.token.onCancellationRequested(() => {
+                    const errorOutput = utilities.createErrorOutput("Cell execution cancelled by user");
+                    const resultPromise = () => updateCellOutputs(executionTask, cell, [...cell.outputs, errorOutput])
+                        .then(() => endExecution(cell, false));
+                    client.cancel()
+                        .then(resultPromise)
+                        .catch(resultPromise);
+                });
+                const source = cell.document.getText();
+                function outputObserver(outputs: Array<vscodeLike.NotebookCellOutput>) {
+                    updateCellOutputs(executionTask!, cell, outputs).then(() => { });
+                }
+
+                const diagnosticCollection = diagnostics.getDiagnosticCollection(cell.document.uri);
+
+                function diagnosticObserver(diags: Array<contracts.Diagnostic>) {
+                    diagnosticCollection.set(cell.document.uri, diags.filter(d => d.severity !== contracts.DiagnosticSeverity.Hidden).map(vscodeUtilities.toVsCodeDiagnostic));
+                }
+
+                return client.execute(source, getSimpleLanguage(cell.document.languageId), outputObserver, diagnosticObserver, { id: cell.document.uri.toString() }).then(() =>
+                    endExecution(cell, true)
+                ).catch(() => endExecution(cell, false)
+                ).then(() => {
+                    return updateCellLanguages(cell.notebook);
+                });
+            } catch (err) {
+                const errorOutput = utilities.createErrorOutput(`Error executing cell: ${err}`);
+                await updateCellOutputs(executionTask, cell, [errorOutput]);
+                endExecution(cell, false);
+                throw err;
+            }
+        }
+    }
+}
+
+export async function updateCellLanguages(document: vscode.NotebookDocument): Promise<void> {
+    const documentLanguageInfo = getLanguageInfoMetadata(document.metadata);
+
+    // update cell language
+    let applyUpdate = false;
+    let cellDatas: Array<vscode.NotebookCellData> = [];
+    for (const cell of versionSpecificFunctions.getCells(document)) {
+        const cellMetadata = getDotNetMetadata(cell.metadata);
+        const cellText = cell.document.getText();
+        const newLanguage = getCellLanguage(cellText, cellMetadata, documentLanguageInfo, cell.document.languageId);
+        const cellData = new vscode.NotebookCellData(
+            cell.kind,
+            cellText,
+            newLanguage,
+            cell.outputs.concat(), // can't pass through a readonly property, so we have to make it a regular array
+            cell.metadata,
+        );
+        cellDatas.push(cellData);
+        applyUpdate ||= cell.document.languageId !== newLanguage;
+    }
+
+    if (applyUpdate) {
+        const edit = new vscode.WorkspaceEdit();
+        edit.replaceNotebookCells(document.uri, new vscode.NotebookRange(0, document.cellCount), cellDatas);
+        await vscode.workspace.applyEdit(edit);
+    }
+}
+
+function setCellLockState(cell: vscode.NotebookCell, locked: boolean) {
+    const edit = new vscode.WorkspaceEdit();
+    edit.replaceNotebookCellMetadata(cell.notebook.uri, cell.index, cell.metadata.with({ editable: !locked }));
+    return vscode.workspace.applyEdit(edit);
+}
+
+async function updateCellOutputs(executionTask: vscode.NotebookCellExecutionTask, cell: vscode.NotebookCell, outputs: Array<vscodeLike.NotebookCellOutput>): Promise<void> {
+    const reshapedOutputs = outputs.map(o => new vscode.NotebookCellOutput(o.outputs.map(oi => generateVsCodeNotebookCellOutputItem(oi.mime, oi.value))));
+    await executionTask.replaceOutput(reshapedOutputs, cell.index);
+}
+
+export function endExecution(cell: vscode.NotebookCell, success: boolean) {
+    setCellLockState(cell, false);
+    const executionTask = executionTasks.get(cell.document.uri);
+    if (executionTask) {
+        executionTasks.delete(cell.document.uri);
+        executionTask.end({
+            success,
+            endTime: Date.now(),
+        });
+    }
+}
+
+function generateVsCodeNotebookCellOutputItem(mimeType: string, value: unknown): vscode.NotebookCellOutputItem {
+    const displayValue = reshapeOutputValueForVsCode(mimeType, value);
+    return new vscode.NotebookCellOutputItem(mimeType, displayValue);
+}
+
+async function updateDocumentKernelspecMetadata(document: vscode.NotebookDocument): Promise<void> {
+    const edit = new vscode.WorkspaceEdit();
+    const documentKernelMetadata = withDotNetKernelMetadata(document.metadata);
+
+    // workaround for https://github.com/microsoft/vscode/issues/115912; capture all cell data so we can re-apply it at the end
+    const cellData: Array<vscode.NotebookCellData> = versionSpecificFunctions.getCells(document).map(c => {
+        return new vscode.NotebookCellData(
+            c.kind,
+            c.document.getText(),
+            c.document.languageId,
+            c.outputs.concat(), // can't pass through a readonly property, so we have to make it a regular array
+            c.metadata,
+        );
+    });
+
+    edit.replaceNotebookMetadata(document.uri, documentKernelMetadata);
+
+    // this is the re-application for the workaround mentioned above
+    const range = new vscode.NotebookRange(0, document.cellCount);
+    edit.replaceNotebookCells(document.uri, range, cellData);
+
+    await vscode.workspace.applyEdit(edit);
+}

--- a/src/dotnet-interactive-vscode/insiders/src/notebookSerializers.ts
+++ b/src/dotnet-interactive-vscode/insiders/src/notebookSerializers.ts
@@ -1,0 +1,146 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import * as vscode from 'vscode';
+import * as contracts from './common/interfaces/contracts';
+import * as utilities from './common/interfaces/utilities';
+import * as vscodeLike from './common/interfaces/vscode-like';
+import { ClientMapper } from './common/clientMapper';
+import { InteractiveClient } from './common/interactiveClient';
+import { defaultNotebookCellLanguage, getNotebookSpecificLanguage, getSimpleLanguage, languageToCellKind } from './common/interactiveNotebook';
+import { OutputChannelAdapter } from './common/vscode/OutputChannelAdapter';
+import { getEol, vsCodeCellOutputToContractCellOutput } from './common/vscode/vscodeUtilities';
+import { Eol } from './common/interfaces';
+import * as ipynbUtilities from './common/ipynbUtilities';
+
+abstract class DotNetNotebookSerializer implements vscode.NotebookSerializer {
+
+    private serializerId = '*DOTNET-INTERACTIVE-NOTEBOOK-SERIALIZATION*';
+    private disposable: vscode.Disposable;
+    private eol: Eol;
+
+    constructor(
+        notebookType: string,
+        private readonly clientMapper: ClientMapper,
+        private readonly outputChannel: OutputChannelAdapter,
+        private readonly extension: string,
+    ) {
+        this.disposable = vscode.notebook.registerNotebookSerializer(notebookType, this);
+        this.eol = getEol();
+    }
+
+    dispose(): void {
+        this.disposable.dispose();
+    }
+
+    async deserializeNotebook(content: Uint8Array, token: vscode.CancellationToken): Promise<vscode.NotebookData> {
+        const client = await this.getClient();
+        let notebookCells: contracts.NotebookCell[] = [];
+        try {
+            const notebook = await client.parseNotebook(this.getNotebookName(), content);
+            notebookCells = notebook.cells;
+        } catch (e) {
+            this.outputChannel.appendLine(`Error parsing file:\n${e}`);
+        }
+
+        if (notebookCells.length === 0) {
+            // ensure at least one cell
+            notebookCells.push({
+                language: defaultNotebookCellLanguage,
+                contents: '',
+                outputs: [],
+            });
+        }
+
+        // peek at kernelspec to see if it's possibly not us
+        if (this.extension === '.ipynb') {
+            try {
+                const notebookObject = JSON.parse(content.toString());
+                ipynbUtilities.validateNotebookShape(
+                    notebookObject,
+                    (isError, message) => {
+                        if (isError) {
+                            vscode.window.showErrorMessage(message);
+                        } else {
+                            vscode.window.showWarningMessage(message);
+                        }
+                    });
+            } catch (e) {
+                // if it didn't parse as JSON then we don't care
+            }
+        }
+
+        const notebookData: vscode.NotebookData = {
+            metadata: new vscode.NotebookDocumentMetadata().with({ cellHasExecutionOrder: false }),
+            cells: notebookCells.map(toVsCodeNotebookCellData)
+        };
+        return notebookData;
+    }
+
+    async serializeNotebook(data: vscode.NotebookData, token: vscode.CancellationToken): Promise<Uint8Array> {
+        const client = await this.getClient();
+        const notebook = {
+            cells: data.cells.map(toNotebookCell)
+        };
+        const content = await client.serializeNotebook(this.getNotebookName(), notebook, this.eol);
+        return content;
+    }
+
+    private getClient(): Promise<InteractiveClient> {
+        return this.clientMapper.getOrAddClient({ fsPath: this.serializerId });
+    }
+
+    private getNotebookName(): string {
+        return `dotnet-interactive-notebook${this.extension}`;
+    }
+}
+
+function toNotebookCell(cell: vscode.NotebookCellData): contracts.NotebookCell {
+    const outputs = cell.outputs || [];
+    return {
+        language: getSimpleLanguage(cell.language),
+        contents: cell.source,
+        outputs: outputs.map(vsCodeCellOutputToContractCellOutput)
+    };
+}
+
+export class DotNetDibNotebookSerializer extends DotNetNotebookSerializer {
+    constructor(clientMapper: ClientMapper, outputChannel: OutputChannelAdapter) {
+        super('dotnet-interactive', clientMapper, outputChannel, '.dib');
+    }
+}
+
+export class DotNetIpynbNotebookSerializer extends DotNetNotebookSerializer {
+    constructor(clientMapper: ClientMapper, outputChannel: OutputChannelAdapter) {
+        super('dotnet-interactive-jupyter', clientMapper, outputChannel, '.ipynb');
+    }
+}
+
+function toVsCodeNotebookCellData(cell: contracts.NotebookCell): vscode.NotebookCellData {
+    return new vscode.NotebookCellData(
+        <number>languageToCellKind(cell.language),
+        cell.contents,
+        getNotebookSpecificLanguage(cell.language),
+        cell.outputs.map(contractCellOutputToVsCodeCellOutput),
+    );
+}
+
+function contractCellOutputToVsCodeCellOutput(output: contracts.NotebookCellOutput): vscode.NotebookCellOutput {
+    const outputItems: Array<vscode.NotebookCellOutputItem> = [];
+    if (utilities.isDisplayOutput(output)) {
+        for (const mimeKey in output.data) {
+            outputItems.push(generateVsCodeNotebookCellOutputItem(mimeKey, output.data[mimeKey]));
+        }
+    } else if (utilities.isErrorOutput(output)) {
+        outputItems.push(generateVsCodeNotebookCellOutputItem(vscodeLike.ErrorOutputMimeType, output.errorValue));
+    } else if (utilities.isTextOutput(output)) {
+        outputItems.push(generateVsCodeNotebookCellOutputItem('text/plain', output.text));
+    }
+
+    return new vscode.NotebookCellOutput(outputItems);
+}
+
+function generateVsCodeNotebookCellOutputItem(mimeType: string, value: unknown): vscode.NotebookCellOutputItem {
+    const displayValue = utilities.reshapeOutputValueForVsCode(mimeType, value);
+    return new vscode.NotebookCellOutputItem(mimeType, displayValue);
+}

--- a/src/dotnet-interactive-vscode/insiders/src/versionSpecificFunctions.ts
+++ b/src/dotnet-interactive-vscode/insiders/src/versionSpecificFunctions.ts
@@ -6,14 +6,12 @@ import * as contracts from './common/interfaces/contracts';
 import * as vscodeLike from './common/interfaces/vscode-like';
 import * as interactiveNotebook from './common/interactiveNotebook';
 import * as utilities from './common/utilities';
-import * as notebookContentProvider from './common/vscode/notebookContentProvider';
-import * as notebookKernel from './common/vscode/notebookKernel';
 import * as diagnostics from './common/vscode/diagnostics';
 import * as vscodeUtilities from './common/vscode/vscodeUtilities';
-
-export function registerAdditionalContentProvider(context: vscode.ExtensionContext, contentProvider: vscode.NotebookContentProvider) {
-    // empty for insiders
-}
+import * as notebookControllers from './notebookControllers';
+import * as notebookSerializers from './notebookSerializers';
+import { ClientMapper } from './common/clientMapper';
+import { OutputChannelAdapter } from './common/vscode/OutputChannelAdapter';
 
 export function cellAt(document: vscode.NotebookDocument, index: number): vscode.NotebookCell {
     return document.cellAt(index);
@@ -29,4 +27,14 @@ export function getCells(document: vscode.NotebookDocument | undefined): Array<v
     }
 
     return [];
+}
+
+export function registerWithVsCode(context: vscode.ExtensionContext, clientMapper: ClientMapper, outputChannel: OutputChannelAdapter, useJupyterExtension: boolean, ...preloadUris: vscode.Uri[]) {
+    context.subscriptions.push(new notebookControllers.DotNetNotebookKernel(clientMapper, preloadUris));
+    context.subscriptions.push(new notebookSerializers.DotNetDibNotebookSerializer(clientMapper, outputChannel));
+    //context.subscriptions.push(new notebookSerializers.DotNetIpynbNotebookSerializer(clientMapper, outputChannel)); // only stable uses our ipynb handler
+}
+
+export function endExecution(cell: vscode.NotebookCell, success: boolean) {
+    notebookControllers.endExecution(cell, success);
 }

--- a/src/dotnet-interactive-vscode/insiders/src/vscode.d.ts
+++ b/src/dotnet-interactive-vscode/insiders/src/vscode.d.ts
@@ -1665,6 +1665,12 @@ declare module 'vscode' {
 	 * Options to configure the behavior of the quick pick UI.
 	 */
 	export interface QuickPickOptions {
+
+		/**
+		 * An optional string that represents the title of the quick pick.
+		 */
+		title?: string;
+
 		/**
 		 * An optional flag to include the description when filtering the picks.
 		 */
@@ -1846,6 +1852,11 @@ declare module 'vscode' {
 	 * Options to configure the behavior of the input box UI.
 	 */
 	export interface InputBoxOptions {
+
+		/**
+		 * An optional string that represents the title of the input box.
+		 */
+		title?: string;
 
 		/**
 		 * The value to prefill in the input box.
@@ -10686,6 +10697,16 @@ declare module 'vscode' {
 		 * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
 		 */
 		export function registerFileSystemProvider(scheme: string, provider: FileSystemProvider, options?: { readonly isCaseSensitive?: boolean, readonly isReadonly?: boolean }): Disposable;
+
+		/**
+		 * When true, the user has explicitly trusted the contents of the workspace.
+		 */
+		export const isTrusted: boolean;
+
+		/**
+		 * Event that fires when the current workspace has been trusted.
+		 */
+		export const onDidGrantWorkspaceTrust: Event<void>;
 	}
 
 	/**

--- a/src/dotnet-interactive-vscode/insiders/src/vscode.proposed.d.ts
+++ b/src/dotnet-interactive-vscode/insiders/src/vscode.proposed.d.ts
@@ -80,8 +80,16 @@ declare module 'vscode' {
 		constructor(host: string, port: number, connectionToken?: string);
 	}
 
+	export enum RemoteTrustOption {
+		Unknown = 0,
+		DisableTrust = 1,
+		MachineTrusted = 2
+	}
+
 	export interface ResolvedOptions {
 		extensionHostEnv?: { [key: string]: string | null; };
+
+		trust?: RemoteTrustOption;
 	}
 
 	export interface TunnelOptions {
@@ -953,69 +961,53 @@ declare module 'vscode' {
 
 	//#endregion
 
-	//#region allow title property to QuickPickOptions/InputBoxOptions: https://github.com/microsoft/vscode/issues/77423
-
-	interface QuickPickOptions {
-		/**
-		 * An optional string that represents the tile of the quick pick.
-		 */
-		title?: string;
-	}
-
-	interface InputBoxOptions {
-		/**
-		 * An optional string that represents the tile of the input box.
-		 */
-		title?: string;
-	}
-
-	//#endregion
-
 	//#region https://github.com/microsoft/vscode/issues/106744, Notebooks (misc)
 
 	export enum NotebookCellKind {
+		// todo@API rename/rethink as "Markup" cell
 		Markdown = 1,
 		Code = 2
 	}
 
 	export class NotebookCellMetadata {
 		/**
-		 * Controls whether a cell's editor is editable/readonly.
-		 */
-		readonly editable?: boolean;
-		/**
-		 * Controls if the cell has a margin to support the breakpoint UI.
-		 * This metadata is ignored for markdown cell.
-		 */
-		readonly breakpointMargin?: boolean;
-		/**
 		 * Whether a code cell's editor is collapsed
 		 */
-		readonly outputCollapsed?: boolean;
+		readonly inputCollapsed?: boolean;
+
 		/**
 		 * Whether a code cell's outputs are collapsed
 		 */
-		readonly inputCollapsed?: boolean;
+		readonly outputCollapsed?: boolean;
+
 		/**
 		 * Additional attributes of a cell metadata.
 		 */
-		readonly custom?: Record<string, any>;
+		readonly [key: string]: any;
 
-		// todo@API duplicates status bar API
-		readonly statusMessage?: string;
+		/**
+		 * Create a new notebook cell metadata.
+		 *
+		 * @param inputCollapsed Whether a code cell's editor is collapsed
+		 * @param outputCollapsed Whether a code cell's outputs are collapsed
+		 */
+		constructor(inputCollapsed?: boolean, outputCollapsed?: boolean);
 
-		// run related API, will be removed
-		readonly hasExecutionOrder?: boolean;
-
-		constructor(editable?: boolean, breakpointMargin?: boolean, hasExecutionOrder?: boolean, statusMessage?: string, lastRunDuration?: number, inputCollapsed?: boolean, outputCollapsed?: boolean, custom?: Record<string, any>)
-
-		with(change: { editable?: boolean | null, breakpointMargin?: boolean | null, hasExecutionOrder?: boolean | null, statusMessage?: string | null, lastRunDuration?: number | null, inputCollapsed?: boolean | null, outputCollapsed?: boolean | null, custom?: Record<string, any> | null, }): NotebookCellMetadata;
+		/**
+		 * Derived a new cell metadata from this metadata.
+		 *
+		 * @param change An object that describes a change to this NotebookCellMetadata.
+		 * @return A new NotebookCellMetadata that reflects the given change. Will return `this` NotebookCellMetadata if the change
+		 *  is not changing anything.
+		 */
+		with(change: { inputCollapsed?: boolean | null, outputCollapsed?: boolean | null, [key: string]: any }): NotebookCellMetadata;
 	}
 
 	export interface NotebookCellExecutionSummary {
-		executionOrder?: number;
-		success?: boolean;
-		duration?: number;
+		readonly executionOrder?: number;
+		readonly success?: boolean;
+		readonly startTime?: number;
+		readonly endTime?: number;
 	}
 
 	// todo@API support ids https://github.com/jupyter/enhancement-proposals/blob/master/62-cell-id/cell-id.md
@@ -1026,37 +1018,37 @@ declare module 'vscode' {
 		readonly document: TextDocument;
 		readonly metadata: NotebookCellMetadata
 		readonly outputs: ReadonlyArray<NotebookCellOutput>;
+
+		// todo@API maybe just executionSummary or lastExecutionSummary?
 		readonly latestExecutionSummary: NotebookCellExecutionSummary | undefined;
 	}
 
 	export class NotebookDocumentMetadata {
-
-		/**
-		 * Controls if users can add or delete cells
-		 * Defaults to true
-		 */
-		readonly editable: boolean;
-		/**
-		 * Default value for [cell editable metadata](#NotebookCellMetadata.editable).
-		 * Defaults to true.
-		 */
-		readonly cellEditable: boolean;
-		/**
-		 * Additional attributes of the document metadata.
-		 */
-		readonly custom: { [key: string]: any; };
 		/**
 		 * Whether the document is trusted, default to true
 		 * When false, insecure outputs like HTML, JavaScript, SVG will not be rendered.
 		 */
 		readonly trusted: boolean;
 
-		// todo@API is this a kernel property?
-		readonly cellHasExecutionOrder: boolean;
+		/**
+		 * Additional attributes of the document metadata.
+		 */
+		readonly [key: string]: any;
 
-		constructor(editable?: boolean, cellEditable?: boolean, cellHasExecutionOrder?: boolean, custom?: { [key: string]: any; }, trusted?: boolean);
+		/**
+		 * Create a new notebook document metadata
+		 * @param trusted Whether the document metadata is trusted.
+		 */
+		constructor(trusted?: boolean);
 
-		with(change: { editable?: boolean | null, cellEditable?: boolean | null, cellHasExecutionOrder?: boolean | null, custom?: { [key: string]: any; } | null, trusted?: boolean | null, }): NotebookDocumentMetadata
+		/**
+		 * Derived a new document metadata from this metadata.
+		 *
+		 * @param change An object that describes a change to this NotebookDocumentMetadata.
+		 * @return A new NotebookDocumentMetadata that reflects the given change. Will return `this` NotebookDocumentMetadata if the change
+		 *  is not changing anything.
+		 */
+		with(change: { trusted?: boolean | null, [key: string]: any }): NotebookDocumentMetadata
 	}
 
 	export interface NotebookDocumentContentOptions {
@@ -1064,24 +1056,55 @@ declare module 'vscode' {
 		 * Controls if outputs change will trigger notebook document content change and if it will be used in the diff editor
 		 * Default to false. If the content provider doesn't persisit the outputs in the file document, this should be set to true.
 		 */
-		transientOutputs: boolean;
+		transientOutputs?: boolean;
 
 		/**
-		 * Controls if a meetadata property change will trigger notebook document content change and if it will be used in the diff editor
+		 * Controls if a cell metadata property change will trigger notebook document content change and if it will be used in the diff editor
 		 * Default to false. If the content provider doesn't persisit a metadata property in the file document, it should be set to true.
 		 */
-		transientMetadata: { [K in keyof NotebookCellMetadata]?: boolean };
+		transientCellMetadata?: { [K in keyof NotebookCellMetadata]?: boolean };
+
+		/**
+		* Controls if a document metadata property change will trigger notebook document content change and if it will be used in the diff editor
+		* Default to false. If the content provider doesn't persisit a metadata property in the file document, it should be set to true.
+		*/
+		transientDocumentMetadata?: { [K in keyof NotebookDocumentMetadata]?: boolean };
 	}
 
+	/**
+	 * Represents a notebook. Notebooks are composed of cells and metadata.
+	 */
 	export interface NotebookDocument {
+
+		/**
+		 * The associated uri for this notebook.
+		 *
+		 * *Note* that most notebooks use the `file`-scheme, which means they are files on disk. However, **not** all notebooks are
+		 * saved on disk and therefore the `scheme` must be checked before trying to access the underlying file or siblings on disk.
+		 *
+		 * @see [FileSystemProvider](#FileSystemProvider)
+		 * @see [TextDocumentContentProvider](#TextDocumentContentProvider)
+		 */
 		readonly uri: Uri;
+
+		// todo@API should we really expose this?
+		// todo@API should this be called `notebookType` or `notebookKind`
+		readonly viewType: string;
+
+		/**
+		 * The version number of this notebook (it will strictly increase after each
+		 * change, including undo/redo).
+		 */
 		readonly version: number;
 
-		/** @deprecated Use `uri` instead */
-		// todo@API don't have this...
-		readonly fileName: string;
-
+		/**
+		 * `true` if there are unpersisted changes.
+		 */
 		readonly isDirty: boolean;
+
+		/**
+		 * Is this notebook representing an untitled file which has not been saved yet.
+		 */
 		readonly isUntitled: boolean;
 
 		/**
@@ -1090,13 +1113,13 @@ declare module 'vscode' {
 		 */
 		readonly isClosed: boolean;
 
+		/**
+		 * The [metadata](#NotebookDocumentMetadata) for this notebook.
+		 */
 		readonly metadata: NotebookDocumentMetadata;
 
-		// todo@API should we really expose this?
-		readonly viewType: string;
-
 		/**
-		 * The number of cells in the notebook document.
+		 * The number of cells in the notebook.
 		 */
 		readonly cellCount: number;
 
@@ -1115,7 +1138,7 @@ declare module 'vscode' {
 		 * @param range A notebook range.
 		 * @returns The cells contained by the range or all cells.
 		 */
-		getCells(range?: NotebookCellRange): ReadonlyArray<NotebookCell>;
+		getCells(range?: NotebookRange): NotebookCell[];
 
 		/**
 		 * Save the document. The saving will be handled by the corresponding content provider
@@ -1127,20 +1150,44 @@ declare module 'vscode' {
 		save(): Thenable<boolean>;
 	}
 
-	// todo@API RENAME to NotebookRange
-	// todo@API maybe have a NotebookCellPosition sibling
-	export class NotebookCellRange {
-		readonly start: number;
+	/**
+	 * A notebook range represents on ordered pair of two cell indicies.
+	 * It is guaranteed that start is less than or equal to end.
+	 */
+	export class NotebookRange {
+
 		/**
-		 * exclusive
+		 * The zero-based start index of this range.
+		 */
+		readonly start: number;
+
+		/**
+		 * The exclusive end index of this range (zero-based).
 		 */
 		readonly end: number;
 
+		/**
+		 * `true` if `start` and `end` are equal.
+		 */
 		readonly isEmpty: boolean;
 
+		/**
+		 * Create a new notebook range. If `start` is not
+		 * before or equal to `end`, the values will be swapped.
+		 *
+		 * @param start start index
+		 * @param end end index.
+		 */
 		constructor(start: number, end: number);
 
-		with(change: { start?: number, end?: number }): NotebookCellRange;
+		/**
+		 * Derive a new range for this range.
+		 *
+		 * @param change An object that describes a change to this range.
+		 * @return A range that reflects the given change. Will return `this` range if the change
+		 * is not changing anything.
+		 */
+		with(change: { start?: number, end?: number }): NotebookRange;
 	}
 
 	export enum NotebookEditorRevealType {
@@ -1148,6 +1195,7 @@ declare module 'vscode' {
 		 * The range will be revealed with as little scrolling as possible.
 		 */
 		Default = 0,
+
 		/**
 		 * The range will always be revealed in the center of the viewport.
 		 */
@@ -1172,25 +1220,24 @@ declare module 'vscode' {
 		readonly document: NotebookDocument;
 
 		/**
-		 * @deprecated
-		 */
-		// todo@API should not be undefined, rather a default
-		readonly selection?: NotebookCell;
-
-		/**
-		 * todo@API should replace selection
 		 * The selections on this notebook editor.
 		 *
 		 * The primary selection (or focused range) is `selections[0]`. When the document has no cells, the primary selection is empty `{ start: 0, end: 0 }`;
 		 */
-		readonly selections: NotebookCellRange[];
+		readonly selections: NotebookRange[];
 
 		/**
 		 * The current visible ranges in the editor (vertically).
 		 */
-		readonly visibleRanges: NotebookCellRange[];
+		readonly visibleRanges: NotebookRange[];
 
-		revealRange(range: NotebookCellRange, revealType?: NotebookEditorRevealType): void;
+		/**
+		 * Scroll as indicated by `revealType` in order to reveal the given range.
+		 *
+		 * @param range A range.
+		 * @param revealType The scrolling strategy for revealing `range`.
+		 */
+		revealRange(range: NotebookRange, revealType?: NotebookEditorRevealType): void;
 
 		/**
 		 * The column in which this editor shows.
@@ -1199,60 +1246,66 @@ declare module 'vscode' {
 	}
 
 	export interface NotebookDocumentMetadataChangeEvent {
+		/**
+		 * The [notebook document](#NotebookDocument) for which the document metadata have changed.
+		 */
 		readonly document: NotebookDocument;
 	}
 
 	export interface NotebookCellsChangeData {
 		readonly start: number;
+		// todo@API end? Use NotebookCellRange instead?
 		readonly deletedCount: number;
+		// todo@API removedCells, deletedCells?
 		readonly deletedItems: NotebookCell[];
+		// todo@API addedCells, insertedCells, newCells?
 		readonly items: NotebookCell[];
 	}
 
 	export interface NotebookCellsChangeEvent {
-
 		/**
-		 * The affected document.
+		 * The [notebook document](#NotebookDocument) for which the cells have changed.
 		 */
 		readonly document: NotebookDocument;
 		readonly changes: ReadonlyArray<NotebookCellsChangeData>;
 	}
 
 	export interface NotebookCellOutputsChangeEvent {
-
 		/**
-		 * The affected document.
+		 * The [notebook document](#NotebookDocument) for which the cell outputs have changed.
 		 */
 		readonly document: NotebookDocument;
 		readonly cells: NotebookCell[];
 	}
 
-	export interface NotebookCellLanguageChangeEvent {
-
-		/**
-		 * The affected document.
-		 */
-		readonly document: NotebookDocument;
-		readonly cell: NotebookCell;
-		readonly language: string;
-	}
-
 	export interface NotebookCellMetadataChangeEvent {
+		/**
+		 * The [notebook document](#NotebookDocument) for which the cell metadata have changed.
+		 */
 		readonly document: NotebookDocument;
 		readonly cell: NotebookCell;
 	}
 
 	export interface NotebookEditorSelectionChangeEvent {
+		/**
+		 * The [notebook editor](#NotebookEditor) for which the selections have changed.
+		 */
 		readonly notebookEditor: NotebookEditor;
-		readonly selections: ReadonlyArray<NotebookCellRange>
+		readonly selections: ReadonlyArray<NotebookRange>
 	}
 
 	export interface NotebookEditorVisibleRangesChangeEvent {
+		/**
+		 * The [notebook editor](#NotebookEditor) for which the visible ranges have changed.
+		 */
 		readonly notebookEditor: NotebookEditor;
-		readonly visibleRanges: ReadonlyArray<NotebookCellRange>;
+		readonly visibleRanges: ReadonlyArray<NotebookRange>;
 	}
 
 	export interface NotebookCellExecutionStateChangeEvent {
+		/**
+		 * The [notebook document](#NotebookDocument) for which the cell execution state has changed.
+		 */
 		readonly document: NotebookDocument;
 		readonly cell: NotebookCell;
 		readonly executionState: NotebookCellExecutionState;
@@ -1263,10 +1316,11 @@ declare module 'vscode' {
 		kind: NotebookCellKind;
 		// todo@API better names: value? text?
 		source: string;
-		// todo@API how does language and MD relate?
+		// todo@API languageId (as in TextDocument)
 		language: string;
 		outputs?: NotebookCellOutput[];
 		metadata?: NotebookCellMetadata;
+		// todo@API just executionSummary or lastExecutionSummary
 		latestExecutionSummary?: NotebookCellExecutionSummary;
 		constructor(kind: NotebookCellKind, source: string, language: string, outputs?: NotebookCellOutput[], metadata?: NotebookCellMetadata, latestExecutionSummary?: NotebookCellExecutionSummary);
 	}
@@ -1277,49 +1331,11 @@ declare module 'vscode' {
 		constructor(cells: NotebookCellData[], metadata?: NotebookDocumentMetadata);
 	}
 
-	/**
-	 * Communication object passed to the {@link NotebookContentProvider} and
-	 * {@link NotebookOutputRenderer} to communicate with the webview.
-	 */
-	export interface NotebookCommunication {
-		/**
-		 * ID of the editor this object communicates with. A single notebook
-		 * document can have multiple attached webviews and editors, when the
-		 * notebook is split for instance. The editor ID lets you differentiate
-		 * between them.
-		 */
-		readonly editorId: string;
-
-		/**
-		 * Fired when the output hosting webview posts a message.
-		 */
-		readonly onDidReceiveMessage: Event<any>;
-		/**
-		 * Post a message to the output hosting webview.
-		 *
-		 * Messages are only delivered if the editor is live.
-		 *
-		 * @param message Body of the message. This must be a string or other json serializable object.
-		 */
-		postMessage(message: any): Thenable<boolean>;
-
-		/**
-		 * Convert a uri for the local file system to one that can be used inside outputs webview.
-		 */
-		asWebviewUri(localResource: Uri): Uri;
-
-		// @rebornix
-		// readonly onDidDispose: Event<void>;
-	}
-
-	// export function registerNotebookKernel(selector: string, kernel: NotebookKernel): Disposable;
-
-
 	export interface NotebookDocumentShowOptions {
 		viewColumn?: ViewColumn;
 		preserveFocus?: boolean;
 		preview?: boolean;
-		selection?: NotebookCellRange;
+		selections?: NotebookRange[];
 	}
 
 	export namespace notebook {
@@ -1337,8 +1353,11 @@ declare module 'vscode' {
 		export const notebookDocuments: ReadonlyArray<NotebookDocument>;
 		export const onDidChangeNotebookDocumentMetadata: Event<NotebookDocumentMetadataChangeEvent>;
 		export const onDidChangeNotebookCells: Event<NotebookCellsChangeEvent>;
+
+		// todo@API add onDidChangeNotebookCellOutputs
 		export const onDidChangeCellOutputs: Event<NotebookCellOutputsChangeEvent>;
 
+		// todo@API add onDidChangeNotebookCellMetadata
 		export const onDidChangeCellMetadata: Event<NotebookCellMetadataChangeEvent>;
 	}
 
@@ -1370,23 +1389,19 @@ declare module 'vscode' {
 		// static textplain(value:string): NotebookCellOutputItem;
 		// static errortrace(value:any): NotebookCellOutputItem;
 
-		readonly mime: string;
-		readonly value: unknown;
-		readonly metadata?: Record<string, any>;
+		mime: string;
+		value: unknown;
+		metadata?: Record<string, any>;
 
 		constructor(mime: string, value: unknown, metadata?: Record<string, any>);
 	}
 
-	// @jrieken
-	// todo@API think about readonly...
-	//TODO@API add execution count to cell output?
+	// @jrieken transient
 	export class NotebookCellOutput {
-		readonly id: string;
-		readonly outputs: NotebookCellOutputItem[];
-		readonly metadata?: Record<string, any>;
-
+		id: string;
+		outputs: NotebookCellOutputItem[];
+		metadata?: Record<string, any>;
 		constructor(outputs: NotebookCellOutputItem[], metadata?: Record<string, any>);
-
 		constructor(outputs: NotebookCellOutputItem[], id: string, metadata?: Record<string, any>);
 	}
 
@@ -1394,26 +1409,32 @@ declare module 'vscode' {
 
 	//#region https://github.com/microsoft/vscode/issues/106744, NotebookEditorEdit
 
+	// todo@API add NotebookEdit-type which handles all these cases?
+	// export class NotebookEdit {
+	// 	range: NotebookRange;
+	// 	newCells: NotebookCellData[];
+	// 	newMetadata?: NotebookDocumentMetadata;
+	// 	constructor(range: NotebookRange, newCells: NotebookCellData)
+	// }
+
+	// export class NotebookCellEdit {
+	// 	newMetadata?: NotebookCellMetadata;
+	// }
+
+	// export interface WorkspaceEdit {
+	// 	set(uri: Uri, edits: TextEdit[] | NotebookEdit[]): void
+	// }
+
 	export interface WorkspaceEdit {
+		// todo@API add NotebookEdit-type which handles all these cases?
 		replaceNotebookMetadata(uri: Uri, value: NotebookDocumentMetadata): void;
-
-		// todo@API use NotebookCellRange
-		replaceNotebookCells(uri: Uri, start: number, end: number, cells: NotebookCellData[], metadata?: WorkspaceEditEntryMetadata): void;
+		replaceNotebookCells(uri: Uri, range: NotebookRange, cells: NotebookCellData[], metadata?: WorkspaceEditEntryMetadata): void;
 		replaceNotebookCellMetadata(uri: Uri, index: number, cellMetadata: NotebookCellMetadata, metadata?: WorkspaceEditEntryMetadata): void;
-
-		replaceNotebookCellOutput(uri: Uri, index: number, outputs: NotebookCellOutput[], metadata?: WorkspaceEditEntryMetadata): void;
-		appendNotebookCellOutput(uri: Uri, index: number, outputs: NotebookCellOutput[], metadata?: WorkspaceEditEntryMetadata): void;
-
-		// TODO@api
-		// https://jupyter-protocol.readthedocs.io/en/latest/messaging.html#update-display-data
-		replaceNotebookCellOutputItems(uri: Uri, index: number, outputId: string, items: NotebookCellOutputItem[], metadata?: WorkspaceEditEntryMetadata): void;
-		appendNotebookCellOutputItems(uri: Uri, index: number, outputId: string, items: NotebookCellOutputItem[], metadata?: WorkspaceEditEntryMetadata): void;
 	}
 
 	export interface NotebookEditorEdit {
 		replaceMetadata(value: NotebookDocumentMetadata): void;
 		replaceCells(start: number, end: number, cells: NotebookCellData[]): void;
-		replaceCellOutput(index: number, outputs: NotebookCellOutput[]): void;
 		replaceCellMetadata(index: number, metadata: NotebookCellMetadata): void;
 	}
 
@@ -1436,16 +1457,202 @@ declare module 'vscode' {
 
 	//#region https://github.com/microsoft/vscode/issues/106744, NotebookSerializer
 
+	/**
+	 * The notebook serializer enables the editor to open notebook files.
+	 *
+	 * At its core the editor only knows a [notebook data structure](#NotebookData) but not
+	 * how that data structure is written to a file, nor how it is read from a file. The
+	 * notebook serializer bridges this gap by deserializing bytes into notebook data and
+	 * vice versa.
+	 */
 	export interface NotebookSerializer {
-		dataToNotebook(data: Uint8Array): NotebookData | Thenable<NotebookData>;
-		notebookToData(data: NotebookData): Uint8Array | Thenable<Uint8Array>;
+
+		/**
+		 * Deserialize contents of a notebook file into the notebook data structure.
+		 *
+		 * @param content Contents of a notebook file.
+		 * @param token A cancellation token.
+		 * @return Notebook data or a thenable that resolves to such.
+		 */
+		deserializeNotebook(content: Uint8Array, token: CancellationToken): NotebookData | Thenable<NotebookData>;
+
+		/**
+		 * Serialize notebook data into file contents.
+		 *
+		 * @param data A notebook data structure.
+		 * @param token A cancellation token.
+		 * @returns An array of bytes or a thenable that resolves to such.
+		 */
+		serializeNotebook(data: NotebookData, token: CancellationToken): Uint8Array | Thenable<Uint8Array>;
 	}
 
 	export namespace notebook {
 
-		// TODO@api use NotebookDocumentFilter instead of just notebookType:string?
-		// TODO@API options duplicates the more powerful variant on NotebookContentProvider
-		export function registerNotebookSerializer(notebookType: string, provider: NotebookSerializer, options?: NotebookDocumentContentOptions): Disposable;
+		// todo@API remove output when notebook marks that as transient, same for metadata
+		/**
+		 * Register a [notebook serializer](#NotebookSerializer).
+		 *
+		 * @param notebookType A notebook.
+		 * @param serializer A notebook serialzier.
+		 * @param options Optional context options that define what parts of a notebook should be persisted
+		 * @return A [disposable](#Disposable) that unregisters this serializer when being disposed.
+		 */
+		export function registerNotebookSerializer(notebookType: string, serializer: NotebookSerializer, options?: NotebookDocumentContentOptions): Disposable;
+	}
+
+	//#endregion
+
+	//#region https://github.com/microsoft/vscode/issues/119949
+
+
+	export interface NotebookFilter {
+		readonly viewType?: string;
+		readonly scheme?: string;
+		readonly pattern?: GlobPattern;
+	}
+
+	export type NotebookSelector = NotebookFilter | string | ReadonlyArray<NotebookFilter | string>;
+
+	export interface NotebookExecutionHandler {
+		/**
+		 * @param cells The notebook cells to execute
+		 * @param controller The controller that the handler is attached to
+		 */
+		(this: NotebookController, cells: NotebookCell[], controller: NotebookController): void | Thenable<void>
+	}
+
+	export interface NotebookInterruptHandler {
+		(this: NotebookController): void | Thenable<void>;
+	}
+
+	export interface NotebookController {
+
+		/**
+		 * The unique identifier of this notebook controller.
+		 */
+		readonly id: string;
+
+		/**
+		 * The selector allows to narrow down on specific notebook types or
+		 * instances.
+		 *
+		 * For instance `{ viewType: 'notebook.test' }` selects all notebook
+		 * documents of the type `notebook.test`, whereas `{ pattern: '/my/file/test.nb' }`
+		 * selects only the notebook with the path `/my/file/test.nb`.
+		 */
+		readonly selector: NotebookSelector;
+
+		/**
+		 * The human-readable label of this notebook controller.
+		 */
+		label: string;
+
+		/**
+		 * The human-readable description which is rendered less prominent.
+		 */
+		description?: string;
+
+		/**
+		 * The human-readable detail which is rendered less prominent.
+		 */
+		detail?: string;
+
+		/**
+		 * Marks this notebook controller as preferred.
+		 *
+		 * When multiple notebook controller apply to a single notebook then
+		 * users can select one - preferred controllers will be shows more
+		 * prominent then.
+		 */
+		isPreferred?: boolean;
+
+		/**
+		 * An array of language identifiers that are supported by this
+		 * controller.
+		 */
+		supportedLanguages: string[];
+
+		/**
+		 * Whether this controller supports execution order so that the
+		 * editor can render placeholders for them.
+		 */
+		// todo@API rename to supportsExecutionOrder, usesExecutionOrder
+		hasExecutionOrder?: boolean;
+
+		/**
+		 * The execute handler is invoked when the run gestures in the UI are selected, e.g Run Cell, Run All,
+		 * Run Selection etc.
+		 */
+		executeHandler: NotebookExecutionHandler;
+
+		/**
+		 * The interrupt handler is invoked the interrupt all execution. This is contrary to cancellation (available via
+		 * [`NotebookCellExecutionTask#token`](NotebookCellExecutionTask#token)) and should only be used when
+		 * execution-level cancellation is supported
+		 */
+		interruptHandler?: NotebookInterruptHandler
+
+		/**
+		 * Dispose and free associated resources.
+		 */
+		dispose(): void;
+
+		/**
+		 * A kernel can apply to one or many notebook documents but a notebook has only one active
+		 * kernel. This event fires whenever a notebook has been associated to a kernel or when
+		 * that association has been removed.
+		 */
+		readonly onDidChangeNotebookAssociation: Event<{ notebook: NotebookDocument, selected: boolean }>;
+
+		/**
+		 * Create a cell execution task.
+		 *
+		 * This should be used in response to the [execution handler](#NotebookController.executeHandler)
+		 * being calleed or when cell execution has been started else, e.g when a cell was already
+		 * executing or when cell execution was triggered from another source.
+		 *
+		 * @param cell The notebook cell for which to create the execution.
+		 * @returns A notebook cell execution.
+		 */
+		createNotebookCellExecutionTask(cell: NotebookCell): NotebookCellExecutionTask;
+
+		// todo@API allow add, not remove
+		// ipc
+		readonly preloads: NotebookKernelPreload[];
+
+		/**
+		 * An event that fires when a renderer (see `preloads`) has send a message to the controller.
+		 */
+		readonly onDidReceiveMessage: Event<{ editor: NotebookEditor, message: any }>;
+
+		/**
+		 * Send a message to the renderer of notebook editors.
+		 *
+		 * Note that only editors showing documents that are bound to this controller
+		 * are receiving the message.
+		 *
+		 * @param message The message to send.
+		 * @param editor A specific editor to send the message to. When `undefined` all applicable editors are receiving the message.
+		 * @returns A promise that resolves to a boolean indicating if the message has been send or not.
+		 */
+		postMessage(message: any, editor?: NotebookEditor): Thenable<boolean>;
+
+		//todo@API validate this works
+		asWebviewUri(localResource: Uri): Uri;
+	}
+
+	export namespace notebook {
+
+		/**
+		 * Creates a new notebook controller.
+		 *
+		 * @param id Unique identifier of the controller
+		 * @param selector A notebook selector to narrow down notebook type or path
+		 * @param label The label of the controller
+		 * @param handler
+		 * @param preloads
+		 */
+		export function createNotebookController(id: string, selector: NotebookSelector, label: string, handler?: NotebookExecutionHandler, preloads?: NotebookKernelPreload[]): NotebookController;
 	}
 
 	//#endregion
@@ -1492,75 +1699,45 @@ declare module 'vscode' {
 		 */
 		openNotebook(uri: Uri, openContext: NotebookDocumentOpenContext, token: CancellationToken): NotebookData | Thenable<NotebookData>;
 
+		// todo@API use NotebookData instead
 		saveNotebook(document: NotebookDocument, token: CancellationToken): Thenable<void>;
 
+		// todo@API use NotebookData instead
 		saveNotebookAs(targetResource: Uri, document: NotebookDocument, token: CancellationToken): Thenable<void>;
 
+		// todo@API use NotebookData instead
 		backupNotebook(document: NotebookDocument, context: NotebookDocumentBackupContext, token: CancellationToken): Thenable<NotebookDocumentBackup>;
+	}
+
+	export interface NotebookDocumentContentOptions {
+		/**
+		 * Not ready for production or development use yet.
+		 */
+		viewOptions?: {
+			displayName: string;
+			filenamePattern: (GlobPattern | { include: GlobPattern; exclude: GlobPattern; })[];
+			exclusive?: boolean;
+		};
 	}
 
 	export namespace notebook {
 
 		// TODO@api use NotebookDocumentFilter instead of just notebookType:string?
 		// TODO@API options duplicates the more powerful variant on NotebookContentProvider
-		export function registerNotebookContentProvider(notebookType: string, provider: NotebookContentProvider,
-			options?: NotebookDocumentContentOptions & {
-				/**
-				 * Not ready for production or development use yet.
-				 */
-				viewOptions?: {
-					displayName: string;
-					filenamePattern: NotebookFilenamePattern[];
-					exclusive?: boolean;
-				};
-			}
-		): Disposable;
+		export function registerNotebookContentProvider(notebookType: string, provider: NotebookContentProvider, options?: NotebookDocumentContentOptions): Disposable;
 	}
 
 	//#endregion
 
 	//#region https://github.com/microsoft/vscode/issues/106744, NotebookKernel
 
-	export interface NotebookKernel {
-
-		// todo@API make this mandatory?
-		readonly id?: string;
-
-		label: string;
-		description?: string;
-		detail?: string;
-		isPreferred?: boolean;
-
-		// todo@API is this maybe an output property?
-		preloads?: Uri[];
-
-		/**
-		 * languages supported by kernel
-		 * - first is preferred
-		 * - `undefined` means all languages available in the editor
-		 */
-		supportedLanguages?: string[];
-
-		// todo@API kernel updating itself
-		// fired when properties like the supported languages etc change
-		// onDidChangeProperties?: Event<void>
-
-		/**
-		 * A kernel can optionally implement this which will be called when any "cancel" button is clicked in the document.
-		 */
-		interrupt?(document: NotebookDocument): void;
-
-		/**
-		 * Called when the user triggers execution of a cell by clicking the run button for a cell, multiple cells,
-		 * or full notebook. The cell will be put into the Pending state when this method is called. If
-		 * createNotebookCellExecutionTask has not been called by the time the promise returned by this method is
-		 * resolved, the cell will be put back into the Idle state.
-		 */
-		executeCellsRequest(document: NotebookDocument, ranges: NotebookCellRange[]): Thenable<void>;
+	// todo@API make class?
+	export interface NotebookKernelPreload {
+		provides?: string | string[];
+		uri: Uri;
 	}
 
 	export interface NotebookCellExecuteStartContext {
-		// TODO@roblou are we concerned about clock issues with this absolute time?
 		/**
 		 * The time that execution began, in milliseconds in the Unix epoch. Used to drive the clock
 		 * that shows for how long a cell has been running. If not given, the clock won't be shown.
@@ -1576,9 +1753,9 @@ declare module 'vscode' {
 		success?: boolean;
 
 		/**
-		 * The total execution time in milliseconds.
+		 * The time that execution finished, in milliseconds in the Unix epoch.
 		 */
-		duration?: number;
+		endTime?: number;
 	}
 
 	/**
@@ -1616,54 +1793,10 @@ declare module 'vscode' {
 	}
 
 	export namespace notebook {
-		/**
-		 * Creates a [`NotebookCellExecutionTask`](#NotebookCellExecutionTask). Should only be called by a kernel. Returns undefined unless requested by the active kernel.
-		 * @param uri The [uri](#Uri) of the notebook document.
-		 * @param index The index of the cell.
-		 * @param kernelId The id of the kernel requesting this run task. If this kernel is not the current active kernel, `undefined` is returned.
-		 */
+		/** @deprecated use NotebookController */
 		export function createNotebookCellExecutionTask(uri: Uri, index: number, kernelId: string): NotebookCellExecutionTask | undefined;
 
 		export const onDidChangeCellExecutionState: Event<NotebookCellExecutionStateChangeEvent>;
-	}
-
-	export type NotebookFilenamePattern = GlobPattern | { include: GlobPattern; exclude: GlobPattern; };
-
-	// todo@API why not for NotebookContentProvider?
-	export interface NotebookDocumentFilter {
-		viewType?: string | string[];
-		filenamePattern?: NotebookFilenamePattern;
-	}
-
-	// export interface NotebookFilter {
-	// 	readonly viewType?: string;
-	// 	readonly scheme?: string;
-	// 	readonly pattern?: GlobPattern;
-	// }
-
-	// export type NotebookSelector = NotebookFilter | string | ReadonlyArray<NotebookFilter | string>;
-
-	// todo@API very unclear, provider MUST not return alive object but only data object
-	// todo@API unclear how the flow goes
-	export interface NotebookKernelProvider<T extends NotebookKernel = NotebookKernel> {
-		onDidChangeKernels?: Event<NotebookDocument | undefined>;
-		provideKernels(document: NotebookDocument, token: CancellationToken): ProviderResult<T[]>;
-		resolveKernel?(kernel: T, document: NotebookDocument, webview: NotebookCommunication, token: CancellationToken): ProviderResult<void>;
-	}
-
-	export interface NotebookEditor {
-		/**
-		 * Active kernel used in the editor
-		 */
-		// todo@API unsure about that
-		// kernel, kernel selection, kernel provider
-		readonly kernel?: NotebookKernel;
-	}
-
-	export namespace notebook {
-		export const onDidChangeActiveNotebookKernel: Event<{ document: NotebookDocument, kernel: NotebookKernel | undefined; }>;
-
-		export function registerNotebookKernelProvider(selector: NotebookDocumentFilter, provider: NotebookKernelProvider): Disposable;
 	}
 
 	//#endregion
@@ -1671,7 +1804,7 @@ declare module 'vscode' {
 	//#region https://github.com/microsoft/vscode/issues/106744, NotebookEditorDecorationType
 
 	export interface NotebookEditor {
-		setDecorations(decorationType: NotebookEditorDecorationType, range: NotebookCellRange): void;
+		setDecorations(decorationType: NotebookEditorDecorationType, range: NotebookRange): void;
 	}
 
 	export interface NotebookDecorationRenderOptions {
@@ -1709,32 +1842,32 @@ declare module 'vscode' {
 		Right = 2
 	}
 
-	export interface NotebookCellStatusBarItem {
-		readonly cell: NotebookCell;
+	// todo@API remove readonlyness.
+	export class NotebookCellStatusBarItem {
+		readonly text: string;
 		readonly alignment: NotebookCellStatusBarAlignment;
+		readonly command?: string | Command;
+		readonly tooltip?: string;
 		readonly priority?: number;
-		text: string;
-		tooltip: string | undefined;
-		command: string | Command | undefined;
-		accessibilityInformation?: AccessibilityInformation;
-		show(): void;
-		hide(): void;
-		dispose(): void;
+		readonly accessibilityInformation?: AccessibilityInformation;
+
+		constructor(text: string, alignment: NotebookCellStatusBarAlignment, command?: string | Command, tooltip?: string, priority?: number, accessibilityInformation?: AccessibilityInformation);
+	}
+
+	interface NotebookCellStatusBarItemProvider {
+		/**
+		 * Implement and fire this event to signal that statusbar items have changed. The provide method will be called again.
+		 */
+		onDidChangeCellStatusBarItems?: Event<void>;
+
+		/**
+		 * The provider will be called when the cell scrolls into view, when its content, outputs, language, or metadata change, and when it changes execution state.
+		 */
+		provideCellStatusBarItems(cell: NotebookCell, token: CancellationToken): ProviderResult<NotebookCellStatusBarItem[]>;
 	}
 
 	export namespace notebook {
-		/**
-		 * Creates a notebook cell status bar [item](#NotebookCellStatusBarItem).
-		 * It will be disposed automatically when the notebook document is closed or the cell is deleted.
-		 *
-		 * @param cell The cell on which this item should be shown.
-		 * @param alignment The alignment of the item.
-		 * @param priority The priority of the item. Higher values mean the item should be shown more to the left.
-		 * @return A new status bar item.
-		 */
-		// @roblourens
-		// todo@API this should be a provider, https://github.com/microsoft/vscode/issues/105809
-		export function createCellStatusBarItem(cell: NotebookCell, alignment?: NotebookCellStatusBarAlignment, priority?: number): NotebookCellStatusBarItem;
+		export function registerNotebookCellStatusBarItemProvider(selector: NotebookSelector, provider: NotebookCellStatusBarItemProvider): Disposable;
 	}
 
 	//#endregion
@@ -1749,17 +1882,16 @@ declare module 'vscode' {
 		 * @param notebook
 		 * @param selector
 		 */
-		// @jrieken REMOVE. p_never
 		// todo@API really needed? we didn't find a user here
 		export function createConcatTextDocument(notebook: NotebookDocument, selector?: DocumentSelector): NotebookConcatTextDocument;
 	}
 
 	export interface NotebookConcatTextDocument {
-		uri: Uri;
-		isClosed: boolean;
+		readonly uri: Uri;
+		readonly isClosed: boolean;
 		dispose(): void;
-		onDidChange: Event<void>;
-		version: number;
+		readonly onDidChange: Event<void>;
+		readonly version: number;
 		getText(): string;
 		getText(range: Range): string;
 
@@ -2099,70 +2231,85 @@ declare module 'vscode' {
 	//#endregion
 
 	//#region https://github.com/microsoft/vscode/issues/107467
-	/*
-		General activation events:
-			- `onLanguage:*` most test extensions will want to activate when their
-				language is opened to provide code lenses.
-			- `onTests:*` new activation event very simiular to `workspaceContains`,
-				but only fired when the user wants to run tests or opens the test explorer.
-	*/
 	export namespace test {
 		/**
-		 * Registers a provider that discovers tests in workspaces and documents.
+		 * Registers a controller that can discover and
+		 * run tests in workspaces and documents.
 		 */
-		export function registerTestProvider<T extends TestItem>(testProvider: TestProvider<T>): Disposable;
+		export function registerTestController<T>(testController: TestController<T>): Disposable;
 
 		/**
-		 * Runs tests. The "run" contains the list of tests to run as well as a
-		 * method that can be used to update their state. At the point in time
-		 * that "run" is called, all tests given in the run have their state
-		 * automatically set to {@link TestRunState.Queued}.
+		 * Requests that tests be run by their controller.
+		 * @param run Run options to use
+		 * @param token Cancellation token for the test run
 		 */
-		export function runTests<T extends TestItem>(run: TestRunRequest<T>, token?: CancellationToken): Thenable<void>;
+		export function runTests<T>(run: TestRunRequest<T>, token?: CancellationToken): Thenable<void>;
 
 		/**
 		 * Returns an observer that retrieves tests in the given workspace folder.
+		 * @stability experimental
 		 */
 		export function createWorkspaceTestObserver(workspaceFolder: WorkspaceFolder): TestObserver;
 
 		/**
 		 * Returns an observer that retrieves tests in the given text document.
+		 * @stability experimental
 		 */
 		export function createDocumentTestObserver(document: TextDocument): TestObserver;
 
 		/**
-		 * Inserts custom test results into the VS Code UI. The results are
-		 * inserted and sorted based off the `completedAt` timestamp. If the
-		 * results are being read from a file, for example, the `completedAt`
-		 * time should generally be the modified time of the file if not more
-		 * specific time is available.
+		 * Creates a {@link TestRunTask<T>}. This should be called by the
+		 * {@link TestRunner} when a request is made to execute tests, and may also
+		 * be called if a test run is detected externally. Once created, tests
+		 * that are included in the results will be moved into the
+		 * {@link TestResultState.Pending} state.
 		 *
-		 * This will no-op if the inserted results are deeply equal to an
-		 * existing result.
-		 *
-		 * @param results test results
-		 * @param persist whether the test results should be saved by VS Code
-		 * and persisted across reloads. Defaults to true.
+		 * @param request Test run request. Only tests inside the `include` may be
+		 * modified, and tests in its `exclude` are ignored.
+		 * @param name The human-readable name of the run. This can be used to
+		 * disambiguate multiple sets of results in a test run. It is useful if
+		 * tests are run across multiple platforms, for example.
+		 * @param persist Whether the results created by the run should be
+		 * persisted in VS Code. This may be false if the results are coming from
+		 * a file already saved externally, such as a coverage information file.
 		 */
-		export function publishTestResult(results: TestRunResult, persist?: boolean): void;
+		export function createTestRunTask<T>(request: TestRunRequest<T>, name?: string, persist?: boolean): TestRunTask<T>;
 
 		/**
-		* List of test results stored by VS Code, sorted in descnding
-		* order by their `completedAt` time.
-		*/
+		 * Creates a new managed {@link TestItem} instance.
+		 * @param options Initial/required options for the item
+		 * @param data Custom data to be stored in {@link TestItem.data}
+		 */
+		export function createTestItem<T, TChildren = T>(options: TestItemOptions, data: T): TestItem<T, TChildren>;
+
+		/**
+		 * Creates a new managed {@link TestItem} instance.
+		 * @param options Initial/required options for the item
+		 */
+		export function createTestItem<T = void, TChildren = any>(options: TestItemOptions): TestItem<T, TChildren>;
+
+		/**
+		 * List of test results stored by VS Code, sorted in descnding
+		 * order by their `completedAt` time.
+		 * @stability experimental
+		 */
 		export const testResults: ReadonlyArray<TestRunResult>;
 
 		/**
-		* Event that fires when the {@link testResults} array is updated.
-		*/
+		 * Event that fires when the {@link testResults} array is updated.
+		 * @stability experimental
+		 */
 		export const onDidChangeTestResults: Event<void>;
 	}
 
+	/**
+	 * @stability experimental
+	 */
 	export interface TestObserver {
 		/**
 		 * List of tests returned by test provider for files in the workspace.
 		 */
-		readonly tests: ReadonlyArray<TestItem>;
+		readonly tests: ReadonlyArray<TestItem<never>>;
 
 		/**
 		 * An event that fires when an existing test in the collection changes, or
@@ -2188,32 +2335,30 @@ declare module 'vscode' {
 		dispose(): void;
 	}
 
+	/**
+	 * @stability experimental
+	 */
 	export interface TestsChangeEvent {
 		/**
 		 * List of all tests that are newly added.
 		 */
-		readonly added: ReadonlyArray<TestItem>;
+		readonly added: ReadonlyArray<TestItem<never>>;
 
 		/**
 		 * List of existing tests that have updated.
 		 */
-		readonly updated: ReadonlyArray<TestItem>;
+		readonly updated: ReadonlyArray<TestItem<never>>;
 
 		/**
 		 * List of existing tests that have been removed.
 		 */
-		readonly removed: ReadonlyArray<TestItem>;
+		readonly removed: ReadonlyArray<TestItem<never>>;
 	}
 
 	/**
-	 * Discovers and provides tests.
-	 *
-	 * Additionally, the UI may request it to discover tests for the workspace
-	 * via `addWorkspaceTests`.
-	 *
-	 * @todo rename from provider
+	 * Interface to discover and execute tests.
 	 */
-	export interface TestProvider<T extends TestItem = TestItem> {
+	export interface TestController<T> {
 		/**
 		 * Requests that tests be provided for the given workspace. This will
 		 * be called when tests need to be enumerated for the workspace, such as
@@ -2226,7 +2371,7 @@ declare module 'vscode' {
 		 * @param cancellationToken Token that signals the used asked to abort the test run.
 		 * @returns the root test item for the workspace
 		 */
-		provideWorkspaceTestRoot(workspace: WorkspaceFolder, token: CancellationToken): ProviderResult<T>;
+		createWorkspaceTestRoot(workspace: WorkspaceFolder, token: CancellationToken): ProviderResult<TestItem<T>>;
 
 		/**
 		 * Requests that tests be provided for the given document. This will be
@@ -2234,8 +2379,8 @@ declare module 'vscode' {
 		 * instance by code lens UI.
 		 *
 		 * It's suggested that the provider listen to change events for the text
-		 * document to provide information for test that might not yet be
-		 * saved, if possible.
+		 * document to provide information for tests that might not yet be
+		 * saved.
 		 *
 		 * If the test system is not able to provide or estimate for tests on a
 		 * per-file basis, this method may not be implemented. In that case, the
@@ -2243,119 +2388,139 @@ declare module 'vscode' {
 		 *
 		 * @param document The document in which to observe tests
 		 * @param cancellationToken Token that signals the used asked to abort the test run.
-		 * @returns the root test item for the workspace
+		 * @returns the root test item for the document
 		 */
-		provideDocumentTestRoot?(document: TextDocument, token: CancellationToken): ProviderResult<T>;
+		createDocumentTestRoot?(document: TextDocument, token: CancellationToken): ProviderResult<TestItem<T>>;
 
 		/**
-		 * @todo this will move out of the provider soon
-		 * @todo this will eventually need to be able to return a summary report, coverage for example.
+		 * Starts a test run. When called, the controller should call
+		 * {@link vscode.test.createTestRunTask}. All tasks associated with the
+		 * run should be created before the function returns or the reutrned
+		 * promise is resolved.
 		 *
-		 * Starts a test run. This should cause {@link onDidChangeTest} to
-		 * fire with update test states during the run.
 		 * @param options Options for this test run
 		 * @param cancellationToken Token that signals the used asked to abort the test run.
 		 */
-		// eslint-disable-next-line vscode-dts-provider-naming
-		runTests(options: TestRunOptions<T>, token: CancellationToken): ProviderResult<void>;
+		runTests(options: TestRunRequest<T>, token: CancellationToken): Thenable<void> | void;
 	}
 
 	/**
 	 * Options given to {@link test.runTests}.
 	 */
-	export interface TestRunRequest<T extends TestItem = TestItem> {
+	export interface TestRunRequest<T> {
 		/**
-		 * Array of specific tests to run. The {@link TestProvider.testRoot} may
-		 * be provided as an indication to run all tests.
+		 * Array of specific tests to run. The controllers should run all of the
+		 * given tests and all children of the given tests, excluding any tests
+		 * that appear in {@link TestRunRequest.exclude}.
 		 */
-		tests: T[];
+		tests: TestItem<T>[];
 
 		/**
 		 * An array of tests the user has marked as excluded in VS Code. May be
-		 * omitted if no exclusions were requested. Test providers should not run
+		 * omitted if no exclusions were requested. Test controllers should not run
 		 * excluded tests or any children of excluded tests.
 		 */
-		exclude?: T[];
+		exclude?: TestItem<T>[];
 
 		/**
-		 * Whether or not tests in this run should be debugged.
+		 * Whether tests in this run should be debugged.
 		 */
 		debug: boolean;
 	}
 
 	/**
-	 * Options given to {@link TestProvider.runTests}
+	 * Options given to {@link TestController.runTests}
 	 */
-	export interface TestRunOptions<T extends TestItem = TestItem> extends TestRunRequest<T> {
+	export interface TestRunTask<T = void> {
 		/**
-		 * Updates the state of the test in the run. By default, all tests involved
-		 * in the run will have a "queued" state until they are updated by this method.
-		 *
-		 * Calling with method with nodes outside the {@link TestRunRequesttests}
-		 * or in the {@link TestRunRequestexclude} array will no-op.
+		 * The human-readable name of the run. This can be used to
+		 * disambiguate multiple sets of results in a test run. It is useful if
+		 * tests are run across multiple platforms, for example.
+		 */
+		readonly name?: string;
+
+		/**
+		 * Updates the state of the test in the run. Calling with method with nodes
+		 * outside the {@link TestRunRequest.tests} or in the
+		 * {@link TestRunRequest.exclude} array will no-op.
 		 *
 		 * @param test The test to update
 		 * @param state The state to assign to the test
 		 * @param duration Optionally sets how long the test took to run
 		 */
-		setState(test: T, state: TestResultState, duration?: number): void;
+		setState(test: TestItem<T>, state: TestResultState, duration?: number): void;
 
 		/**
 		 * Appends a message, such as an assertion error, to the test item.
 		 *
-		 * Calling with method with nodes outside the {@link TestRunRequesttests}
-		 * or in the {@link TestRunRequestexclude} array will no-op.
+		 * Calling with method with nodes outside the {@link TestRunRequest.tests}
+		 * or in the {@link TestRunRequest.exclude} array will no-op.
 		 *
 		 * @param test The test to update
 		 * @param state The state to assign to the test
 		 *
 		 */
-		appendMessage(test: T, message: TestMessage): void;
+		appendMessage(test: TestItem<T>, message: TestMessage): void;
 
 		/**
 		 * Appends raw output from the test runner. On the user's request, the
 		 * output will be displayed in a terminal. ANSI escape sequences,
 		 * such as colors and text styles, are supported.
+		 *
+		 * @param output Output text to append
+		 * @param associateTo Optionally, associate the given segment of output
 		 */
 		appendOutput(output: string): void;
+
+		/**
+		 * Signals that the end of the test run. Any tests whose states have not
+		 * been updated will be moved into the {@link TestResultState.Unset} state.
+		 */
+		end(): void;
 	}
 
-	export interface TestChildrenCollection<T> extends Iterable<T> {
+	/**
+	 * Indicates the the activity state of the {@link TestItem}.
+	 */
+	export enum TestItemStatus {
 		/**
-		 * Gets the number of children in the collection.
+		 * All children of the test item, if any, have been discovered.
 		 */
-		readonly size: number;
+		Resolved = 1,
 
 		/**
-		 * Gets an existing TestItem by its ID, if it exists.
-		 * @param id ID of the test.
-		 * @returns the TestItem instance if it exists.
+		 * The test item may have children who have not been discovered yet.
 		 */
-		get(id: string): T | undefined;
+		Pending = 0,
+	}
+
+	/**
+	 * Options initially passed into `vscode.test.createTestItem`
+	 */
+	export interface TestItemOptions {
+		/**
+		 * Unique identifier for the TestItem. This is used to correlate
+		 * test results and tests in the document with those in the workspace
+		 * (test explorer). This cannot change for the lifetime of the TestItem.
+		 */
+		id: string;
 
 		/**
-		 * Adds a new child test item. No-ops if the test was already a child.
-		 * @param child The test item to add.
+		 * URI this TestItem is associated with. May be a file or directory.
 		 */
-		add(child: T): void;
+		uri: Uri;
 
 		/**
-		 * Removes the child test item by reference or ID from the collection.
-		 * @param child Child ID or instance to remove.
+		 * Display name describing the test item.
 		 */
-		delete(child: T | string): void;
-
-		/**
-		 * Removes all children from the collection.
-		 */
-		clear(): void;
+		label: string;
 	}
 
 	/**
 	 * A test item is an item shown in the "test explorer" view. It encompasses
 	 * both a suite and a test, since they have almost or identical capabilities.
 	 */
-	export class TestItem<TChildren = any> {
+	export interface TestItem<T, TChildren = any> {
 		/**
 		 * Unique identifier for the TestItem. This is used to correlate
 		 * test results and tests in the document with those in the workspace
@@ -2369,10 +2534,28 @@ declare module 'vscode' {
 		readonly uri: Uri;
 
 		/**
-		 * A set of children this item has. You can add new children to it, which
-		 * will propagate to the editor UI.
+		 * A mapping of children by ID to the associated TestItem instances.
 		 */
-		readonly children: TestChildrenCollection<TChildren>;
+		readonly children: ReadonlyMap<string, TestItem<TChildren>>;
+
+		/**
+		 * The parent of this item, if any. Assigned automatically when calling
+		 * {@link TestItem.addChild}.
+		 */
+		readonly parent?: TestItem<any>;
+
+		/**
+		 * Indicates the state of the test item's children. The editor will show
+		 * TestItems in the `Pending` state and with a `resolveHandler` as being
+		 * expandable, and will call the `resolveHandler` to request items.
+		 *
+		 * A TestItem in the `Resolved` state is assumed to have discovered and be
+		 * watching for changes in its children if applicable. TestItems are in the
+		 * `Resolved` state when initially created; if the editor should call
+		 * the `resolveHandler` to discover children, set the state to `Pending`
+		 * after creating the item.
+		 */
+		status: TestItemStatus;
 
 		/**
 		 * Display name describing the test case.
@@ -2391,6 +2574,13 @@ declare module 'vscode' {
 		range?: Range;
 
 		/**
+		 * May be set to an error associated with loading the test. Note that this
+		 * is not a test result and should only be used to represent errors in
+		 * discovery, such as syntax errors.
+		 */
+		error?: string | MarkdownString;
+
+		/**
 		 * Whether this test item can be run by providing it in the
 		 * {@link TestRunRequest.tests} array. Defaults to `true`.
 		 */
@@ -2403,20 +2593,10 @@ declare module 'vscode' {
 		debuggable: boolean;
 
 		/**
-		 * Whether this test item can be expanded in the tree view, implying it
-		 * has (or may have) children. If this is true, VS Code may call
-		 * the {@link TestItem.discoverChildren} method.
+		 * Custom extension data on the item. This data will never be serialized
+		 * or shared outside the extenion who created the item.
 		 */
-		expandable: boolean;
-
-		/**
-		 * Creates a new TestItem instance.
-		 * @param id Value of the "id" property
-		 * @param label Value of the "label" property.
-		 * @param uri Value of the "uri" property.
-		 * @param expandable Value of the "expandable" property.
-		 */
-		constructor(id: string, label: string, uri: Uri, expandable: boolean);
+		data: T;
 
 		/**
 		 * Marks the test as outdated. This can happen as a result of file changes,
@@ -2429,17 +2609,18 @@ declare module 'vscode' {
 		invalidate(): void;
 
 		/**
-		 * Requests the children of the test item. Extensions should override this
-		 * method for any test that can discover children.
+		 * A function provided by the extension that the editor may call to request
+		 * children of the item, if the {@link TestItem.status} is `Pending`.
 		 *
-		 * When called, the item should discover tests and update its's `children`.
-		 * The provider will be marked as 'busy' when this method is called, and
-		 * the provider should report `{ busy: false }` to {@link Progress.report}
-		 * once discovery is complete.
+		 * When called, the item should discover tests and call {@link TestItem.addChild}.
+		 * The items should set its {@link TestItem.status} to `Resolved` when
+		 * discovery is finished.
 		 *
 		 * The item should continue watching for changes to the children and
 		 * firing updates until the token is cancelled. The process of watching
-		 * the tests may involve creating a file watcher, for example.
+		 * the tests may involve creating a file watcher, for example. After the
+		 * token is cancelled and watching stops, the TestItem should set its
+		 * {@link TestItem.status} back to `Pending`.
 		 *
 		 * The editor will only call this method when it's interested in refreshing
 		 * the children of the item, and will not call it again while there's an
@@ -2447,9 +2628,20 @@ declare module 'vscode' {
 		 *
 		 * @param token Cancellation for the request. Cancellation will be
 		 * requested if the test changes before the previous call completes.
-		 * @returns a provider result of child test items
 		 */
-		discoverChildren(progress: Progress<{ busy: boolean }>, token: CancellationToken): void;
+		resolveHandler?: (token: CancellationToken) => void;
+
+		/**
+		 * Attaches a child, created from the {@link test.createTestItem} function,
+		 * to this item. A `TestItem` may be a child of at most one other item.
+		 */
+		addChild(child: TestItem<TChildren>): void;
+
+		/**
+		 * Removes the test and its children from the tree. Any tokens passed to
+		 * child `resolveHandler` methods will be cancelled.
+		 */
+		dispose(): void;
 	}
 
 	/**
@@ -2545,6 +2737,11 @@ declare module 'vscode' {
 		completedAt: number;
 
 		/**
+		 * Optional raw output from the test run.
+		 */
+		output?: string;
+
+		/**
 		 * List of test results. The items in this array are the items that
 		 * were passed in the {@link test.runTests} method.
 		 */
@@ -2585,6 +2782,19 @@ declare module 'vscode' {
 		readonly range?: Range;
 
 		/**
+		 * State of the test in each task. In the common case, a test will only
+		 * be executed in a single task and the length of this array will be 1.
+		 */
+		readonly taskStates: ReadonlyArray<TestSnapshoptTaskState>;
+
+		/**
+		 * Optional list of nested tests for this item.
+		 */
+		readonly children: Readonly<TestResultSnapshot>[];
+	}
+
+	export interface TestSnapshoptTaskState {
+		/**
 		 * Current result of the test.
 		 */
 		readonly state: TestResultState;
@@ -2600,11 +2810,6 @@ declare module 'vscode' {
 		 * failure information if the test fails.
 		 */
 		readonly messages: ReadonlyArray<TestMessage>;
-
-		/**
-		 * Optional list of nested tests for this item.
-		 */
-		readonly children: Readonly<TestResultSnapshot>[];
 	}
 
 	//#endregion
@@ -2785,66 +2990,27 @@ declare module 'vscode' {
 	//#endregion
 
 	//#region https://github.com/microsoft/vscode/issues/120173
-
-	export enum WorkspaceTrustState {
-		/**
-		 * The workspace is untrusted, and it will have limited functionality.
-		 */
-		Untrusted = 0,
-
-		/**
-		 * The workspace is trusted, and all functionality will be available.
-		 */
-		Trusted = 1,
-
-		/**
-		 * The initial state of the workspace.
-		 *
-		 * If trust will be required, users will be prompted to make a choice.
-		 */
-		Unspecified = 2
-	}
-
-	/**
-	 * The event data that is fired when the trust state of the workspace changes.
-	 * When trust is revoked, the workspace will be reloaded. Therefore, extensions are
-	 * not expected to handle transitions out of a trusted state.
-	 */
-	export interface WorkspaceTrustStateChangeEvent {
-		/**
-		 * New trust state of the workspace
-		 */
-		readonly newTrustState: WorkspaceTrustState;
-	}
-
 	/**
 	 * The object describing the properties of the workspace trust request
 	 */
 	export interface WorkspaceTrustRequestOptions {
 		/**
 		 * When true, a modal dialog will be used to request workspace trust.
-		 * When false, a badge will be displayed on the Setting activity bar item
+		 * When false, a badge will be displayed on the settings gear activity bar item.
 		 */
 		readonly modal: boolean;
 	}
 
 	export namespace workspace {
 		/**
-		 * The trust state of the current workspace
-		 */
-		export const trustState: WorkspaceTrustState;
-
-		/**
 		 * Prompt the user to chose whether to trust the current workspace
 		 * @param options Optional object describing the properties of the
-		 * workspace trust request
+		 * workspace trust request. Defaults to { modal: false }
+		 * When using a non-modal request, the promise will return immediately.
+		 * Any time trust is not given, it is recommended to use the
+		* `onDidGrantWorkspaceTrust` event to listen for trust changes.
 		 */
-		export function requestWorkspaceTrust(options?: WorkspaceTrustRequestOptions): Thenable<WorkspaceTrustState | undefined>;
-
-		/**
-		 * Event that fires when the trust state of the current workspace changes
-		 */
-		export const onDidChangeWorkspaceTrustState: Event<WorkspaceTrustStateChangeEvent>;
+		export function requestWorkspaceTrust(options?: WorkspaceTrustRequestOptions): Thenable<boolean>;
 	}
 
 	//#endregion

--- a/src/dotnet-interactive-vscode/stable/package.json
+++ b/src/dotnet-interactive-vscode/stable/package.json
@@ -113,7 +113,7 @@
         },
         "dotnet-interactive.minimumInteractiveToolVersion": {
           "type": "string",
-          "default": "1.0.221503",
+          "default": "1.0.222102",
           "description": "The minimum required version of the .NET Interactive tool."
         },
         "dotnet-interactive.useDotNetInteractiveExtensionForIpynbFiles": {
@@ -357,7 +357,7 @@
     "lint": "eslint src --ext ts",
     "watch": "tsc -watch -p ./",
     "integration-test": "node ./out/tests/integration/runTest.js",
-    "pretest": "npm run compile && npm run lint",
+    "pretest": "npm run compile",
     "test": "mocha --opts mocha.opts",
     "ciTest": "npm test -- --reporter mocha-multi-reporters --reporter-options configFile=testConfig.json",
     "tdd": "npm test -- --watch",

--- a/src/dotnet-interactive-vscode/stable/src/notebookKernel.ts
+++ b/src/dotnet-interactive-vscode/stable/src/notebookKernel.ts
@@ -3,18 +3,17 @@
 
 import * as vscode from 'vscode';
 
-import { ClientMapper } from "../clientMapper";
-import { getSimpleLanguage, notebookCellLanguages } from "../interactiveNotebook";
-import { getCellLanguage, getDotNetMetadata, getLanguageInfoMetadata, withDotNetKernelMetadata } from '../ipynbUtilities';
-import * as contracts from '../interfaces/contracts';
-import * as vscodeLike from '../interfaces/vscode-like';
-import * as diagnostics from './diagnostics';
+import { KernelId } from './common/vscode/extension';
+import { ClientMapper } from "./common/clientMapper";
+import { getSimpleLanguage, notebookCellLanguages } from "./common/interactiveNotebook";
+import { getCellLanguage, getDotNetMetadata, getLanguageInfoMetadata, withDotNetKernelMetadata } from './common/ipynbUtilities';
+import * as contracts from './common/interfaces/contracts';
+import * as vscodeLike from './common/interfaces/vscode-like';
+import * as diagnostics from './common/vscode/diagnostics';
 import * as notebookContentProvider from './notebookContentProvider';
-import * as utilities from '../utilities';
-import * as versionSpecificFunctions from '../../versionSpecificFunctions';
-import * as vscodeUtilities from './vscodeUtilities';
-
-export const KernelId: string = 'dotnet-interactive';
+import * as utilities from './common/utilities';
+import * as versionSpecificFunctions from './versionSpecificFunctions';
+import * as vscodeUtilities from './common/vscode/vscodeUtilities';
 
 export class DotNetInteractiveNotebookKernel implements vscode.NotebookKernel {
     id: string = KernelId;
@@ -22,12 +21,12 @@ export class DotNetInteractiveNotebookKernel implements vscode.NotebookKernel {
     description?: string | undefined;
     detail?: string | undefined;
     isPreferred: boolean;
-    preloads?: vscode.Uri[] | undefined;
+    preloads?: vscode.Uri[];
     supportedLanguages: Array<string>;
 
-    constructor(readonly clientMapper: ClientMapper, apiBootstrapperUri: vscode.Uri, isPreferred: boolean) {
+    constructor(readonly clientMapper: ClientMapper, preloadUris: vscode.Uri[], isPreferred: boolean) {
         this.label = ".NET Interactive";
-        this.preloads = [apiBootstrapperUri];
+        this.preloads = preloadUris;
         this.isPreferred = isPreferred;
         this.supportedLanguages = notebookCellLanguages;
     }

--- a/src/dotnet-interactive-vscode/stable/src/notebookKernelProvider.ts
+++ b/src/dotnet-interactive-vscode/stable/src/notebookKernelProvider.ts
@@ -4,17 +4,17 @@
 import * as vscode from 'vscode';
 
 import { DotNetInteractiveNotebookKernel } from "./notebookKernel";
-import { configureWebViewMessaging } from "./vscodeUtilities";
-import { ClientMapper } from '../clientMapper';
-import { isDotNetKernelPreferred } from '../utilities';
+import { ClientMapper } from './common/clientMapper';
+import { isDotNetKernelPreferred } from './common/utilities';
+import { configureWebViewMessaging } from './notebookContentProvider';
 
 export class DotNetInteractiveNotebookKernelProvider implements vscode.NotebookKernelProvider<DotNetInteractiveNotebookKernel> {
     private preferredKernel: DotNetInteractiveNotebookKernel;
     private nonPreferredKernel: DotNetInteractiveNotebookKernel;
 
-    constructor(readonly apiBootstrapperUri: vscode.Uri, readonly clientMapper: ClientMapper) {
-        this.preferredKernel = new DotNetInteractiveNotebookKernel(clientMapper, this.apiBootstrapperUri, true);
-        this.nonPreferredKernel = new DotNetInteractiveNotebookKernel(clientMapper, this.apiBootstrapperUri, false);
+    constructor(preloadUris: vscode.Uri[], readonly clientMapper: ClientMapper) {
+        this.preferredKernel = new DotNetInteractiveNotebookKernel(clientMapper, preloadUris, true);
+        this.nonPreferredKernel = new DotNetInteractiveNotebookKernel(clientMapper, preloadUris, false);
     }
 
     onDidChangeKernels?: vscode.Event<vscode.NotebookDocument | undefined> | undefined;

--- a/src/dotnet-interactive-vscode/stable/src/versionSpecificFunctions.ts
+++ b/src/dotnet-interactive-vscode/stable/src/versionSpecificFunctions.ts
@@ -5,15 +5,16 @@ import * as vscode from 'vscode';
 import * as contracts from './common/interfaces/contracts';
 import * as vscodeLike from './common/interfaces/vscode-like';
 import * as utilities from './common/utilities';
-import * as notebookContentProvider from './common/vscode/notebookContentProvider';
-import * as notebookKernel from './common/vscode/notebookKernel';
+import * as notebookKernel from './notebookKernel';
 import * as interactiveNotebook from './common/interactiveNotebook';
 import * as diagnostics from './common/vscode/diagnostics';
 import * as vscodeUtilities from './common/vscode/vscodeUtilities';
-
-export function registerAdditionalContentProvider(context: vscode.ExtensionContext, contentProvider: vscode.NotebookContentProvider) {
-    context.subscriptions.push(vscode.notebook.registerNotebookContentProvider('dotnet-interactive-jupyter', contentProvider));
-}
+import { KernelId } from './common/vscode/extension';
+import { DotNetInteractiveNotebookKernelProvider } from './notebookKernelProvider';
+import { DotNetInteractiveNotebookContentProvider } from './notebookContentProvider';
+import { ClientMapper } from './common/clientMapper';
+import { OutputChannelAdapter } from './common/vscode/OutputChannelAdapter';
+import { isStableBuild, offerToReOpen } from './common/vscode/vscodeUtilities';
 
 export function cellAt(document: vscode.NotebookDocument, index: number): vscode.NotebookCell {
     return document.cells[index];
@@ -29,4 +30,57 @@ export function getCells(document: vscode.NotebookDocument | undefined): Array<v
     }
 
     return [];
+}
+
+export function registerWithVsCode(context: vscode.ExtensionContext, clientMapper: ClientMapper, diagnosticsChannel: OutputChannelAdapter, useJupyterExtension: boolean, ...preloadUris: vscode.Uri[]) {
+    const selectorDib = {
+        viewType: ['dotnet-interactive'],
+        filenamePattern: '*.{dib,dotnet-interactive}'
+    };
+    const selectorIpynbWithJupyter = {
+        viewType: ['jupyter-notebook'],
+        filenamePattern: '*.ipynb'
+    };
+    const selectorIpynbWithDotNetInteractive = {
+        viewType: ['dotnet-interactive-jupyter'],
+        filenamePatter: '*.ipynb'
+    };
+    const notebookContentProvider = new DotNetInteractiveNotebookContentProvider(diagnosticsChannel, clientMapper);
+
+    // notebook content
+    context.subscriptions.push(vscode.notebook.registerNotebookContentProvider('dotnet-interactive', notebookContentProvider));
+    context.subscriptions.push(vscode.notebook.registerNotebookContentProvider('dotnet-interactive-jupyter', notebookContentProvider));
+    const notebookKernelProvider = new DotNetInteractiveNotebookKernelProvider(preloadUris, clientMapper);
+    context.subscriptions.push(vscode.notebook.registerNotebookKernelProvider(selectorDib, notebookKernelProvider));
+    if (useJupyterExtension) {
+        context.subscriptions.push(vscode.notebook.registerNotebookKernelProvider(selectorIpynbWithJupyter, notebookKernelProvider));
+    }
+
+    // always register as a possible .ipynb handler
+    context.subscriptions.push(vscode.notebook.registerNotebookKernelProvider(selectorIpynbWithDotNetInteractive, notebookKernelProvider));
+
+    context.subscriptions.push(vscode.notebook.onDidChangeActiveNotebookKernel(async e => await handleNotebookKernelChange(e, clientMapper)));
+    context.subscriptions.push(vscode.notebook.onDidCloseNotebookDocument(notebookDocument => vscodeUtilities.resolveNotebookDocumentClose(notebookDocument)));
+}
+
+export function endExecution(cell: vscode.NotebookCell, success: boolean) {
+    notebookKernel.endExecution(cell, success);
+}
+
+async function handleNotebookKernelChange(e: { document: vscode.NotebookDocument, kernel: vscode.NotebookKernel | undefined }, clientMapper: ClientMapper) {
+    if (e.kernel?.id === KernelId) {
+        try {
+            // update various metadata
+            await notebookKernel.updateDocumentKernelspecMetadata(e.document);
+            await notebookKernel.updateCellLanguages(e.document);
+
+            // force creation of the client so we don't have to wait for the user to execute a cell to get the tool
+            await clientMapper.getOrAddClient(e.document.uri);
+        } catch (err) {
+            vscode.window.showErrorMessage(`Failed to set document metadata for '${e.document.uri}': ${err}`);
+        }
+    } else if (isStableBuild()) {
+        const kernelspecName = e.document.metadata?.custom?.metadata?.kernelspec?.name;
+        await offerToReOpen(e.document, kernelspecName);
+    }
 }


### PR DESCRIPTION
This is a big one.

The VS Code notebook APIs have taken a large change that's mostly incompatible with the current Stable release.  Because of that a bunch of common code had to be moved into the `stable/src` and `insiders/src` directories and other helpers rearranged as necessary.

These changes aren't meant to be used in Stable currently, only in Insiders so we can unblock our users.  The differences between the two will be reconciled before the next Stable release which will then bring both back into close alignment.

There are some bugs yet to be filed against VS Code once this has been merged, specifically:

- [x] Notebook controller webview not getting `postMessage` calls via `onDidReceiveMessage()`.  **Because of this bug, JavaScript cells don't behave as expected.** (microsoft/vscode#121895)
- [ ] `onDidChangeNotebookAssociation` should fire even on initial notebook open (microsoft/vscode#121904).
- [ ] cannot set cell language using mouse on the cell itself, only via command palette (microsoft/vscode#121927)