### PR TITLE
Update Jupyter Message Protocol to handle differences between kernels 

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Jupyter/Messaging/JsonElementExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/Messaging/JsonElementExtensions.cs
@@ -22,6 +22,16 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Messaging
             };
         }
 
+        public static IReadOnlyDictionary<string, object> ToReadOnlyDictionary(this JsonElement source)
+        {
+            var ret = new Dictionary<string, object>();
+            foreach (var value in source.EnumerateObject())
+            {
+                ret[value.Name] = value.Value.ToObject();
+            }
+            return ret;
+        }
+
         public static IDictionary<string, object> ToDictionary(this JsonElement source)
         {
             var ret = new Dictionary<string, object>();

--- a/src/Microsoft.DotNet.Interactive.Jupyter/Protocol/CommClose.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/Protocol/CommClose.cs
@@ -8,6 +8,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.DotNet.Interactive.Jupyter.Protocol
 {
+    [JsonConverter(typeof(CommCloseConverter))]
     [JupyterMessageType(JupyterMessageContentTypes.CommClose)]
     public class CommClose : Message
     {

--- a/src/Microsoft.DotNet.Interactive.Jupyter/Protocol/CommCloseConverter.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/Protocol/CommCloseConverter.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.Interactive.Jupyter.Messaging;
+using System;
+using System.Text.Json;
+
+namespace Microsoft.DotNet.Interactive.Jupyter.Protocol
+{
+    public class CommCloseConverter : JsonConverter<CommClose>
+    {
+        public override CommClose Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            EnsureStartObject(reader, typeToConvert);
+
+            _ = JsonDocument.TryParseValue(ref reader, out JsonDocument doc);
+            JsonElement root = doc.RootElement;
+
+            _ = root.TryGetProperty("comm_id", out JsonElement commIdElement);
+            _ = root.TryGetProperty("data", out JsonElement dataElement);
+
+            return new CommClose(commIdElement.GetString(),
+                dataElement.ValueKind == JsonValueKind.Object ?
+                dataElement.ToReadOnlyDictionary() : null);
+        }
+
+        public override void Write(Utf8JsonWriter writer, CommClose value, JsonSerializerOptions options)
+        {
+            JsonSerializer.Serialize(writer, value, value.GetType(), options);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Interactive.Jupyter/Protocol/CommOpen.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/Protocol/CommOpen.cs
@@ -11,15 +11,29 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Protocol
     public class CommOpen : Message
     {
         [JsonPropertyName("comm_id")]
-        public string CommId { get; set; }
+        public string CommId { get; }
 
         [JsonPropertyName("target_name")]
-        public string TargetName { get; set; }
+        public string TargetName { get; }
 
         [JsonPropertyName("data")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        public object Data { get; } = new Dictionary<string,object>();
+        public object Data { get; }
 
+        public CommOpen(string commId, string targetName, object data)
+        {
+            if (string.IsNullOrWhiteSpace(commId))
+            {
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(commId));
+            }
 
+            if (string.IsNullOrWhiteSpace(targetName))
+            {
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(targetName));
+            }
+
+            CommId = commId;
+            TargetName = targetName;
+            Data = data ?? new Dictionary<string, object>();
+        }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Jupyter/Protocol/InspectReply.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/Protocol/InspectReply.cs
@@ -10,16 +10,16 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Protocol
     [JupyterMessageType(JupyterMessageContentTypes.InspectReply)]
     public class InspectReply : ReplyMessage
     {
-        public static InspectReply Ok(string source, IReadOnlyDictionary<string, object> data, IReadOnlyDictionary<string, object> metaData) => new InspectReply(source, StatusValues.Ok, data, metaData);
-        public static InspectReply Error(string source, IReadOnlyDictionary<string, object> data, IReadOnlyDictionary<string, object> metaData) => new InspectReply(source, StatusValues.Error, data, metaData);
-        public InspectReply(string source, string status, IReadOnlyDictionary<string, object> data = null, IReadOnlyDictionary<string, object> metaData = null)
+        public static InspectReply Ok(bool found, IReadOnlyDictionary<string, object> data, IReadOnlyDictionary<string, object> metaData) => new InspectReply(StatusValues.Ok, found, data, metaData);
+        public static InspectReply Error(IReadOnlyDictionary<string, object> data, IReadOnlyDictionary<string, object> metaData) => new InspectReply(StatusValues.Error, false, data, metaData);
+        public InspectReply(string status, bool found, IReadOnlyDictionary<string, object> data = null, IReadOnlyDictionary<string, object> metaData = null)
         {
             if (string.IsNullOrWhiteSpace(status))
             {
                 throw new ArgumentException("Value cannot be null or whitespace.", nameof(status));
             }
             Status = status;
-            Source = source ?? throw new ArgumentNullException(nameof(source));
+            Found = found;
             Data = data?? new Dictionary<string, object>();
             MetaData = metaData?? new Dictionary<string, object>();
         }
@@ -27,8 +27,8 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Protocol
         [JsonPropertyName("status")]
         public string Status { get; }
 
-        [JsonPropertyName("source")]
-        public string Source { get;  }
+        [JsonPropertyName("found")]
+        public bool Found { get;  }
 
         [JsonPropertyName("data")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/Microsoft.DotNet.Interactive.Jupyter/Protocol/KernelInfoReply.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/Protocol/KernelInfoReply.cs
@@ -44,11 +44,6 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Protocol
                 throw new ArgumentException("Value cannot be null or whitespace.", nameof(implementation));
             }
 
-            if (string.IsNullOrWhiteSpace(implementationVersion))
-            {
-                throw new ArgumentException("Value cannot be null or whitespace.", nameof(implementationVersion));
-            }
-
             ProtocolVersion = protocolVersion;
             Implementation = implementation;
             ImplementationVersion = implementationVersion;


### PR DESCRIPTION
Update the message protocol for jupyter to be compatible with https://jupyter-client.readthedocs.io/en/stable/messaging.html specifically around `InspectReply` and also to allow for differences in how different jupyter kernels implement the protocol. E.g. Julia does not send back a `implementation_version` in `kernel_info_reply` and R default sends a list instead of an object on `comm_close`. 