### PR TITLE
load script extensions from NuGet packages

### DIFF
--- a/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
@@ -54,6 +54,7 @@ namespace Microsoft.DotNet.Interactive.CSharp
         internal ScriptOptions ScriptOptions;
 
         private readonly AssemblyBasedExtensionLoader _extensionLoader = new();
+        private readonly ScriptBasedExtensionLoader _scriptExtensionLoader = new();
 
         private string _workingDirectory;
 
@@ -428,6 +429,11 @@ namespace Microsoft.DotNet.Interactive.CSharp
             KernelInvocationContext context)
         {
             await _extensionLoader.LoadFromDirectoryAsync(
+                directory,
+                this,
+                context);
+
+            await _scriptExtensionLoader.LoadFromDirectoryAsync(
                 directory,
                 this,
                 context);

--- a/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
@@ -45,6 +45,7 @@ type FSharpKernel () as this =
     let script = lazy createScript ()
 
     let extensionLoader: AssemblyBasedExtensionLoader = AssemblyBasedExtensionLoader()
+    let scriptExtensionLoader: ScriptBasedExtensionLoader = ScriptBasedExtensionLoader()
 
     let mutable cancellationTokenSource = new CancellationTokenSource()
 
@@ -456,4 +457,7 @@ type FSharpKernel () as this =
 
     interface IExtensibleKernel with
         member this.LoadExtensionsFromDirectoryAsync(directory:DirectoryInfo, context:KernelInvocationContext) =
-            extensionLoader.LoadFromDirectoryAsync(directory, this, context)
+            async {
+                do! extensionLoader.LoadFromDirectoryAsync(directory, this, context) |> Async.AwaitTask
+                do! scriptExtensionLoader.LoadFromDirectoryAsync(directory, this, context) |> Async.AwaitTask
+            } |> Async.StartAsTask :> Task

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelExtensionLoadingTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelExtensionLoadingTests.cs
@@ -111,11 +111,11 @@ namespace Microsoft.DotNet.Interactive.Tests
         [Theory]
         [InlineData(Language.CSharp)]
         [InlineData(Language.FSharp)]
-        public async Task it_loads_script_extension_found_in_nuget_package(Language language)
+        public async Task it_loads_script_extension_found_in_nuget_package(Language defaultLanguage)
         {
             var extensionPackage = KernelExtensionTestHelper.GetOrCreateScriptBasedExtensionPackage();
 
-            var kernel = CreateKernel(language);
+            var kernel = CreateCompositeKernel(defaultLanguage);
 
             await kernel.SubmitCodeAsync($@"
 #i ""nuget:{extensionPackage.PackageLocation}""

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelExtensionLoadingTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelExtensionLoadingTests.cs
@@ -107,5 +107,27 @@ namespace Microsoft.DotNet.Interactive.Tests
                         .Should()
                         .Contain("SimpleExtension");
         }
+
+        [Theory]
+        [InlineData(Language.CSharp)]
+        [InlineData(Language.FSharp)]
+        public async Task it_loads_script_extension_found_in_nuget_package(Language language)
+        {
+            var extensionPackage = KernelExtensionTestHelper.GetOrCreateScriptBasedExtensionPackage();
+
+            var kernel = CreateKernel(language);
+
+            await kernel.SubmitCodeAsync($@"
+#i ""nuget:{extensionPackage.PackageLocation}""
+#r ""nuget:{extensionPackage.Name},{extensionPackage.Version}""");
+
+            KernelEvents.Should()
+                        .ContainSingle<ReturnValueProduced>()
+                        .Which
+                        .Value
+                        .As<string>()
+                        .Should()
+                        .Contain("ScriptExtension");
+        }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Tests/Utility/KernelExtensionTestHelper.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Utility/KernelExtensionTestHelper.cs
@@ -86,7 +86,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Utility
 
                     var extensionScriptPath = new FileInfo(Path.Combine(projectDir.FullName, "extension.dib"));
                     var extensionScriptContent = @"
-#! csharp
+#!csharp
 ""ScriptExtension""
 ";
                     File.WriteAllText(extensionScriptPath.FullName, extensionScriptContent);

--- a/src/Microsoft.DotNet.Interactive/CompositeKernel.cs
+++ b/src/Microsoft.DotNet.Interactive/CompositeKernel.cs
@@ -33,6 +33,7 @@ namespace Microsoft.DotNet.Interactive
         private readonly List<Kernel> _childKernels = new();
         private readonly Dictionary<string, Kernel> _kernelsByNameOrAlias;
         private readonly AssemblyBasedExtensionLoader _extensionLoader = new();
+        private readonly ScriptBasedExtensionLoader _scriptExtensionLoader = new();
         private string _defaultKernelName;
         private Command _connectDirective;
 
@@ -317,6 +318,11 @@ namespace Microsoft.DotNet.Interactive
             KernelInvocationContext context)
         {
             await _extensionLoader.LoadFromDirectoryAsync(
+                directory,
+                this,
+                context);
+
+            await _scriptExtensionLoader.LoadFromDirectoryAsync(
                 directory,
                 this,
                 context);

--- a/src/Microsoft.DotNet.Interactive/Extensions/AssemblyBasedExtensionLoader.cs
+++ b/src/Microsoft.DotNet.Interactive/Extensions/AssemblyBasedExtensionLoader.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Interactive.Extensions
                 {
                     using var op = new ConfirmationLogger(
                         Log.Category,
-                        message: "Loading extensions in directory {directory}",
+                        message: $"Loading extensions in directory {directory}",
                         logOnStart: true,
                         args: new object[] { directory });
 

--- a/src/Microsoft.DotNet.Interactive/Extensions/ScriptBasedExtensionLoader.cs
+++ b/src/Microsoft.DotNet.Interactive/Extensions/ScriptBasedExtensionLoader.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Pocket;
+using static Pocket.Logger<Microsoft.DotNet.Interactive.Extensions.ScriptBasedExtensionLoader>;
+
+namespace Microsoft.DotNet.Interactive.Extensions
+{
+    public class ScriptBasedExtensionLoader : IKernelExtensionLoader
+    {
+        private const string ExtensionScriptName = "extension.dib";
+
+        public async Task LoadFromDirectoryAsync(DirectoryInfo directory, Kernel kernel, KernelInvocationContext context)
+        {
+            if (directory is null)
+            {
+                throw new ArgumentNullException(nameof(directory));
+            }
+
+            if (kernel is null)
+            {
+                throw new ArgumentNullException(nameof(kernel));
+            }
+
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (!directory.Exists)
+            {
+                throw new ArgumentException($"Directory {directory.FullName} doesn't exist", nameof(directory));
+            }
+
+            await LoadScriptExtensionFromDirectory(
+                directory,
+                kernel,
+                context);
+        }
+
+        private async Task LoadScriptExtensionFromDirectory(
+            DirectoryInfo directory,
+            Kernel kernel,
+            KernelInvocationContext context)
+        {
+            var extensionFile = new FileInfo(Path.Combine(directory.FullName, ExtensionScriptName));
+            if (extensionFile.Exists)
+            {
+                var logMessage = $"Loading extension script from `{extensionFile.FullName}`";
+                using var op = new ConfirmationLogger(
+                    Log.Category,
+                    message: logMessage,
+                    logOnStart: true,
+                    args: new object[] { extensionFile });
+
+                context.Display(logMessage, "text/markdown");
+
+                var scriptContents = File.ReadAllText(extensionFile.FullName, Encoding.UTF8);
+                await kernel.SubmitCodeAsync(scriptContents);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a purely source-based version of loading interactive extensions.  The existing binary-based one loads all assemblies from `<NUGET_PACKAGE_PATH>/interactive-extensions/dotnet/*.dll` so this one plays off of that scenario by simply loading and executing the file `<NUGET_PACKAGE_PATH>/interactive-extensions/dotnet/extension.dib` if it was found.

This takes advantage of the fact that a multi-cell `.dib` file can be executed with a single call to `SubmitCode`.