### PR TITLE
Await clearOutput promise when starting cell execution.

### DIFF
--- a/src/dotnet-interactive-vscode-ads/src/notebookControllers.ts
+++ b/src/dotnet-interactive-vscode-ads/src/notebookControllers.ts
@@ -139,7 +139,7 @@ export class DotNetNotebookKernel {
             try {
                 const startTime = Date.now();
                 executionTask.start(startTime);
-                executionTask.clearOutput(cell);
+                await executionTask.clearOutput(cell);
                 const controllerErrors: vscodeLike.NotebookCellOutput[] = [];
 
                 function outputObserver(outputs: Array<vscodeLike.NotebookCellOutput>) {

--- a/src/dotnet-interactive-vscode-insiders/src/notebookControllers.ts
+++ b/src/dotnet-interactive-vscode-insiders/src/notebookControllers.ts
@@ -150,7 +150,7 @@ export class DotNetNotebookKernel {
             try {
                 const startTime = Date.now();
                 executionTask.start(startTime);
-                executionTask.clearOutput(cell);
+                await executionTask.clearOutput(cell);
                 const controllerErrors: vscodeLike.NotebookCellOutput[] = [];
 
                 function outputObserver(outputs: Array<vscodeLike.NotebookCellOutput>) {

--- a/src/dotnet-interactive-vscode/src/notebookControllers.ts
+++ b/src/dotnet-interactive-vscode/src/notebookControllers.ts
@@ -150,7 +150,7 @@ export class DotNetNotebookKernel {
             try {
                 const startTime = Date.now();
                 executionTask.start(startTime);
-                executionTask.clearOutput(cell);
+                await executionTask.clearOutput(cell);
                 const controllerErrors: vscodeLike.NotebookCellOutput[] = [];
 
                 function outputObserver(outputs: Array<vscodeLike.NotebookCellOutput>) {


### PR DESCRIPTION
I was doing some testing with Run All Cells in Azure Data Studio, and occasionally when running an Interactive notebook I would see that cell outputs wouldn't get updated when the cell execution completed. When I dug into it I saw that the cell's output was getting cleared after the cell execution had completed. Looks like the promise for the clearOutput call in DotNetNotebookKenel.executeCell wasn't being awaited, so a very fast code cell (e.g. immediately returning a number) could finish before that promise resolved.