### PR TITLE
update build machine image name

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,10 +49,10 @@ stages:
         pool:
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
             name: NetCore1ESPool-Public
-            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
+            demands: ImageOverride -equals windows.vs2022.amd64.open
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
             name: NetCore1ESPool-Internal
-            demands: ImageOverride -equals build.windows.10.amd64.vs2019
+            demands: ImageOverride -equals windows.vs2022.amd64
         timeoutInMinutes: 90
         variables:
         # Enable signing for internal, non-PR builds


### PR DESCRIPTION
Following instructions [here](https://github.com/dotnet/arcade/blob/main/Documentation/NativeToolsOnMachine.md) to update build machine image names.

~~Leaving as draft until internal build has completed.~~