### PR TITLE
don't call `vscode.env.asExternalUri` on http scheme

### DIFF
--- a/src/dotnet-interactive-vscode/common/vscode/extension.ts
+++ b/src/dotnet-interactive-vscode/common/vscode/extension.ts
@@ -123,11 +123,16 @@ export async function activate(context: vscode.ExtensionContext) {
         const transport = new StdioKernelTransport(notebookPath, processStart, diagnosticsChannel, vscode.Uri.parse, notification, (pid, code, signal) => {
             clientMapper.closeClient({ fsPath: notebookPath }, false);
         });
+
         await transport.waitForReady();
 
-        let externalUri = await vscode.env.asExternalUri(vscode.Uri.parse(`http://localhost:${transport.httpPort}`));
-        //create tunnel for teh kernel transport
-        await transport.setExternalUri(externalUri);
+        try {
+            let externalUri = vscode.Uri.parse(`http://127.0.0.1:${transport.httpPort}`);
+            await transport.setExternalUri(externalUri);
+        }
+        catch (e) {
+            vscode.window.showErrorMessage(`Error configuring http connection with .NET Interactive on ${kernelUri.toString()} : ${e.message}`);
+        }
 
         return transport;
     }, diagnosticsChannel);

--- a/src/dotnet-interactive-vscode/common/vscode/extension.ts
+++ b/src/dotnet-interactive-vscode/common/vscode/extension.ts
@@ -125,13 +125,13 @@ export async function activate(context: vscode.ExtensionContext) {
         });
 
         await transport.waitForReady();
-
+        let externalUri = vscode.Uri.parse(`http://127.0.0.1:${transport.httpPort}`);
         try {
-            let externalUri = vscode.Uri.parse(`http://127.0.0.1:${transport.httpPort}`);
+
             await transport.setExternalUri(externalUri);
         }
         catch (e) {
-            vscode.window.showErrorMessage(`Error configuring http connection with .NET Interactive on ${kernelUri.toString()} : ${e.message}`);
+            vscode.window.showErrorMessage(`Error configuring http connection with .NET Interactive on ${externalUri.toString()} : ${e.message}`);
         }
 
         return transport;


### PR DESCRIPTION
Addressing #124507 as suggested by @rebornix.
This is related to the api changes in this [commit](https://github.com/microsoft/vscode/commit/a6f7aa5e4c5832c3d788ab9a8146ac69a6e5a77f)