### PR TITLE
Add whos for supported commands

### DIFF
--- a/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
@@ -340,7 +340,8 @@ namespace Microsoft.DotNet.Interactive
         public static TKernel UseWho<TKernel>(this TKernel kernel)
             where TKernel : Kernel
         {
-            if (kernel.KernelInfo.SupportsCommand(nameof(RequestValueInfos)))
+            if (kernel.KernelInfo.SupportsCommand(nameof(RequestValueInfos))
+                    && kernel.KernelInfo.SupportsCommand(nameof(RequestValue)))
             {
                 kernel.AddDirective(who());
                 kernel.AddDirective(whos());

--- a/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
@@ -337,27 +337,15 @@ namespace Microsoft.DotNet.Interactive
             }
         }
 
-        public static ProxyKernel UseWho(this ProxyKernel kernel)
+        public static TKernel UseWho<TKernel>(this TKernel kernel)
+            where TKernel : Kernel
         {
             if (kernel.KernelInfo.SupportsCommand(nameof(RequestValueInfos)))
             {
-                return kernel.AddWhoDirective();
+                kernel.AddDirective(who());
+                kernel.AddDirective(whos());
+                Formatter.Register(new CurrentVariablesFormatter());
             }
-            return kernel;
-        }
-
-        public static TKernel UseWho<TKernel>(this TKernel kernel)
-            where TKernel : Kernel, ISupportGetValue
-        {
-            return kernel.AddWhoDirective();
-        }
-
-        private static TKernel AddWhoDirective<TKernel>(this TKernel kernel)
-            where TKernel : Kernel
-        {
-            kernel.AddDirective(who());
-            kernel.AddDirective(whos());
-            Formatter.Register(new CurrentVariablesFormatter());
             return kernel;
         }
 


### PR DESCRIPTION
Allow the who directive to be applicable all kernels that support `RequestValueInfos` and `RequestValue` command so that proxy kernels are also supported. 