### PR TITLE
Move stuff about

### DIFF
--- a/dotnet-interactive.sln
+++ b/dotnet-interactive.sln
@@ -80,7 +80,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Interactiv
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Interactive.PackageManagement", "src\Microsoft.DotNet.Interactive.PackageManagement\Microsoft.DotNet.Interactive.PackageManagement.csproj", "{53EF46D6-5E21-4507-B8C0-779B634262AA}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Interactive.Netstandard20", "src\Microsoft.DotNet.Interactive\Microsoft.DotNet.Interactive.Netstandard20.csproj", "{0FAA07B9-DBE4-47B5-939F-E1A69B975AD0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Interactive.Netstandard20", "src\Microsoft.DotNet.Interactive.NetStandard20\Microsoft.DotNet.Interactive.Netstandard20.csproj", "{0FAA07B9-DBE4-47B5-939F-E1A69B975AD0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Microsoft.DotNet.Interactive.NetStandard20/Microsoft.DotNet.Interactive.Netstandard20.csproj
+++ b/src/Microsoft.DotNet.Interactive.NetStandard20/Microsoft.DotNet.Interactive.Netstandard20.csproj
@@ -7,6 +7,6 @@
     <PackageTags>interactive desktop</PackageTags>
   </PropertyGroup>
 
-  <Import Project="Microsoft.DotNet.Interactive.csproj" />
+  <Import Project="$(MSBuildThisFileDirectory)../Microsoft.DotNet.Interactive/Microsoft.DotNet.Interactive.csproj" />
 
 </Project>

--- a/src/Microsoft.DotNet.Interactive/Microsoft.DotNet.Interactive.csproj
+++ b/src/Microsoft.DotNet.Interactive/Microsoft.DotNet.Interactive.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.DotNet.Interactive.Formatting\Microsoft.DotNet.Interactive.Formatting.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\Microsoft.DotNet.Interactive.Formatting\Microsoft.DotNet.Interactive.Formatting.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Because I am a frivolous and somwewhat foolish young man (ahem ... I am I tell ya).  When doing the netstandard20 stuff I put two projects in the same directory.  When DisableArcade=1 is set then this causes the tooling to overwrite the project.assets.json file created by the nuget build tasks, when both files are created.

If you want my opinion this is an sdk build bug ... but I suppose only one project per directory is fairly strong convention.

This fix just moves Netstandard20 into it's own top level project directory, thus eliminating the overwrite.

