### PR TITLE
ping the windows kernel every 500ms until command completion

### DIFF
--- a/src/dotnet-interactive-vscode-common/src/extension.ts
+++ b/src/dotnet-interactive-vscode-common/src/extension.ts
@@ -123,7 +123,7 @@ export async function activate(context: vscode.ExtensionContext) {
             displayError: async (message: string) => { await vscode.window.showErrorMessage(message, { modal: false }); },
             displayInfo: async (message: string) => { await vscode.window.showInformationMessage(message, { modal: false }); },
         };
-        const channel = new StdioDotnetInteractiveChannel(notebookUri.toString(), processStart, diagnosticsChannel, vscode.Uri.parse, notification, (pid, code, signal) => {
+        const channel = new StdioDotnetInteractiveChannel(notebookUri.toString(), processStart, diagnosticsChannel, (pid, code, signal) => {
             clientMapper.closeClient(notebookUri, false);
         });
 


### PR DESCRIPTION
In some cases cell execution appears to hang.  The cause is that `Console.ReadLineAsync()` isn't actualy asynchronous.  According to the [documentation](https://docs.microsoft.com/en-us/dotnet/api/system.console.in?view=net-6.0#remarks):

> Read operations on the standard input stream execute synchronously. That is, they block until the specified read operation has completed. This is true even if an asynchronous method, such as `ReadLineAsync`, is called on the `TextReader` object returned by the `In` property.

This issue is only specific to Windows, and only when a client is communicating over STDIO, so the fix is very targeted: when code execution is invoked, start a timer to periodically "ping" the kernel with a single newline character until the execution has completed.

Fixes #1832.