### PR TITLE
improve error messages when appropriate .NET SDK can't be found

### DIFF
--- a/src/dotnet-interactive-vscode/common/vscode/extension.ts
+++ b/src/dotnet-interactive-vscode/common/vscode/extension.ts
@@ -17,7 +17,7 @@ import { registerAcquisitionCommands, registerKernelCommands, registerFileComman
 import { getNotebookSpecificLanguage, getSimpleLanguage, isDotnetInteractiveLanguage, isJupyterNotebookViewType, languageToCellKind } from '../interactiveNotebook';
 import { InteractiveLaunchOptions, InstallInteractiveArgs } from '../interfaces';
 
-import { createOutput, executeSafe, getWorkingDirectoryForNotebook, isDotNetUpToDate, processArguments } from '../utilities';
+import { createOutput, executeSafe, getDotNetVersionOrThrow, getVersionNumber, getWorkingDirectoryForNotebook, isVersionSufficient, processArguments } from '../utilities';
 import { OutputChannelAdapter } from './OutputChannelAdapter';
 
 import * as notebookControllers from '../../notebookControllers';
@@ -84,13 +84,16 @@ export async function activate(context: vscode.ExtensionContext) {
     // this must happen early, because some following functions use the acquisition command
     registerAcquisitionCommands(context, diagnosticsChannel);
 
-    async function kernelTransportCreator(notebookUri: vscodeLike.Uri): Promise<contracts.KernelTransport> {
-        if (!await checkForDotNetSdk(minDotNetSdkVersion!)) {
-            const message = 'Unable to find appropriate .NET SDK.';
-            vscode.window.showErrorMessage(message);
-            throw new Error(message);
-        }
+    // check sdk version
+    const dotnetVersion = await getDotNetVersionOrThrow(DotNetPathManager.getDotNetPath(), diagnosticsChannel);
+    if (!isVersionSufficient(dotnetVersion, minDotNetSdkVersion)) {
+        const message = `The .NET SDK version ${dotnetVersion} is not sufficient. The minimum required version is ${minDotNetSdkVersion}.`;
+        diagnosticsChannel.appendLine(message);
+        vscode.window.showErrorMessage(message);
+        throw new Error(message);
+    }
 
+    async function kernelTransportCreator(notebookUri: vscodeLike.Uri): Promise<contracts.KernelTransport> {
         const launchOptions = await getInteractiveLaunchOptions();
         if (!launchOptions) {
             throw new Error(`Unable to get interactive launch options.  Please see the '${diagnosticsChannel.getName()}' output window for details.`);
@@ -347,10 +350,4 @@ async function getInteractiveLaunchOptions(): Promise<InteractiveLaunchOptions |
     };
     const launchOptions = await vscode.commands.executeCommand<InteractiveLaunchOptions>('dotnet-interactive.acquire', installArgs);
     return launchOptions;
-}
-
-async function checkForDotNetSdk(minVersion: string): Promise<boolean> {
-    const result = await executeSafe(DotNetPathManager.getDotNetPath(), ['--version']);
-    const checkResult = isDotNetUpToDate(minVersion, result);
-    return checkResult;
 }


### PR DESCRIPTION
This PR moves the check for the appropriate .NET SDK right to the beginning of the extension activation.

There are essentially 2 scenarios here:

1. Calling `dotnet --version` failed in some way.  In this case we throw an exception which informs the user something went wrong:

![image](https://user-images.githubusercontent.com/926281/140437837-e38fea24-314d-409e-9b84-01dfb667683e.png)

Then we write all the information we have to our diagnostics output channel:

![image](https://user-images.githubusercontent.com/926281/140437846-cd15dda0-2b9a-4acb-8a09-2f5c41396e88.png)

2. Calling `dotnet --version` was successful, but the user's version was too low.  In that case we show this message in the bottom corner:

![image](https://user-images.githubusercontent.com/926281/140437852-f07135f9-c494-4c86-b361-ac61376c37bf.png)

Then we also put the same text in the diagnostics output channel:

![image](https://user-images.githubusercontent.com/926281/140437859-888b40a5-3998-4224-bdee-b65f8f98bd27.png)
