### PR TITLE
set handler in kernel using custom interface

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Tests/Utility/CustomCommandTypes.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Utility/CustomCommandTypes.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Utility
         {
             public class MyCommand : KernelCommand
             {
-                public MyCommand(string info)
+                public MyCommand(string info, string targetKernelName = null) : base(targetKernelName)
                 {
                     Info = info;
                 }
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Interactive.Tests.Utility
         {
             public class MyCommand : KernelCommand
             {
-                public MyCommand(string info, int additionalProperty)
+                public MyCommand(string info, int additionalProperty, string targetKernelName = null) : base(targetKernelName)
                 {
                     Info = info;
                     AdditionalProperty = additionalProperty;


### PR DESCRIPTION
When kernels implement custom command handler via the IKernelCommadnHandler interface it is enough to resolve the handler for the custom command