### PR TITLE
kernelInfo events updates the kernelInfo on proxies

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
@@ -621,7 +621,7 @@ Microsoft.DotNet.Interactive.Events
     .ctor(Microsoft.DotNet.Interactive.IKernelExtension kernelExtension, Microsoft.DotNet.Interactive.Commands.KernelCommand command)
     public Microsoft.DotNet.Interactive.IKernelExtension KernelExtension { get;}
   public class KernelInfoProduced : KernelEvent
-    .ctor(Microsoft.DotNet.Interactive.KernelInfo kernelInfo, Microsoft.DotNet.Interactive.Commands.RequestKernelInfo command)
+    .ctor(Microsoft.DotNet.Interactive.KernelInfo kernelInfo, Microsoft.DotNet.Interactive.Commands.KernelCommand command)
     public Microsoft.DotNet.Interactive.KernelInfo KernelInfo { get;}
   public class KernelReady : KernelEvent
     .ctor()

--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
@@ -229,8 +229,8 @@ Microsoft.DotNet.Interactive
   public class KernelInfo
     .ctor(System.String localName, System.String languageName = null, System.String languageVersion = null, System.String[] aliases = null)
     public System.String[] Aliases { get; set;}
-    public System.String LanguageName { get;}
-    public System.String LanguageVersion { get;}
+    public System.String LanguageName { get; set;}
+    public System.String LanguageVersion { get; set;}
     public System.String LocalName { get;}
     public System.Uri RemoteUri { get; set;}
     public System.Collections.Generic.ICollection<KernelDirectiveInfo> SupportedDirectives { get; set;}

--- a/src/Microsoft.DotNet.Interactive.Tests/KernelInfoTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/KernelInfoTests.cs
@@ -79,7 +79,7 @@ public class KernelInfoTests
             var events = result.KernelEvents.ToSubscribedList();
 
             events.Should()
-                  .ContainSingle<KernelInfoProduced>()
+                  .ContainSingle<KernelInfoProduced>(e => e.KernelInfo.LocalName == "fsharp")
                   .Which
                   .KernelInfo
                   .Should()

--- a/src/Microsoft.DotNet.Interactive/CompositeKernel.cs
+++ b/src/Microsoft.DotNet.Interactive/CompositeKernel.cs
@@ -93,6 +93,17 @@ namespace Microsoft.DotNet.Interactive
 
             RegisterForDisposal(kernel.KernelEvents.Subscribe(PublishEvent));
             RegisterForDisposal(kernel);
+
+            var command = KernelInvocationContext.Current?.Command ?? KernelCommand.None;
+            var kernelInfoProduced = new KernelInfoProduced(kernel.KernelInfo, command);
+            if (KernelInvocationContext.Current is { })
+            {
+                KernelInvocationContext.Current.Publish(kernelInfoProduced);
+            }
+            else
+            {
+                PublishEvent(kernelInfoProduced);
+            }
         }
 
         public void SetDefaultTargetKernelNameForCommand(
@@ -128,9 +139,9 @@ namespace Microsoft.DotNet.Interactive
                 var extensionDir =
                     new DirectoryInfo
                     (Path.Combine(
-                         packageRootDir,
-                         "interactive-extensions",
-                         "dotnet"));
+                        packageRootDir,
+                        "interactive-extensions",
+                        "dotnet"));
 
                 if (extensionDir.Exists)
                 {
@@ -327,7 +338,7 @@ namespace Microsoft.DotNet.Interactive
 
                     var chooseKernelDirective =
                         Directives.OfType<ChooseKernelDirective>()
-                                  .Single(d => d.Kernel == connectedKernel);
+                            .Single(d => d.Kernel == connectedKernel);
 
                     if (!string.IsNullOrWhiteSpace(connectionCommand.ConnectedKernelDescription))
                     {

--- a/src/Microsoft.DotNet.Interactive/Events/KernelInfoProduced.cs
+++ b/src/Microsoft.DotNet.Interactive/Events/KernelInfoProduced.cs
@@ -9,7 +9,7 @@ public class KernelInfoProduced : KernelEvent
 {
     public KernelInfoProduced(
         KernelInfo kernelInfo,
-        RequestKernelInfo command) : base(command)
+        KernelCommand command) : base(command)
     {
         KernelInfo = kernelInfo;
     }

--- a/src/Microsoft.DotNet.Interactive/KernelHost.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelHost.cs
@@ -5,9 +5,11 @@
 
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Reactive;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Connection;
 using Microsoft.DotNet.Interactive.Events;
 
@@ -106,6 +108,17 @@ namespace Microsoft.DotNet.Interactive
             await _defaultSender.SendAsync(
                 new KernelReady(),
                 _cancellationTokenSource.Token);
+
+            await _defaultSender.SendAsync(
+                new KernelInfoProduced(_kernel.KernelInfo, KernelCommand.None),
+                _cancellationTokenSource.Token);
+            
+            foreach (var kernel in _kernel.ChildKernels.Where(k => k is not ProxyKernel))
+            {
+                await _defaultSender.SendAsync(
+                    new KernelInfoProduced(kernel.KernelInfo, KernelCommand.None),
+                    _cancellationTokenSource.Token);
+            }
         }
 
         public async Task ConnectAndWaitAsync()

--- a/src/Microsoft.DotNet.Interactive/KernelInfo.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelInfo.cs
@@ -46,9 +46,9 @@ namespace Microsoft.DotNet.Interactive
             init => NameAndAliases.UnionWith(value);
         }
 
-        public string? LanguageName { get; }
+        public string? LanguageName { get; set; }
 
-        public string? LanguageVersion { get; }
+        public string? LanguageVersion { get; set; }
 
         public string LocalName { get; }
 

--- a/src/microsoft-dotnet-interactive/src/compositeKernel.ts
+++ b/src/microsoft-dotnet-interactive/src/compositeKernel.ts
@@ -78,6 +78,26 @@ export class CompositeKernel extends Kernel {
         }
 
         this._childKernels.add(kernel, aliases);
+
+        const invocationContext = KernelInvocationContext.current;
+
+        if (invocationContext) {
+            invocationContext.commandEnvelope;//?
+            invocationContext.publish({
+                eventType: contracts.KernelInfoProducedType,
+                event: <contracts.KernelInfoProduced>{
+                    kernelInfo: kernel.kernelInfo
+                },
+                command: invocationContext.commandEnvelope
+            });
+        } else {
+            this.publishEvent({
+                eventType: contracts.KernelInfoProducedType,
+                event: <contracts.KernelInfoProduced>{
+                    kernelInfo: kernel.kernelInfo
+                }
+            });
+        }
     }
 
     setDefaultTargetKernelNameForCommand(commandType: contracts.KernelCommandType, kernelName: string) {

--- a/src/microsoft-dotnet-interactive/src/kernelHost.ts
+++ b/src/microsoft-dotnet-interactive/src/kernelHost.ts
@@ -107,5 +107,13 @@ export class KernelHost {
             }
         });
 
+        this._defaultSender.send({ eventType: contracts.KernelReadyType, event: {} });
+
+        this._defaultSender.send({ eventType: contracts.KernelInfoProducedType, event: <contracts.KernelInfoProduced>{ kernelInfo: this._kernel.kernelInfo } });
+
+        for (let kernel of this._kernel.childKernels) {
+            this._defaultSender.send({ eventType: contracts.KernelInfoProducedType, event: <contracts.KernelInfoProduced>{ kernelInfo: kernel.kernelInfo } });
+        }
+
     }
 }

--- a/src/microsoft-dotnet-interactive/src/kernelInvocationContext.ts
+++ b/src/microsoft-dotnet-interactive/src/kernelInvocationContext.ts
@@ -104,6 +104,10 @@ export class KernelInvocationContext implements Disposable {
     }
 
     private internalPublish(kernelEvent: contracts.KernelEventEnvelope) {
+        if (!kernelEvent.command) {
+            kernelEvent.command = this._commandEnvelope;
+        }
+
         let command = kernelEvent.command;
 
         if (this.handlingKernel) {
@@ -113,8 +117,9 @@ export class KernelInvocationContext implements Disposable {
         } else {
             kernelEvent;//?
         }
-
+        this._commandEnvelope;//?
         if (command === null ||
+            command === undefined ||
             areCommandsTheSame(command!, this._commandEnvelope) ||
             this._childCommands.includes(command!)) {
             this._eventSubject.next(kernelEvent);
@@ -135,6 +140,9 @@ export class KernelInvocationContext implements Disposable {
 }
 
 export function areCommandsTheSame(envelope1: contracts.KernelCommandEnvelope, envelope2: contracts.KernelCommandEnvelope): boolean {
+    envelope1;//?
+    envelope2;//?
+    envelope1 === envelope2;//?
     return envelope1 === envelope2
-        || (envelope1.commandType === envelope2.commandType && envelope1.token === envelope2.token);
+        || (envelope1?.commandType === envelope2?.commandType && envelope1?.token === envelope2?.token);
 }

--- a/src/microsoft-dotnet-interactive/src/proxyKernel.ts
+++ b/src/microsoft-dotnet-interactive/src/proxyKernel.ts
@@ -122,6 +122,7 @@ export class ProxyKernel extends Kernel {
                                             routingSlip: envelope.routingSlip,
                                             command: commandInvocation.commandEnvelope
                                         }, commandInvocation.context);
+                                    this.delegatePublication(envelope, commandInvocation.context);
                                 }
                                 break;
                             case contracts.CommandFailedType:

--- a/src/microsoft-dotnet-interactive/tests/kernelHost.test.ts
+++ b/src/microsoft-dotnet-interactive/tests/kernelHost.test.ts
@@ -18,6 +18,62 @@ describe("kernelHost",
 
         it("provides uri for kernels", () => {
             const inMemory = createInMemoryChannels();
+            inMemory.local.messagesSent
+            const compositeKernel = new CompositeKernel("vscode");
+            const childKernel = new Kernel("test", "customLanguage");
+            childKernel.registerCommandHandler({
+                commandType: "customCommand",
+                handle: (_commandInvocation) => { return Promise.resolve(); }
+            })
+            compositeKernel.add(childKernel, ["test1", "test2"]);
+
+            const kernelHost = new KernelHost(compositeKernel, inMemory.local.sender, inMemory.local.receiver, "kernel://vscode");
+            kernelHost.connect();
+
+            expect(inMemory.local.messagesSent).to.deep.equal([
+                {
+                    event: {},
+                    eventType: 'KernelReady'
+                },
+                {
+                    event:
+                    {
+                        kernelInfo:
+                        {
+                            aliases: [],
+                            languageName: undefined,
+                            languageVersion: undefined,
+                            localName: 'vscode',
+                            supportedDirectives: [],
+                            supportedKernelCommands: [{ name: 'RequestKernelInfo' }],
+                            uri: 'kernel://vscode'
+                        }
+                    },
+                    eventType: 'KernelInfoProduced'
+                },
+                {
+                    event:
+                    {
+                        kernelInfo:
+                        {
+                            aliases: ['test1', 'test2'],
+                            languageName: "customLanguage",
+                            languageVersion: undefined,
+                            localName: 'test',
+                            supportedDirectives: [],
+                            supportedKernelCommands: [
+                                { name: 'RequestKernelInfo' },
+                                { name: 'customCommand' }
+                            ],
+                            uri: 'kernel://vscode/test'
+                        }
+                    },
+                    eventType: 'KernelInfoProduced'
+                }]);
+        });
+
+        it("provides uri for kernels", () => {
+            const inMemory = createInMemoryChannels();
             const compositeKernel = new CompositeKernel("vscode");
             const kernelHost = new KernelHost(compositeKernel, inMemory.local.sender, inMemory.local.receiver, "kernel://vscode");
 

--- a/src/microsoft-dotnet-interactive/tests/kernelInfo.test.ts
+++ b/src/microsoft-dotnet-interactive/tests/kernelInfo.test.ts
@@ -103,7 +103,7 @@ describe("kernelInfo", () => {
             }]);
         });
 
-        it.only("when commands adde a kernel it produces KernelInfoProduced events", async () => {
+        it("when commands adde a kernel it produces KernelInfoProduced events", async () => {
             const events: contracts.KernelEventEnvelope[] = [];
             const kernel = new CompositeKernel("root");
             const childKernel = new Kernel("child1", "customLLanguage");

--- a/src/microsoft-dotnet-interactive/tests/testSupport.ts
+++ b/src/microsoft-dotnet-interactive/tests/testSupport.ts
@@ -70,3 +70,20 @@ export function createInMemoryChannels(): {
 
     return channels;
 }
+
+export function clearTokenAndId(envelope: connection.KernelCommandOrEventEnvelope): connection.KernelCommandOrEventEnvelope {
+    if (connection.isKernelEventEnvelope(envelope)) {
+        let clone: contracts.KernelEventEnvelope = { ...envelope };
+        if (clone.command) {
+            clone.command = <contracts.KernelCommandEnvelope>clearTokenAndId(clone.command);
+        }
+        return clone;
+    } else if (connection.isKernelCommandEnvelope(envelope)) {
+        let clone = { ...envelope };
+        clone.token = "commandToken";
+        clone.id = "commandId";
+        return clone;
+    }
+
+    throw new Error("Unknown envelope type");
+}


### PR DESCRIPTION
KernelInfoProduced events are now generated by the host and ProxyKernels augments their info to reflect  the capabilites of the remote ones.

Typescript api is also reflecting the api changes