### PR TITLE
allow custom environment variables to be set when launching a kernel

### DIFF
--- a/src/dotnet-interactive-vscode-ads/package.json
+++ b/src/dotnet-interactive-vscode-ads/package.json
@@ -113,6 +113,11 @@
           ],
           "description": "Command and arguments used to start a notebook session."
         },
+        "dotnet-interactive.kernelEnvironmentVariables": {
+          "type": "object",
+          "default": {},
+          "description": "Environment variables to set when starting a notebook session."
+        },
         "dotnet-interactive.notebookParserArgs": {
           "type": "array",
           "default": [

--- a/src/dotnet-interactive-vscode-common/src/extension.ts
+++ b/src/dotnet-interactive-vscode-common/src/extension.ts
@@ -100,6 +100,7 @@ export async function activate(context: vscode.ExtensionContext) {
     }
 
     async function kernelChannelCreator(notebookUri: vscodeLike.Uri): Promise<KernelCommandAndEventChannel> {
+        const config = vscode.workspace.getConfiguration('dotnet-interactive');
         const launchOptions = await getInteractiveLaunchOptions();
         if (!launchOptions) {
             throw new Error(`Unable to get interactive launch options.  Please see the '${diagnosticsChannel.getName()}' output window for details.`);
@@ -120,7 +121,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
         const workspaceFolderUris = vscode.workspace.workspaceFolders?.map(folder => folder.uri) || [];
         const workingDirectory = getWorkingDirectoryForNotebook(notebookUri, workspaceFolderUris, fallbackWorkingDirectory);
-        const processStart = processArguments(argsTemplate, workingDirectory, DotNetPathManager.getDotNetPath(), launchOptions!.workingDirectory);
+        const environmentVariables = config.get<{ [key: string]: string }>('kernelEnvironmentVariables');
+        const processStart = processArguments(argsTemplate, workingDirectory, DotNetPathManager.getDotNetPath(), launchOptions!.workingDirectory, environmentVariables);
         let notification = {
             displayError: async (message: string) => { await vscode.window.showErrorMessage(message, { modal: false }); },
             displayInfo: async (message: string) => { await vscode.window.showInformationMessage(message, { modal: false }); },

--- a/src/dotnet-interactive-vscode-common/src/interfaces.ts
+++ b/src/dotnet-interactive-vscode-common/src/interfaces.ts
@@ -9,6 +9,7 @@ export interface ProcessStart {
     command: string;
     args: Array<string>;
     workingDirectory: string;
+    env: { [key: string]: string };
 }
 
 // interactive acquisition

--- a/src/dotnet-interactive-vscode-common/src/stdioDotnetInteractiveChannel.ts
+++ b/src/dotnet-interactive-vscode-common/src/stdioDotnetInteractiveChannel.ts
@@ -66,7 +66,7 @@ export class StdioDotnetInteractiveChannel implements DotnetInteractiveChannel {
             let args = processStart.args;
             // launch the process
             this.diagnosticChannel.appendLine(`Starting kernel for '${notebookPath}' using: ${processStart.command} ${args.join(' ')}`);
-            let childProcess = cp.spawn(processStart.command, args, { cwd: processStart.workingDirectory });
+            let childProcess = cp.spawn(processStart.command, args, { cwd: processStart.workingDirectory, env: processStart.env });
             let pid = childProcess.pid;
 
             this.childProcess = childProcess;

--- a/src/dotnet-interactive-vscode-common/src/utilities.ts
+++ b/src/dotnet-interactive-vscode-common/src/utilities.ts
@@ -89,7 +89,7 @@ export async function getDotNetVersionOrThrow(dotnetPath: string, outputChannel:
     return dotnetVersion;
 }
 
-export function processArguments(template: { args: Array<string>, workingDirectory: string }, workingDirectory: string, dotnetPath: string, globalStoragePath: string): ProcessStart {
+export function processArguments(template: { args: Array<string>, workingDirectory: string }, workingDirectory: string, dotnetPath: string, globalStoragePath: string, env?: { [key: string]: string }): ProcessStart {
     let map: { [key: string]: string } = {
         'dotnet_path': dotnetPath,
         'global_storage_path': globalStoragePath,
@@ -100,7 +100,8 @@ export function processArguments(template: { args: Array<string>, workingDirecto
     return {
         command: processed[0],
         args: [...processed.slice(1)],
-        workingDirectory: performReplacement(template.workingDirectory, map)
+        workingDirectory: performReplacement(template.workingDirectory, map),
+        env: env || {},
     };
 }
 

--- a/src/dotnet-interactive-vscode-common/tests/misc.test.ts
+++ b/src/dotnet-interactive-vscode-common/tests/misc.test.ts
@@ -91,7 +91,8 @@ describe('Miscellaneous tests', () => {
                 '--working-dir',
                 'replacement-working-dir'
             ],
-            workingDirectory: 'replacement-global-storage-path'
+            workingDirectory: 'replacement-global-storage-path',
+            env: {}
         });
     });
 

--- a/src/dotnet-interactive-vscode-insiders/package.json
+++ b/src/dotnet-interactive-vscode-insiders/package.json
@@ -124,6 +124,11 @@
           ],
           "description": "Command and arguments used to start a notebook session."
         },
+        "dotnet-interactive.kernelEnvironmentVariables": {
+          "type": "object",
+          "default": {},
+          "description": "Environment variables to set when starting a notebook session."
+        },
         "dotnet-interactive.notebookParserArgs": {
           "type": "array",
           "default": [

--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -124,6 +124,11 @@
           ],
           "description": "Command and arguments used to start a notebook session."
         },
+        "dotnet-interactive.kernelEnvironmentVariables": {
+          "type": "object",
+          "default": {},
+          "description": "Environment variables to set when starting a notebook session."
+        },
         "dotnet-interactive.notebookParserArgs": {
           "type": "array",
           "default": [


### PR DESCRIPTION
This also fixes a longstanding issue where we weren't properly refreshing the kernelLaunchArguments.

An example in the user's `settings.json`:

``` json
"dotnet-interactive.kernelEnvironmentVariables": {
    "THE_ANSWER": "42",
    "PI": "EXACTLY_3"
}
```

After setting those values, executing a PowerShell cell will report:

``` pwsh
$env:THE_ANSWER
```

result:

```
42
```