### PR TITLE
[release/dotnet6] enable docker builds on dotnet6 feeds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ RUN echo "\
   </solution>\
   <packageSources>\
     <clear />\
+    <add key=\"dotnet-experimental\" value=\"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json\" />\
     <add key=\"dotnet-public\" value=\"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json\" />\
     <add key=\"dotnet-eng\" value=\"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json\" />\
     <add key=\"dotnet-tools\" value=\"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json\" />\
@@ -80,8 +81,8 @@ USER ${USER}
 #Install nteract 
 RUN pip install nteract_on_jupyter
 
-# Install lastest build from main branch of Microsoft.DotNet.Interactive
-RUN dotnet tool install -g Microsoft.dotnet-interactive --add-source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
+# Install lastest build of Microsoft.DotNet.Interactive
+RUN dotnet tool install -g Microsoft.dotnet-interactive --add-source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json"
 
 ENV PATH="${PATH}:${HOME}/.dotnet/tools"
 RUN echo "$PATH"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -343,47 +343,47 @@ stages:
             command: build
             Dockerfile: "$(Build.SourcesDirectory)/samples/docker-image/Dockerfile"
 
-  # - template: /eng/common/templates/jobs/jobs.yml
-  #   parameters:
-  #     enableMicrobuild: true
-  #     jobs:
-  #     - job: Dockerfile_Main
-  #       pool:
-  #         ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-  #           name: NetCorePublic-Pool
-  #           queue: BuildPool.Ubuntu.1604.amd64.Open
-  #         ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  #           name: NetCoreInternal-Pool
-  #           queue: BuildPool.Ubuntu.1604.amd64
-  #       steps:
-  #       - checkout: self
-  #         clean: true
-  #       - task: Docker@2
-  #         displayName: Build main Dockerfile
-  #         inputs:
-  #           command: build
-  #           Dockerfile: "$(Build.SourcesDirectory)/Dockerfile"
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
+      enableMicrobuild: true
+      jobs:
+      - job: Dockerfile_Main
+        pool:
+          ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+            name: NetCorePublic-Pool
+            queue: BuildPool.Ubuntu.1604.amd64.Open
+          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+            name: NetCoreInternal-Pool
+            queue: BuildPool.Ubuntu.1604.amd64
+        steps:
+        - checkout: self
+          clean: true
+        - task: Docker@2
+          displayName: Build main Dockerfile
+          inputs:
+            command: build
+            Dockerfile: "$(Build.SourcesDirectory)/Dockerfile"
 
-  # - template: /eng/common/templates/jobs/jobs.yml
-  #   parameters:
-  #     enableMicrobuild: true
-  #     jobs:
-  #     - job: Dockerfile_Binder_Dependency
-  #       pool:
-  #         ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-  #           name: NetCorePublic-Pool
-  #           queue: BuildPool.Ubuntu.1604.amd64.Open
-  #         ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  #           name: NetCoreInternal-Pool
-  #           queue: BuildPool.Ubuntu.1604.amd64
-  #       steps:
-  #       - checkout: self
-  #         clean: true
-  #       - task: Docker@2
-  #         displayName: Build Binder dependency Dockerfile
-  #         inputs:
-  #           command: build
-  #           Dockerfile: "$(Build.SourcesDirectory)/samples/my binder/Dockerfile"
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
+      enableMicrobuild: true
+      jobs:
+      - job: Dockerfile_Binder_Dependency
+        pool:
+          ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+            name: NetCorePublic-Pool
+            queue: BuildPool.Ubuntu.1604.amd64.Open
+          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+            name: NetCoreInternal-Pool
+            queue: BuildPool.Ubuntu.1604.amd64
+        steps:
+        - checkout: self
+          clean: true
+        - task: Docker@2
+          displayName: Build Binder dependency Dockerfile
+          inputs:
+            command: build
+            Dockerfile: "$(Build.SourcesDirectory)/samples/my binder/Dockerfile"
 
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:

--- a/samples/my binder/Dockerfile
+++ b/samples/my binder/Dockerfile
@@ -64,6 +64,7 @@ RUN echo "\
   </solution>\
   <packageSources>\
     <clear />\
+    <add key=\"dotnet-experimental\" value=\"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json\" />\
     <add key=\"dotnet-public\" value=\"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json\" />\
     <add key=\"dotnet-eng\" value=\"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json\" />\
     <add key=\"dotnet-tools\" value=\"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json\" />\
@@ -82,8 +83,8 @@ USER ${USER}
 # Install nteract 
 RUN pip install nteract_on_jupyter
 
-# Install lastest build from master branch of Microsoft.DotNet.Interactive
-RUN dotnet tool install -g Microsoft.dotnet-interactive --add-source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
+# Install lastest build of Microsoft.DotNet.Interactive
+RUN dotnet tool install -g Microsoft.dotnet-interactive --add-source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json"
 
 # Latest stable from nuget.org
 #RUN dotnet tool install -g Microsoft.dotnet-interactive --add-source "https://api.nuget.org/v3/index.json"


### PR DESCRIPTION
Follow-up to #1477, this PR re-enables the Docker CI checks, but against the `dotnet-experimental` feeds where the .NET 6 packages of this repo are being published.  The experimental feed is being used so that we don't pollute the commonly used `dotnet-tools` feed with incompatible builds.