### PR TITLE
add devcontainer files

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.205.2/containers/dotnet/.devcontainer/base.Dockerfile
+
+# [Choice] .NET version: 6.0, 5.0, 3.1, 6.0-bullseye, 5.0-bullseye, 3.1-bullseye, 6.0-focal, 5.0-focal, 3.1-focal
+ARG VARIANT="6.0-bullseye-slim"
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
+
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
+ARG NODE_VERSION="none"
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,74 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.205.2/containers/dotnet
+{
+  "name": "C# (.NET)",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      // Update 'VARIANT' to pick a .NET Core version: 3.1, 5.0, 6.0
+      // Append -bullseye or -focal to pin to an OS version.
+      "VARIANT": "6.0",
+      // Options
+      "NODE_VERSION": "16"
+    }
+  },
+  // Set *default* container specific settings.json values on container create.
+  "settings": {
+    "dotnet-interactive.kernelTransportArgs": [
+      "{dotnet_path}",
+      "/workspaces/interactive/artifacts/bin/dotnet-interactive/Debug/net6.0/Microsoft.DotNet.Interactive.App.dll",
+      "[vscode]",
+      "stdio",
+      "--working-dir",
+      "{working_dir}"
+    ],
+    "dotnet-interactive.notebookParserArgs": [
+      "{dotnet_path}",
+      "/workspaces/interactive/artifacts/bin/dotnet-interactive/Debug/net6.0/Microsoft.DotNet.Interactive.App.dll",
+      "notebook-parser"
+    ],
+    "editor.formatOnSave": true,
+    "files.trimTrailingWhitespace": true,
+  },
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [
+    "dbaeumer.vscode-eslint",
+    "ms-dotnettools.csharp",
+    "ms-dotnettools.dotnet-interactive-vscode",
+    "ms-toolsai.jupyter",
+    "ms-toolsai.jupyter-keymap",
+    "ms-toolsai.jupyter-renderers",
+    "ionide.ionide-fsharp"
+  ],
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [5000, 5001],
+  // [Optional] To reuse of your local HTTPS dev cert:
+  //
+  // 1. Export it locally using this command:
+  //    * Windows PowerShell:
+  //        dotnet dev-certs https --trust; dotnet dev-certs https -ep "$env:USERPROFILE/.aspnet/https/aspnetapp.pfx" -p "SecurePwdGoesHere"
+  //    * macOS/Linux terminal:
+  //        dotnet dev-certs https --trust; dotnet dev-certs https -ep "${HOME}/.aspnet/https/aspnetapp.pfx" -p "SecurePwdGoesHere"
+  // 
+  // 2. Uncomment these 'remoteEnv' lines:
+  //    "remoteEnv": {
+  // 	      "ASPNETCORE_Kestrel__Certificates__Default__Password": "SecurePwdGoesHere",
+  //        "ASPNETCORE_Kestrel__Certificates__Default__Path": "/home/vscode/.aspnet/https/aspnetapp.pfx",
+  //    },
+  //
+  // 3. Do one of the following depending on your scenario:
+  //    * When using GitHub Codespaces and/or Remote - Containers:
+  //      1. Start the container
+  //      2. Drag ~/.aspnet/https/aspnetapp.pfx into the root of the file explorer
+  //      3. Open a terminal in VS Code and run "mkdir -p /home/vscode/.aspnet/https && mv aspnetapp.pfx /home/vscode/.aspnet/https"
+  //
+  //    * If only using Remote - Containers with a local container, uncomment this line instead:
+  //      "mounts": [ "source=${env:HOME}${env:USERPROFILE}/.aspnet/https,target=/home/vscode/.aspnet/https,type=bind" ],
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "dotnet restore",
+  // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "vscode",
+  "features": {
+    "powershell": "latest"
+  }
+}

--- a/.devcontainer/workspace.code-workspace
+++ b/.devcontainer/workspace.code-workspace
@@ -1,0 +1,24 @@
+{
+  "folders": [
+    {
+      "name": "Repo Root",
+      "path": ".."
+    },
+    {
+      "name": "NPM Package",
+      "path": "..\\src\\dotnet-interactive-npm"
+    },
+    {
+      "name": "VS Code - Stable",
+      "path": "..\\src\\dotnet-interactive-vscode\\stable"
+    },
+    {
+      "name": "VS Code - Insiders",
+      "path": "..\\src\\dotnet-interactive-vscode\\insiders"
+    },
+    {
+      "path": "..\\src\\Microsoft.DotNet.Interactive.Js"
+    }
+  ],
+  "settings": {}
+}


### PR DESCRIPTION
This is the initial run at being able to develop from this repo entirely in GitHub Codespaces.

So far I've just done some smoke testing, but you can build/debug the VS Code extension (it opens a new tab.)  There are still some process improvements to make, but this at least gets us started.