### PR TITLE
update logic for valuekernel chooser

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Kql.Tests/KqlConnectionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql.Tests/KqlConnectionTests.cs
@@ -144,7 +144,7 @@ StormEvents | take 10
                   .NotContainErrors();
 
             result = await kernel.SubmitCodeAsync($@"
-#!kql-KustoHelp --mime-type {TabularDataResourceFormatter.MimeType}
+#!kql-KustoHelp
 StormEvents | take 10
 ");
 
@@ -214,7 +214,7 @@ StormEvents | take 10
                   .NotContainErrors();
 
             result = await kernel.SubmitCodeAsync($@"
-#!kql-KustoHelp --mime-type {TabularDataResourceFormatter.MimeType}
+#!kql-KustoHelp
 StormEvents | take 0
 ");
 

--- a/src/Microsoft.DotNet.Interactive.Kql/ChooseMsKqlKernelDirective.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql/ChooseMsKqlKernelDirective.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.CommandLine;
+
+namespace Microsoft.DotNet.Interactive.Kql
+{
+    public class ChooseMsKqlKernelDirective : ChooseKernelDirective
+    {
+        public ChooseMsKqlKernelDirective(Kernel kernel) : base(kernel, $"Run a Kusto query using the \"{kernel.Name}\" connection.")
+        {
+            Add(NameOption);
+        }
+
+        public Option<string> NameOption { get; } = new(
+            "--name",
+            description: "Specify the value name to store the results.",
+            getDefaultValue: () => "lastResults");
+
+    }
+}

--- a/src/Microsoft.DotNet.Interactive.SqlServer.Tests/MsSqlConnectionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer.Tests/MsSqlConnectionTests.cs
@@ -151,7 +151,7 @@ SELECT TOP 100 * FROM Person.Person
                   .NotContainErrors();
 
             result = await kernel.SubmitCodeAsync($@"
-#!sql-adventureworks --mime-type {TabularDataResourceFormatter.MimeType}
+#!sql-adventureworks
 select * from sys.databases
 ");
 
@@ -182,7 +182,7 @@ select * from sys.databases
                 .NotContainErrors();
 
             result = await kernel.SubmitCodeAsync($@"
-#!sql-adventureworks --mime-type {TabularDataResourceFormatter.MimeType}
+#!sql-adventureworks
 select * from sys.databases
 ");
 

--- a/src/Microsoft.DotNet.Interactive.SqlServer/ChooseMsSqlKernelDirective.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/ChooseMsSqlKernelDirective.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.CommandLine;
+
+namespace Microsoft.DotNet.Interactive.SqlServer
+{
+    public class ChooseMsSqlKernelDirective : ChooseKernelDirective
+    {
+        public ChooseMsSqlKernelDirective(Kernel kernel) : base(kernel, $"Run a T-SQL query using the \"{kernel.Name}\" connection.")
+        {
+            Add(NameOption);
+        }
+
+        public Option<string> NameOption { get; } = new(
+            "--name",
+            description: "Specify the value name to store the results.",
+            getDefaultValue: () => "lastResults");
+
+    }
+}

--- a/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernel.cs
@@ -3,10 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.CommandLine;
 using System.CommandLine.Parsing;
 using System.Data;
 using System.Threading.Tasks;
+
 using Microsoft.Data.SqlClient.Server;
 using Microsoft.DotNet.Interactive.Formatting.TabularData;
 
@@ -15,6 +15,7 @@ namespace Microsoft.DotNet.Interactive.SqlServer
     internal class MsSqlKernel : ToolsServiceKernel
     {
         private readonly string _connectionString;
+        private ChooseMsSqlKernelDirective _chooseKernelDirective;
 
         internal MsSqlKernel(
             string name,
@@ -25,7 +26,7 @@ namespace Microsoft.DotNet.Interactive.SqlServer
             {
                 throw new ArgumentException("Value cannot be null or whitespace.", nameof(connectionString));
             }
-            
+
             _connectionString = connectionString;
         }
 
@@ -39,10 +40,8 @@ namespace Microsoft.DotNet.Interactive.SqlServer
             }
         }
 
-        protected override ChooseKernelDirective CreateChooseKernelDirective() =>
-            new ChooseMsSqlKernelDirective(this);
+        public override ChooseMsSqlKernelDirective ChooseKernelDirective => _chooseKernelDirective ??= new(this);
 
-       
 
         protected override string CreateVariableDeclaration(string name, object value)
         {
@@ -105,20 +104,6 @@ namespace Microsoft.DotNet.Interactive.SqlServer
             {
                 QueryResults[name] = results;
             }
-        }
-
-        private class ChooseMsSqlKernelDirective : ChooseKernelDirective
-        {
-            public ChooseMsSqlKernelDirective(Kernel kernel) : base(kernel, $"Run a T-SQL query using the \"{kernel.Name}\" connection.")
-            {
-                Add(NameOption);
-            }
-
-            public Option<string> NameOption { get; } = new(
-                "--name",
-                description: "Specify the value name to store the results.",
-                getDefaultValue: () => "lastResults");
-
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive/ChooseKeyValueStoreKernelDirective.cs
+++ b/src/Microsoft.DotNet.Interactive/ChooseKeyValueStoreKernelDirective.cs
@@ -1,0 +1,114 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.CommandLine;
+using System.CommandLine.Binding;
+using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Interactive
+{
+
+    public class ChooseKeyValueStoreKernelDirective : ChooseKernelDirective
+    {
+        public ChooseKeyValueStoreKernelDirective(Kernel kernel) : base(kernel,
+            "Stores a value that can then be shared with other subkernels.")
+        {
+
+            NameOption = new Option<string>(
+                "--name",
+                "The name of the value to create. You can use #!share to retrieve this value from another subkernel.")
+            {
+                IsRequired = true
+            };
+
+            FromUrlOption = new Option<Uri>(
+                "--from-url",
+                description: "Specifies a URL whose content will be stored.");
+
+            FromFileOption = new Option<FileInfo>(
+                "--from-file",
+                description: "Specifies a file whose contents will be stored.",
+                parseArgument: result =>
+                {
+                    var filePath = result.Tokens.Single().Value;
+
+                    var fromUrlResult = result.FindResultFor(FromUrlOption);
+
+                    if (fromUrlResult is { })
+                    {
+                        result.ErrorMessage =
+                            $"The {fromUrlResult.Token.Value} and {((OptionResult)result.Parent).Token.Value} options cannot be used together.";
+                        return null;
+                    }
+                    else if (!File.Exists(filePath))
+                    {
+                        result.ErrorMessage = Resources.Instance.FileDoesNotExist(filePath);
+                        return null;
+                    }
+                    else
+                    {
+                        return new FileInfo(filePath);
+                    }
+                });
+
+            MimeTypeOption = new Option<string>(
+                    "--mime-type",
+                    "A mime type for the value. If specified, displays the value immediately as an output using the specified mime type.")
+                .AddSuggestions((_, __) => new[]
+                {
+                    "application/json",
+                    "text/html",
+                    "text/plain",
+                    "text/csv"
+                });
+
+            Add(NameOption);
+            Add(FromUrlOption);
+            Add(FromFileOption);
+            Add(MimeTypeOption);
+        }
+
+        protected override async Task Handle(KernelInvocationContext kernelInvocationContext,
+            InvocationContext commandLineInvocationContext)
+        {
+            var options = ValueDirectiveOptions.Create(commandLineInvocationContext.ParseResult);
+            var kernel = Kernel as KeyValueStoreKernel;
+
+
+            {
+                await kernel.TryStoreValueFromOptionsAsync(kernelInvocationContext, options);
+            }
+
+            await base.Handle(kernelInvocationContext, commandLineInvocationContext);
+        }
+
+        public Option<string> MimeTypeOption { get; }
+
+        public Option<Uri> FromUrlOption { get; }
+
+        public Option<FileInfo> FromFileOption { get; }
+
+        public Option<string> NameOption { get; }
+
+        internal class ValueDirectiveOptions
+        {
+            private static readonly ModelBinder<ValueDirectiveOptions> _modelBinder = new();
+
+            public static ValueDirectiveOptions Create(ParseResult parseResult) =>
+                _modelBinder.CreateInstance(new BindingContext(parseResult)) as ValueDirectiveOptions;
+
+            public string Name { get; set; }
+
+            public FileInfo FromFile { get; set; }
+
+            public Uri FromUrl { get; set; }
+
+            public string MimeType { get; set; }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Interactive/Commands/DirectiveCommand.cs
+++ b/src/Microsoft.DotNet.Interactive/Commands/DirectiveCommand.cs
@@ -31,7 +31,6 @@ namespace Microsoft.DotNet.Interactive.Commands
             {
                 throw new InvalidOperationException($"{string.Join(";", ParseResult.Errors)}");
             }
-
             await ParseResult.InvokeAsync();
         }
 

--- a/src/Microsoft.DotNet.Interactive/Kernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Kernel.cs
@@ -695,12 +695,8 @@ namespace Microsoft.DotNet.Interactive
 
         public void Dispose() => _disposables.Dispose();
 
-        protected virtual ChooseKernelDirective CreateChooseKernelDirective()
-        {
-            return new(this);
-        }
+        public virtual ChooseKernelDirective ChooseKernelDirective => _chooseKernelDirective ??= new(this);
 
-        public ChooseKernelDirective ChooseKernelDirective => _chooseKernelDirective ??= CreateChooseKernelDirective();
         protected internal ParseResult SelectorParserResults { protected get; set; }
 
         public bool SupportsCommand<T>() where T : KernelCommand

--- a/src/Microsoft.DotNet.Interactive/KeyValueStoreKernel.cs
+++ b/src/Microsoft.DotNet.Interactive/KeyValueStoreKernel.cs
@@ -4,10 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.CommandLine;
-using System.CommandLine.Binding;
-using System.CommandLine.Invocation;
-using System.CommandLine.Parsing;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -26,6 +22,8 @@ namespace Microsoft.DotNet.Interactive
         internal const string DefaultKernelName = "value";
 
         private readonly ConcurrentDictionary<string, object> _values = new();
+        private ChooseKeyValueStoreKernelDirective _chooseKernelDirective;
+        private (bool hadValue, object previousValue, string newValue)? _lastOperation;
 
         public KeyValueStoreKernel() : base(DefaultKernelName)
         {
@@ -55,40 +53,107 @@ namespace Microsoft.DotNet.Interactive
             }
         }
 
+        // todo: change to ChooseKeyValueStoreKernelDirective after removing NetStandardc2.0 dependency
+        public override ChooseKernelDirective ChooseKernelDirective =>
+            _chooseKernelDirective ??= new (this);
+
         public async Task HandleAsync(SubmitCode command, KernelInvocationContext context)
         {
-            var parseResult = command.KernelNameDirectiveNode.GetDirectiveParseResult();
+            var parseResult = command.KernelChooserParseResult;
 
             var value = command.LanguageNode.Text.Trim();
 
-            var options = ValueDirectiveOptions.Create(parseResult);
+            var options = ChooseKeyValueStoreKernelDirective.ValueDirectiveOptions.Create(parseResult);
+            
+            await StoreValueAsync(command, context, options, value);
+        }
 
-            if (options.FromFile is {})
+        internal async Task TryStoreValueFromOptionsAsync(KernelInvocationContext context,
+            ChooseKeyValueStoreKernelDirective.ValueDirectiveOptions options)
+        {
+            string newValue = null;
+            var loadedFromOptions = false;
+            if (options.FromFile is { })
+            {
+                newValue = File.ReadAllText(options.FromFile.FullName);
+                loadedFromOptions = true;
+            }
+            else if (options.FromUrl is { })
+            {
+                var client = new HttpClient();
+                var response = await client.GetAsync(options.FromUrl, context.CancellationToken);
+                newValue = await response.Content.ReadAsStringAsync();
+                loadedFromOptions = true;
+            }
+
+            if (loadedFromOptions)
+            {
+
+                var hadValue = TryGetValue(options.Name, out object previousValue);
+
+                _lastOperation = (hadValue, previousValue, newValue);
+
+                await StoreValueAsync(newValue, options, context);
+            }
+            else
+            {
+                _lastOperation = null;
+            }
+        }
+
+        private async Task StoreValueAsync(KernelCommand command, KernelInvocationContext context, ChooseKeyValueStoreKernelDirective.ValueDirectiveOptions options,
+            string value = null)
+        {
+            if (options.FromFile is { })
             {
                 if (!string.IsNullOrWhiteSpace(value))
                 {
-                    context.Fail(command, message: "The --from-file option cannot be used in combination with a content submission.");
+                    UndoSetValue();
+                    context.Fail(command,
+                        message: "The --from-file option cannot be used in combination with a content submission.");
                 }
-
-                return;
+                
             }
-
-            if (options.FromUrl is {})
+            else if (options.FromUrl is { })
             {
                 if (!string.IsNullOrWhiteSpace(value))
                 {
-                    context.Fail(command, message: "The --from-url option cannot be used in combination with a content submission.");
+                    UndoSetValue();
+                    context.Fail(command,
+                        message: "The --from-url option cannot be used in combination with a content submission.");
                 }
+            }
+            else
+            {
 
-                return;
+                await StoreValueAsync(value, options, context);
             }
 
-            await StoreValueAsync(value, options, context);
+            _lastOperation = default;
+
+            void UndoSetValue()
+            {
+                if (_lastOperation is {})
+                {
+                    if (_lastOperation?.hadValue == true)
+                    {
+                        // restore value
+                        _values[options.Name] = _lastOperation?.previousValue;
+                    }
+                    else
+                    {
+                        // remove entry
+                        _values.TryRemove(options.Name, out _);
+                    }
+
+                    _lastOperation = null;
+                }
+            }
         }
 
         private async Task StoreValueAsync(
             string value,
-            ValueDirectiveOptions options,
+            ChooseKeyValueStoreKernelDirective.ValueDirectiveOptions options,
             KernelInvocationContext context)
         {
             await SetValueAsync(options.Name, value);
@@ -97,109 +162,6 @@ namespace Microsoft.DotNet.Interactive
             {
                 context.DisplayAs(value, mimeType);
             }
-        }
-
-        protected override ChooseKernelDirective CreateChooseKernelDirective()
-        {
-            var nameOption = new Option<string>(
-                "--name",
-                "The name of the value to create. You can use #!share to retrieve this value from another subkernel.")
-            {
-                IsRequired = true
-            };
-
-            var fromUrlOption = new Option<Uri>(
-                "--from-url",
-                description: "Specifies a URL whose content will be stored.");
-
-            var fromFileOption = new Option<FileInfo>(
-                "--from-file",
-                description: "Specifies a file whose contents will be stored.",
-                parseArgument: result =>
-                {
-                    var filePath = result.Tokens.Single().Value;
-
-                    var fromUrlResult = result.FindResultFor(fromUrlOption);
-
-                    if (fromUrlResult is {})
-                    {
-                        result.ErrorMessage = $"The {fromUrlResult.Token.Value} and {((OptionResult) result.Parent).Token.Value} options cannot be used together.";
-                        return null;
-                    }
-                    else if (!File.Exists(filePath))
-                    {
-                        result.ErrorMessage = Resources.Instance.FileDoesNotExist(filePath);
-                        return null;
-                    }
-                    else
-                    {
-                        return new FileInfo(filePath);
-                    }
-                });
-
-            var mimeTypeOption = new Option<string>(
-                    "--mime-type",
-                    "A mime type for the value. If specified, displays the value immediately as an output using the specified mime type.")
-                .AddSuggestions((_,__) => new[]
-                {
-                    "application/json",
-                    "text/html",
-                    "text/plain",
-                    "text/csv"
-                });
-
-            return new ValueDirective(this, "Stores a value that can then be shared with other subkernels.")
-            {
-                nameOption,
-                fromFileOption,
-                fromUrlOption,
-                mimeTypeOption
-            };
-        }
-
-        private class ValueDirective : ChooseKernelDirective
-        {
-            private readonly KeyValueStoreKernel _kernel;
-
-            public ValueDirective(KeyValueStoreKernel kernel, string description = null) : base(kernel, description)
-            {
-                _kernel = kernel;
-            }
-
-            protected override async Task Handle(KernelInvocationContext kernelInvocationContext, InvocationContext commandLineInvocationContext)
-            {
-                var options = ValueDirectiveOptions.Create(commandLineInvocationContext.ParseResult);
-
-                if (options.FromFile is {} fromFile)
-                {
-                    var value = File.ReadAllText(fromFile.FullName);
-                    await _kernel.StoreValueAsync(value, options, kernelInvocationContext);
-                }
-                else if (options.FromUrl is {} fromUrl)
-                {
-                    var client = new HttpClient();
-                    var response = await client.GetAsync(fromUrl, kernelInvocationContext.CancellationToken);
-                    var value = await response.Content.ReadAsStringAsync();
-                    await _kernel.StoreValueAsync(value, options, kernelInvocationContext);
-                }
-
-                await base.Handle(kernelInvocationContext, commandLineInvocationContext);
-            }
-        }
-
-        private class ValueDirectiveOptions
-        {
-            private static readonly ModelBinder<ValueDirectiveOptions> _modelBinder = new();
-
-            public static ValueDirectiveOptions Create(ParseResult parseResult) => _modelBinder.CreateInstance(new BindingContext(parseResult)) as ValueDirectiveOptions;
-
-            public string Name { get; set; }
-
-            public FileInfo FromFile { get; set; }
-
-            public Uri FromUrl { get; set; }
-
-            public string MimeType { get; set; }
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive/KeyValueStoreKernel.cs
+++ b/src/Microsoft.DotNet.Interactive/KeyValueStoreKernel.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.Interactive
 
         private readonly ConcurrentDictionary<string, object> _values = new();
         private ChooseKeyValueStoreKernelDirective _chooseKernelDirective;
-        private (bool hadValue, object previousValue, string newValue)? _lastOperation;
+        private (bool hadValue, object previousValue, object newValue)? _lastOperation;
 
         public KeyValueStoreKernel() : base(DefaultKernelName)
         {


### PR DESCRIPTION
value kernel is using parse invoke when options --from-file or --from-url are used
if there is a command for the kernel then at that point errors are handled
errors won't store value
errors will retain previous value if present