### PR TITLE
#r nuget output

### DIFF
--- a/src/Microsoft.DotNet.Interactive.PackageManagement/KernelSupportsNugetExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.PackageManagement/KernelSupportsNugetExtensions.cs
@@ -104,7 +104,7 @@ namespace Microsoft.DotNet.Interactive
                     if (alreadyGotten is { } && !string.IsNullOrWhiteSpace(pkg.PackageVersion) && pkg.PackageVersion != alreadyGotten.PackageVersion)
                     {
                         var errorMessage = GenerateErrorMessage(pkg, alreadyGotten).ToString(OutputMode.NonAnsi);
-                        context.Publish(new ErrorProduced(errorMessage, context.Command));
+                        context.Fail(message: errorMessage);
                     }
                     else
                     {
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.Interactive
                         if (added is null)
                         {
                             var errorMessage = GenerateErrorMessage(pkg).ToString(OutputMode.NonAnsi);
-                            context.Publish(new ErrorProduced(errorMessage, context.Command));
+                            context.Fail(message: errorMessage);
                         }
                     }
 
@@ -194,7 +194,6 @@ namespace Microsoft.DotNet.Interactive
 
                     var requestedPackages =
                         kernel.RequestedPackageReferences
-                              .Except(kernel.ResolvedPackageReferences, PackageReferenceComparer.Instance)
                               .Select(s => s.PackageName).OrderBy(s => s).ToList();
 
                     var requestedSources =
@@ -209,7 +208,6 @@ namespace Microsoft.DotNet.Interactive
 
                     CreateOrUpdateDisplayValue(context, installPackagesPropertyName, installMessage);
 
-                    var currentPackageReferences = kernel.ResolvedPackageReferences?.ToHashSet() ?? new HashSet<ResolvedPackageReference>();
                     var restorePackagesTask = kernel.RestoreAsync();
                     var delay = 500;
                     while (await Task.WhenAny(Task.Delay(delay), restorePackagesTask) != restorePackagesTask)
@@ -227,7 +225,7 @@ namespace Microsoft.DotNet.Interactive
                     var resultMessage = new InstallPackagesMessage(
                             requestedSources,
                             Enumerable.Empty<string>().ToList(),
-                            kernel.ResolvedPackageReferences.Where(r => requestedPackages.Contains(r.PackageName, StringComparer.OrdinalIgnoreCase)).Where(currentPackageReferences.Add).Select(s => $"{s.PackageName}, {s.PackageVersion}").OrderBy(s => s).ToList(),
+                            kernel.ResolvedPackageReferences.Where(r => requestedPackages.Contains(r.PackageName, StringComparer.OrdinalIgnoreCase)).Select(s => $"{s.PackageName}, {s.PackageVersion}").OrderBy(s => s).ToList(),
                             0);
 
                     if (result.Succeeded)

--- a/src/Microsoft.DotNet.Interactive.PackageManagement/PackageRestoreContext.cs
+++ b/src/Microsoft.DotNet.Interactive.PackageManagement/PackageRestoreContext.cs
@@ -91,6 +91,11 @@ namespace Microsoft.DotNet.Interactive
                     {
                         resolvedPackage = requested;
                     }
+                    else
+                    {
+                        // Package already loaded with a different version
+                        return null;
+                    }
                 }
             }
 

--- a/src/Microsoft.DotNet.Interactive.PackageManagement/PackageRestoreContext.cs
+++ b/src/Microsoft.DotNet.Interactive.PackageManagement/PackageRestoreContext.cs
@@ -103,7 +103,7 @@ namespace Microsoft.DotNet.Interactive
 
             PackageReference AppendPathSeparator(PackageReference resolved)
             {
-                if (resolved == null)
+                if (resolved is null)
                 {
                     var newPackageRef = new PackageReference(packageName, packageVersion);
                     _requestedPackageReferences.TryAdd(key, newPackageRef);


### PR DESCRIPTION
Fixes issue: https://github.com/dotnet/interactive/issues/1518

Now produces Installing: and Installed for #r "nuget ...." when it requests an already requested package.

![image](https://user-images.githubusercontent.com/5175830/128104473-5c0f370d-ca30-4baf-b1a5-0d2472da0462.png)


And ...
![image](https://user-images.githubusercontent.com/5175830/128104514-0c17789d-975f-4771-a41a-18e306987f07.png)
