### PR TITLE
Use NameInCode to backtick-escape necessary F# completions when inserting

### DIFF
--- a/src/Microsoft.DotNet.Interactive.FSharp.Tests/KernelTests.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp.Tests/KernelTests.fs
@@ -140,5 +140,14 @@ type KernelTests() =
 
         completionItem.Documentation.Should().Equals("Returns the average of the elements in the list.")
         
+    [<Fact>]
+    member _.``Completion items that need double backticks have the right display in tools but insert with the backticks``() =
+        let src = """
+type C() =
+    member _.``Yee Yee`` = 12
+C().
+        """
+        let completions = getCompletions 3 4 [src] |> Array.map (fun item -> item.DisplayText, item.InsertText)
 
-
+        let hasYeeYeeBackticked = completions |> Array.contains ("Yee Yee", "``Yee Yee``")
+        Assert.True(hasYeeYeeBackticked, $"Insert and display text aren't correct:\n%A{completions}")

--- a/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
@@ -156,7 +156,7 @@ type FSharpKernel () as this =
             let kind = getKindString declarationItem.Glyph
             let filterText = getFilterText declarationItem
             let! documentation = getDocumentation declarationItem
-            return CompletionItem(declarationItem.Name, kind, filterText=filterText, documentation=documentation)
+            return CompletionItem(declarationItem.Name, kind, filterText=filterText, documentation=documentation, insertText=declarationItem.NameInCode)
         }
 
     let getDiagnostic (error: FSharpDiagnostic) =


### PR DESCRIPTION
Before this change, some F# completions that require backticks would show up correctly in the completion list, but would insert as the display name rather than the "name in code".

After this change, the display remains the same, but when inserting the completion, the `NameInCode` value is used, which has backticks. This is what we do in the VS tools for F# as well (although it is a much more complex process... 🙂)