### PR TITLE
better handling of notebook and cell readonly metadata

### DIFF
--- a/src/dotnet-interactive-vscode/common/ipynbUtilities.ts
+++ b/src/dotnet-interactive-vscode/common/ipynbUtilities.ts
@@ -57,7 +57,7 @@ export function getLanguageInfoMetadata(metadata: any): LanguageInfoMetadata {
         metadata.custom.metadata &&
         metadata.custom.metadata.language_info &&
         isLanguageInfoMetadata(metadata.custom.metadata.language_info)) {
-        languageMetadata = metadata.custom.metadata.language_info;
+        languageMetadata = { ...metadata.custom.metadata.language_info };
     }
 
     languageMetadata.name = mapIpynbLanguageName(languageMetadata.name);
@@ -119,6 +119,14 @@ export const requiredKernelspecData: KernelspecMetadata = {
     name: '.net-csharp',
 };
 
+export const requiredLanguageInfoData = {
+    file_extension: '.cs',
+    mimetype: 'text/x-csharp',
+    name: 'C#',
+    pygments_lexer: 'csharp',
+    version: '9.0',
+};
+
 export function withDotNetKernelMetadata(metadata: { [key: string]: any } | undefined): any | undefined {
     // clone the existing metadata
     let result: { [key: string]: any } = {};
@@ -128,11 +136,18 @@ export function withDotNetKernelMetadata(metadata: { [key: string]: any } | unde
         }
     }
 
-    result.custom ||= {};
-    result.custom.metadata ||= {};
+    result.custom = {
+        ...result.custom,
+        metadata: {
+            ...result.custom?.metadata,
+            kernelspec: {
+                ...result.custom?.metadata?.kernelspec,
+                ...requiredKernelspecData,
+            },
+            language_info: requiredLanguageInfoData,
+        },
+    };
 
-    // always set kernelspec data so that this notebook can be opened in Jupyter Lab
-    result.custom.metadata.kernelspec = { ...result.custom.metadata.kernelspec, ...requiredKernelspecData };
     return result;
 }
 

--- a/src/dotnet-interactive-vscode/common/ipynbUtilities.ts
+++ b/src/dotnet-interactive-vscode/common/ipynbUtilities.ts
@@ -128,26 +128,20 @@ export const requiredLanguageInfoData = {
 };
 
 export function withDotNetKernelMetadata(metadata: { [key: string]: any } | undefined): any | undefined {
-    // clone the existing metadata
-    let result: { [key: string]: any } = {};
-    if (metadata) {
-        for (const key in metadata) {
-            result[key] = metadata[key];
-        }
-    }
-
-    result.custom = {
-        ...result.custom,
-        metadata: {
-            ...result.custom?.metadata,
-            kernelspec: {
-                ...result.custom?.metadata?.kernelspec,
-                ...requiredKernelspecData,
+    const result = {
+        ...metadata,
+        custom: {
+            ...metadata?.custom,
+            metadata: {
+                ...metadata?.custom?.metadata,
+                kernelspec: {
+                    ...metadata?.custom?.metadata?.kernelspec,
+                    ...requiredKernelspecData,
+                },
+                language_info: requiredLanguageInfoData,
             },
-            language_info: requiredLanguageInfoData,
-        },
+        }
     };
-
     return result;
 }
 

--- a/src/dotnet-interactive-vscode/common/tests/unit/ipynbMetadata.test.ts
+++ b/src/dotnet-interactive-vscode/common/tests/unit/ipynbMetadata.test.ts
@@ -145,7 +145,14 @@ describe('ipynb metadata tests', () => {
                             display_name: '.NET (C#)',
                             language: 'C#',
                             name: '.net-csharp',
-                        }
+                        },
+                        language_info: {
+                            file_extension: '.cs',
+                            mimetype: 'text/x-csharp',
+                            name: 'C#',
+                            pygments_lexer: 'csharp',
+                            version: '9.0',
+                        },
                     }
                 }
             });
@@ -164,7 +171,14 @@ describe('ipynb metadata tests', () => {
                             display_name: '.NET (C#)',
                             language: 'C#',
                             name: '.net-csharp',
-                        }
+                        },
+                        language_info: {
+                            file_extension: '.cs',
+                            mimetype: 'text/x-csharp',
+                            name: 'C#',
+                            pygments_lexer: 'csharp',
+                            version: '9.0',
+                        },
                     }
                 }
             });
@@ -189,7 +203,14 @@ describe('ipynb metadata tests', () => {
                             language: 'C#',
                             name: '.net-csharp',
                             some_existing_key: 'some existing value',
-                        }
+                        },
+                        language_info: {
+                            file_extension: '.cs',
+                            mimetype: 'text/x-csharp',
+                            name: 'C#',
+                            pygments_lexer: 'csharp',
+                            version: '9.0',
+                        },
                     }
                 }
             });
@@ -216,6 +237,13 @@ describe('ipynb metadata tests', () => {
                             display_name: '.NET (C#)',
                             language: 'C#',
                             name: '.net-csharp',
+                        },
+                        language_info: {
+                            file_extension: '.cs',
+                            mimetype: 'text/x-csharp',
+                            name: 'C#',
+                            pygments_lexer: 'csharp',
+                            version: '9.0',
                         },
                         some_custom_metadata: {
                             key1: 'value 1'
@@ -254,6 +282,13 @@ describe('ipynb metadata tests', () => {
                             language: 'C#',
                             name: '.net-csharp',
                             some_existing_key: 'some existing value'
+                        },
+                        language_info: {
+                            file_extension: '.cs',
+                            mimetype: 'text/x-csharp',
+                            name: 'C#',
+                            pygments_lexer: 'csharp',
+                            version: '9.0',
                         },
                         some_custom_metadata: {
                             key1: 'value 1'

--- a/src/dotnet-interactive-vscode/common/vscode/extension.ts
+++ b/src/dotnet-interactive-vscode/common/vscode/extension.ts
@@ -201,8 +201,10 @@ async function updateNotebookCellLanguageInMetadata(candidateNotebookCellDocumen
         if (cell) {
             const newMetadata = cell.metadata.with({
                 custom: {
-                    dotnet_interactive: {
-                        language: getSimpleLanguage(candidateNotebookCellDocument.languageId)
+                    metadata: {
+                        dotnet_interactive: {
+                            language: getSimpleLanguage(candidateNotebookCellDocument.languageId)
+                        }
                     }
                 }
             });

--- a/src/dotnet-interactive-vscode/insiders/package.json
+++ b/src/dotnet-interactive-vscode/insiders/package.json
@@ -104,7 +104,7 @@
         },
         "dotnet-interactive.minimumInteractiveToolVersion": {
           "type": "string",
-          "default": "1.0.222102",
+          "default": "1.0.222103",
           "description": "The minimum required version of the .NET Interactive tool."
         }
       }

--- a/src/dotnet-interactive-vscode/insiders/src/versionSpecificFunctions.ts
+++ b/src/dotnet-interactive-vscode/insiders/src/versionSpecificFunctions.ts
@@ -32,7 +32,9 @@ export function getCells(document: vscode.NotebookDocument | undefined): Array<v
 export function registerWithVsCode(context: vscode.ExtensionContext, clientMapper: ClientMapper, outputChannel: OutputChannelAdapter, useJupyterExtension: boolean, ...preloadUris: vscode.Uri[]) {
     context.subscriptions.push(new notebookControllers.DotNetNotebookKernel(clientMapper, preloadUris));
     context.subscriptions.push(new notebookSerializers.DotNetDibNotebookSerializer(clientMapper, outputChannel));
-    //context.subscriptions.push(new notebookSerializers.DotNetIpynbNotebookSerializer(clientMapper, outputChannel)); // only stable uses our ipynb handler
+    if (vscodeUtilities.isStableBuild()) {
+        context.subscriptions.push(new notebookSerializers.DotNetIpynbNotebookSerializer(clientMapper, outputChannel));
+    }
 }
 
 export function endExecution(cell: vscode.NotebookCell, success: boolean) {

--- a/src/dotnet-interactive-vscode/insiders/src/vscode.proposed.d.ts
+++ b/src/dotnet-interactive-vscode/insiders/src/vscode.proposed.d.ts
@@ -385,6 +385,14 @@ declare module 'vscode' {
 	}
 
 	/**
+	 * Represents the severiry of a TextSearchComplete message.
+	 */
+	export enum TextSearchCompleteMessageType {
+		Information = 1,
+		Warning = 2,
+	}
+
+	/**
 	 * Information collected when text search is complete.
 	 */
 	export interface TextSearchComplete {
@@ -396,6 +404,15 @@ declare module 'vscode' {
 		 * - If search hits an internal limit which is less than `maxResults`, this should be true.
 		 */
 		limitHit?: boolean;
+
+		/**
+		 * Additional information regarding the state of the completed search.
+		 *
+		 * Messages with "Information" tyle support links in markdown syntax:
+		 * - Click to [run a command](command:workbench.action.OpenQuickPick)
+		 * - Click to [open a website](https://aka.ms)
+		 */
+		message?: { text: string, type: TextSearchCompleteMessageType } | { text: string, type: TextSearchCompleteMessageType }[];
 	}
 
 	/**

--- a/src/dotnet-interactive-vscode/stable/package.json
+++ b/src/dotnet-interactive-vscode/stable/package.json
@@ -113,7 +113,7 @@
         },
         "dotnet-interactive.minimumInteractiveToolVersion": {
           "type": "string",
-          "default": "1.0.222102",
+          "default": "1.0.222103",
           "description": "The minimum required version of the .NET Interactive tool."
         },
         "dotnet-interactive.useDotNetInteractiveExtensionForIpynbFiles": {


### PR DESCRIPTION
Some notebook document and cell metadata is readonly at runtime so we have to be more explicit about updating values by constructing the higher object and copying everything in.