### PR TITLE
Variable sharing as specified MIME type or CLR type

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Tests/VariableSharingTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/VariableSharingTests.cs
@@ -78,10 +78,7 @@ x")]
             using var kernel = CreateKernel();
 
             using var events = kernel.KernelEvents.ToSubscribedList();
-
-            await kernel.SendAsync(new SubmitCode("", targetKernelName: "fsharp"));
-            events.Should().NotContainErrors();
-
+            
             await kernel.SubmitCodeAsync($"{from}\n{codeToWrite}");
 
             await kernel.SubmitCodeAsync($"#!fsharp\n{codeToRead}");
@@ -311,6 +308,30 @@ x")]
             inputValue.Should().Be("hello!");
         }
 
+        [Fact]
+        public async Task Values_can_be_shared_using_a_specified_MIME_type()
+        {
+            using var kernel = CreateKernel();
+
+            using var events = kernel.KernelEvents.ToSubscribedList();
+
+            await kernel.SubmitCodeAsync("#!csharp\nvar x = 123;");
+
+            var result = await kernel.SubmitCodeAsync(@"
+#!fsharp
+#!share --from csharp x --mime-type text/html
+x");
+
+            events.Should().NotContainErrors();
+
+            events.Should()
+                  .ContainSingle<ValueProduced>()
+                  .Which
+                  .FormattedValue
+                  .Should()
+                  .BeEquivalentTo(new FormattedValue("text/html", 123.ToDisplayString("text/html")));
+        }
+
         private async Task<(CompositeKernel, FakeKernel)> CreateCompositeKernelWithJavaScriptProxyKernel()
         {
             var localCompositeKernel = new CompositeKernel
@@ -359,12 +380,6 @@ x")]
                 new PowerShellKernel()
                     .UseValueSharing()
             }.LogEventsToPocketLogger();
-        }
-
-        [Fact(Skip = "WIP")]
-        public void Internal_types_are_shared_as_their_most_public_supertype()
-        {
-            throw new NotImplementedException("test not written");
         }
 
         public void Dispose() => _disposables.Dispose();

--- a/src/Microsoft.DotNet.Interactive.Tests/VariableSharingTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/VariableSharingTests.cs
@@ -79,11 +79,8 @@ x")]
 
             using var events = kernel.KernelEvents.ToSubscribedList();
 
-
-            await kernel.SendAsync(new SubmitCode("",targetKernelName:"fsharp"));
+            await kernel.SendAsync(new SubmitCode("", targetKernelName: "fsharp"));
             events.Should().NotContainErrors();
-
-
 
             await kernel.SubmitCodeAsync($"{from}\n{codeToWrite}");
 

--- a/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
@@ -236,21 +236,26 @@ namespace Microsoft.DotNet.Interactive
                 return Array.Empty<CompletionItem>();
             });
 
+            var mimeTypeOption = new Option<string>("--mime-type", "Share the value as a string formatted to the specified MIME type.")
+                .AddCompletions(JsonFormatter.MimeType, HtmlFormatter.MimeType, PlainTextFormatter.MimeType);
+
             var share = new Command("#!share", "Share a value between subkernels")
             {
                 fromKernelOption,
-                valueNameArg
+                valueNameArg,
+                mimeTypeOption
             };
 
-            share.Handler = CommandHandler.Create(async (InvocationContext cmdLineContext) =>
+            share.SetHandler(async cmdLineContext =>
             {
                 var from = cmdLineContext.ParseResult.GetValueForOption(fromKernelOption);
                 var valueName = cmdLineContext.ParseResult.GetValueForArgument(valueNameArg);
                 var context = cmdLineContext.GetService<KernelInvocationContext>();
+                var mimeType = cmdLineContext.ParseResult.GetValueForOption(mimeTypeOption);
 
                 if (kernel.FindKernel(from) is { } fromKernel)
                 {
-                    await fromKernel.GetValueAndImportTo(kernel, valueName);
+                    await fromKernel.GetValueAndImportTo(kernel, valueName, mimeType);
                 }
                 else
                 {
@@ -266,7 +271,8 @@ namespace Microsoft.DotNet.Interactive
         internal static async Task GetValueAndImportTo(
             this Kernel fromKernel,
             Kernel toKernel,
-            string valueName)
+            string valueName, 
+            string mimeType)
         {
             var supportedRequestValue = fromKernel.SupportsCommandType(typeof(RequestValue));
 
@@ -275,7 +281,7 @@ namespace Microsoft.DotNet.Interactive
                 throw new InvalidOperationException($"Kernel {fromKernel} does not support command {nameof(RequestValue)}");
             }
 
-            var requestValueResult = await fromKernel.SendAsync(new RequestValue(valueName));
+            var requestValueResult = await fromKernel.SendAsync(new RequestValue(valueName, mimeType: mimeType));
 
             if (requestValueResult.KernelEvents.ToEnumerable().OfType<ValueProduced>().SingleOrDefault() is { } valueProduced)
             {


### PR DESCRIPTION
This will include adding support for sharing directly to `DataFrame` types when querying data: #2060.