### PR TITLE
reusable stdio connector 

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
@@ -184,6 +184,7 @@ Microsoft.DotNet.Interactive
     public System.Uri Uri { get;}
     public System.Threading.Tasks.Task ConnectAndWaitAsync()
     public System.Threading.Tasks.Task ConnectAsync()
+    public System.Threading.Tasks.Task<Microsoft.DotNet.Interactive.Connection.ProxyKernel> CreateProxyKernelOnConnectorAsync(KernelInfo kernelInfo, Microsoft.DotNet.Interactive.Connection.IKernelConnector kernelConnector)
     public System.Threading.Tasks.Task<Microsoft.DotNet.Interactive.Connection.ProxyKernel> CreateProxyKernelOnDefaultConnectorAsync(KernelInfo kernelInfo)
     public System.Void Dispose()
     public System.Boolean TryGetKernelByDestinationUri(System.Uri destinationUri, ref Kernel& kernel)
@@ -456,11 +457,12 @@ Microsoft.DotNet.Interactive.Connection
      System.Void DelegatePublication(Microsoft.DotNet.Interactive.Events.KernelEvent kernelEvent)
     public Microsoft.DotNet.Interactive.ValueSharing.IKernelValueDeclarer GetValueDeclarer(System.Object value)
     public System.Threading.Tasks.Task StartAsync()
-  public class StdIoKernelConnector, IKernelConnector
+  public class StdIoKernelConnector, IKernelConnector, System.IDisposable
     .ctor(System.String[] command, System.IO.DirectoryInfo workingDirectory = null)
     public System.String[] Command { get;}
     public System.IO.DirectoryInfo WorkingDirectory { get;}
     public System.Threading.Tasks.Task<Microsoft.DotNet.Interactive.Kernel> ConnectKernelAsync(Microsoft.DotNet.Interactive.KernelInfo kernelInfo)
+    public System.Void Dispose()
 Microsoft.DotNet.Interactive.Events
   public class CodeSubmissionReceived : KernelEvent
     .ctor(Microsoft.DotNet.Interactive.Commands.SubmitCode command)

--- a/src/Microsoft.DotNet.Interactive/Connection/StdIoKernelConnector.cs
+++ b/src/Microsoft.DotNet.Interactive/Connection/StdIoKernelConnector.cs
@@ -14,107 +14,106 @@ using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Utility;
 
-namespace Microsoft.DotNet.Interactive.Connection
+namespace Microsoft.DotNet.Interactive.Connection;
+
+public class StdIoKernelConnector : IKernelConnector, IDisposable
 {
-    public class StdIoKernelConnector : IKernelConnector, IDisposable
+    private MultiplexingKernelCommandAndEventReceiver? _receiver;
+    private KernelCommandAndEventTextStreamSender? _sender;
+    private Process? _process;
+
+    public string[] Command { get; }
+
+    public DirectoryInfo WorkingDirectory { get; }
+
+    public async Task<Kernel> ConnectKernelAsync(KernelInfo kernelInfo)
     {
-        private MultiplexingKernelCommandAndEventReceiver? _receiver;
-        private KernelCommandAndEventTextStreamSender? _sender;
-        private Process? _process;
-
-        public string[] Command { get; }
-
-        public DirectoryInfo WorkingDirectory { get; }
-
-        public async Task<Kernel> ConnectKernelAsync(KernelInfo kernelInfo)
+        if (_receiver is not null)
         {
-            if (_receiver is not null)
+            var kernel = new ProxyKernel(kernelInfo.LocalName, _receiver.CreateChildReceiver(), _sender);
+            var _ = kernel.StartAsync();
+            return kernel;
+        }
+        else
+        {
+            // QUESTION: (ConnectKernelAsync) tests?
+            var command = Command[0];
+            var arguments = string.Join(" ", Command.Skip(1));
+            var psi = new ProcessStartInfo
             {
-                var kernel = new ProxyKernel(kernelInfo.LocalName, _receiver.CreateChildReceiver(), _sender);
-                var _ = kernel.StartAsync();
-                return kernel;
-            }
-            else
+                FileName = command,
+                Arguments = arguments,
+                WorkingDirectory = WorkingDirectory.FullName,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            _process = new Process { StartInfo = psi };
+            _process.EnableRaisingEvents = true;
+            var stdErr = new StringBuilder();
+            _process.ErrorDataReceived += (o, args) => { stdErr.Append(args.Data); };
+            await Task.Yield();
+            _process.Start();
+            _process.BeginErrorReadLine();
+            _receiver = new MultiplexingKernelCommandAndEventReceiver(
+                new KernelCommandAndEventTextReceiver(_process.StandardOutput));
+            _sender = new KernelCommandAndEventTextStreamSender(_process.StandardInput);
+            var kernel = new ProxyKernel(kernelInfo.LocalName, _receiver, _sender);
+            kernel.RegisterForDisposal(this);
+
+            var r = _receiver.CreateChildReceiver();
+            var _ = kernel.StartAsync();
+
+            var checkReady = Task.Run(async () =>
             {
-                // QUESTION: (ConnectKernelAsync) tests?
-                var command = Command[0];
-                var arguments = string.Join(" ", Command.Skip(1));
-                var psi = new ProcessStartInfo
+                await foreach (var eoc in r.CommandsAndEventsAsync(CancellationToken.None))
                 {
-                    FileName = command,
-                    Arguments = arguments,
-                    WorkingDirectory = WorkingDirectory.FullName,
-                    RedirectStandardInput = true,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                };
-                _process = new Process { StartInfo = psi };
-                _process.EnableRaisingEvents = true;
-                var stdErr = new StringBuilder();
-                _process.ErrorDataReceived += (o, args) => { stdErr.Append(args.Data); };
-                await Task.Yield();
-                _process.Start();
-                _process.BeginErrorReadLine();
-                _receiver = new MultiplexingKernelCommandAndEventReceiver(
-                    new KernelCommandAndEventTextReceiver(_process.StandardOutput));
-                _sender = new KernelCommandAndEventTextStreamSender(_process.StandardInput);
-                var kernel = new ProxyKernel(kernelInfo.LocalName, _receiver, _sender);
-                kernel.RegisterForDisposal(this);
-
-                var r = _receiver.CreateChildReceiver();
-                var _ = kernel.StartAsync();
-
-                var checkReady = Task.Run(async () =>
-                {
-                    await foreach (var eoc in r.CommandsAndEventsAsync(CancellationToken.None))
+                    if (eoc.Event is KernelReady)
                     {
-                        if (eoc.Event is KernelReady)
+                        return;
+                    }
+                }
+            });
+
+            var checkProcessError = Task.Run(async () =>
+            {
+                while (!checkReady.IsCompleted)
+                {
+                    await Task.Delay(200);
+                    if (_process.HasExited)
+                    {
+                        if (_process.ExitCode != 0)
                         {
-                            return;
+                            throw new CommandLineInvocationException(
+                                new CommandLineResult(_process.ExitCode,
+                                    error: stdErr.ToString().Split(new[] { '\r', '\n' },
+                                        StringSplitOptions.RemoveEmptyEntries)));
                         }
                     }
-                });
+                }
+            });
 
-                var checkProcessError = Task.Run(async () =>
-                {
-                    while (!checkReady.IsCompleted)
-                    {
-                        await Task.Delay(200);
-                        if (_process.HasExited)
-                        {
-                            if (_process.ExitCode != 0)
-                            {
-                                throw new CommandLineInvocationException(
-                                    new CommandLineResult(_process.ExitCode,
-                                        error: stdErr.ToString().Split(new[] { '\r', '\n' },
-                                            StringSplitOptions.RemoveEmptyEntries)));
-                            }
-                        }
-                    }
-                });
-
-                await Task.WhenAny(checkProcessError, checkReady);
-                return kernel;
-            }
-
-
+            await Task.WhenAny(checkProcessError, checkReady);
+            return kernel;
         }
 
-        public StdIoKernelConnector(string[] command, DirectoryInfo? workingDirectory = null)
-        {
-            Command = command;
-            WorkingDirectory = workingDirectory ?? new DirectoryInfo(Environment.CurrentDirectory);
-        }
 
-        public void Dispose()
+    }
+
+    public StdIoKernelConnector(string[] command, DirectoryInfo? workingDirectory = null)
+    {
+        Command = command;
+        WorkingDirectory = workingDirectory ?? new DirectoryInfo(Environment.CurrentDirectory);
+    }
+
+    public void Dispose()
+    {
+        if (_process is not null && _process.HasExited == false)
         {
-            if (_process is not null && _process.HasExited == false)
-            {
-                _process?.Kill();
-                _process?.Dispose();
-                _process = null;
-            }
+            _process?.Kill();
+            _process?.Dispose();
+            _process = null;
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive/KernelHost.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelHost.cs
@@ -253,7 +253,13 @@ namespace Microsoft.DotNet.Interactive
 
         public async Task<ProxyKernel> CreateProxyKernelOnDefaultConnectorAsync(KernelInfo kernelInfo)
         {
-            var childKernel = await _defaultConnector.ConnectKernelAsync(kernelInfo) as ProxyKernel;
+            var childKernel = await CreateProxyKernelOnConnectorAsync(kernelInfo,_defaultConnector);
+            return childKernel;
+        }
+
+        public async Task<ProxyKernel> CreateProxyKernelOnConnectorAsync(KernelInfo kernelInfo, IKernelConnector kernelConnector )
+        {
+            var childKernel = await kernelConnector.ConnectKernelAsync(kernelInfo) as ProxyKernel;
             _kernel.Add(childKernel, kernelInfo.Aliases);
             RegisterDestinationUriForProxy(kernelInfo.LocalName, kernelInfo.DestinationUri);
             return childKernel;

--- a/src/dotnet-interactive.Tests/StdIOConnectionTests.cs
+++ b/src/dotnet-interactive.Tests/StdIOConnectionTests.cs
@@ -110,9 +110,9 @@ namespace Microsoft.DotNet.Interactive.Tests
 
             using var localKernel2 = await connector.ConnectKernelAsync(new KernelInfo("kernel2"));
 
-            var kernelCommand1 = new SubmitCode("\"echo1\"");
+            var kernelCommand1 = new SubmitCode("(1+1).Display(\"text/plain\")");
 
-            var kernelCommand2 = new SubmitCode("\"echo2\"");
+            var kernelCommand2 = new SubmitCode("(3+3).Display(\"text/plain\")");
 
             var res1 = await localKernel1.SendAsync(kernelCommand1);
 
@@ -125,12 +125,12 @@ namespace Microsoft.DotNet.Interactive.Tests
             kernelEvents1.Should().ContainSingle<CommandSucceeded>().Which.Command.As<SubmitCode>().Code.Should()
                 .Be(kernelCommand1.Code);
 
-            kernelEvents1.Should().ContainSingle<ReturnValueProduced>().Which.FormattedValues.Should().ContainSingle(f => f.Value == "echo1");
+            kernelEvents1.Should().ContainSingle<DisplayedValueProduced>().Which.FormattedValues.Should().ContainSingle(f => f.Value == "2");
 
             kernelEvents2.Should().ContainSingle<CommandSucceeded>().Which.Command.As<SubmitCode>().Code.Should()
                 .Be(kernelCommand2.Code);
 
-            kernelEvents2.Should().ContainSingle<ReturnValueProduced>().Which.FormattedValues.Should().ContainSingle(f => f.Value == "echo2");
+            kernelEvents2.Should().ContainSingle<DisplayedValueProduced>().Which.FormattedValues.Should().ContainSingle(f => f.Value == "6");
         }
     }
 }

--- a/src/dotnet-interactive.Tests/dotnet-interactive.Tests.v3.ncrunchproject
+++ b/src/dotnet-interactive.Tests/dotnet-interactive.Tests.v3.ncrunchproject
@@ -41,6 +41,9 @@
       <NamedTestSelector>
         <TestName>Microsoft.DotNet.Interactive.App.Tests.AspNetCoreTests.can_define_aspnet_endpoint_with_MapGet</TestName>
       </NamedTestSelector>
+      <NamedTestSelector>
+        <TestName>Microsoft.DotNet.Interactive.Tests.StdIOConnectionTests.it_can_reuse_connection_for_multiple_proxy_kernel</TestName>
+      </NamedTestSelector>
     </IgnoredTests>
   </Settings>
 </ProjectConfiguration>


### PR DESCRIPTION
stdio connector should be reused for multiple proxies
kernelHost needs to be able to track proxies created on connectors other than the default connector