### PR TITLE
Performance improvement to the csharp kernel language services

### DIFF
--- a/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
@@ -217,7 +217,7 @@ namespace Microsoft.DotNet.Interactive.CSharp
                         cancellationToken: context.CancellationToken)
                     .UntilCancelled(context.CancellationToken) ?? ScriptState;
 
-                _workspace.UpdateWorkspace(ScriptState);
+                await _workspace.UpdateWorkspaceAsync(ScriptState);
             }
         }
 
@@ -364,7 +364,7 @@ namespace Microsoft.DotNet.Interactive.CSharp
 
             if (ScriptState is not null && ScriptState.Exception is null)
             {
-                _workspace.UpdateWorkspace(ScriptState);
+                await _workspace.UpdateWorkspaceAsync(ScriptState);
             }
 
             void UpdateScriptOptionsIfWorkingDirectoryChanged()


### PR DESCRIPTION
Partially fixes #1391

The performance of the language services (`RequestCompletions`, `RequestDiagnostics`, etc.) for the C# kernel degrades the more submission the kernel receives. This causes the kernel to be almost unusable after a while because it becomes so slow. 

The performance degradation is caused because of the way the language services are implemented. Normally, when you do any language service request (eg. `CompletionService.GetCompletionsAsync`) on the current solution, the solution would cache some information like the compilation of the projects on that solution. The problem is that each time the C# kernel ask a language service question, it forks the current solution (`InteractiveWorkspace.ForkDocumentForLanguageServices`). Therefore, the cached information is discarded at the end of language service question request.

The changes in this PR forces the creation of a compilation object every time code is submitted, so the language service doesn't need to create a new compilation for the entire project each time a language service question is asked.

Disclaimer: this is my first pull request on GitHub, so let me know if did anything incorrectly.