### PR TITLE
support multiple mimeType

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/NteractKernelExtensionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/NteractKernelExtensionTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab.Tests
         }
 
         [Fact]
-        public async Task it_registers_tabularResource_formatter()
+        public async Task it_registers_TabularDataResourceFormatter()
         {
             using var kernel = new CompositeKernel();
 

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/SandDanceKernelExtensionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/SandDanceKernelExtensionTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 
 using Assent;
@@ -11,7 +12,7 @@ using Assent;
 using FluentAssertions;
 
 using Microsoft.DotNet.Interactive.Formatting;
-
+using Microsoft.DotNet.Interactive.Formatting.TabularData;
 using Xunit;
 
 namespace Microsoft.DotNet.Interactive.ExtensionLab.Tests
@@ -28,7 +29,22 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab.Tests
         }
 
         [Fact]
-        public async Task it_registers_formatters()
+        public async Task it_configures_preferred_mimeTypes()
+        {
+            using var kernel = new CompositeKernel();
+
+            var kernelExtension = new SandDanceKernelExtension();
+
+            await kernelExtension.OnLoadAsync(kernel);
+
+            var mimetypes = Formatter.GetPreferredMimeTypesFor(typeof(SandDanceDataExplorer)).Distinct();
+
+            mimetypes
+                .Should().BeEquivalentTo(HtmlFormatter.MimeType, TabularDataResourceFormatter.MimeType);
+        }
+        
+        [Fact]
+        public async Task it_registers_html_formatter()
         {
             using var kernel = new CompositeKernel();
 
@@ -46,6 +62,50 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab.Tests
             var formatted = data.ExploreWithSandDance().ToDisplayString(HtmlFormatter.MimeType);
 
             formatted.Should().Contain("configureRequireFromExtension('SandDance','1.0.0')(['SandDance/sanddanceapi'], (sandDance) => {");
+        }
+
+        [Fact]
+        public async Task it_registers_tabularResource_formatter()
+        {
+            using var kernel = new CompositeKernel();
+
+            var kernelExtension = new SandDanceKernelExtension();
+
+            await kernelExtension.OnLoadAsync(kernel);
+
+            var data = new[]
+            {
+                new {Type="orange", Price=1.2},
+                new {Type="apple" , Price=1.3},
+                new {Type="grape" , Price=1.4}
+            };
+
+
+            var formattedValue = data.ExploreWithSandDance().ToDisplayString(TabularDataResourceFormatter.MimeType);
+            formattedValue.Should().Contain("\"profile\": \"tabular-data-resource\"");
+        }
+
+        [Fact]
+        public async Task it_is_formatted_as_multiple_mimeTypes()
+        {
+            using var kernel = new CompositeKernel();
+
+            var kernelExtension = new SandDanceKernelExtension();
+
+            await kernelExtension.OnLoadAsync(kernel);
+
+            var data = new[]
+            {
+                new {Type="orange", Price=1.2},
+                new {Type="apple" , Price=1.3},
+                new {Type="grape" , Price=1.4}
+            };
+
+
+            var formattedValues = FormattedValue.FromObject(data.ExploreWithSandDance());
+            formattedValues.Select(fv => fv.MimeType)
+                .Should()
+                .BeEquivalentTo(HtmlFormatter.MimeType, TabularDataResourceFormatter.MimeType);
         }
 
         [Fact]

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/SandDanceKernelExtensionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/SandDanceKernelExtensionTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab.Tests
         }
 
         [Fact]
-        public async Task it_registers_tabularResource_formatter()
+        public async Task it_registers_TabularDataResourceFormatter()
         {
             using var kernel = new CompositeKernel();
 

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/FormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/FormatterTests.cs
@@ -165,38 +165,6 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
                 widget.ToDisplayString().Should().Be(defaultValue);
             }
-
-            [Fact]
-            public void Check_default_formatting_of_strings_with_escapes()
-            {
-                var value = "hola! \n \t \" \" ' ' the joy of escapes! and    white  space  ";
-
-                var mimeType = Formatter.GetPreferredMimeTypesFor(typeof(string));
-                var text = value.ToDisplayString(mimeType.FirstOrDefault());
-
-                mimeType.Should().BeEquivalentTo("text/plain");
-                text.Should().Be(value);
-            }
-
-            [Fact]
-            public void Check_default_HTML_formatting_of_strings_with_escapes()
-            {
-                var value = "hola! \n \t \" \" ' ' the joy of escapes! ==> &   white  space  ";
-
-                var text = value.ToDisplayString("text/html");
-
-                text.Should().Be("<div class=\"dni-plaintext\">hola! \n \t &quot; &quot; &#39; &#39; the joy of escapes! ==&gt; &amp;   white  space  </div>");
-            }
-
-            [Fact]
-            public void Check_default_HTML_formatting_of_unicode()
-            {
-                var value = "hola! ʰ˽˵ΘϱϪԘÓŴ𝓌🦁♿🌪🍒☝🏿";
-
-                var text = value.ToDisplayString("text/html");
-
-                text.Should().Be($"<div class=\"dni-plaintext\">{value.HtmlEncode()}</div>");
-            }
         }
 
         public class Registration : FormatterTestBase

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/FormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/FormatterTests.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.IO;
+using System.Linq;
 using FluentAssertions;
 using System.Reflection;
 using System.Text.Json;
@@ -170,10 +171,10 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
             {
                 var value = "hola! \n \t \" \" ' ' the joy of escapes! and    white  space  ";
 
-                var mimeType = Formatter.GetPreferredMimeTypeFor(typeof(string));
-                var text = value.ToDisplayString(mimeType);
+                var mimeType = Formatter.GetPreferredMimeTypesFor(typeof(string));
+                var text = value.ToDisplayString(mimeType.FirstOrDefault());
 
-                mimeType.Should().Be("text/plain");
+                mimeType.Should().BeEquivalentTo("text/plain");
                 text.Should().Be(value);
             }
 
@@ -650,9 +651,9 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
             {
                 Formatter.DefaultMimeType = mimeType;
 
-                Formatter.GetPreferredMimeTypeFor(typeof(int)).Should().Be(mimeType);
-                Formatter.GetPreferredMimeTypeFor(typeof(object)).Should().Be(mimeType);
-                Formatter.GetPreferredMimeTypeFor(typeof(Type)).Should().Be(mimeType);
+                Formatter.GetPreferredMimeTypesFor(typeof(int)).Should().BeEquivalentTo(mimeType);
+                Formatter.GetPreferredMimeTypesFor(typeof(object)).Should().BeEquivalentTo(mimeType);
+                Formatter.GetPreferredMimeTypesFor(typeof(Type)).Should().BeEquivalentTo(mimeType);
             }
 
             [Theory]
@@ -660,13 +661,13 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
             [InlineData("text/html")]
             public void Type_specific_mime_type_preference_applies_to_derived_types(string mimeType)
             {
-                Formatter.SetPreferredMimeTypeFor(typeof(object), mimeType);
+                Formatter.SetPreferredMimeTypesFor(typeof(object), mimeType);
 
-                Formatter.GetPreferredMimeTypeFor(typeof(int)).Should().Be(mimeType);
-                Formatter.GetPreferredMimeTypeFor(typeof(object)).Should().Be(mimeType);
-                Formatter.GetPreferredMimeTypeFor(typeof(string)).Should().Be(mimeType);
-                Formatter.GetPreferredMimeTypeFor(typeof(Type)).Should().Be(mimeType);
-                Formatter.GetPreferredMimeTypeFor(typeof(JsonElement)).Should().Be(mimeType);
+                Formatter.GetPreferredMimeTypesFor(typeof(int)).Should().BeEquivalentTo(mimeType);
+                Formatter.GetPreferredMimeTypesFor(typeof(object)).Should().BeEquivalentTo(mimeType);
+                Formatter.GetPreferredMimeTypesFor(typeof(string)).Should().BeEquivalentTo(mimeType);
+                Formatter.GetPreferredMimeTypesFor(typeof(Type)).Should().BeEquivalentTo(mimeType);
+                Formatter.GetPreferredMimeTypesFor(typeof(JsonElement)).Should().BeEquivalentTo(mimeType);
             }
 
             [Theory]
@@ -676,17 +677,17 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
             public void Last_specified_type_specific_mime_type_preference_applies_to_non_specified_derived_types(string mimeType)
             {
                 // the last one should win
-                Formatter.SetPreferredMimeTypeFor(typeof(object), mimeType);
-                Formatter.SetPreferredMimeTypeFor(typeof(object), "text/plain");
-                Formatter.SetPreferredMimeTypeFor(typeof(object), mimeType);
-                Formatter.SetPreferredMimeTypeFor(typeof(object), "text/html");
-                Formatter.SetPreferredMimeTypeFor(typeof(object), mimeType);
+                Formatter.SetPreferredMimeTypesFor(typeof(object), mimeType);
+                Formatter.SetPreferredMimeTypesFor(typeof(object), "text/plain");
+                Formatter.SetPreferredMimeTypesFor(typeof(object), mimeType);
+                Formatter.SetPreferredMimeTypesFor(typeof(object), "text/html");
+                Formatter.SetPreferredMimeTypesFor(typeof(object), mimeType);
 
-                Formatter.GetPreferredMimeTypeFor(typeof(int)).Should().Be(mimeType);
-                Formatter.GetPreferredMimeTypeFor(typeof(object)).Should().Be(mimeType);
-                Formatter.GetPreferredMimeTypeFor(typeof(string)).Should().Be(mimeType);
-                Formatter.GetPreferredMimeTypeFor(typeof(Type)).Should().Be(mimeType);
-                Formatter.GetPreferredMimeTypeFor(typeof(JsonElement)).Should().Be(mimeType);
+                Formatter.GetPreferredMimeTypesFor(typeof(int)).Should().BeEquivalentTo(mimeType);
+                Formatter.GetPreferredMimeTypesFor(typeof(object)).Should().BeEquivalentTo(mimeType);
+                Formatter.GetPreferredMimeTypesFor(typeof(string)).Should().BeEquivalentTo(mimeType);
+                Formatter.GetPreferredMimeTypesFor(typeof(Type)).Should().BeEquivalentTo(mimeType);
+                Formatter.GetPreferredMimeTypesFor(typeof(JsonElement)).Should().BeEquivalentTo(mimeType);
             }
 
             [Theory]
@@ -695,10 +696,10 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
             [InlineData("text/whacky")]
             public void Formatters_can_override_default_preference_for_base_type(string mimeType)
             {
-                Formatter.SetPreferredMimeTypeFor(typeof(object), "text/default");
-                Formatter.SetPreferredMimeTypeFor(typeof(int), mimeType);
+                Formatter.SetPreferredMimeTypesFor(typeof(object), "text/default");
+                Formatter.SetPreferredMimeTypesFor(typeof(int), mimeType);
 
-                Formatter.GetPreferredMimeTypeFor(typeof(int)).Should().Be(mimeType);
+                Formatter.GetPreferredMimeTypesFor(typeof(int)).Should().BeEquivalentTo(mimeType);
             }
 
             [Theory]
@@ -708,9 +709,9 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
             public void Formatters_can_override_default_mime_type(string mimeType)
             {
                 Formatter.DefaultMimeType = "text/default";
-                Formatter.SetPreferredMimeTypeFor(typeof(int), mimeType);
+                Formatter.SetPreferredMimeTypesFor(typeof(int), mimeType);
 
-                Formatter.GetPreferredMimeTypeFor(typeof(int)).Should().Be(mimeType);
+                Formatter.GetPreferredMimeTypesFor(typeof(int)).Should().BeEquivalentTo(mimeType);
             }
 
             [Theory]
@@ -719,10 +720,10 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
             [InlineData("text/whacky")]
             public void Formatters_can_clear_default_preference_for_single_type(string mimeType)
             {
-                Formatter.SetPreferredMimeTypeFor(typeof(int), mimeType);
+                Formatter.SetPreferredMimeTypesFor(typeof(int), mimeType);
                 Formatter.ResetToDefault();
 
-                Formatter.GetPreferredMimeTypeFor(typeof(int)).Should().Be("text/html");
+                Formatter.GetPreferredMimeTypesFor(typeof(int)).Should().BeEquivalentTo("text/html");
             }
         }
     }

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -1270,6 +1270,26 @@ string";
 
                 html.Should().Contain(
                     "<tr><td><span>&quot;apple&quot;</span></td></tr><tr><td><span>&quot;banana&quot;</span></td></tr><tr><td><span>&quot;cherry&quot;</span></td></tr>");
+            }
+
+            [Fact]
+            public void Strings_with_escaped_sequences_are_encoded()
+            {
+                var value = "hola! \n \t \" \" ' ' the joy of escapes! ==> &   white  space  ";
+
+                var text = value.ToDisplayString("text/html");
+
+                text.Should().Be("<div class=\"dni-plaintext\">hola! \n \t &quot; &quot; &#39; &#39; the joy of escapes! ==&gt; &amp;   white  space  </div>");
+            }
+
+            [Fact]
+            public void Strings_with_unicode_sequences_are_encoded()
+            {
+                var value = "hola! ʰ˽˵ΘϱϪԘÓŴ𝓌🦁♿🌪🍒☝🏿";
+
+                var text = value.ToDisplayString("text/html");
+
+                text.Should().Be($"<div class=\"dni-plaintext\">{value.HtmlEncode()}</div>");
             }
         }
     }

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/PlainTextFormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/PlainTextFormatterTests.cs
@@ -551,6 +551,20 @@ namespace Microsoft.DotNet.Interactive.Formatting.Tests
 
                 writer.ToString().Should().Be("[ 1, <null>, 3 ]");
             }
+
+            [Fact]
+            public void Strings_with_escaped_sequences_are_preserved()
+            {
+                var formatter = PlainTextFormatter.GetPreferredFormatterFor(typeof(string));
+                
+                var value = "hola! \n \t \" \" ' ' the joy of escapes! and    white  space  ";
+
+                var writer = new StringWriter();
+
+                formatter.Format(value, writer);
+
+                writer.ToString().Should().Be(value);
+            }
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Formatting/DefaultTabularDataFormatterSet.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/DefaultTabularDataFormatterSet.cs
@@ -16,15 +16,7 @@ namespace Microsoft.DotNet.Interactive.Formatting
                     var tabularDataSet = value.Cast<object>().ToTabularDataResource();
                     var tabularData = tabularDataSet.ToJsonString();
                     context.Writer.Write(tabularData.ToString());
-                    return true;
-                }),
-
-                new TabularDataResourceFormatter<TabularDataResource>((value, context) =>
-                {
-                    var tabularData = value.ToJsonString();
-                    context.Writer.Write(tabularData);
-                    return true;
-                }),
+                })
             };
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Formatting/JsonFormatter{T}.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/JsonFormatter{T}.cs
@@ -33,6 +33,17 @@ namespace Microsoft.DotNet.Interactive.Formatting
             _format = format;
         }
 
+        public JsonFormatter(Action<T, FormatContext> format)
+        {
+            _format = FormatInstance;
+
+            bool FormatInstance(T instance, FormatContext context)
+            {
+                format(instance, context);
+                return true;
+            }
+        }
+
         public override string MimeType { get; } = JsonFormatter.MimeType;
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Formatting/TabularData/TabularDataFormatterSource.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/TabularData/TabularDataFormatterSource.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using Microsoft.AspNetCore.Html;
 using static Microsoft.DotNet.Interactive.Formatting.PocketViewTags;
 
@@ -26,6 +27,20 @@ namespace Microsoft.DotNet.Interactive.Formatting.TabularData
                          .ToArray();
 
                 Html.Table(headers, rows).WriteTo(context);
+            });
+
+            yield return new JsonFormatter<TabularDataResource>((value, context) =>
+            {
+                var json = JsonSerializer.Serialize(value.Data, TabularDataResourceFormatter.JsonSerializerOptions);
+
+                context.Writer.Write(json);
+            });
+
+            yield return new TabularDataResourceFormatter<TabularDataResource>((value, context) =>
+            {
+                var json = JsonSerializer.Serialize(value, TabularDataResourceFormatter.JsonSerializerOptions);
+
+                context.Writer.Write(json);
             });
         }
     }

--- a/src/Microsoft.DotNet.Interactive.Formatting/TabularData/TabularDataResourceFormatter{T}.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/TabularData/TabularDataResourceFormatter{T}.cs
@@ -14,6 +14,17 @@ namespace Microsoft.DotNet.Interactive.Formatting.TabularData
             _format = format;
         }
 
+        public TabularDataResourceFormatter(Action<T, FormatContext> format)
+        {
+            _format = FormatInstance;
+
+            bool FormatInstance(T instance, FormatContext context)
+            {
+                format(instance, context);
+                return true;
+            }
+        }
+
         public override bool Format(T value, FormatContext context)
         {
             return _format(value, context);

--- a/src/Microsoft.DotNet.Interactive/Commands/RequestValue.cs
+++ b/src/Microsoft.DotNet.Interactive/Commands/RequestValue.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Formatting;
@@ -32,7 +33,7 @@ namespace Microsoft.DotNet.Interactive.Commands
                     if (value is { })
                     {
                         var valueType = value.GetType();
-                        var mimeType = MimeType ?? Formatter.GetPreferredMimeTypeFor(valueType);
+                        var mimeType = MimeType ?? Formatter.GetPreferredMimeTypesFor(valueType).FirstOrDefault();
                         var formatter = Formatter.GetPreferredFormatterFor(valueType, mimeType);
                         if (formatter.MimeType != mimeType)
                         {
@@ -46,7 +47,7 @@ namespace Microsoft.DotNet.Interactive.Commands
                     }
                     else
                     {
-                        var mimeType = MimeType ?? Formatter.GetPreferredMimeTypeFor(typeof(object));
+                        var mimeType = MimeType ?? Formatter.GetPreferredMimeTypesFor(typeof(object)).FirstOrDefault();
                         var formatted = new FormattedValue(mimeType, "null");
 
                         context.Publish(new ValueProduced(value, Name, formatted, this));

--- a/src/Microsoft.DotNet.Interactive/Commands/RequestValue.cs
+++ b/src/Microsoft.DotNet.Interactive/Commands/RequestValue.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.Interactive.Commands
                     if (value is { })
                     {
                         var valueType = value.GetType();
-                        var mimeType = MimeType ?? Formatter.GetPreferredMimeTypesFor(valueType).FirstOrDefault();
+                        var mimeType = MimeType ?? JsonFormatter.MimeType;
                         var formatter = Formatter.GetPreferredFormatterFor(valueType, mimeType);
                         if (formatter.MimeType != mimeType)
                         {
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.Interactive.Commands
                     }
                     else
                     {
-                        var mimeType = MimeType ?? Formatter.GetPreferredMimeTypesFor(typeof(object)).FirstOrDefault();
+                        var mimeType = MimeType ?? JsonFormatter.MimeType;
                         var formatted = new FormattedValue(mimeType, "null");
 
                         context.Publish(new ValueProduced(value, Name, formatted, this));

--- a/src/Microsoft.DotNet.Interactive/DataExplorerFormatterSource.cs
+++ b/src/Microsoft.DotNet.Interactive/DataExplorerFormatterSource.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Text.Json;
+using Microsoft.DotNet.Interactive.Formatting;
+using Microsoft.DotNet.Interactive.Formatting.TabularData;
+
+namespace Microsoft.DotNet.Interactive
+{
+    internal class DataExplorerFormatterSource : ITypeFormatterSource
+    {
+        public IEnumerable<ITypeFormatter> CreateTypeFormatters()
+        {
+            yield return new JsonFormatter<DataExplorer<TabularDataResource>>((value, context) =>
+            {
+                var json = JsonSerializer.Serialize(value.Data.Data,
+                    TabularDataResourceFormatter.JsonSerializerOptions);
+
+                context.Writer.Write(json);
+            });
+
+            yield return new TabularDataResourceFormatter<DataExplorer<TabularDataResource>>((value, context) =>
+            {
+                var json = JsonSerializer.Serialize(value.Data, TabularDataResourceFormatter.JsonSerializerOptions);
+
+                context.Writer.Write(json);
+            });
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Interactive/DataExplorer{T}.cs
+++ b/src/Microsoft.DotNet.Interactive/DataExplorer{T}.cs
@@ -2,12 +2,15 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Linq;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Html;
 using Microsoft.DotNet.Interactive.Formatting;
+using Microsoft.DotNet.Interactive.Formatting.TabularData;
 
 namespace Microsoft.DotNet.Interactive
 {
+    [TypeFormatterSource(typeof(DataExplorerFormatterSource))]
     public abstract class DataExplorer<TData>
     {
         public string Id { get; } = Guid.NewGuid().ToString("N");
@@ -26,6 +29,7 @@ namespace Microsoft.DotNet.Interactive
                 explorer.ToHtml().WriteTo(writer, HtmlEncoder.Default);
             }, HtmlFormatter.MimeType);
             
+            Formatter.SetPreferredMimeTypesFor(typeof(DataExplorer<TData>), HtmlFormatter.MimeType, TabularDataResourceFormatter.MimeType);
         }
 
         static DataExplorer()

--- a/src/Microsoft.DotNet.Interactive/DisplayExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/DisplayExtensions.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.DotNet.Interactive;
 using Microsoft.DotNet.Interactive.Formatting;
+using Microsoft.DotNet.Interactive.Formatting.TabularData;
 
 namespace System
 {
@@ -12,27 +13,18 @@ namespace System
         /// Formats an object using the <see cref="Formatter"/> into a string to be displayed. 
         /// </summary>
         /// <param name="value">The value to display.</param>
-        /// <param name="mimeType">The MIME type.</param>
+        /// <param name="mimeTypes">The MIME types.</param>
         /// <returns>An instance of <see cref="DisplayedValue"/> that can be used to later update the display.</returns>
         public static DisplayedValue Display(this object value,
-            string mimeType = null)
+            params string[] mimeTypes)
         {
-            return KernelInvocationContext.Current.Display(value, mimeType);
+            return KernelInvocationContext.Current.Display(value, mimeTypes);
         }
 
         public static DisplayedValue DisplayAs(this string value, string mimeType)
         {
              return KernelInvocationContext.Current.DisplayAs(value, mimeType);
         }
-
-        /// <summary>
-        /// Display the formatted DataExplorer.
-        /// </summary>
-        /// <param name="explorer">The DataExplorer to display.</param>
-        /// <returns>An instance of <see cref="DisplayedValue"/> that can be used to later update the display.</returns>
-        public static DisplayedValue Display<TData>(this DataExplorer<TData> explorer)
-        {
-            return explorer.Display(HtmlFormatter.MimeType);
-        }
+        
     }
 }

--- a/src/Microsoft.DotNet.Interactive/DisplayedValue.cs
+++ b/src/Microsoft.DotNet.Interactive/DisplayedValue.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Formatting;
@@ -11,38 +13,45 @@ namespace Microsoft.DotNet.Interactive
     public class DisplayedValue
     {
         private readonly string _displayId;
-        private readonly string _mimeType;
+        private readonly HashSet<string> _mimeTypes;
         private KernelInvocationContext _context;
+        
+        public DisplayedValue(string displayId, string mimeType, KernelInvocationContext context): this(displayId, new []{mimeType}, context)
+        {
+           
+        }
 
-        public DisplayedValue(string displayId, string mimeType, KernelInvocationContext context)
+        public DisplayedValue(string displayId, string[] mimeTypes, KernelInvocationContext context)
         {
             if (string.IsNullOrWhiteSpace(displayId))
             {
                 throw new ArgumentException("Value cannot be null or whitespace.", nameof(displayId));
             }
 
-            if (string.IsNullOrWhiteSpace(mimeType))
+            if (mimeTypes is null || mimeTypes.Count(mimetype => !string.IsNullOrWhiteSpace(mimetype)) == 0)
             {
-                throw new ArgumentException("Value cannot be null or whitespace.", nameof(mimeType));
+                throw new ArgumentException("Value cannot be null or empty.", nameof(mimeTypes));
             }
 
             _displayId = displayId;
-            _mimeType = mimeType;
+            _mimeTypes = new HashSet<string>(mimeTypes.Where(mimetype => !string.IsNullOrWhiteSpace(mimetype)));
             _context = context ?? throw new ArgumentNullException(nameof(context));
         }
 
+        public IReadOnlyCollection<string> MimeTypes => _mimeTypes;
+
         public void Update(object updatedValue)
         {
-            var formatted = new FormattedValue(
-                _mimeType,
-                updatedValue.ToDisplayString(_mimeType));
+            var formattedValues = MimeTypes.Select(mimeType => new FormattedValue(
+                mimeType,
+                updatedValue.ToDisplayString(mimeType))).ToArray();
 
             if (KernelInvocationContext.Current?.Command is SubmitCode)
             {
                 _context = KernelInvocationContext.Current;
             }
 
-            _context.Publish(new DisplayedValueUpdated(updatedValue, _displayId, _context.Command, new[] { formatted }));
+            _context.Publish(new DisplayedValueUpdated(updatedValue, _displayId, _context.Command, formattedValues));
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive/FormattedValue.cs
+++ b/src/Microsoft.DotNet.Interactive/FormattedValue.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.DotNet.Interactive.Formatting;
 
 namespace Microsoft.DotNet.Interactive
@@ -24,15 +25,20 @@ namespace Microsoft.DotNet.Interactive
 
         public string Value { get; }
 
-        public static IReadOnlyCollection<FormattedValue> FromObject(object value, string mimeType = null)
+        public static IReadOnlyCollection<FormattedValue> FromObject(object value, params  string[] mimeTypes)
         {
-            mimeType ??= Formatter.GetPreferredMimeTypeFor(value?.GetType());
+            if (mimeTypes is null 
+                || mimeTypes.Length == 0 
+                || mimeTypes.Count(mimeType => !string.IsNullOrWhiteSpace(mimeType)) == 0)
+            {
+                mimeTypes =  Formatter.GetPreferredMimeTypesFor(value?.GetType()).ToArray();
+            }
 
-            var formattedValue = new FormattedValue(
+            var formattedValues = mimeTypes.Select( mimeType =>  new FormattedValue(
                 mimeType,
-                value.ToDisplayString(mimeType));
+                value.ToDisplayString(mimeType))).ToArray();
 
-            return new[] { formattedValue };
+            return formattedValues;
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive/Kernel.Static.cs
+++ b/src/Microsoft.DotNet.Interactive/Kernel.Static.cs
@@ -20,9 +20,9 @@ namespace Microsoft.DotNet.Interactive
 
         public static DisplayedValue display(
             object value,
-            string mimeType = null)
+            params string[] mimeTypes)
         {
-            return value.Display(mimeType);
+            return value.Display(mimeTypes);
         }
 
         public static IHtmlContent HTML(string content) => content.ToHtmlContent();

--- a/src/Microsoft.DotNet.Interactive/KernelInvocationContextExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelInvocationContextExtensions.cs
@@ -15,11 +15,11 @@ namespace Microsoft.DotNet.Interactive
         public static DisplayedValue Display(
             this KernelInvocationContext context,
             object value,
-            string mimeType = null)
+            params string[] mimeTypes)
         {
             var displayId = Guid.NewGuid().ToString();
 
-            var formattedValues = FormattedValue.FromObject(value, mimeType);
+            var formattedValues = FormattedValue.FromObject(value, mimeTypes);
 
             context.Publish(
                 new DisplayedValueProduced(
@@ -28,11 +28,11 @@ namespace Microsoft.DotNet.Interactive
                     formattedValues,
                     displayId));
 
-            var displayedValue = new DisplayedValue(displayId, mimeType ?? formattedValues.FirstOrDefault()?.MimeType, context);
+            var displayedValue = new DisplayedValue(displayId, formattedValues.Select(fv => fv.MimeType).ToArray(), context);
 
             return displayedValue;
         }
-        
+
         public static DisplayedValue DisplayAs(
             this KernelInvocationContext context,
             string value,

--- a/src/dotnet-interactive.Tests/FormatterConfigurationTests.cs
+++ b/src/dotnet-interactive.Tests/FormatterConfigurationTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Linq;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.DotNet.Interactive.App.CommandLine;
@@ -38,7 +39,7 @@ namespace Microsoft.DotNet.Interactive.App.Tests
         {
             var latex = new LaTeXString(@"F(k) = \int_{-\infty}^{\infty} f(x) e^{2\pi i k} dx");
 
-            var mimeType = Formatter.GetPreferredMimeTypeFor(latex.GetType());
+            var mimeType = Formatter.GetPreferredMimeTypesFor(latex.GetType()).FirstOrDefault();
 
             var formattedValue = new FormattedValue(
                 mimeType,
@@ -53,7 +54,7 @@ namespace Microsoft.DotNet.Interactive.App.Tests
         {
             var latex = new MathString(@"F(k) = \int_{-\infty}^{\infty} f(x) e^{2\pi i k} dx");
 
-            var mimeType = Formatter.GetPreferredMimeTypeFor(latex.GetType());
+            var mimeType = Formatter.GetPreferredMimeTypesFor(latex.GetType()).FirstOrDefault();
 
             var formattedValue = new FormattedValue(
                 mimeType,
@@ -67,7 +68,7 @@ namespace Microsoft.DotNet.Interactive.App.Tests
         public void ScriptContent_type_is_formatted()
         {
             var script = new ScriptContent("alert('hello');");
-            var mimeType = Formatter.GetPreferredMimeTypeFor(script.GetType());
+            var mimeType = Formatter.GetPreferredMimeTypesFor(script.GetType()).FirstOrDefault();
 
             var formattedValue = new FormattedValue(
                 mimeType,
@@ -82,7 +83,7 @@ namespace Microsoft.DotNet.Interactive.App.Tests
         {
             var scriptText = "if (true && false) { alert('hello with embedded <>\" escapes'); };";
             var script = new ScriptContent(scriptText);
-            var mimeType = Formatter.GetPreferredMimeTypeFor(script.GetType());
+            var mimeType = Formatter.GetPreferredMimeTypesFor(script.GetType()).FirstOrDefault();
 
             var formattedValue = new FormattedValue(
                 mimeType,

--- a/src/dotnet-interactive/CommandLine/CommandLineParser.cs
+++ b/src/dotnet-interactive/CommandLine/CommandLineParser.cs
@@ -696,10 +696,10 @@ namespace Microsoft.DotNet.Interactive.App.CommandLine
 
                 case BrowserFrontendEnvironment browserFrontendEnvironment:
                     Formatter.DefaultMimeType = HtmlFormatter.MimeType;
-                    Formatter.SetPreferredMimeTypeFor(typeof(LaTeXString), "text/latex");
-                    Formatter.SetPreferredMimeTypeFor(typeof(MathString), "text/latex");
-                    Formatter.SetPreferredMimeTypeFor(typeof(string), PlainTextFormatter.MimeType);
-                    Formatter.SetPreferredMimeTypeFor(typeof(ScriptContent), HtmlFormatter.MimeType);
+                    Formatter.SetPreferredMimeTypesFor(typeof(LaTeXString), "text/latex");
+                    Formatter.SetPreferredMimeTypesFor(typeof(MathString), "text/latex");
+                    Formatter.SetPreferredMimeTypesFor(typeof(string), PlainTextFormatter.MimeType);
+                    Formatter.SetPreferredMimeTypesFor(typeof(ScriptContent), HtmlFormatter.MimeType);
 
                     Formatter.Register<LaTeXString>((laTeX, writer) => writer.Write(laTeX.ToString()), "text/latex");
                     Formatter.Register<MathString>((math, writer) => writer.Write(math.ToString()), "text/latex");


### PR DESCRIPTION
when using `Displa()` it is possible to produce multiple formatted outputs specifying multiple mimetypes

`DataExplorer<T>` registers formatters for json and tabular json if the type T is TabularDataResource 