### PR TITLE
Resolve SQL Tools Service path upon extension load and improve errors

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.kql_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.kql_api_is_not_changed.approved.txt
@@ -3,7 +3,7 @@ Microsoft.DotNet.Interactive.Kql
     .ctor(Microsoft.DotNet.Interactive.Kernel kernel)
     public System.CommandLine.Option<System.String> NameOption { get;}
   public class ConnectKqlCommand : Microsoft.DotNet.Interactive.Connection.ConnectKernelCommand<KqlKernelConnector>, System.Collections.Generic.IEnumerable<System.CommandLine.Symbol>, System.Collections.IEnumerable, System.CommandLine.ICommand, System.CommandLine.IIdentifierSymbol, System.CommandLine.ISymbol, System.CommandLine.Suggestions.ISuggestionSource
-    .ctor()
+    .ctor(System.String resolvedToolsServicePath)
     public System.Threading.Tasks.Task<Microsoft.DotNet.Interactive.Kernel> ConnectKernelAsync(Microsoft.DotNet.Interactive.KernelInfo kernelInfo, KqlKernelConnector connector, Microsoft.DotNet.Interactive.KernelInvocationContext context)
   public class KqlConnectionDetails
     .ctor()

--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.mssql_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.mssql_api_is_not_changed.approved.txt
@@ -86,7 +86,7 @@ Microsoft.DotNet.Interactive.SqlServer
      System.String ServerName { public get; set;}
      System.String UserName { public get; set;}
   public class ConnectMsSqlCommand : Microsoft.DotNet.Interactive.Connection.ConnectKernelCommand<MsSqlKernelConnector>, System.Collections.Generic.IEnumerable<System.CommandLine.Symbol>, System.Collections.IEnumerable, System.CommandLine.ICommand, System.CommandLine.IIdentifierSymbol, System.CommandLine.ISymbol, System.CommandLine.Suggestions.ISuggestionSource
-    .ctor()
+    .ctor(System.String resolvedToolsServicePath)
     public System.Threading.Tasks.Task<Microsoft.DotNet.Interactive.Kernel> ConnectKernelAsync(Microsoft.DotNet.Interactive.KernelInfo kernelInfo, MsSqlKernelConnector connector, Microsoft.DotNet.Interactive.KernelInvocationContext context)
   public class ConnectParams
     .ctor()

--- a/src/Microsoft.DotNet.Interactive.Kql.Tests/KqlConnectionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql.Tests/KqlConnectionTests.cs
@@ -34,7 +34,8 @@ namespace Microsoft.DotNet.Interactive.Kql.Tests
 
             kernel.DefaultKernelName = csharpKernel.Name;
 
-            kernel.UseKernelClientConnection(new ConnectKqlCommand());
+            var kqlKernelExtension = new KqlKernelExtension();
+            await kqlKernelExtension.OnLoadAsync(kernel);
             kernel.UseNteractDataExplorer();
             kernel.UseSandDanceExplorer();
 

--- a/src/Microsoft.DotNet.Interactive.Kql/ConnectKqlCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql/ConnectKqlCommand.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.Interactive.Kql
 {
     public class ConnectKqlCommand : ConnectKernelCommand<KqlKernelConnector>
     {
-        internal string ResolvedToolsServicePath { get; set; }
+        private readonly string ResolvedToolsServicePath;
 
         public ConnectKqlCommand(string resolvedToolsServicePath)
             : base("kql", "Connects to a Microsoft Kusto Server database")

--- a/src/Microsoft.DotNet.Interactive.Kql/ConnectKqlCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql/ConnectKqlCommand.cs
@@ -4,13 +4,13 @@
 using System.CommandLine;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.Connection;
-using Microsoft.DotNet.Interactive.Documents;
-using Microsoft.DotNet.Interactive.SqlServer;
 
 namespace Microsoft.DotNet.Interactive.Kql
 {
     public class ConnectKqlCommand : ConnectKernelCommand<KqlKernelConnector>
     {
+        public static string ResolvedToolsServicePath { get; internal set; }
+
         public ConnectKqlCommand()
             : base("kql", "Connects to a Microsoft Kusto Server database")
         {
@@ -25,11 +25,7 @@ namespace Microsoft.DotNet.Interactive.Kql
         public override async Task<Kernel> ConnectKernelAsync(KernelInfo kernelInfo, KqlKernelConnector connector,
             KernelInvocationContext context)
         {
-            var root = Kernel.Root.FindResolvedPackageReference();
-
-            var pathToService = root.PathToService("MicrosoftKustoServiceLayer");
-
-            connector.PathToService = pathToService;
+            connector.PathToService = ResolvedToolsServicePath;
 
             var kernel = await connector.ConnectKernelAsync(kernelInfo);
 

--- a/src/Microsoft.DotNet.Interactive.Kql/ConnectKqlCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql/ConnectKqlCommand.cs
@@ -9,11 +9,12 @@ namespace Microsoft.DotNet.Interactive.Kql
 {
     public class ConnectKqlCommand : ConnectKernelCommand<KqlKernelConnector>
     {
-        public static string ResolvedToolsServicePath { get; internal set; }
+        internal string ResolvedToolsServicePath { get; set; }
 
-        public ConnectKqlCommand()
+        public ConnectKqlCommand(string resolvedToolsServicePath)
             : base("kql", "Connects to a Microsoft Kusto Server database")
         {
+            ResolvedToolsServicePath = resolvedToolsServicePath;
             Add(new Option<string>(
                 "--cluster",
                 "The cluster used to connect") {IsRequired = true});

--- a/src/Microsoft.DotNet.Interactive.Kql/KqlKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql/KqlKernelExtension.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
@@ -24,9 +25,8 @@ namespace Microsoft.DotNet.Interactive.Kql
                     {
                         if (File.Exists(pathToService))
                         {
-                            ConnectKqlCommand.ResolvedToolsServicePath = pathToService;
                             compositeKernel
-                                .UseKernelClientConnection(new ConnectKqlCommand());
+                                .UseKernelClientConnection(new ConnectKqlCommand(pathToService));
 
                             KernelInvocationContext.Current?.Display(
                                 new HtmlString(@"<details><summary>Query Microsoft Kusto Server databases.</summary>
@@ -36,18 +36,18 @@ namespace Microsoft.DotNet.Interactive.Kql
                         }
                         else
                         {
-                            KernelInvocationContext.Current?.DisplayStandardError($"The KQL extension was loaded successfully and resolved the path to the Kusto Tools Service but the file {pathToService} does not exist. The connect command will not be available.");
+                            throw new InvalidOperationException($"The KQL extension was loaded successfully and resolved the path to the Kusto Tools Service but the file {pathToService} does not exist. The #!connect kql command will not be available.");
                         }
 
                     }
                     else
                     {
-                        KernelInvocationContext.Current?.DisplayStandardError("The KQL extension was loaded successfully but was unable to determine the path to the KQL Tools Service. The connect command will not be available.");
+                        throw new InvalidOperationException("The KQL extension was loaded successfully but was unable to determine the path to the KQL Tools Service. The #!connect kql command will not be available.");
                     }
                 }
                 else
                 {
-                    KernelInvocationContext.Current?.DisplayStandardError($"The KQL extension was loaded successfully but was unable to find the KQL Tools Service package. The connect command will not be available. (RID: {RuntimeInformation.RuntimeIdentifier})");
+                    throw new InvalidOperationException($"The KQL extension was loaded successfully but was unable to find the KQL Tools Service package. The #!connect kql command will not be available. (RID: {RuntimeInformation.RuntimeIdentifier})");
                 }
 
             }

--- a/src/Microsoft.DotNet.Interactive.Kql/KqlKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql/KqlKernelExtension.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
-using Microsoft.DotNet.Interactive.ExtensionLab;
+using Microsoft.DotNet.Interactive.SqlServer;
 
 namespace Microsoft.DotNet.Interactive.Kql
 {
@@ -13,14 +15,41 @@ namespace Microsoft.DotNet.Interactive.Kql
         {
             if (kernel is CompositeKernel compositeKernel)
             {
-                compositeKernel
-                    .UseKernelClientConnection(new ConnectKqlCommand());
+                var root = Kernel.Root.FindResolvedNativeSqlToolsServicePackageReference();
+                if (root != null)
+                {
+                    var pathToService = root.PathToToolsService("MicrosoftKustoServiceLayer");
 
-                KernelInvocationContext.Current?.Display(
-                    new HtmlString(@"<details><summary>Query Microsoft Kusto Server databases.</summary>
-    <p>This extension adds support for connecting to Microsoft Kusto Server databases using the <code>#!connect kql</code> magic command. For more information, run a cell using the <code>#!kql</code> magic command.</p>
-    </details>"),
-                    "text/html");
+                    if (!string.IsNullOrEmpty(pathToService))
+                    {
+                        if (File.Exists(pathToService))
+                        {
+                            ConnectKqlCommand.ResolvedToolsServicePath = pathToService;
+                            compositeKernel
+                                .UseKernelClientConnection(new ConnectKqlCommand());
+
+                            KernelInvocationContext.Current?.Display(
+                                new HtmlString(@"<details><summary>Query Microsoft Kusto Server databases.</summary>
+        <p>This extension adds support for connecting to Microsoft Kusto Server databases using the <code>#!connect kql</code> magic command. For more information, run a cell using the <code>#!kql</code> magic command.</p>
+        </details>"),
+                                "text/html");
+                        }
+                        else
+                        {
+                            KernelInvocationContext.Current?.DisplayStandardError($"The KQL extension was loaded successfully and resolved the path to the Kusto Tools Service but the file {pathToService} does not exist. The connect command will not be available.");
+                        }
+
+                    }
+                    else
+                    {
+                        KernelInvocationContext.Current?.DisplayStandardError("The KQL extension was loaded successfully but was unable to determine the path to the KQL Tools Service. The connect command will not be available.");
+                    }
+                }
+                else
+                {
+                    KernelInvocationContext.Current?.DisplayStandardError($"The KQL extension was loaded successfully but was unable to find the KQL Tools Service package. The connect command will not be available. (RID: {RuntimeInformation.RuntimeIdentifier})");
+                }
+
             }
 
             return Task.CompletedTask;

--- a/src/Microsoft.DotNet.Interactive.SqlServer.Tests/MsSqlConnectionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer.Tests/MsSqlConnectionTests.cs
@@ -38,7 +38,8 @@ namespace Microsoft.DotNet.Interactive.SqlServer.Tests
 
             kernel.DefaultKernelName = csharpKernel.Name;
 
-            kernel.UseKernelClientConnection(new ConnectMsSqlCommand());
+            var sqlKernelExtension = new MsSqlKernelExtension();
+            await sqlKernelExtension.OnLoadAsync(kernel);
             kernel.UseNteractDataExplorer();
             kernel.UseSandDanceExplorer();
 

--- a/src/Microsoft.DotNet.Interactive.SqlServer/ConnectMsSqlCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/ConnectMsSqlCommand.cs
@@ -5,12 +5,13 @@ using System.CommandLine;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.Connection;
 using Microsoft.DotNet.Interactive.CSharp;
-using Microsoft.DotNet.Interactive.Documents;
 
 namespace Microsoft.DotNet.Interactive.SqlServer
 {
     public class ConnectMsSqlCommand : ConnectKernelCommand<MsSqlKernelConnector>
     {
+        public static string ResolvedToolsServicePath { get; internal set; }
+
         public ConnectMsSqlCommand()
             : base("mssql", "Connects to a Microsoft SQL Server database")
         {
@@ -25,11 +26,7 @@ namespace Microsoft.DotNet.Interactive.SqlServer
         public override async Task<Kernel> ConnectKernelAsync(KernelInfo kernelInfo, MsSqlKernelConnector connector,
             KernelInvocationContext context)
         {
-            var root = Kernel.Root.FindResolvedPackageReference();
-
-            var pathToService = root.PathToService("MicrosoftSqlToolsServiceLayer");
-
-            connector.PathToService = pathToService;
+            connector.PathToService = ResolvedToolsServicePath;
 
             var kernel = await connector.ConnectKernelAsync(kernelInfo);
 
@@ -40,7 +37,7 @@ namespace Microsoft.DotNet.Interactive.SqlServer
 
             return kernel;
         }
-        
+
         private async Task InitializeDbContextAsync(string kernelName, MsSqlKernelConnector options, KernelInvocationContext context)
         {
             CSharpKernel csharpKernel = null;
@@ -114,7 +111,7 @@ foreach (var file in  new[] {{ model.ContextFile.Code }}.Concat(model.Additional
         // trim out the wrapping braces
         .Trim()
         .Trim( new[] {{ '{{', '}}' }} );
-                      
+
     code += fileCode;
 }}
 ";

--- a/src/Microsoft.DotNet.Interactive.SqlServer/ConnectMsSqlCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/ConnectMsSqlCommand.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.Interactive.SqlServer
 {
     public class ConnectMsSqlCommand : ConnectKernelCommand<MsSqlKernelConnector>
     {
-        internal string ResolvedToolsServicePath { get; set; }
+        private readonly string ResolvedToolsServicePath;
 
         public ConnectMsSqlCommand(string resolvedToolsServicePath)
             : base("mssql", "Connects to a Microsoft SQL Server database")

--- a/src/Microsoft.DotNet.Interactive.SqlServer/ConnectMsSqlCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/ConnectMsSqlCommand.cs
@@ -10,11 +10,12 @@ namespace Microsoft.DotNet.Interactive.SqlServer
 {
     public class ConnectMsSqlCommand : ConnectKernelCommand<MsSqlKernelConnector>
     {
-        public static string ResolvedToolsServicePath { get; internal set; }
+        internal string ResolvedToolsServicePath { get; set; }
 
-        public ConnectMsSqlCommand()
+        public ConnectMsSqlCommand(string resolvedToolsServicePath)
             : base("mssql", "Connects to a Microsoft SQL Server database")
         {
+            ResolvedToolsServicePath = resolvedToolsServicePath;
             Add(new Argument<string>(
                     "connectionString",
                     "The connection string used to connect to the database"));

--- a/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelExtension.cs
@@ -1,9 +1,9 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.IO;
 using System.Threading.Tasks;
-using System.Runtime;
 using Microsoft.AspNetCore.Html;
 using System.Runtime.InteropServices;
 
@@ -24,9 +24,8 @@ namespace Microsoft.DotNet.Interactive.SqlServer
                     {
                         if (File.Exists(pathToService))
                         {
-                            ConnectMsSqlCommand.ResolvedToolsServicePath = pathToService;
                             compositeKernel
-                            .UseKernelClientConnection(new ConnectMsSqlCommand());
+                            .UseKernelClientConnection(new ConnectMsSqlCommand(pathToService));
 
                             KernelInvocationContext.Current?.Display(
                                 new HtmlString(@"<details><summary>Query Microsoft SQL Server databases.</summary>
@@ -36,18 +35,18 @@ namespace Microsoft.DotNet.Interactive.SqlServer
                         }
                         else
                         {
-                            KernelInvocationContext.Current?.DisplayStandardError($"The SQL Server extension was loaded successfully and resolved the path to the SQL Tools Service but the file {pathToService} does not exist. The connect command will not be available.");
+                            throw new InvalidOperationException($"The SQL Server extension was loaded successfully and resolved the path to the SQL Tools Service but the file {pathToService} does not exist. The #!connect mssql command will not be available.");
                         }
 
                     }
                     else
                     {
-                        KernelInvocationContext.Current?.DisplayStandardError($"The SQL Server extension was loaded successfully but was unable to determine the path to the SQL Tools Service. The connect command will not be available.");
+                        throw new InvalidOperationException($"The SQL Server extension was loaded successfully but was unable to determine the path to the SQL Tools Service. The #!connect mssql command will not be available.");
                     }
                 }
                 else
                 {
-                    KernelInvocationContext.Current?.DisplayStandardError($"The SQL Server extension was loaded successfully but was unable to find the SQL Tools Service package. The connect command will not be available. (RID: {RuntimeInformation.RuntimeIdentifier})");
+                    throw new InvalidOperationException($"The SQL Server extension was loaded successfully but was unable to find the SQL Tools Service package. The #!connect mssql command will not be available. (RID: {RuntimeInformation.RuntimeIdentifier})");
                 }
             }
 

--- a/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelExtension.cs
@@ -1,8 +1,11 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
 using System.Threading.Tasks;
+using System.Runtime;
 using Microsoft.AspNetCore.Html;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.DotNet.Interactive.SqlServer
 {
@@ -12,15 +15,40 @@ namespace Microsoft.DotNet.Interactive.SqlServer
         {
             if (kernel is CompositeKernel compositeKernel)
             {
+                var root = Kernel.Root.FindResolvedNativeSqlToolsServicePackageReference();
+                if (root != null)
+                {
+                    var pathToService = root.PathToToolsService("MicrosoftSqlToolsServiceLayer");
 
-                compositeKernel
-                    .UseKernelClientConnection(new ConnectMsSqlCommand());
+                    if (!string.IsNullOrEmpty(pathToService))
+                    {
+                        if (File.Exists(pathToService))
+                        {
+                            ConnectMsSqlCommand.ResolvedToolsServicePath = pathToService;
+                            compositeKernel
+                            .UseKernelClientConnection(new ConnectMsSqlCommand());
 
-                KernelInvocationContext.Current?.Display(
-                    new HtmlString(@"<details><summary>Query Microsoft SQL Server databases.</summary>
+                            KernelInvocationContext.Current?.Display(
+                                new HtmlString(@"<details><summary>Query Microsoft SQL Server databases.</summary>
     <p>This extension adds support for connecting to Microsoft SQL Server databases using the <code>#!connect mssql</code> magic command. For more information, run a cell using the <code>#!sql</code> magic command.</p>
     </details>"),
-                    "text/html");
+                                "text/html");
+                        }
+                        else
+                        {
+                            KernelInvocationContext.Current?.DisplayStandardError($"The SQL Server extension was loaded successfully and resolved the path to the SQL Tools Service but the file {pathToService} does not exist. The connect command will not be available.");
+                        }
+
+                    }
+                    else
+                    {
+                        KernelInvocationContext.Current?.DisplayStandardError($"The SQL Server extension was loaded successfully but was unable to determine the path to the SQL Tools Service. The connect command will not be available.");
+                    }
+                }
+                else
+                {
+                    KernelInvocationContext.Current?.DisplayStandardError($"The SQL Server extension was loaded successfully but was unable to find the SQL Tools Service package. The connect command will not be available. (RID: {RuntimeInformation.RuntimeIdentifier})");
+                }
             }
 
             return Task.CompletedTask;

--- a/src/Microsoft.DotNet.Interactive.SqlServer/SqlToolsServiceDiscovery.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/SqlToolsServiceDiscovery.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.Interactive.SqlServer
             {
                 // Extract the platform 'osx-x64' from the package name 'runtime.osx-x64.native.microsoft.sqltoolsservice'
                 var packageNameSegments = resolvedPackageReference.PackageName.Split(".");
-                if (packageNameSegments.Length > 2)
+                if (packageNameSegments.Length < 2)
                 {
                     var platform = packageNameSegments[1];
 

--- a/src/Microsoft.DotNet.Interactive.SqlServer/SqlToolsServiceDiscovery.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/SqlToolsServiceDiscovery.cs
@@ -11,7 +11,13 @@ namespace Microsoft.DotNet.Interactive.SqlServer
 {
     internal static class SqlToolsServiceDiscovery
     {
-        public static ResolvedPackageReference FindResolvedPackageReference(this Kernel rootKernel)
+        /// <summary>
+        /// Finds the resolved native package for the Microsoft.SqlToolsService package which contains the SQL Tools Service binaries. This may fail to find
+        /// a resolved package reference if the platform RID isn't supported by SQL Tools Service.
+        /// </summary>
+        /// <param name="rootKernel">The root kernel to look at the package references of</param>
+        /// <returns>The package reference if a matching one exists, null if not</returns>
+        public static ResolvedPackageReference FindResolvedNativeSqlToolsServicePackageReference(this Kernel rootKernel)
         {
             var runtimePackageIdSuffix = "native.Microsoft.SqlToolsService";
             var resolved = rootKernel.SubkernelsAndSelf()
@@ -21,7 +27,13 @@ namespace Microsoft.DotNet.Interactive.SqlServer
             return resolved;
         }
 
-        public static string PathToService(this ResolvedPackageReference resolvedPackageReference, string serviceName)
+        /// <summary>
+        /// Generates the full path to the service of the name specified from within this resolved package reference.
+        /// </summary>
+        /// <param name="resolvedPackageReference">The package containing the Tools Service binaries</param>
+        /// <param name="serviceName">The name of the exe to search for (without the extension)</param>
+        /// <returns></returns>
+        public static string PathToToolsService(this ResolvedPackageReference resolvedPackageReference, string serviceName)
         {
             var pathToService = "";
             if (resolvedPackageReference is not null)

--- a/src/Microsoft.DotNet.Interactive.SqlServer/SqlToolsServiceDiscovery.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/SqlToolsServiceDiscovery.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.Interactive.SqlServer
             {
                 // Extract the platform 'osx-x64' from the package name 'runtime.osx-x64.native.microsoft.sqltoolsservice'
                 var packageNameSegments = resolvedPackageReference.PackageName.Split(".");
-                if (packageNameSegments.Length < 2)
+                if (packageNameSegments.Length > 2)
                 {
                     var platform = packageNameSegments[1];
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/interactive/issues/1788

Instead of resolving the path every time we connect we'll do it once upon extension load (since it should never be expected to change after loading). 

Also improved the error checking, there's 3 things we specifically check now : 

1. Can't find native STS package

![NoPackage](https://user-images.githubusercontent.com/28519865/143325248-b03f5533-1ef3-4f12-a39a-7477f049dbfd.png)

2. Can't resolve path to STS exe within package

![NoPath](https://user-images.githubusercontent.com/28519865/143325264-4409b37d-ecce-4152-9066-cd4d358363ff.png)

3. Exe doesn't exist

![NoExe](https://user-images.githubusercontent.com/28519865/143325297-10e9bf7e-1dd4-47c5-9a64-3026e499451a.png)

@colombod and I discussed adding a check on every connect to ensure that the exe still exists (like we essentially were doing) but the error message in that case seems clear enough so I think it's fine to leave it as is (if it disappeared that'd be quite strange anyways)

![NoExeConnect](https://user-images.githubusercontent.com/28519865/143325370-47dd47e8-85a1-4318-9660-d141346ff4d5.png)

I am wondering about the way I'm displaying the error currently - it isn't really noticeable currently. Is there some standard formatting I should use? Or should I even throw Exceptions instead? The extension still loaded and so is available for things to reference, it's just the connect command that wouldn't be available. But it seems kind of odd since if that can't be found the whole point of the extension is kind of lost anyways...
