### PR TITLE
allow user to select either .dib or .ipynb when creating a new blank notebook

### DIFF
--- a/src/dotnet-interactive-vscode/common/vscode/extension.ts
+++ b/src/dotnet-interactive-vscode/common/vscode/extension.ts
@@ -60,14 +60,23 @@ export async function activate(context: vscode.ExtensionContext) {
 
     vscode.window.registerUriHandler({
         handleUri(uri: vscode.Uri): vscode.ProviderResult<void> {
+            const params = new URLSearchParams(uri.query);
             switch (uri.path) {
                 case '/newNotebook':
+                    // Examples:
+                    //   vscode://ms-dotnettools.dotnet-interactive-vscode/newNotebook?as=dib
+                    //   vscode://ms-dotnettools.dotnet-interactive-vscode/newNotebook?as=ipynb
+                    const asType = params.get('as');
                     vscode.commands.executeCommand('dotnet-interactive.acquire').then(() => {
-                        vscode.commands.executeCommand('dotnet-interactive.newNotebook').then(() => { });
+                        const commandName = asType === 'ipynb'
+                            ? 'dotnet-interactive.newNotebookIpynb'
+                            : 'dotnet-interactive.newNotebookDib';
+                        vscode.commands.executeCommand(commandName).then(() => { });
                     });
                     break;
                 case '/openNotebook':
-                    const params = new URLSearchParams(uri.query);
+                    // Example
+                    //   vscode://ms-dotnettools.dotnet-interactive-vscode/openNotebook?path=C%3A%5Cpath%5Cto%5Cnotebook.dib
                     const path = params.get('path');
                     if (path) {
                         vscode.commands.executeCommand('dotnet-interactive.acquire').then(() => {

--- a/src/dotnet-interactive-vscode/insiders/package.json
+++ b/src/dotnet-interactive-vscode/insiders/package.json
@@ -49,7 +49,9 @@
     "onCommand:dotnet-interactive.saveAsNotebook"
   ],
   "main": "./out/src/common/vscode/extension.js",
-  "extensionDependencies": [],
+  "extensionDependencies": [
+    "ms-toolsai.jupyter"
+  ],
   "contributes": {
     "notebookProvider": [
       {

--- a/src/dotnet-interactive-vscode/insiders/src/vscode.proposed.d.ts
+++ b/src/dotnet-interactive-vscode/insiders/src/vscode.proposed.d.ts
@@ -2286,7 +2286,7 @@ declare module 'vscode' {
 		export function createDocumentTestObserver(document: TextDocument): TestObserver;
 
 		/**
-		 * Creates a {@link TestRunTask<T>}. This should be called by the
+		 * Creates a {@link TestRun<T>}. This should be called by the
 		 * {@link TestRunner} when a request is made to execute tests, and may also
 		 * be called if a test run is detected externally. Once created, tests
 		 * that are included in the results will be moved into the
@@ -2301,7 +2301,7 @@ declare module 'vscode' {
 		 * persisted in VS Code. This may be false if the results are coming from
 		 * a file already saved externally, such as a coverage information file.
 		 */
-		export function createTestRunTask<T>(request: TestRunRequest<T>, name?: string, persist?: boolean): TestRunTask<T>;
+		export function createTestRun<T>(request: TestRunRequest<T>, name?: string, persist?: boolean): TestRun<T>;
 
 		/**
 		 * Creates a new managed {@link TestItem} instance.
@@ -2422,7 +2422,7 @@ declare module 'vscode' {
 
 		/**
 		 * Starts a test run. When called, the controller should call
-		 * {@link vscode.test.createTestRunTask}. All tasks associated with the
+		 * {@link vscode.test.createTestRun}. All tasks associated with the
 		 * run should be created before the function returns or the reutrned
 		 * promise is resolved.
 		 *
@@ -2459,7 +2459,7 @@ declare module 'vscode' {
 	/**
 	 * Options given to {@link TestController.runTests}
 	 */
-	export interface TestRunTask<T = void> {
+	export interface TestRun<T = void> {
 		/**
 		 * The human-readable name of the run. This can be used to
 		 * disambiguate multiple sets of results in a test run. It is useful if

--- a/src/dotnet-interactive-vscode/stable/package.json
+++ b/src/dotnet-interactive-vscode/stable/package.json
@@ -42,7 +42,6 @@
   "activationEvents": [
     "onUri",
     "onNotebook:dotnet-interactive",
-    "onNotebook:dotnet-interactive-jupyter",
     "onNotebook:*",
     "onCommand:dotnet-interactive.acquire",
     "onCommand:dotnet-interactive.newNotebook",
@@ -50,7 +49,9 @@
     "onCommand:dotnet-interactive.saveAsNotebook"
   ],
   "main": "./out/src/common/vscode/extension.js",
-  "extensionDependencies": [],
+  "extensionDependencies": [
+    "ms-toolsai.jupyter"
+  ],
   "contributes": {
     "notebookProvider": [
       {

--- a/src/dotnet-interactive-vscode/stable/src/versionSpecificFunctions.ts
+++ b/src/dotnet-interactive-vscode/stable/src/versionSpecificFunctions.ts
@@ -36,23 +36,20 @@ export function registerWithVsCode(context: vscode.ExtensionContext, clientMappe
         viewType: ['dotnet-interactive'],
         filenamePattern: '*.{dib,dotnet-interactive}'
     };
-    const selectorIpynbWithJupyter = {
-        viewType: ['jupyter-notebook'],
-        filenamePattern: '*.ipynb'
-    };
     const selectorIpynbWithDotNetInteractive = {
-        viewType: ['dotnet-interactive-jupyter'],
+        viewType: ['jupyter-notebook'],
         filenamePatter: '*.ipynb'
     };
     const notebookContentProvider = new DotNetInteractiveNotebookContentProvider(diagnosticsChannel, clientMapper);
 
     // notebook content
     context.subscriptions.push(vscode.notebook.registerNotebookContentProvider('dotnet-interactive', notebookContentProvider));
-    context.subscriptions.push(vscode.notebook.registerNotebookContentProvider('dotnet-interactive-jupyter', notebookContentProvider));
     const notebookKernelProvider = new DotNetInteractiveNotebookKernelProvider(preloadUris, clientMapper);
+
+    // register kernel for .NET Interactive and .dib
     context.subscriptions.push(vscode.notebook.registerNotebookKernelProvider(selectorDib, notebookKernelProvider));
 
-    // always register as a possible .ipynb handler
+    // register kernel for .NET Interactive and .ipynb
     context.subscriptions.push(vscode.notebook.registerNotebookKernelProvider(selectorIpynbWithDotNetInteractive, notebookKernelProvider));
 
     context.subscriptions.push(vscode.notebook.onDidChangeActiveNotebookKernel(async e => await handleNotebookKernelChange(e, clientMapper)));


### PR DESCRIPTION
Created issue #1305 to track the user experience and notification.

This PR updates the ".NET Interactive: Create new blank notebook" command to prompt the user to create either `.dib` or `.ipynb`.  The `/newNotebook` URI handler has also been updated with an optiona `as` parameter which is used to specify the notebook type.

This new behavior was added behind two new commands, `dotnet-interactive.noteNotebookDib` and `dotnet-interactive.newNotebookIpynb`.  These commands aren't directly executable by the user (that's a lie, they _can_ execute them directly, but they have to know _exactly_ what they want), but it was done this way to that if the user has opted into sending telemetry, we can see which sub-command is used more often so we know what kind of notebooks users want.

This...

![image](https://user-images.githubusercontent.com/926281/116148472-cf1c2c00-a695-11eb-8449-388320dc077a.png)

...now leads to this...

![image](https://user-images.githubusercontent.com/926281/116148505-d7746700-a695-11eb-9c14-1ffb3ebcd28d.png)
