### PR TITLE
allow routing to specific remote kernels

### DIFF
--- a/src/Microsoft.DotNet.Interactive/Connection/ProxyKernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Connection/ProxyKernel.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Parsing;
+using Microsoft.DotNet.Interactive.Utility;
 
 namespace Microsoft.DotNet.Interactive.Connection
 {
@@ -74,8 +75,10 @@ namespace Microsoft.DotNet.Interactive.Connection
                     return;
             }
 
-            var targetKernelName = command.TargetKernelName;
-            command.TargetKernelName = null;
+            var kernelUri = KernelUri.Parse(command.TargetKernelName);
+            var remoteTargetKernelName = kernelUri.GetRemoteKernelName();
+            var localTargetKernelName = command.TargetKernelName;
+            command.TargetKernelName = remoteTargetKernelName;
             var token = command.GetToken();
             var completionSource = new TaskCompletionSource<bool>();
             var sub = KernelEvents
@@ -96,7 +99,7 @@ namespace Microsoft.DotNet.Interactive.Connection
             await completionSource.Task;
             sub.Dispose();
 
-            command.TargetKernelName = targetKernelName;
+            command.TargetKernelName = localTargetKernelName;
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive/Parsing/KernelNameDirectiveNode.cs
+++ b/src/Microsoft.DotNet.Interactive/Parsing/KernelNameDirectiveNode.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Interactive.Parsing
     public class KernelNameDirectiveNode : DirectiveNode
     {
         internal KernelNameDirectiveNode(
-            DirectiveToken directiveToken, 
+            DirectiveToken directiveToken,
             SourceText sourceText,
             PolyglotSyntaxTree? syntaxTree) : base(directiveToken, sourceText, syntaxTree)
         {

--- a/src/Microsoft.DotNet.Interactive/Parsing/ProxyKernelNameDirectiveNode.cs
+++ b/src/Microsoft.DotNet.Interactive/Parsing/ProxyKernelNameDirectiveNode.cs
@@ -11,11 +11,15 @@ namespace Microsoft.DotNet.Interactive.Parsing
     [DebuggerStepThrough]
     public class ProxyKernelNameDirectiveNode : KernelNameDirectiveNode
     {
+        public string RemoteKernelName { get; }
+
         internal ProxyKernelNameDirectiveNode(
+            string remoteKernelName,
             DirectiveToken directiveToken,
             SourceText sourceText,
             PolyglotSyntaxTree? syntaxTree) : base(directiveToken, sourceText, syntaxTree)
         {
+            RemoteKernelName = remoteKernelName;
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive/Parsing/SubmissionParser.cs
+++ b/src/Microsoft.DotNet.Interactive/Parsing/SubmissionParser.cs
@@ -124,6 +124,11 @@ namespace Microsoft.DotNet.Interactive.Parsing
                             TargetKernelName = targetKernelName
                         };
 
+                        if (directiveNode is ProxyKernelNameDirectiveNode p)
+                        {
+                            directiveCommand.TargetKernelName = p.KernelName;
+                        }
+
                         if (directiveNode is KernelNameDirectiveNode kernelNameNode)
                         {
                             targetKernelName = kernelNameNode.KernelName;

--- a/src/Microsoft.DotNet.Interactive/Utility/KernelUriExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/Utility/KernelUriExtensions.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+
+namespace Microsoft.DotNet.Interactive.Utility
+{
+    internal static class KernelUriExtensions
+    {
+        public static string GetLocalKernelName(this string kernelUriString)
+        {
+            if (string.IsNullOrEmpty(kernelUriString))
+            {
+                return kernelUriString;
+            }
+
+            return KernelUri.Parse(kernelUriString).GetLocalKernelName();
+        }
+
+        public static string GetLocalKernelName(this KernelUri uri)
+        {
+            return uri.Parts[0];
+        }
+
+        public static string GetRemoteKernelName(this KernelUri uri)
+        {
+            if (uri.Parts.Length <= 1)
+            {
+                return null;
+            }
+
+            return string.Join("/", uri.Parts.Skip(1));
+        }
+    }
+}


### PR DESCRIPTION
This will shortly be re-written when the composite kernel knows more about proxy kernel subkernels and commands, but it at least adds a useful test.