### PR TITLE
ensure that there are no "nulls" in the signature calculation

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterMessageContractTests.Complete_reply_contract_has_not_been_broken.approved.json
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterMessageContractTests.Complete_reply_contract_has_not_been_broken.approved.json
@@ -1,5 +1,5 @@
 data: <IDS|MSG> more: True
-data: b27e4588f37f9d106875a3de5082622d4475874432c1973c423c4c44690f9fd9 more: True
+data: 24cce1edd8ea947d605d13cd24bbf8d394efa8817dbd41abef7d1ec12e2cb0f9 more: True
 data: {"msg_id":"00000000-0000-0000-0000-000000000000","username":"dotnet_kernel","session":"test session","date":"0001-01-01T00:00:00Z","msg_type":"complete_reply","version":"5.3"} more: True
 data: {} more: True
 data: {} more: True

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterMessageContractTests.Display_data_contract_has_not_been_broken.approved.json
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterMessageContractTests.Display_data_contract_has_not_been_broken.approved.json
@@ -1,5 +1,5 @@
 data: <IDS|MSG> more: True
-data: c5121da74f5ffb064d676a281b3d48f643c9b26f60929966870dc52572cb7912 more: True
+data: 0b5c4e3b755058397070ce1da4d90076f1f7a528b31fdb17f54a2f1a72cd7cb0 more: True
 data: {"msg_id":"00000000-0000-0000-0000-000000000000","username":"dotnet_kernel","session":"test session","date":"0001-01-01T00:00:00Z","msg_type":"display_data","version":"5.3"} more: True
 data: {} more: True
 data: {} more: True

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterMessageContractTests.Execute_result_contract_has_not_been_broken.approved.json
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterMessageContractTests.Execute_result_contract_has_not_been_broken.approved.json
@@ -1,5 +1,5 @@
 data: <IDS|MSG> more: True
-data: 6e64ac95f5a15be7e5efa2a0361145e55c6341b921954889de2a5b0a83161ccf more: True
+data: d2389a67d226a7b8d0458d7c196f16c233862005f7cb8234b227937003bfc5e4 more: True
 data: {"msg_id":"00000000-0000-0000-0000-000000000000","username":"dotnet_kernel","session":"test session","date":"0001-01-01T00:00:00Z","msg_type":"execute_result","version":"5.3"} more: True
 data: {} more: True
 data: {} more: True

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterMessageContractTests.Input_cell_honors_custom_metadata.approved.json
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterMessageContractTests.Input_cell_honors_custom_metadata.approved.json
@@ -1,5 +1,5 @@
 data: <IDS|MSG> more: True
-data: 8ba0f29e039958a3c6de74503641e8673d126410e3a86d58ffffd948792fb969 more: True
+data: cf637d3764524a6bb1a87763d06309eb4e5dc5ff16ccf7ca16ddd40e8e0c3e05 more: True
 data: {"msg_id":"00000000-0000-0000-0000-000000000000","username":"dotnet_kernel","session":"test session","date":"0001-01-01T00:00:00Z","msg_type":"execute_result","version":"5.3"} more: True
 data: {} more: True
 data: {"dotnet_interactive":{"language":"fsharp"}} more: True

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterMessageContractTests.KernelInfoReply_contract_has_not_been_broken.approved.json
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterMessageContractTests.KernelInfoReply_contract_has_not_been_broken.approved.json
@@ -1,5 +1,5 @@
 data: <IDS|MSG> more: True
-data: 5f5b73dad44a06065f04b1d1b0b4656083a8c7bcc7fbbb170663283dcf91da20 more: True
+data: 494b73b6fd5e82a22a11db99d300626e8ca3df9be5f636d0b48321c2de0c57f2 more: True
 data: {"msg_id":"00000000-0000-0000-0000-000000000000","username":"dotnet_kernel","session":"test session","date":"0001-01-01T00:00:00Z","msg_type":"kernel_info_reply","version":"5.3"} more: True
 data: {} more: True
 data: {} more: True

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterMessageContractTests.Update_data_contract_has_not_been_broken.approved.json
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterMessageContractTests.Update_data_contract_has_not_been_broken.approved.json
@@ -1,5 +1,5 @@
 data: <IDS|MSG> more: True
-data: 6622cc56c4ef7c59c1d81a2f7e81cbf6cdeeadaa78a5b17541be690ed04de665 more: True
+data: 87f9010adc05efbedfd598afee91d6efcaa2797666e15ca5b366b1e9221eefeb more: True
 data: {"msg_id":"00000000-0000-0000-0000-000000000000","username":"dotnet_kernel","session":"test session","date":"0001-01-01T00:00:00Z","msg_type":"update_display_data","version":"5.3"} more: True
 data: {} more: True
 data: {} more: True

--- a/src/Microsoft.DotNet.Interactive.Jupyter/ZMQ/SignatureValidator.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/ZMQ/SignatureValidator.cs
@@ -38,11 +38,14 @@ namespace Microsoft.DotNet.Interactive.Jupyter.ZMQ
             return BitConverter.ToString(_signatureGenerator.Hash).Replace("-", "").ToLower();
         }
 
+        /*
+         * The signature should match exactly the packed contents that are sent 
+         */
         private static IEnumerable<string> GetMessagesToAddForDigest(Message message)
         {
             yield return message.Header.ToJson();
-            yield return message.ParentHeader.ToJson();
-            yield return message.MetaData.ToJson();
+            yield return (message.ParentHeader ?? new object()).ToJson();
+            yield return (message.MetaData ?? new object()).ToJson();
             yield return message.Content.ToJson();
         }
     }


### PR DESCRIPTION
Currently, when the Jupyter message is sent over the ZMQ socket, it's sent without any nulls:

https://github.com/dotnet/interactive/blob/474c320cb13c8bd9356713faad10a39782a3af79/src/Microsoft.DotNet.Interactive.Jupyter/ZMQ/MessageSender.cs#L37

But the message with nulls translates those fields `<null>` in signature generation. So the signature no longer matches what is actually sent over the socket. 

https://github.com/dotnet/interactive/blob/474c320cb13c8bd9356713faad10a39782a3af79/src/Microsoft.DotNet.Interactive.Jupyter/ZMQ/SignatureValidator.cs#L44

