### PR TITLE
fix #138

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Formatting_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Formatting_api_is_not_changed.approved.txt
@@ -28,7 +28,6 @@ public static  System.Void Microsoft.DotNet.Interactive.Formatting.Formatter.For
 public static  System.Void Microsoft.DotNet.Interactive.Formatting.Formatter.FormatTo<T>( Microsoft.DotNet.Interactive.Formatting.FormatContext context, System.String mimeType = text/plain )
 public static  Microsoft.DotNet.Interactive.Formatting.ITypeFormatter Microsoft.DotNet.Interactive.Formatting.Formatter.GetPreferredFormatterFor( System.Type actualType, System.String mimeType )
 public static  System.Collections.Generic.IReadOnlyCollection<System.String> Microsoft.DotNet.Interactive.Formatting.Formatter.GetPreferredMimeTypesFor( System.Type type )
-public static  System.Collections.Generic.IEnumerable<Microsoft.DotNet.Interactive.Formatting.ITypeFormatter> Microsoft.DotNet.Interactive.Formatting.Formatter.GetRegisteredFormattersFor( System.Type actualType )
 public static  System.Void Microsoft.DotNet.Interactive.Formatting.Formatter.Register( Microsoft.DotNet.Interactive.Formatting.ITypeFormatter formatter )
 public static  System.Void Microsoft.DotNet.Interactive.Formatting.Formatter.Register<T>( FormatDelegate<T> formatter, System.String mimeType = text/plain )
 public static  System.Void Microsoft.DotNet.Interactive.Formatting.Formatter.Register( System.Type type, Microsoft.DotNet.Interactive.Formatting.FormatDelegate<System.Object> formatter, System.String mimeType = text/plain )

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/HtmlFormatterTests.cs
@@ -539,7 +539,7 @@ string";
             }
 
             [Fact]
-            public void Formatter_truncates_expansion_of_long_IEnumerable()
+            public void Formatter_truncates_expansion_of_ICollection()
             {
                 var list = new List<string>();
                 for (var i = 1; i < 11; i++)
@@ -549,18 +549,18 @@ string";
 
                 Formatter.ListExpansionLimit = 4;
 
-                var formatter = HtmlFormatter.GetPreferredFormatterFor(list.GetType());
+                var formatter = HtmlFormatter.GetPreferredFormatterFor(typeof(ICollection));
 
                 var formatted = list.ToDisplayString(formatter);
 
-                formatted.Contains("number 1").Should().BeTrue();
-                formatted.Contains("number 4").Should().BeTrue();
+                formatted.Should().Contain("number 1");
+                formatted.Should().Contain("number 4");
                 formatted.Should().NotContain("number 5");
-                formatted.Contains("6 more").Should().BeTrue();
+                formatted.Should().Contain("<i>(6 more)</i>");
             }
 
             [Fact]
-            public void Formatter_truncates_expansion_of_long_IDictionary()
+            public void Formatter_truncates_expansion_of_IDictionary()
             {
                 var list = new Dictionary<string, int>();
 
@@ -575,10 +575,31 @@ string";
 
                 var formatted = list.ToDisplayString(formatter);
 
-                formatted.Contains("number 1").Should().BeTrue();
-                formatted.Contains("number 4").Should().BeTrue();
+                formatted.Should().Contain("number 1");
+                formatted.Should().Contain("number 4");
                 formatted.Should().NotContain("number 5");
-                formatted.Contains("6 more").Should().BeTrue();
+                formatted.Should().Contain("6 more");
+            }
+
+            [Fact]
+            public void Formatter_truncates_expansion_of_IEnumerable()
+            {
+                Formatter.ListExpansionLimit = 4;
+
+                var formatter = HtmlFormatter.GetPreferredFormatterFor<IEnumerable<string>>();
+
+                var formatted = InfiniteSequence().ToDisplayString(formatter);
+
+                formatted.Should().Contain("number 9");
+                formatted.Should().Contain("<i>... (more)</i>");
+
+                static IEnumerable<string> InfiniteSequence()
+                {
+                    while(true)
+                    {
+                        yield return "number 9"; 
+                    }
+                }
             }
 
             [Fact]

--- a/src/Microsoft.DotNet.Interactive.Formatting/HtmlFormatter{T}.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/HtmlFormatter{T}.cs
@@ -140,10 +140,12 @@ namespace Microsoft.DotNet.Interactive.Formatting
                     return true;
                 }
 
+                var canCountRemainder = source is ICollection;
+
                 var (rowData, remainingCount) = getValues(source)
                                                 .Cast<object>()
                                                 .Select((v, i) => (v, i))
-                                                .TakeAndCountRemaining(Formatter.ListExpansionLimit);
+                                                .TakeAndCountRemaining(Formatter.ListExpansionLimit, canCountRemainder);
 
                 if (rowData.Count == 0)
                 {
@@ -278,9 +280,11 @@ namespace Microsoft.DotNet.Interactive.Formatting
 
                 if (remainingCount > 0)
                 {
-                    var more = $"({remainingCount} more)";
-
-                    rows.Add(tr(td[colspan: $"{headers.Count}"](more)));
+                    rows.Add(tr(td[colspan: $"{headers.Count}"](i($"({remainingCount} more)"))));
+                }
+                else if (remainingCount is null)
+                {
+                    rows.Add(tr(td[colspan: $"{headers.Count}"](i("... (more)"))));
                 }
 
                 var table = Html.Table(headers, rows);


### PR DESCRIPTION
This fixes #138, limiting output for `IEnumerable` in plain text and HTML formatters.