### PR TITLE
fix issue with casting to ISupportNugetPackage

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Kql/KqlKernelConnection.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql/KqlKernelConnection.cs
@@ -33,37 +33,10 @@ namespace Microsoft.DotNet.Interactive.Kql
             KernelInvocationContext context)
         {
             var connectionDetails = await BuildConnectionDetailsAsync(options);
-
-            var resolvedPackageReferences = ((ISupportNuget)context.HandlingKernel).ResolvedPackageReferences;
-            // Walk through the packages looking for the package that endswith the name "Microsoft.SqlToolsService"
-            // and grab the packageroot
-            var runtimePackageIdSuffix = "native.Microsoft.SqlToolsService";
-            var root = resolvedPackageReferences.FirstOrDefault(p => p.PackageName.EndsWith(runtimePackageIdSuffix, StringComparison.OrdinalIgnoreCase));
-            string pathToService = "";
             
-            if (root is not null)
-            {
-                // Extract the platform 'osx-x64' from the package name 'runtime.osx-x64.native.microsoft.sqltoolsservice'
-                string[] packageNameSegments = root.PackageName.Split(".");
-                if (packageNameSegments.Length > 2)
-                {
-                    string platform = packageNameSegments[1];
-                    
-                    // Build the path to the MicrosoftSqlToolsServiceLayer executable by reaching into the resolve nuget package
-                    // assuming a convention for native binaries.
-                    pathToService = Path.Combine(
-                        root.PackageRoot,
-                        "runtimes",
-                        platform,
-                        "native",
-                        "MicrosoftKustoServiceLayer");
-                    
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                    {
-                        pathToService += ".exe";
-                    }
-                }
-            }
+            var root = Kernel.Root.FindResolvedPackageReference();
+
+            var pathToService = root.PathToService("MicrosoftKustoServiceLayer");
 
             var sqlClient = new ToolsServiceClient(pathToService);
 

--- a/src/Microsoft.DotNet.Interactive.Kql/Microsoft.DotNet.Interactive.Kql.csproj
+++ b/src/Microsoft.DotNet.Interactive.Kql/Microsoft.DotNet.Interactive.Kql.csproj
@@ -18,6 +18,7 @@
    <Compile Include="..\Microsoft.DotNet.Interactive.SqlServer\MsSqlRpcObjects.cs">
      <Link>MsSqlRpcObjects.cs</Link>
    </Compile>
+   <Compile Include="..\Microsoft.DotNet.Interactive.SqlServer\SqlToolsServiceDiscovery.cs" Link="SqlToolsServiceDiscovery.cs" />
    <Compile Include="..\Microsoft.DotNet.Interactive.SqlServer\ToolsServiceClient.cs">
      <Link>ToolsServiceClient.cs</Link>
    </Compile>

--- a/src/Microsoft.DotNet.Interactive.SqlServer/SqlToolsServiceDiscovery.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/SqlToolsServiceDiscovery.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.DotNet.Interactive.SqlServer
+{
+    internal static class SqlToolsServiceDiscovery
+    {
+        public static ResolvedPackageReference FindResolvedPackageReference(this Kernel rootKernel)
+        {
+            var runtimePackageIdSuffix = "native.Microsoft.SqlToolsService";
+            foreach (var kernel in rootKernel.SubkernelsAndSelf().OfType<ISupportNuget>())
+            {
+                var resolvedPackageReferences = kernel.ResolvedPackageReferences;
+
+                // Walk through the packages looking for the package that ends with the name "Microsoft.SqlToolsService"
+                // and grab the packageroot
+
+                var resolved = resolvedPackageReferences.FirstOrDefault(p => p.PackageName.EndsWith(runtimePackageIdSuffix, StringComparison.OrdinalIgnoreCase));
+
+                if (resolved is { })
+                {
+                    return resolved;
+                }
+
+            }
+            ;
+            return null;
+        }
+
+        public static string PathToService(this ResolvedPackageReference resolvedPackageReference, string serviceName)
+        {
+            var pathToService = "";
+            if (resolvedPackageReference is not null)
+            {
+                // Extract the platform 'osx-x64' from the package name 'runtime.osx-x64.native.microsoft.sqltoolsservice'
+                string[] packageNameSegments = resolvedPackageReference.PackageName.Split(".");
+                if (packageNameSegments.Length > 2)
+                {
+                    string platform = packageNameSegments[1];
+
+                    // Build the path to the MicrosoftSqlToolsServiceLayer executable by reaching into the resolve nuget package
+                    // assuming a convention for native binaries.
+                    pathToService = Path.Combine(
+                        resolvedPackageReference.PackageRoot,
+                        "runtimes",
+                        platform,
+                        "native",
+                        serviceName);
+
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    {
+                        pathToService += ".exe";
+                    }
+                }
+            }
+
+            return pathToService;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
@@ -373,9 +373,20 @@ namespace Microsoft.DotNet.Interactive
             Action<Kernel> onVisit,
             bool recursive = false)
         {
-            onVisit(kernel);
+            if (kernel is null)
+            {
+                throw new ArgumentNullException(nameof(kernel));
+            }
 
-            VisitSubkernels(kernel, onVisit, recursive);
+            if (onVisit is null)
+            {
+                throw new ArgumentNullException(nameof(onVisit));
+            }
+
+            foreach (var k in kernel.SubkernelsAndSelf(recursive))
+            {
+                onVisit(k);
+            }
         }
 
         public static async Task VisitSubkernelsAsync(
@@ -404,9 +415,20 @@ namespace Microsoft.DotNet.Interactive
             Func<Kernel, Task> onVisit,
             bool recursive = false)
         {
-            await onVisit(kernel);
+            if (kernel is null)
+            {
+                throw new ArgumentNullException(nameof(kernel));
+            }
 
-            await VisitSubkernelsAsync(kernel, onVisit, recursive);
+            if (onVisit is null)
+            {
+                throw new ArgumentNullException(nameof(onVisit));
+            }
+
+            foreach (var k in kernel.SubkernelsAndSelf(recursive))
+            {
+                await onVisit(k);
+            }
         }
 
         public static IEnumerable<Kernel> SubkernelsAndSelf(

--- a/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
@@ -424,5 +424,22 @@ namespace Microsoft.DotNet.Interactive
 
             await VisitSubkernelsAsync(kernel, onVisit, recursive);
         }
+
+        public static IEnumerable<Kernel> SubkernelsAndSelf(
+            this Kernel kernel)
+        {
+            yield return kernel;
+
+            if (kernel is CompositeKernel compositeKernel)
+            {
+                foreach (var subKernel in compositeKernel.ChildKernels)
+                {
+                    foreach (var recursive in subKernel.SubkernelsAndSelf())
+                    {
+                        yield return recursive;
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/dotnet-interactive.Tests/dotnet-interactive.Tests.v3.ncrunchproject
+++ b/src/dotnet-interactive.Tests/dotnet-interactive.Tests.v3.ncrunchproject
@@ -17,6 +17,21 @@
       <NamedTestSelector>
         <TestName>Microsoft.DotNet.Interactive.App.Tests.TypeScriptInterfacesContractTests.http_generated_TypeScript_interfaces_file_has_known_shape</TestName>
       </NamedTestSelector>
+      <NamedTestSelector>
+        <TestName>Microsoft.DotNet.Interactive.Tests.StdIOConnectionTests.stdio_server_encoding_is_utf_8</TestName>
+      </NamedTestSelector>
+      <NamedTestSelector>
+        <TestName>Microsoft.DotNet.Interactive.Tests.StdIOConnectionTests.dotnet_kernels_can_execute_code("PowerShell", "2")</TestName>
+      </NamedTestSelector>
+      <NamedTestSelector>
+        <TestName>Microsoft.DotNet.Interactive.Tests.StdIOConnectionTests.dotnet_kernels_can_execute_code("FSharp", "&lt;div class=\"dni-plaintext\"&gt;2&lt;/div&gt;")</TestName>
+      </NamedTestSelector>
+      <NamedTestSelector>
+        <TestName>Microsoft.DotNet.Interactive.Tests.StdIOConnectionTests.dotnet_kernels_can_execute_code("CSharp", "&lt;div class=\"dni-plaintext\"&gt;2&lt;/div&gt;")</TestName>
+      </NamedTestSelector>
+      <NamedTestSelector>
+        <TestName>Microsoft.DotNet.Interactive.App.Tests.HttpApiTests.kernel_server_returns_javascript_api_via_http</TestName>
+      </NamedTestSelector>
     </IgnoredTests>
   </Settings>
 </ProjectConfiguration>


### PR DESCRIPTION
When performing #!connect is kql and sql connection assume that the command is handled in a kernel that supports nuget packages. 