### PR TITLE
Update SqlToolsService to 157

### DIFF
--- a/DEVELOPER-GUIDE.md
+++ b/DEVELOPER-GUIDE.md
@@ -107,9 +107,9 @@ If you've made changes to `dotnet-interactive` and want to try them out with Vis
       ```js
         "dotnet-interactive.kernelTransportArgs": [
             "{dotnet_path}",
-            "/PATH/TO/REPO/ROOT/artifacts/bin/dotnet-interactive/Debug/net5.0/Microsoft.DotNet.Interactive.App.dll",
+            "/PATH/TO/REPO/ROOT/artifacts/bin/dotnet-interactive/Debug/$(TargetFramework)/Microsoft.DotNet.Interactive.App.dll",
             "[vscode]",
-            "vscode",
+            "stdio",
             "--log-path",
             "/path/to/a/folder/for/your/logs/",
             "--verbose",
@@ -119,7 +119,7 @@ If you've made changes to `dotnet-interactive` and want to try them out with Vis
 
         "dotnet-interactive.notebookParserArgs": [
             "{dotnet_path}",
-            "/PATH/TO/REPO/ROOT/artifacts/bin/dotnet-interactive/Debug/net5.0/Microsoft.DotNet.Interactive.App.dll",
+            "/PATH/TO/REPO/ROOT/artifacts/bin/dotnet-interactive/Debug/$(TargetFramework)/Microsoft.DotNet.Interactive.App.dll",
             "notebook-parser"
         ]
       ```

--- a/src/Microsoft.DotNet.Interactive.Kql.Tests/KqlConnectionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql.Tests/KqlConnectionTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.Interactive.Kql.Tests
         {
             var csharpKernel = new CSharpKernel().UseNugetDirective();
             await csharpKernel.SubmitCodeAsync(@$"
-#r ""nuget:microsoft.sqltoolsservice,3.0.0-release.53""
+#r ""nuget:microsoft.sqltoolsservice,3.0.0-release.157""
 ");
 
             var kernel = new CompositeKernel
@@ -259,7 +259,7 @@ print testVar";
             result = await kernel.SendAsync(new SubmitCode(code));
 
             var events = result.KernelEvents.ToSubscribedList();
-            
+
             events
                 .ShouldDisplayTabularDataResourceWhich()
                 .Data
@@ -281,7 +281,7 @@ print testVar";
         {
             var cluster = KqlFactAttribute.GetClusterForTests();
             using var kernel = await CreateKernel();
-            
+
             var result = await kernel.SubmitCodeAsync(
                 $"#!connect kql --kernel-name KustoHelp --cluster \"{cluster}\" --database \"Samples\"");
 

--- a/src/Microsoft.DotNet.Interactive.Kql/Microsoft.DotNet.Interactive.Kql.csproj
+++ b/src/Microsoft.DotNet.Interactive.Kql/Microsoft.DotNet.Interactive.Kql.csproj
@@ -26,7 +26,7 @@
 
  <ItemGroup>
    <PackageReference Include="Microsoft.Azure.Kusto.Data" Version="9.3.1" />
-   <PackageReference Include="Microsoft.SqlToolsService" Version="3.0.0-release.53" />
+   <PackageReference Include="Microsoft.SqlToolsService" Version="3.0.0-release.157" />
    <PackageReference Include="StreamJsonRpc" Version="2.8.28" />
  </ItemGroup>
 
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="bin\Debug\net5.0\/Microsoft.DotNet.Interactive.Kql.dll" />
+    <None Remove="bin\Debug\$(TargetFramework)\Microsoft.DotNet.Interactive.Kql.dll" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Interactive.SqlServer.Tests/MsSqlConnectionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer.Tests/MsSqlConnectionTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Interactive.SqlServer.Tests
         {
             var csharpKernel = new CSharpKernel().UseNugetDirective().UseValueSharing();
             await csharpKernel.SubmitCodeAsync(@$"
-#r ""nuget:microsoft.sqltoolsservice,3.0.0-release.53""
+#r ""nuget:microsoft.sqltoolsservice,3.0.0-release.157""
 ");
 
             // TODO: remove SQLKernel it is used to test current patch

--- a/src/Microsoft.DotNet.Interactive.SqlServer/Microsoft.DotNet.Interactive.SqlServer.csproj
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/Microsoft.DotNet.Interactive.SqlServer.csproj
@@ -22,7 +22,7 @@
  <ItemGroup>
    <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.1" />
    <PackageReference Include="Humanizer" Version="2.8.26" />
-   <PackageReference Include="Microsoft.SqlToolsService" Version="3.0.0-release.53" />
+   <PackageReference Include="Microsoft.SqlToolsService" Version="3.0.0-release.157" />
    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0">
      <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
NOTE: These packages are NOT published as of the opening of this PR. 

This brings in the full set of Linux RIDs as well as many other bug fixes/improvements to the service itself
Also : 

1. Fixed a couple of places that were still referencing net5.0 
2. Changed result handler to only store the query results once at the end (regardless of whether an error occurred or not)