### PR TITLE
disable docker detector

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,8 @@ variables:
     value: true
   - name: _DotNetArtifactsCategory
     value: .NETCore
+  - name: DisableDockerDetector
+    value: true
   - name: PocketLoggerLogPath
     value: $(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)
   - name: TryDotNetPackagesPath


### PR DESCRIPTION
Don't generate warnings in the internal build for Dockerfiles.  Validated in one-off build [here](https://dev.azure.com/dnceng/internal/_build/results?buildId=1793845&view=results).