### PR TITLE
use resolved uri query parameters for notebook type

### DIFF
--- a/INTERNAL.md
+++ b/INTERNAL.md
@@ -8,6 +8,16 @@ Open the VS Code extension test script in VS Code - Insiders
 vscode-insiders://ms-dotnettools.dotnet-interactive-vscode/openNotebook?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdotnet%2Finteractive%2Fmain%2FNotebookTestScript.dib
 ```
 
+If the URL provided does not end in the notebook file's extension, you can specify the `notebookFormat` query parameter as an override with the supported values of 'dib' and 'ipynb'.
+
+E.g.,
+
+```
+vscode-insiders://ms-dotnettools.dotnet-interactive-vscode/openNotebook?notebookFormat=ipynb&url=https://contoso.com/myNotebook
+```
+
+URL redirects are supported by this scenario and the extension and/or `notebookFormat` parameter will be pulled from the final resolved URL.
+
 ## PR Build Definition
 
 The PR build definition can be found [here](https://dev.azure.com/dnceng/public/_build?definitionId=744&_a=summary) or by nagivating through an existing PR.

--- a/src/dotnet-interactive-vscode/insiders/package.json
+++ b/src/dotnet-interactive-vscode/insiders/package.json
@@ -442,6 +442,8 @@
   },
   "mocha": {},
   "devDependencies": {
+    "@rollup/plugin-commonjs": "21.0.0",
+    "@rollup/plugin-node-resolve": "13.0.5",
     "@types/chai": "4.2.11",
     "@types/chai-as-promised": "7.1.3",
     "@types/chai-fs": "2.0.2",
@@ -463,17 +465,15 @@
     "mocha": "9.1.2",
     "mocha-multi-reporters": "1.5.1",
     "mocha-trx-reporter": "3.3.1",
+    "rollup": "2.58.0",
+    "rollup-plugin-typescript2": "0.30.0",
+    "source-map-support": "0.5.19",
     "tmp": "0.2.1",
     "typescript": "4.1.3",
     "vsce": "1.88.0",
     "vscode-oniguruma": "1.3.1",
     "vscode-test": "1.3.0",
-    "vscode-textmate": "5.1.1",
-    "rollup": "2.58.0",
-    "@rollup/plugin-commonjs": "21.0.0",
-    "@rollup/plugin-node-resolve": "13.0.5",
-    "rollup-plugin-typescript2": "0.30.0",
-    "source-map-support": "0.5.19"
+    "vscode-textmate": "5.1.1"
   },
   "dependencies": {
     "compare-versions": "3.6.0",

--- a/src/dotnet-interactive-vscode/insiders/src/notebookSerializers.ts
+++ b/src/dotnet-interactive-vscode/insiders/src/notebookSerializers.ts
@@ -52,10 +52,8 @@ export function createAndRegisterNotebookSerializers(context: vscode.ExtensionCo
     };
 
     const serializers = new Map<string, vscode.NotebookSerializer>();
-    const dibSerializer = createAndRegisterSerializer(contracts.DocumentSerializationType.Dib, 'dotnet-interactive');
-    serializers.set('.dib', dibSerializer);
-    serializers.set('.dotnet-interactive', dibSerializer);
-    serializers.set('.ipynb', createAndRegisterSerializer(contracts.DocumentSerializationType.Ipynb, 'dotnet-interactive-jupyter'));
+    serializers.set('dotnet-interactive', createAndRegisterSerializer(contracts.DocumentSerializationType.Dib, 'dotnet-interactive'));
+    serializers.set('jupyter-notebook', createAndRegisterSerializer(contracts.DocumentSerializationType.Ipynb, 'dotnet-interactive-jupyter'));
     return serializers;
 }
 

--- a/src/dotnet-interactive-vscode/stable/src/notebookSerializers.ts
+++ b/src/dotnet-interactive-vscode/stable/src/notebookSerializers.ts
@@ -52,10 +52,8 @@ export function createAndRegisterNotebookSerializers(context: vscode.ExtensionCo
     };
 
     const serializers = new Map<string, vscode.NotebookSerializer>();
-    const dibSerializer = createAndRegisterSerializer(contracts.DocumentSerializationType.Dib, 'dotnet-interactive');
-    serializers.set('.dib', dibSerializer);
-    serializers.set('.dotnet-interactive', dibSerializer);
-    serializers.set('.ipynb', createAndRegisterSerializer(contracts.DocumentSerializationType.Ipynb, 'dotnet-interactive-jupyter'));
+    serializers.set('dotnet-interactive', createAndRegisterSerializer(contracts.DocumentSerializationType.Dib, 'dotnet-interactive'));
+    serializers.set('jupyter-notebook', createAndRegisterSerializer(contracts.DocumentSerializationType.Ipynb, 'dotnet-interactive-jupyter'));
     return serializers;
 }
 


### PR DESCRIPTION
If no notebook format is given, fall back to the previous extension check.

This allows for a notebook to be behind a shortening service along with the expected notebook type.  E.g., this URL:

```
vscode-insiders://ms-dotnettools.dotnet-interactive-vscode/openNotebook?notebookFormat=dib&url=https://bit.ly/3mPRbKR
```

Resolves to:

```
https://gist.githubusercontent.com/brettfo/dbfcc35909dfa1e08c78a08e22fc09ef/raw/e59559f0ec0760b462f1e4426571e1ec061dcaa2/myNotebook.notebook
```

And the `notebookFormat` parameter tells the extension that it's a `.dib` notebook.  (The file extension was purposely set to `.bmp` because it's not a supported notebook.)