### PR TITLE
ensure our kernel is selected when appropriate

### DIFF
--- a/src/dotnet-interactive-vscode/common/vscode/commands.ts
+++ b/src/dotnet-interactive-vscode/common/vscode/commands.ts
@@ -179,10 +179,7 @@ export function registerFileCommands(context: vscode.ExtensionContext, clientMap
     context.subscriptions.push(vscode.commands.registerCommand('dotnet-interactive.newNotebookIpynb', async () => {
         // note, new .ipynb notebooks are currently affected by this bug: https://github.com/microsoft/vscode/issues/121974
         await newNotebook('.ipynb');
-        if (isStableBuild()) {
-            // on stable we can explicitly select our kernel
-            selectDotNetInteractiveKernel();
-        }
+        selectDotNetInteractiveKernel();
     }));
 
     async function newNotebook(extension: string): Promise<void> {
@@ -254,8 +251,7 @@ export function registerFileCommands(context: vscode.ExtensionContext, clientMap
     }));
 }
 
-async function selectDotNetInteractiveKernel(): Promise<void> {
-    // on stable we can explicitly select our kernel
+export async function selectDotNetInteractiveKernel(): Promise<void> {
     const extension = 'ms-dotnettools.dotnet-interactive-vscode';
     const id = KernelId;
     await vscode.commands.executeCommand('notebook.selectKernel', { extension, id });

--- a/src/dotnet-interactive-vscode/insiders/package.json
+++ b/src/dotnet-interactive-vscode/insiders/package.json
@@ -67,15 +67,15 @@
     "jupyter.kernels": [
       {
         "title": ".NET Interactive (C#)",
-        "defaultLanguage": "dotnet-interactive.csharp"
+        "defaultlanguage": "dotnet-interactive.csharp"
       },
       {
         "title": ".NET Interactive (F#)",
-        "defaultLanguage": "dotnet-interactive.fsharp"
+        "defaultlanguage": "dotnet-interactive.fsharp"
       },
       {
         "title": ".NET Interactive (PowerShell)",
-        "defaultLanguage": "dotnet-interactive.pwsh"
+        "defaultlanguage": "dotnet-interactive.pwsh"
       }
     ],
     "configuration": {

--- a/src/dotnet-interactive-vscode/stable/package.json
+++ b/src/dotnet-interactive-vscode/stable/package.json
@@ -67,15 +67,15 @@
     "jupyter.kernels": [
       {
         "title": ".NET Interactive (C#)",
-        "defaultLanguage": "dotnet-interactive.csharp"
+        "defaultlanguage": "dotnet-interactive.csharp"
       },
       {
         "title": ".NET Interactive (F#)",
-        "defaultLanguage": "dotnet-interactive.fsharp"
+        "defaultlanguage": "dotnet-interactive.fsharp"
       },
       {
         "title": ".NET Interactive (PowerShell)",
-        "defaultLanguage": "dotnet-interactive.pwsh"
+        "defaultlanguage": "dotnet-interactive.pwsh"
       }
     ],
     "configuration": {


### PR DESCRIPTION
Call `notebook.selectKernel` after the user explicitly opens/creates a new .NET Interactive notebook.