### PR TITLE
Update the formatting of the _style attribute's value

### DIFF
--- a/src/Microsoft.DotNet.Interactive.FSharp.Tests/HtmlFormatterTests.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp.Tests/HtmlFormatterTests.fs
@@ -4,7 +4,6 @@
 namespace Microsoft.DotNet.Interactive.FSharp.Tests
 
 open Microsoft.DotNet.Interactive
-open Microsoft.DotNet.Interactive.Formatting
 open Microsoft.DotNet.Interactive.FSharp.FSharpKernelHelpers.Html
 open Xunit
 
@@ -55,3 +54,7 @@ type HtmlFormatterTests() =
     [<Fact>]
     member __.``HTML varargs 2``() =
         Assert.Equal("<div>ab</div>", (div [] [str "a"; str "b"]).ToString())
+
+    [<Fact>]
+    member __.``Formatting _style attribute value`` () =
+        Assert.Equal((_style ["a"; " b; "; "c;"]), HtmlAttribute ("style", "a; b; c"))

--- a/src/Microsoft.DotNet.Interactive.FSharp.Tests/HtmlFormatterTests.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp.Tests/HtmlFormatterTests.fs
@@ -58,3 +58,9 @@ type HtmlFormatterTests() =
     [<Fact>]
     member __.``Formatting _style attribute value`` () =
         Assert.Equal((_style ["a"; " b; "; "c;"]), HtmlAttribute ("style", "a; b; c"))
+        Assert.Equal(_style [
+            "width: 3em;";
+            "background: rgb(0,0,0);";
+            "display: inline-block;";
+            "border: 3px solid black;";
+        ], HtmlAttribute ("style", "width: 3em; background: rgb(0,0,0); display: inline-block; border: 3px solid black"))

--- a/src/Microsoft.DotNet.Interactive.FSharp/FSharpHtml.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp/FSharpHtml.fs
@@ -448,7 +448,13 @@ module Html =
         /// Specifies an HTML attribute
         let _step (s: string) = HtmlAttribute ("step", s)
         /// Specifies an HTML attribute
-        let _style (s: string list) = HtmlAttribute ("style", (s |> String.concat " "))
+        let _style (strings: string list) =
+            let styleString =
+                // Formats ["a"; " b; "; "c;"] as "a; b; c"
+                strings
+                |> List.map (fun x -> x.Trim().TrimEnd(';'))
+                |> String.concat "; "
+            HtmlAttribute ("style", styleString)
         /// Specifies an HTML attribute
         let _summary (s: string) = HtmlAttribute ("summary", s)
         /// Specifies an HTML attribute

--- a/src/Microsoft.DotNet.Interactive.FSharp/FSharpHtml.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp/FSharpHtml.fs
@@ -447,7 +447,7 @@ module Html =
         let _start (v: float) = HtmlAttribute("start", v)
         /// Specifies an HTML attribute
         let _step (s: string) = HtmlAttribute ("step", s)
-        /// Specifies an HTML attribute
+        /// Specifies an HTML attribute. The style attribute value strings are typically given as "name: value".
         let _style (strings: string list) =
             let styleString =
                 // Formats ["a"; " b; "; "c;"] as "a; b; c"


### PR DESCRIPTION
The `_style` attribute function already took in a list of strings, however it wasn't clear how the strings in the list should be formatted. I found that something like

```fsharp
_style [
    "width: 3em";
    $"background: {colorString}";
    "display: inline-block";
    "border: 3px solid black";
]
```

did not work as expected, while

```fsharp
_style [
    "width: 3em;";
    $"background: {colorString};";
    "display: inline-block;";
    "border: 3px solid black;";
]
```

worked.

I think that since `_style` takes in a list of strings, it should automatically handle the formatting. If it only took a string, then the formatting should be explicitly given of course.

The change I made is to have the `_style` function automatically normalize the formatting of the strings with regards to handling the `;`. The change should be backwards compatible with existing uses of `_style`, and I have added documentation and a test.