### PR TITLE
hunting test deadlocks

### DIFF
--- a/src/Microsoft.DotNet.Interactive.FSharp/FsAutoComplete/Utils.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp/FsAutoComplete/Utils.fs
@@ -30,7 +30,7 @@ open System.Threading.Tasks
 
 module internal ProcessHelper =
     let WaitForExitAsync(p: Process) = async {
-        let tcs = new TaskCompletionSource<obj>()
+        let tcs = new TaskCompletionSource<obj>(TaskCreationOptions.RunContinuationsAsynchronously)
         p.EnableRaisingEvents <- true
         p.Exited.Add(fun _args -> tcs.TrySetResult(null) |> ignore)
 

--- a/src/Microsoft.DotNet.Interactive.Http/HtmlNotebookFrontendEnvironment.cs
+++ b/src/Microsoft.DotNet.Interactive.Http/HtmlNotebookFrontendEnvironment.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.Interactive.Http
         public HtmlNotebookFrontendEnvironment(TimeSpan? apiUriTimeout = null)
         {
             RequiresAutomaticBootstrapping = true;
-            _completionSource = new TaskCompletionSource<Uri>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _completionSource = new TaskCompletionSource<Uri>();
             _tokenToInvocationContext = new Dictionary<string, (KernelInvocationContext, TaskCompletionSource)>();
             _getApiUriTimeout = apiUriTimeout ?? TimeSpan.FromSeconds(30);
         }
@@ -37,7 +37,6 @@ namespace Microsoft.DotNet.Interactive.Http
         {
             _completionSource.TrySetResult(apiUri);
         }
-
 
         public Task<Uri> GetApiUriAsync()
         {
@@ -111,6 +110,5 @@ await Object.getPrototypeOf(async function() {{}}).constructor(
 
             _tokenToInvocationContext.Remove(token);
         }
-
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Http/HtmlNotebookFrontendEnvironment.cs
+++ b/src/Microsoft.DotNet.Interactive.Http/HtmlNotebookFrontendEnvironment.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using System.Web;
 using Microsoft.AspNetCore.Html;
 using Microsoft.DotNet.Interactive.Commands;
-using Microsoft.DotNet.Interactive.Connection;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Formatting;
 
@@ -17,12 +16,12 @@ namespace Microsoft.DotNet.Interactive.Http
     {
         private readonly TimeSpan _getApiUriTimeout;
         private readonly TaskCompletionSource<Uri> _completionSource;
-        private Dictionary<string, (KernelInvocationContext Context, TaskCompletionSource CompletionSource)> _tokenToInvocationContext;
+        private readonly Dictionary<string, (KernelInvocationContext Context, TaskCompletionSource CompletionSource)> _tokenToInvocationContext;
        
         public HtmlNotebookFrontendEnvironment(TimeSpan? apiUriTimeout = null)
         {
             RequiresAutomaticBootstrapping = true;
-            _completionSource = new TaskCompletionSource<Uri>();
+            _completionSource = new TaskCompletionSource<Uri>(TaskCreationOptions.RunContinuationsAsynchronously);
             _tokenToInvocationContext = new Dictionary<string, (KernelInvocationContext, TaskCompletionSource)>();
             _getApiUriTimeout = apiUriTimeout ?? TimeSpan.FromSeconds(30);
         }
@@ -85,7 +84,7 @@ await Object.getPrototypeOf(async function() {{}}).constructor(
 }}
 ".Replace("\r\n", "\n");
             var wrappedCode = $"{codePrelude}{HttpUtility.JavaScriptStringEncode(code)}{codePostlude}";
-            var executionCompletionSource = new TaskCompletionSource();
+            var executionCompletionSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             _tokenToInvocationContext[commandToken] = (context, executionCompletionSource);
             IHtmlContent content = PocketViewTags.script[type: "text/javascript"](wrappedCode.ToHtmlContent());
             var formattedValues = FormattedValue.FromObject(content);

--- a/src/Microsoft.DotNet.Interactive.Jupyter/JupyterRequestContext.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/JupyterRequestContext.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter
 {
     public class JupyterRequestContext
     {
-        private readonly TaskCompletionSource<Unit> _done = new TaskCompletionSource<Unit>();
+        private readonly TaskCompletionSource<Unit> _done = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         internal static JupyterRequestContext Current { get; set; }
 

--- a/src/Microsoft.DotNet.Interactive.PowerShell/AzureShellConnection.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/AzureShellConnection.cs
@@ -287,7 +287,7 @@ namespace Microsoft.DotNet.Interactive.PowerShell
         {
             if (waitForExecutionCompletion)
             {
-                _codeExecutedTaskSource = new TaskCompletionSource<object>();
+                _codeExecutedTaskSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             }
 
             // The command could contain multi-line statement, which would require double line endings

--- a/src/Microsoft.DotNet.Interactive.SqlServer/ToolsServiceKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/ToolsServiceKernel.cs
@@ -106,7 +106,7 @@ namespace Microsoft.DotNet.Interactive.SqlServer
                 return;
             }
 
-            var completion = new TaskCompletionSource<bool>();
+            var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             _queryCompletionHandler = async queryParams =>
             {

--- a/src/Microsoft.DotNet.Interactive.VSCode/VSCodeInteractiveHost.cs
+++ b/src/Microsoft.DotNet.Interactive.VSCode/VSCodeInteractiveHost.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.Interactive.VSCode
         public Task<string> GetInputAsync(string prompt = "", bool isPassword = false, CancellationToken cancellationToken = default)
         {
             var command = new GetInput(prompt, isPassword, targetKernelName: VSCodeKernelName);
-            var completionSource = new TaskCompletionSource<string>();
+            var completionSource = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
             var token = command.GetToken();
             _kernel.KernelEvents.Where(e => e.Command.GetToken() == token).Subscribe(e =>
             {

--- a/src/dotnet-interactive.Tests/InProcessTestServer.cs
+++ b/src/dotnet-interactive.Tests/InProcessTestServer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.Interactive.App.Tests
         {
             var server = new InProcessTestServer();
 
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var parser = CommandLineParser.Create(
                 server._serviceCollection,
                 (startupOptions, invocationContext) =>


### PR DESCRIPTION
This sprinkles around some `TaskCreationOptions.RunContinuationsAsynchronously` to see if it's the cause of intermittent deadlocks in some tests.