### PR TITLE
set CI as Frontend telemetry 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,6 +123,7 @@ stages:
           env:
             POCKETLOGGER_LOG_PATH: $(PocketLoggerLogPath)
             TRYDOTNET_PACKAGES_PATH: $(TryDotNetPackagesPath)
+            DOTNET_INTERACTIVE_FRONTEND_NAME: CI
 
         - script: dotnet test -l trx --no-build --blame-hang-timeout 5m --blame-hang-dump-type full -c $(_BuildConfig) --results-directory $(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)
           displayName: Test / Blame
@@ -266,6 +267,7 @@ stages:
           env:
             POCKETLOGGER_LOG_PATH: $(PocketLoggerLogPath)
             TRYDOTNET_PACKAGES_PATH: $(TryDotNetPackagesPath)
+            DOTNET_INTERACTIVE_FRONTEND_NAME: CI
 
         - script: dotnet test -l trx --no-build --blame-hang-timeout 5m --blame-hang-dump-type full -c $(_BuildConfig) --results-directory $(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)
           displayName: Test / Blame

--- a/src/dotnet-interactive.Tests/CommandLine/TelemetryTests.cs
+++ b/src/dotnet-interactive.Tests/CommandLine/TelemetryTests.cs
@@ -199,7 +199,7 @@ public class TelemetryTests : IDisposable
     }
 
     [Fact]
-    public async Task Jupyter_install_command_sends_default_fronted_telemetry()
+    public async Task Jupyter_install_command_sends_default_frontend_telemetry()
     {
         var defaultFrontend = GetDefaultFrontendName();
         await _parser.InvokeAsync("jupyter install", _console);

--- a/src/dotnet-interactive/CommandLine/CommandLineParser.cs
+++ b/src/dotnet-interactive/CommandLine/CommandLineParser.cs
@@ -162,13 +162,18 @@ public static class CommandLineParser
                     {
                         case "jupyter":
                             entryItems.Add(new KeyValuePair<string, string>("frontend", commandResult.Command.Name));
-                            break;
-                        default:
-                            entryItems.Add(new KeyValuePair<string, string>("frontend", "unknown"));
+                            frontendTelemetryAdded = true;
                             break;
                     }
                 }
 
+                if(!frontendTelemetryAdded){
+                    var frontendName = Environment.GetEnvironmentVariable("DOTNET_INTERACTIVE_FRONTEND_NAME");
+                    if(string.IsNullOrWhiteSpace(frontendName)){
+                        frontendName = "unknown";
+                    }
+                    entryItems.Add(new KeyValuePair<string, string>("frontend", frontendName));                    
+                }
             });
 
         var verboseOption = new Option<bool>(


### PR DESCRIPTION
Added api to get frontend name from environment variable, CI is using itsown so we can also remove it from telemetry count