### PR TITLE
include base library version in `#!about`

### DIFF
--- a/src/dotnet-interactive.Tests/MagicCommandTests.about.cs
+++ b/src/dotnet-interactive.Tests/MagicCommandTests.about.cs
@@ -39,6 +39,7 @@ namespace Microsoft.DotNet.Interactive.App.Tests
                       .ContainAll(
                           ".NET Interactive",
                           "Version",
+                          "Library version",
                           "https://github.com/dotnet/interactive");
             }
         }

--- a/src/dotnet-interactive/KernelExtensions.cs
+++ b/src/dotnet-interactive/KernelExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.CommandLine.NamingConventionBinder;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.Formatting;
 using Microsoft.DotNet.Interactive.Utility;
@@ -47,6 +48,11 @@ namespace Microsoft.DotNet.Interactive.App
 
                 }
 
+                var libraryAssembly = typeof(Kernel).Assembly;
+                var libraryInformationalVersion = libraryAssembly
+                                               .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                                               .InformationalVersion;
+
                 PocketView html = table(
                     tbody(
                         tr(
@@ -55,6 +61,7 @@ namespace Microsoft.DotNet.Interactive.App
                                 p[style: "font-size:1.5em"](b(".NET Interactive")),
                                 p("© 2020 Microsoft Corporation"),
                                 p(b("Version: "), info.AssemblyInformationalVersion),
+                                p(b("Library version: "), libraryInformationalVersion),
                                 p(b("Build date: "), info.BuildDate),
                                 p(a[href: url](url))
                             ))


### PR DESCRIPTION
Since the `Microsoft.dotnet-interactive` global tool and `Microsoft.DotNet.Interactive(.*)` packages have different version numbers, I've modified the `#!about` magic command to include both.  This will make it easier for extension authors to properly correlate package versions.

Before:
<img width="442" alt="image" src="https://user-images.githubusercontent.com/926281/161140201-ca124286-eae2-484a-9bd9-c855d831cccd.png">

After:
<img width="524" alt="image" src="https://user-images.githubusercontent.com/926281/161140257-d9d891bf-c093-4f5b-90ff-ec94b6b90b30.png">
