### PR TITLE
Validate nuget package contract breaking changes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,7 @@
   <PropertyGroup>
     <SystemReactiveVersion>5.0.0</SystemReactiveVersion>
     <MicrosoftCodeAnalysisCommonVersion>4.0.0-4.final</MicrosoftCodeAnalysisCommonVersion>
+    <PackageBaselineVersion>1.0.0-beta.21506.4</PackageBaselineVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
   <PropertyGroup>
     <SystemReactiveVersion>5.0.0</SystemReactiveVersion>
     <MicrosoftCodeAnalysisCommonVersion>4.0.0-4.final</MicrosoftCodeAnalysisCommonVersion>
-    <PackageBaselineVersion>1.0.0-beta.21506.4</PackageBaselineVersion>
+    <PackageBaselineVersion>1.0.0-beta.21559.5</PackageBaselineVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Interactive.CSharp/Microsoft.DotNet.Interactive.CSharp.csproj
+++ b/src/Microsoft.DotNet.Interactive.CSharp/Microsoft.DotNet.Interactive.CSharp.csproj
@@ -1,10 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
+
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <NoWarn>$(NoWarn);2003;CS8002</NoWarn> <!-- AssemblyInformationalVersionAttribute contains a non-standard value -->
     <Deterministic Condition="'$(NCrunch)' == '1'">false</Deterministic>
+    <PackageValidationBaselineVersion>$(PackageBaselineVersion)</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Interactive.Documents/Microsoft.DotNet.Interactive.Documents.csproj
+++ b/src/Microsoft.DotNet.Interactive.Documents/Microsoft.DotNet.Interactive.Documents.csproj
@@ -1,9 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <PackageId Condition="'$(PackageId)'==''">Microsoft.DotNet.Interactive.Documents</PackageId>
+    <PackageValidationBaselineVersion>$(PackageBaselineVersion)</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Interactive.FSharp/Microsoft.DotNet.Interactive.FSharp.fsproj
+++ b/src/Microsoft.DotNet.Interactive.FSharp/Microsoft.DotNet.Interactive.FSharp.fsproj
@@ -1,10 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+	<Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);2003;57</NoWarn> <!-- AssemblyInformationalVersionAttribute contains a non-standard value -->
     <Deterministic Condition="'$(NCrunch)' == '1'">false</Deterministic>
     <LangVersion>preview</LangVersion>
+	  <PackageValidationBaselineVersion>$(PackageBaselineVersion)</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Interactive.Formatting/Microsoft.DotNet.Interactive.Formatting.csproj
+++ b/src/Microsoft.DotNet.Interactive.Formatting/Microsoft.DotNet.Interactive.Formatting.csproj
@@ -1,8 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>preview</LangVersion>
+    <PackageValidationBaselineVersion>$(PackageBaselineVersion)</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Interactive.Journey/Microsoft.DotNet.Interactive.Journey.csproj
+++ b/src/Microsoft.DotNet.Interactive.Journey/Microsoft.DotNet.Interactive.Journey.csproj
@@ -1,8 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
+
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Library</OutputType>
+    <PackageValidationBaselineVersion>$(PackageBaselineVersion)</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Interactive.Kql/Microsoft.DotNet.Interactive.Kql.csproj
+++ b/src/Microsoft.DotNet.Interactive.Kql/Microsoft.DotNet.Interactive.Kql.csproj
@@ -1,8 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
+
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Library</OutputType>
+    <PackageValidationBaselineVersion>$(PackageBaselineVersion)</PackageValidationBaselineVersion>
   </PropertyGroup>
 
  <PropertyGroup>

--- a/src/Microsoft.DotNet.Interactive.NetStandard20/Microsoft.DotNet.Interactive.Netstandard20.csproj
+++ b/src/Microsoft.DotNet.Interactive.NetStandard20/Microsoft.DotNet.Interactive.Netstandard20.csproj
@@ -1,10 +1,12 @@
 <Project>
+  <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Microsoft.DotNet.Interactive.Netstandard20</PackageId>
     <PackageDescription>Core types for building applications providing interactive programming for .NET. for the desktop</PackageDescription>
     <PackageTags>interactive desktop</PackageTags>
+    <PackageValidationBaselineVersion>$(PackageBaselineVersion)</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)../Microsoft.DotNet.Interactive/Microsoft.DotNet.Interactive.csproj" />

--- a/src/Microsoft.DotNet.Interactive.PackageManagement/Microsoft.DotNet.Interactive.PackageManagement.csproj
+++ b/src/Microsoft.DotNet.Interactive.PackageManagement/Microsoft.DotNet.Interactive.PackageManagement.csproj
@@ -1,10 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
+
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <PackageId>Microsoft.DotNet.Interactive.PackageManagement</PackageId>
     <NoWarn>$(NoWarn);8002;CS8002</NoWarn>
+    <PackageValidationBaselineVersion>$(PackageBaselineVersion)</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -1,11 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
+
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <NoWarn>$(NoWarn);2003;CS8002;NU1608;</NoWarn> <!-- AssemblyInformationalVersionAttribute contains a non-standard value -->
     <NoWarn>$(NoWarn);NU5100</NoWarn><!-- dll outside of lib/ folder; expected since it's under contentFiles/any/any/Modules/ -->
     <Deterministic Condition="'$(NCrunch)' == '1'">false</Deterministic>
+    <PackageValidationBaselineVersion>$(PackageBaselineVersion)</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Interactive.SqlServer/Microsoft.DotNet.Interactive.SqlServer.csproj
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/Microsoft.DotNet.Interactive.SqlServer.csproj
@@ -1,8 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
+
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Library</OutputType>
+    <PackageValidationBaselineVersion>$(PackageBaselineVersion)</PackageValidationBaselineVersion>
   </PropertyGroup>
 
  <PropertyGroup>

--- a/src/Microsoft.DotNet.Interactive/Microsoft.DotNet.Interactive.csproj
+++ b/src/Microsoft.DotNet.Interactive/Microsoft.DotNet.Interactive.csproj
@@ -1,10 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
+
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFramework)'==''">netstandard2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <PackageId Condition="'$(PackageId)'==''">Microsoft.DotNet.Interactive</PackageId>
     <NoWarn>$(NoWarn);8002;CS8002</NoWarn>
+    <PackageValidationBaselineVersion>$(PackageBaselineVersion)</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
@dsyme pointed me to a tool that can be used during packaging to ensure binary compatibility. This would allow us to intercept breaking changes on public api.
