### PR TITLE
better support for json literals in jupyter

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/kernel-client-impl.ts
+++ b/src/Microsoft.DotNet.Interactive.Js/src/dotnet-interactive/kernel-client-impl.ts
@@ -76,9 +76,9 @@ class InteractiveConsoleWrapper {
         for (const arg of args) {
             let mimeType: string;
             let value: string;
-            if (typeof arg === 'string') {
+            if (typeof arg !== 'object' && !Array.isArray(arg)) {
                 mimeType = 'text/plain';
-                value = arg;
+                value = arg.toString();
             } else {
                 mimeType = 'application/json';
                 value = JSON.stringify(arg);

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/ExecuteRequestHandlerTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/ExecuteRequestHandlerTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -13,7 +14,6 @@ using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Jupyter.Protocol;
 using Microsoft.DotNet.Interactive.Notebook;
 using Microsoft.DotNet.Interactive.Tests;
-using Newtonsoft.Json.Linq;
 using Pocket;
 using Recipes;
 using Xunit;
@@ -180,7 +180,7 @@ f();"));
 
             JupyterMessageSender.PubSubMessages
                                 .Should()
-                                .ContainSingle<DisplayData>(r => r.Data["application/json"] is JToken token && token.Type == JTokenType.Integer);
+                                .ContainSingle<DisplayData>(r => r.Data["application/json"] is JsonElement element && element.ValueKind == JsonValueKind.Number);
         }
         
         [Theory]

--- a/src/Microsoft.DotNet.Interactive.Jupyter/(Recipes)/JsonSerializationExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/(Recipes)/JsonSerializationExtensions.cs
@@ -4,17 +4,27 @@
 using System;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.DotNet.Interactive.Formatting;
 
 namespace Recipes
 {
     internal static class JsonSerializationExtensions
     {
-        public static JsonSerializerOptions SerializerOptions { get; } =
-            new JsonSerializerOptions(JsonSerializerDefaults.General)
-            {
-                WriteIndented = false,
-                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
-            };
+        static JsonSerializationExtensions()
+        {
+            SerializerOptions =
+                new JsonSerializerOptions(JsonSerializerDefaults.General)
+                {
+                    WriteIndented = false,
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                    NumberHandling = JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.AllowNamedFloatingPointLiterals,
+                    Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+                };
+            SerializerOptions.Converters.Add(new DataDictionaryConverter());
+        }
+
+        public static JsonSerializerOptions SerializerOptions { get; }
 
         public static string ToJson(this object source) =>
             JsonSerializer.Serialize(source, SerializerOptions);

--- a/src/Microsoft.DotNet.Interactive.Jupyter/ExecuteRequestHandler.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/ExecuteRequestHandler.cs
@@ -11,10 +11,11 @@ using System.Collections.Generic;
 using System.CommandLine.Rendering;
 using System.Linq;
 using System.Reactive.Concurrency;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
 using ZeroMQMessage = Microsoft.DotNet.Interactive.Jupyter.ZMQ.Message;
+using Recipes;
 
 namespace Microsoft.DotNet.Interactive.Jupyter
 {
@@ -270,7 +271,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter
         {
             var value = mimeType switch
             {
-                JsonFormatter.MimeType => (object) JToken.Parse(formattedValue),
+                JsonFormatter.MimeType => (object)formattedValue.FromJsonTo<JsonElement>(),
                 _ => formattedValue,
             };
             return value;


### PR DESCRIPTION
@colombod and I noticed that when JSON literals were getting passed to Jupyter for display, they were being parsed with the Newtonsoft APIs instead of System.Text.Json, which means they Jupyter display would think everything was an array.  This fixes that.