### PR TITLE
wrap `NotebookSerializer` on insiders

### DIFF
--- a/src/dotnet-interactive-vscode/common/vscode/commands.ts
+++ b/src/dotnet-interactive-vscode/common/vscode/commands.ts
@@ -160,8 +160,8 @@ export function registerFileCommands(context: vscode.ExtensionContext, clientMap
     }
 
     // using .ipynb as default until https://github.com/microsoft/vscode/issues/121974 is fixed
-    //const [newNotebookExtension, newNotebookViewType] = ['.dib', 'dotnet-interactive'];
-    const [newNotebookExtension, newNotebookViewType] = ['.ipynb', 'jupyter-notebook'];
+    const [newNotebookExtension, newNotebookViewType] = ['.dib', 'dotnet-interactive'];
+    //const [newNotebookExtension, newNotebookViewType] = ['.ipynb', 'jupyter-notebook'];
 
     function getNewNotebookName(): string {
         let suffix = 1;

--- a/src/dotnet-interactive-vscode/insiders/package.json
+++ b/src/dotnet-interactive-vscode/insiders/package.json
@@ -116,7 +116,7 @@
         },
         "dotnet-interactive.minimumInteractiveToolVersion": {
           "type": "string",
-          "default": "1.0.222202",
+          "default": "1.0.222401",
           "description": "The minimum required version of the .NET Interactive tool."
         }
       }

--- a/src/dotnet-interactive-vscode/insiders/src/notebookContentProviderWrapper.ts
+++ b/src/dotnet-interactive-vscode/insiders/src/notebookContentProviderWrapper.ts
@@ -1,0 +1,85 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import { backupNotebook, defaultNotebookCellLanguage } from './common/interactiveNotebook';
+import { isUnsavedNotebook } from './common/vscode/vscodeUtilities';
+import { OutputChannelAdapter } from './common/vscode/OutputChannelAdapter';
+
+// a thin wrapper around the new `vscode.NotebookSerializer` api
+export class DotNetNotebookContentProviderWrapper implements vscode.NotebookContentProvider {
+    constructor(private readonly serializer: vscode.NotebookSerializer, private readonly outputChannel: OutputChannelAdapter) {
+    }
+
+    async openNotebook(uri: vscode.Uri, openContext: vscode.NotebookDocumentOpenContext, token: vscode.CancellationToken): Promise<vscode.NotebookData> {
+        let fileUri: vscode.Uri | undefined = isUnsavedNotebook(uri)
+            ? undefined
+            : uri;
+        if (openContext.backupId) {
+            // restoring a backed up notebook
+
+            // N.B., when F5 debugging, the `backupId` property is _always_ `undefined`, so to properly test this you'll
+            // have to build and install a VSIX.
+            fileUri = vscode.Uri.file(openContext.backupId);
+        }
+
+        let notebookData: vscode.NotebookData | undefined = undefined;
+        if (fileUri && fs.existsSync(fileUri.fsPath)) {
+            // file on disk
+            try {
+                const buffer = Buffer.from(await vscode.workspace.fs.readFile(fileUri));
+                notebookData = await this.serializer.deserializeNotebook(buffer, token);
+            } catch (e) {
+                vscode.window.showErrorMessage(`Error opening file '${fileUri.fsPath}'; check the '${this.outputChannel.getName()}' output channel for details`);
+                this.outputChannel.appendLine(`Error opening file '${fileUri.fsPath}':\n${e?.message}`);
+            }
+        } else {
+            // new empty/blank notebook; nothing to do
+        }
+
+        if (!notebookData) {
+            notebookData = new vscode.NotebookData([]);
+        }
+
+        if (notebookData.cells.length === 0) {
+            // ensure at least one cell
+            notebookData = new vscode.NotebookData([{
+                kind: vscode.NotebookCellKind.Code,
+                source: '',
+                language: defaultNotebookCellLanguage,
+            }]);
+        }
+
+        return notebookData;
+    }
+
+    saveNotebook(document: vscode.NotebookDocument, token: vscode.CancellationToken): Thenable<void> {
+        return this.saveNotebookToUri(document, document.uri, token);
+    }
+
+    saveNotebookAs(targetResource: vscode.Uri, document: vscode.NotebookDocument, token: vscode.CancellationToken): Thenable<void> {
+        return this.saveNotebookToUri(document, targetResource, token);
+    }
+
+    async backupNotebook(document: vscode.NotebookDocument, context: vscode.NotebookDocumentBackupContext, token: vscode.CancellationToken): Promise<vscode.NotebookDocumentBackup> {
+        const extension = path.extname(document.uri.fsPath);
+        const content = await this.notebookAsUint8Array(document, token);
+        return backupNotebook(content, context.destination.fsPath + extension);
+    }
+
+    private async notebookAsUint8Array(document: vscode.NotebookDocument, token: vscode.CancellationToken): Promise<Uint8Array> {
+        const notebookData: vscode.NotebookData = {
+            cells: document.getCells().map(cell => new vscode.NotebookCellData(cell.kind, cell.document.getText(), cell.document.languageId)),
+            metadata: new vscode.NotebookDocumentMetadata(),
+        };
+        const content = await this.serializer.serializeNotebook(notebookData, token);
+        return content;
+    }
+
+    private async saveNotebookToUri(document: vscode.NotebookDocument, uri: vscode.Uri, token: vscode.CancellationToken): Promise<void> {
+        const content = await this.notebookAsUint8Array(document, token);
+        await vscode.workspace.fs.writeFile(uri, content);
+    }
+}

--- a/src/dotnet-interactive-vscode/insiders/src/notebookSerializers.ts
+++ b/src/dotnet-interactive-vscode/insiders/src/notebookSerializers.ts
@@ -11,6 +11,7 @@ import { defaultNotebookCellLanguage, getNotebookSpecificLanguage, getSimpleLang
 import { OutputChannelAdapter } from './common/vscode/OutputChannelAdapter';
 import { getEol, vsCodeCellOutputToContractCellOutput } from './common/vscode/vscodeUtilities';
 import { Eol } from './common/interfaces';
+import { DotNetNotebookContentProviderWrapper } from './notebookContentProviderWrapper';
 
 abstract class DotNetNotebookSerializer implements vscode.NotebookSerializer {
 
@@ -20,12 +21,19 @@ abstract class DotNetNotebookSerializer implements vscode.NotebookSerializer {
 
     constructor(
         notebookType: string,
+        registerAsSerializer: boolean,
         private readonly clientMapper: ClientMapper,
         private readonly outputChannel: OutputChannelAdapter,
         private readonly extension: string,
     ) {
-        this.disposable = vscode.notebook.registerNotebookSerializer(notebookType, this);
         this.eol = getEol();
+        if (registerAsSerializer) {
+            this.disposable = vscode.notebook.registerNotebookSerializer(notebookType, this);
+        } else {
+            // temporarly workaround for https://github.com/microsoft/vscode/issues/121974
+            const contentProviderWrapper = new DotNetNotebookContentProviderWrapper(this, this.outputChannel);
+            this.disposable = vscode.notebook.registerNotebookContentProvider(notebookType, contentProviderWrapper);
+        }
     }
 
     dispose(): void {
@@ -87,7 +95,7 @@ function toNotebookCell(cell: vscode.NotebookCellData): contracts.NotebookCell {
 
 export class DotNetDibNotebookSerializer extends DotNetNotebookSerializer {
     constructor(clientMapper: ClientMapper, outputChannel: OutputChannelAdapter) {
-        super('dotnet-interactive', clientMapper, outputChannel, '.dib');
+        super('dotnet-interactive', false, clientMapper, outputChannel, '.dib');
     }
 }
 

--- a/src/dotnet-interactive-vscode/stable/package.json
+++ b/src/dotnet-interactive-vscode/stable/package.json
@@ -117,7 +117,7 @@
         },
         "dotnet-interactive.minimumInteractiveToolVersion": {
           "type": "string",
-          "default": "1.0.222202",
+          "default": "1.0.222401",
           "description": "The minimum required version of the .NET Interactive tool."
         }
       }


### PR DESCRIPTION
This is to enable new untitled notebooks to be .dib instead of .ipynb to work around this bug:
https://github.com/microsoft/vscode/issues/121974