### PR TITLE
Fix docs bug

### DIFF
--- a/docs/NotebooksOnBinder.md
+++ b/docs/NotebooksOnBinder.md
@@ -42,4 +42,4 @@ Now that you have had a tour of .NET notebooks with Binder, you can get started 
 
 Follow the link below to get started.
  
-[Create your notebook on your machine](NotebooksLocalExperience.md)
+[Create your notebook on your machine](NotebookswithJupyter.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ _Our documentation is still a work in progress. There are a number of topics lis
 There are several ways to get started using .NET Interactive with Jupyter, including Jupyter Notebook, JupyterLab, and nteract.
 
 * [Try sample .NET notebooks online using Binder](NotebooksOnBinder.md).
-* [Create and run .NET notebooks on your machine](NotebooksLocalExperience.md).
+* [Create and run .NET notebooks on your machine](NotebookswithJupyter.md).
 * [Share .NET notebooks online using Binder](CreateBinder.md).
 
 ### Visual Studio Code

--- a/docs/install-dotnet-interactive.md
+++ b/docs/install-dotnet-interactive.md
@@ -4,7 +4,7 @@ The .NET Interactive tool works with multiple frontends, and so depending on how
 
 ## Jupyter
 
-.NET Interactive is a Jupyter kernel. To install it for use with Jupyter (including Jupyter Notebook, JupyterLab, nteract, Azure Data Studio, and others), follow the instructions [here](NotebooksLocalExperience.md). 
+.NET Interactive is a Jupyter kernel. To install it for use with Jupyter (including Jupyter Notebook, JupyterLab, nteract, Azure Data Studio, and others), follow the instructions [here](NotebookswithJupyter.md). 
 
 ## Visual Studio Code
 


### PR DESCRIPTION
There were similar links pointing to the missing file _docs/NotebooksLocalExperience.md_. Historically, that file was renamed to _docs/NotebookswithJupyter.md_ in the commit 4039b7a.

### Broken links

https://github.com/dotnet/interactive/blob/0ea16bf35a93e7dac464a49e14da426e9d658d41/docs/README.md?plain=1#L12

https://github.com/dotnet/interactive/blob/0ea16bf35a93e7dac464a49e14da426e9d658d41/docs/NotebooksOnBinder.md?plain=1#L45

https://github.com/dotnet/interactive/blob/0ea16bf35a93e7dac464a49e14da426e9d658d41/docs/install-dotnet-interactive.md?plain=1#L7
