### PR TITLE
report error if dotnet(.exe) couldn't be found

### DIFF
--- a/src/dotnet-interactive-vscode-common/src/extension.ts
+++ b/src/dotnet-interactive-vscode-common/src/extension.ts
@@ -84,12 +84,17 @@ export async function activate(context: vscode.ExtensionContext) {
     registerAcquisitionCommands(context, diagnosticsChannel);
 
     // check sdk version
-    const dotnetVersion = await getDotNetVersionOrThrow(DotNetPathManager.getDotNetPath(), diagnosticsChannel);
-    if (!isVersionSufficient(dotnetVersion, minDotNetSdkVersion)) {
-        const message = `The .NET SDK version ${dotnetVersion} is not sufficient. The minimum required version is ${minDotNetSdkVersion}.`;
-        diagnosticsChannel.appendLine(message);
-        vscode.window.showErrorMessage(message);
-        throw new Error(message);
+    try {
+        const dotnetVersion = await getDotNetVersionOrThrow(DotNetPathManager.getDotNetPath(), diagnosticsChannel);
+        if (!isVersionSufficient(dotnetVersion, minDotNetSdkVersion)) {
+            const message = `The .NET SDK version ${dotnetVersion} is not sufficient. The minimum required version is ${minDotNetSdkVersion}.`;
+            diagnosticsChannel.appendLine(message);
+            vscode.window.showErrorMessage(message);
+            throw new Error(message);
+        }
+    } catch (e) {
+        vscode.window.showErrorMessage(`Unable to determine the .NET SDK version.  Please download the ${minDotNetSdkVersion} SDK from https://dotnet.microsoft.com/en-us/download`);
+        throw e;
     }
 
     async function kernelChannelCreator(notebookUri: vscodeLike.Uri): Promise<contracts.KernelCommandAndEventChannel> {

--- a/src/dotnet-interactive-vscode-common/src/extension.ts
+++ b/src/dotnet-interactive-vscode-common/src/extension.ts
@@ -93,7 +93,7 @@ export async function activate(context: vscode.ExtensionContext) {
             throw new Error(message);
         }
     } catch (e) {
-        vscode.window.showErrorMessage(`Unable to determine the .NET SDK version.  Please download the ${minDotNetSdkVersion} SDK from https://dotnet.microsoft.com/en-us/download`);
+        vscode.window.showErrorMessage(`Please install the .NET SDK version ${minDotNetSdkVersion} from https://dotnet.microsoft.com/en-us/download`);
         throw e;
     }
 


### PR DESCRIPTION
When the extension starts up we first call `dotnet --version` to determine if the SDK is up-to-date.  If it's not even there we used to just blow up, but now we can at least give the user a pointer.

![screenshot](https://user-images.githubusercontent.com/926281/152450329-1a58e957-abb1-4cee-b6b2-49b5178d426f.png)
