### PR TITLE
add license info to extension

### DIFF
--- a/src/dotnet-interactive-vscode/insiders/License.txt
+++ b/src/dotnet-interactive-vscode/insiders/License.txt
@@ -1,0 +1,23 @@
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation.
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/src/dotnet-interactive-vscode/insiders/README.md
+++ b/src/dotnet-interactive-vscode/insiders/README.md
@@ -27,3 +27,9 @@ To create a new notebook, open the Command Palette(`Ctrl+Shift+P`), and select *
 ## Telemetry
 
 The .NET Interactive extension for VS Code uses the `dotnet-interactive` tool which collects usage and sends telemetry to Microsoft to help us improve our products and services.  Read our [privacy statement](https://privacy.microsoft.com/privacystatement) to learn more.  See [here](https://github.com/dotnet/interactive/tree/main/docs#telemetry) to learn more about telemetry in .NET Interactive.
+
+## License
+
+Copyright © .NET Foundation, and contributors.
+
+The source code to this extension is available on [https://github.com/dotnet/interactive](https://github.com/dotnet/interactive) and licensed under the [MIT license](https://github.com/dotnet/interactive/blob/main/License.txt).

--- a/src/dotnet-interactive-vscode/stable/License.txt
+++ b/src/dotnet-interactive-vscode/stable/License.txt
@@ -1,0 +1,23 @@
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation.
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/src/dotnet-interactive-vscode/stable/README.md
+++ b/src/dotnet-interactive-vscode/stable/README.md
@@ -27,3 +27,9 @@ To create a new notebook, open the Command Palette(`Ctrl+Shift+P`), and select *
 ## Telemetry
 
 The .NET Interactive extension for VS Code uses the `dotnet-interactive` tool which collects usage and sends telemetry to Microsoft to help us improve our products and services.  Read our [privacy statement](https://privacy.microsoft.com/privacystatement) to learn more.  See [here](https://github.com/dotnet/interactive/tree/main/docs#telemetry) to learn more about telemetry in .NET Interactive.
+
+## License
+
+Copyright © .NET Foundation, and contributors.
+
+The source code to this extension is available on [https://github.com/dotnet/interactive](https://github.com/dotnet/interactive) and licensed under the [MIT license](https://github.com/dotnet/interactive/blob/main/License.txt).


### PR DESCRIPTION
Add a license section to the extension's README and copy in the root license so it gets bundled with the extension.

These changes won't be visible on the [marketplace listing](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode) until we publish again.