### PR TITLE
Improve NuGet package performance by using cache

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -25,8 +25,8 @@
     FSharp.Compiler.Service: https://dev.azure.com/dnceng/internal/_release?view=mine&_a=releases&definitionId=98
 
     -->
-    <PackageReference Update="FSharp.Core" Version="6.0.4" />
-    <PackageReference Update="FSharp.Compiler.Service" Version="41.0.4" />
+    <PackageReference Update="FSharp.Core" Version="6.0.5-beta.22327.2" />
+    <PackageReference Update="FSharp.Compiler.Service" Version="41.0.5-preview.22327.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
@@ -76,6 +76,7 @@ type FSharpKernel () as this =
         | FSharpGlyph.Struct -> WellKnownTags.Structure
         | FSharpGlyph.Typedef -> WellKnownTags.Class
         | FSharpGlyph.Type -> WellKnownTags.Class
+        | FSharpGlyph.TypeParameter -> WellKnownTags.TypeParameter
         | FSharpGlyph.Union -> WellKnownTags.Enum
         | FSharpGlyph.Variable -> WellKnownTags.Local
         | FSharpGlyph.ExtensionMethod -> WellKnownTags.ExtensionMethod

--- a/src/Microsoft.DotNet.Interactive.PackageManagement/PackageRestoreContext.cs
+++ b/src/Microsoft.DotNet.Interactive.PackageManagement/PackageRestoreContext.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Interactive
 
         public PackageRestoreContext()
         {
-            _dependencyProvider = new DependencyProvider(AssemblyProbingPaths, NativeProbingRoots);
+            _dependencyProvider = new DependencyProvider(AssemblyProbingPaths, NativeProbingRoots, useResultsCache: true);
             AppDomain.CurrentDomain.AssemblyLoad += OnAssemblyLoad;
         }
 


### PR DESCRIPTION
## Before this can be pulled out of draft

- [x] Publish F# packages from the internal build [20220627.2](https://dev.azure.com/dnceng/internal/_build/results?buildId=1848427&view=results) from the `Packages/Shipping` artifact, version `*.22327.2`.

**tl;dr** - Initial package restore unchanged, 4.2s.  Cached package restore 1.5s.  Subsequent restores within the same process (i.e., no longer JITing anything): 0.1s.

### Long Version

Some local tests showed:

- With old NuGet package manager:
  1. Create new blank notebook.
  2. Execute `1+1` to start the backing process and warm up the kernel.
  3. Execute `#r "nuget:SomePackage, 1.0.0"`
  4. Result: 4.2s

- With new NuGet package manager, cache not populated:
  1. Create new blank notebook.
  2. Execute `1+1` to start the backing process and warm up the kernel.
  3. Execute `#r "nuget:SomePackage, 1.0.0"`
  4. Result: 4.2s, and cache created on disk.

- With new NuGet package manager, cache populated by previous run:
  1. Create new blank notebook.
  2. Execute `1+1` to start the backing process and warm up the kernel.
  3. Execute `#r "nuget:SomePackage, 1.0.0"`
  4. Result: 1.5s, cache used from disk, package manager was jitted.
  5. Execute `#r "nuget:SomePackage, 1.0.0"` again
  6. Result: 0.1s, cache used from disk, package manager native code was re-used.