### PR TITLE
Add support for Ansi codes in outputs

### DIFF
--- a/NotebookTestScript.dib
+++ b/NotebookTestScript.dib
@@ -151,3 +151,23 @@ let x = 1 +
 1. `Ctrl+Shift+P` => ".NET Interactive: Open notebook"
 2. Select the "Untitled-1.dib"/"Untitled-1.ipynb" from before.
 3. Verify that it contains a single F# cell with the contents "1+1" and that it can execute.
+
+#!markdown
+
+# Support ANSI Codes
+
+#!csharp
+
+Console.Write("\x1b[38;2;0;255;0m");
+Console.WriteLine("this should be green");
+Console.Write("\x1b[0m");
+
+#!csharp
+
+Console.Write("\x1b[38;2;0;255;0mthis should be green\x1b[0m");
+
+#!csharp
+
+Console.Error.Write("\x1b[38;2;0;255;0m"); // set text color to green
+Console.Error.WriteLine("more green in stderr");
+Console.Error.Write("\x1b[0m"); // reset colors

--- a/src/dotnet-interactive-vscode/common/interactiveClient.ts
+++ b/src/dotnet-interactive-vscode/common/interactiveClient.ts
@@ -127,8 +127,7 @@ export class InteractiveClient {
             };
 
             let reportOutputs = () => {
-                outputObserver([...outputs]);
-                outputs = [];
+                outputObserver(outputs);
             };
 
             let failureReported = false;

--- a/src/dotnet-interactive-vscode/common/interfaces/vscode-like.ts
+++ b/src/dotnet-interactive-vscode/common/interfaces/vscode-like.ts
@@ -13,6 +13,7 @@ export const ErrorOutputMimeType = 'application/vnd.code.notebook.error';
 export interface NotebookCellOutputItem {
     readonly mime: string;
     readonly data: Uint8Array;
+    stream?: 'stdout' | 'stderr';
     [key: string]: any; // this is to make compilation on stable happy
 }
 

--- a/src/dotnet-interactive-vscode/insiders/src/notebookControllers.ts
+++ b/src/dotnet-interactive-vscode/insiders/src/notebookControllers.ts
@@ -126,7 +126,9 @@ export class DotNetNotebookKernel {
                 const controllerErrors: vscodeLike.NotebookCellOutput[] = [];
 
                 function outputObserver(outputs: Array<vscodeLike.NotebookCellOutput>) {
-                    outputUpdatePromise = outputUpdatePromise.finally(() => updateCellOutputs(executionTask!, [...outputs])).catch(() => {});
+                    outputUpdatePromise = outputUpdatePromise.catch(ex => {
+                        console.error('Failed to update output', ex);
+                    }).finally(() => updateCellOutputs(executionTask!, [...outputs]));
                 }
                 const client = await this.config.clientMapper.getOrAddClient(cell.notebook.uri);
                 executionTask.token.onCancellationRequested(() => {

--- a/src/dotnet-interactive-vscode/insiders/src/notebookControllers.ts
+++ b/src/dotnet-interactive-vscode/insiders/src/notebookControllers.ts
@@ -118,6 +118,7 @@ export class DotNetNotebookKernel {
         const executionTask = controller.createNotebookCellExecution(cell);
         if (executionTask) {
             executionTasks.set(cell.document.uri.toString(), executionTask);
+            let outputUpdatePromise = Promise.resolve();
             try {
                 const startTime = Date.now();
                 executionTask.start(startTime);
@@ -125,21 +126,15 @@ export class DotNetNotebookKernel {
                 const controllerErrors: vscodeLike.NotebookCellOutput[] = [];
 
                 function outputObserver(outputs: Array<vscodeLike.NotebookCellOutput>) {
-                    updateCellOutputs(executionTask!, [...outputs, ...controllerErrors]).then(() => { });
+                    outputUpdatePromise = outputUpdatePromise.finally(() => updateCellOutputs(executionTask!, [...outputs]));
                 }
-
-                function displayOutputs() {
-                    outputObserver([...cell.outputs]);
-                }
-
                 const client = await this.config.clientMapper.getOrAddClient(cell.notebook.uri);
                 executionTask.token.onCancellationRequested(() => {
                     client.cancel().catch(async err => {
                         // command failed to cancel
                         const cancelFailureMessage = typeof err?.message === 'string' ? <string>err.message : '' + err;
-                        const cancelFailureOutput = this.config.createErrorOutput(cancelFailureMessage);
-                        controllerErrors.push(cancelFailureOutput);
-                        displayOutputs();
+                        const errorOutput = new vscode.NotebookCellOutput(this.config.createErrorOutput(cancelFailureMessage).items.map(oi => generateVsCodeNotebookCellOutputItem(oi.data, oi.mime, oi.stream)));
+                        await executionTask.appendOutput(errorOutput);
                     });
                 });
                 const source = cell.document.getText();
@@ -149,14 +144,17 @@ export class DotNetNotebookKernel {
                     diagnosticCollection.set(cell.document.uri, diags.filter(d => d.severity !== contracts.DiagnosticSeverity.Hidden).map(vscodeUtilities.toVsCodeDiagnostic));
                 }
 
-                return client.execute(source, getSimpleLanguage(cell.document.languageId), outputObserver, diagnosticObserver, { id: cell.document.uri.toString() }).then(() => {
+                return client.execute(source, getSimpleLanguage(cell.document.languageId), outputObserver, diagnosticObserver, { id: cell.document.uri.toString() }).then(async () => {
+                    await outputUpdatePromise;
                     endExecution(cell, true);
-                }).catch(() => {
+                }).catch(async () => {
+                    await outputUpdatePromise;
                     endExecution(cell, false);
                 });
             } catch (err) {
-                const errorOutput = this.config.createErrorOutput(`Error executing cell: ${err}`);
-                await updateCellOutputs(executionTask, [errorOutput]);
+                const errorOutput = new vscode.NotebookCellOutput(this.config.createErrorOutput(`Error executing cell: ${err}`).items.map(oi => generateVsCodeNotebookCellOutputItem(oi.data, oi.mime, oi.stream)));
+                await executionTask.appendOutput(errorOutput);
+                await outputUpdatePromise;
                 endExecution(cell, false);
                 throw err;
             }
@@ -204,8 +202,21 @@ export async function updateCellLanguages(document: vscode.NotebookDocument): Pr
 }
 
 async function updateCellOutputs(executionTask: vscode.NotebookCellExecution, outputs: Array<vscodeLike.NotebookCellOutput>): Promise<void> {
-    const reshapedOutputs = outputs.map(o => new vscode.NotebookCellOutput(o.items.map(oi => generateVsCodeNotebookCellOutputItem(oi.data, oi.mime))));
-    await executionTask.replaceOutput(reshapedOutputs);
+    const previousOutput = executionTask.cell.outputs.length ? executionTask.cell.outputs[executionTask.cell.outputs.length - 1] : undefined;
+    const previousOutputItem = previousOutput?.items.length ? previousOutput.items[previousOutput.items.length - 1] : undefined;
+    await Promise.all(outputs.map(async (o, index) => {
+        const items = o.items.map(oi => generateVsCodeNotebookCellOutputItem(oi.data, oi.mime, oi.stream));
+        // If all of these items are of the same stream type & previous item is the same stream, then append it.
+        if (index === 0 && previousOutput && previousOutputItem?.mime && ['application/vnd.code.notebook.stderr', 'application/vnd.code.notebook.stdout'].includes(previousOutputItem?.mime)){
+            const decoder = new TextDecoder();
+            const newText = `${decoder.decode(previousOutputItem.data)}${items.map(item => decoder.decode(item.data)).join()}`;
+            const newItem = previousOutputItem.mime === 'application/vnd.code.notebook.stderr' ? vscode.NotebookCellOutputItem.stderr(newText) : vscode.NotebookCellOutputItem.stdout(newText);
+            const newItems = [...previousOutput.items.slice(0, -1), newItem];
+            await executionTask.replaceOutputItems(newItems, previousOutput);
+        } else {
+            await executionTask.appendOutput(new vscode.NotebookCellOutput(items));
+        }
+    }));
 }
 
 export function endExecution(cell: vscode.NotebookCell, success: boolean) {
@@ -218,9 +229,16 @@ export function endExecution(cell: vscode.NotebookCell, success: boolean) {
     }
 }
 
-function generateVsCodeNotebookCellOutputItem(data: Uint8Array, mime: string): vscode.NotebookCellOutputItem {
+function generateVsCodeNotebookCellOutputItem(data: Uint8Array, mime: string, stream?: 'stdout' | 'stderr'): vscode.NotebookCellOutputItem {
     const displayData = reshapeOutputValueForVsCode(data, mime);
-    return new vscode.NotebookCellOutputItem(displayData, mime);
+    switch(stream){
+        case 'stdout':
+            return vscode.NotebookCellOutputItem.stdout(new TextDecoder().decode(displayData));
+        case 'stderr':
+            return vscode.NotebookCellOutputItem.stderr(new TextDecoder().decode(displayData));
+        default:
+            return new vscode.NotebookCellOutputItem(displayData, mime);
+    }
 }
 
 async function updateDocumentKernelspecMetadata(document: vscode.NotebookDocument): Promise<void> {


### PR DESCRIPTION
https://github.com/dotnet/interactive/issues/1471

* Fixes support for ansi output
* Also ensures the generated ipynb is identicatal (if not similar) to the one generated by jupyter
	* This is because we're using VS Codes stderr & stdout output items.

![Screen Shot 2021-07-07 at 12 14 26](https://user-images.githubusercontent.com/1948812/124816071-eb9dd580-df1c-11eb-901c-d532554c0de1.png)
