### PR TITLE
Updating all Microsoft.CodeAnalysis.* packages to version 4.0.0-4.final to support C# 10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
 
   <PropertyGroup>
     <SystemReactiveVersion>5.0.0</SystemReactiveVersion>
-    <MicrosoftCodeAnalysisCommonVersion>3.11.0</MicrosoftCodeAnalysisCommonVersion>
+    <MicrosoftCodeAnalysisCommonVersion>4.0.0-4.final</MicrosoftCodeAnalysisCommonVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
C# 10 is supported starting from version `4` and the current `3.11.0` version does not support it yet.
This PR updates all `Microsoft.CodeAnalysis.*` packages to the prerelease version `4.0.0-4.final` which enables C# 10 support in Interactive Notebooks running on .NET 6