### PR TITLE
Added support for C4 diagrams in mermaid kernel

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Mermaid/MermaidMarkdownFormatter.cs
+++ b/src/Microsoft.DotNet.Interactive.Mermaid/MermaidMarkdownFormatter.cs
@@ -12,9 +12,10 @@ namespace Microsoft.DotNet.Interactive.Mermaid;
 
 internal class MermaidMarkdownFormatter : ITypeFormatterSource
 {
-    private static readonly Uri DefaultLibraryUri = new(@"https://cdn.jsdelivr.net/npm/mermaid@9.1.3/dist/mermaid.min.js", UriKind.Absolute);
-    private static readonly Uri RequireUri = new("https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js");
     private const string DefaultLibraryVersion = "9.1.3";
+    private static readonly Uri DefaultLibraryUri = new($@"https://cdn.jsdelivr.net/npm/mermaid@{DefaultLibraryVersion}/dist/mermaid.min.js", UriKind.Absolute);
+    private static readonly Uri RequireUri = new("https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js");
+    
     
     private static string? _cacheBuster;
     private static Uri? _libraryUri;

--- a/src/Microsoft.DotNet.Interactive.Mermaid/MermaidMarkdownFormatter.cs
+++ b/src/Microsoft.DotNet.Interactive.Mermaid/MermaidMarkdownFormatter.cs
@@ -12,9 +12,9 @@ namespace Microsoft.DotNet.Interactive.Mermaid;
 
 internal class MermaidMarkdownFormatter : ITypeFormatterSource
 {
-    private static readonly Uri DefaultLibraryUri = new(@"https://cdn.jsdelivr.net/npm/mermaid@9.1.1/dist/mermaid.min.js", UriKind.Absolute);
+    private static readonly Uri DefaultLibraryUri = new(@"https://cdn.jsdelivr.net/npm/mermaid@9.1.3/dist/mermaid.min.js", UriKind.Absolute);
     private static readonly Uri RequireUri = new("https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js");
-    private const string DefaultLibraryVersion = "9.1.1";
+    private const string DefaultLibraryVersion = "9.1.3";
     
     private static string? _cacheBuster;
     private static Uri? _libraryUri;


### PR DESCRIPTION
Adds supports for 
 - System Context (C4Context)
 - Container diagram (C4Container)
 - Component diagram (C4Component)
 - Dynamic diagram (C4Dynamic)
 - Deployment diagram (C4Deployment)

Please refer to [C4 mermaid](https://mermaid-js.github.io/mermaid/#/c4c?id=c4-diagrams) documentation and the linked document [C4-PlantUML syntax](https://github.com/plantuml-stdlib/C4-PlantUML/blob/master/README.md) for how to write the c4 diagram.

<img width="467" alt="image" src="https://user-images.githubusercontent.com/375556/178455269-2077157c-be4e-4d45-a3d3-5398bb6a9c0a.png">
