### PR TITLE
fix formatting of null ReturnValueProduced

### DIFF
--- a/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
@@ -30,7 +30,6 @@ open FSharp.Compiler.Text.Position
 
 open FsAutoComplete
 open FSharp.Compiler.Symbols
-open FSharp.Compiler.Syntax
 
 type FSharpKernel () as this =
 
@@ -206,17 +205,16 @@ type FSharpKernel () as this =
 
             match result with
             | Ok(result) when not isError ->
-
                 match result with
-                | Some(value) when value.ReflectionType <> typeof<unit>  ->
+                | Some(value) when value.ReflectionType <> typeof<unit> ->
                     let value = value.ReflectionValue
                     let formattedValues = FormattedValue.FromObject(value)
                     context.Publish(ReturnValueProduced(value, codeSubmission, formattedValues))
-                | Some _ 
+                | Some _
                 | None -> ()
             | _ ->
                 if not (tokenSource.IsCancellationRequested) then
-                    let aggregateError = String.Join("\n", fsiDiagnostics )
+                    let aggregateError = String.Join("\n", fsiDiagnostics)
                     match result with
                     | Error (:? FsiCompilationException) 
                     | Ok _ ->

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/FormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/FormatterTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.Data;
 using System.IO;
 using FluentAssertions;

--- a/src/Microsoft.DotNet.Interactive/FormattedValue.cs
+++ b/src/Microsoft.DotNet.Interactive/FormattedValue.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.DotNet.Interactive.Formatting;
 
 namespace Microsoft.DotNet.Interactive
@@ -25,32 +24,15 @@ namespace Microsoft.DotNet.Interactive
 
         public string Value { get; }
 
-        public static IReadOnlyCollection<FormattedValue> FromObject(object value)
+        public static IReadOnlyCollection<FormattedValue> FromObject(object value, string mimeType = null)
         {
-            var type = value?.GetType();
+            mimeType ??= Formatter.GetPreferredMimeTypeFor(value?.GetType());
 
-            var mimeTypes = MimeTypesFor(type).ToArray();
+            var formattedValue = new FormattedValue(
+                mimeType,
+                value.ToDisplayString(mimeType));
 
-            var formattedValues = mimeTypes
-                                     .Select(mimeType =>
-                                                 new FormattedValue(mimeType, value.ToDisplayString(mimeType)))
-                                     .ToArray();
-
-            return formattedValues;
-        }
-
-        private static IEnumerable<string> MimeTypesFor(Type type)
-        {
-            var mimeTypes = new HashSet<string>();
-
-            if (type is not null)
-            {
-                var preferredMimeType = Formatter.GetPreferredMimeTypeFor(type);
-
-                mimeTypes.Add(preferredMimeType);
-            }
-
-            return mimeTypes;
+            return new[] { formattedValue };
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive/KernelInvocationContextExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelInvocationContextExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Formatting;
@@ -18,20 +19,16 @@ namespace Microsoft.DotNet.Interactive
         {
             var displayId = Guid.NewGuid().ToString();
 
-            mimeType ??= Formatter.GetPreferredMimeTypeFor(value?.GetType());
-
-            var formattedValue = new FormattedValue(
-                mimeType,
-                value.ToDisplayString(mimeType));
+            var formattedValues = FormattedValue.FromObject(value, mimeType);
 
             context.Publish(
                 new DisplayedValueProduced(
                     value,
                     context?.Command,
-                    new[] { formattedValue },
+                    formattedValues,
                     displayId));
 
-            var displayedValue = new DisplayedValue(displayId, mimeType, context);
+            var displayedValue = new DisplayedValue(displayId, mimeType ?? formattedValues.FirstOrDefault()?.MimeType, context);
 
             return displayedValue;
         }


### PR DESCRIPTION
Currently, `null` return values in `ReturnValueProduced` events are not correctly formatted as they are with null-valued `DisplayedValueProduced`. This fixes that for C#. I'm still looking at an appropriate fix for F#.

