### PR TITLE
Add a separate `vscode` command

### DIFF
--- a/src/dotnet-interactive-vscode/common/stdioKernelTransport.ts
+++ b/src/dotnet-interactive-vscode/common/stdioKernelTransport.ts
@@ -5,8 +5,6 @@ import { AddressInfo, createServer } from "net";
 import * as cp from 'child_process';
 import {
     DisposableSubscription,
-    KernelCommand,
-    KernelCommandType,
     KernelEventEnvelope,
     KernelEventEnvelopeObserver,
     KernelTransport,
@@ -52,6 +50,7 @@ export class StdioKernelTransport implements KernelTransport {
 
             let args = await this.configureHttpArgs(processStart.args);
             // launch the process
+            this.diagnosticChannel.appendLine(`Starting kernel for '${notebookPath}' using: ${processStart.command} ${args.join(' ')}`);
             let childProcess = cp.spawn(processStart.command, args, { cwd: processStart.workingDirectory });
             let pid = childProcess.pid;
 

--- a/src/dotnet-interactive-vscode/insiders/package.json
+++ b/src/dotnet-interactive-vscode/insiders/package.json
@@ -106,8 +106,7 @@
             "run",
             "dotnet-interactive",
             "--",
-            "[vscode]",
-            "stdio",
+            "vscode",
             "--working-dir",
             "{working_dir}"
           ],

--- a/src/dotnet-interactive/CommandLine/VSCodeCommand.cs
+++ b/src/dotnet-interactive/CommandLine/VSCodeCommand.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.CommandLine;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Interactive.Server;
+
+namespace Microsoft.DotNet.Interactive.App.CommandLine
+{
+    internal static class VSCodeCommand
+    {
+        public static async Task<int> Do(StartupOptions startupOptions, KernelServer kernelServer, IConsole console)
+        {
+            var disposable = Program.StartToolLogging(startupOptions);
+            var run = kernelServer.RunAsync();
+            kernelServer.NotifyIsReady();
+            await run;
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
For now the behavior is exactly the same as `[vscode] stdio`, but shortly the behaviors will start to diverge.