### PR TITLE
add support for RequestInput type hints and a file picker

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
@@ -407,7 +407,8 @@ Microsoft.DotNet.Interactive.Commands
   public class RequestHoverText : LanguageServiceCommand
     .ctor(System.String code, Microsoft.DotNet.Interactive.LinePosition linePosition, System.String targetKernelName = null)
   public class RequestInput : KernelCommand
-    .ctor(System.String prompt, System.Boolean isPassword = False, System.String targetKernelName = null)
+    .ctor(System.String prompt, System.Boolean isPassword = False, System.String targetKernelName = null, System.String inputTypeHint = null)
+    public System.String InputTypeHint { get;}
     public System.Boolean IsPassword { get;}
     public System.String Prompt { get;}
   public class RequestKernelInfo : KernelCommand

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Command_contract_has_not_been_broken.approved.RequestInput.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Command_contract_has_not_been_broken.approved.RequestInput.json
@@ -5,6 +5,7 @@
   "command": {
     "prompt": "provide answer",
     "isPassword": true,
+    "inputTypeHint": "text",
     "targetKernelName": "vscode",
     "originUri": null,
     "destinationUri": null

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.InputProduced.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.InputProduced.json
@@ -10,6 +10,7 @@
     "command": {
       "prompt": "Input?",
       "isPassword": false,
+      "inputTypeHint": "text",
       "targetKernelName": "vscode",
       "originUri": null,
       "destinationUri": null

--- a/src/Microsoft.DotNet.Interactive/Commands/RequestInput.cs
+++ b/src/Microsoft.DotNet.Interactive/Commands/RequestInput.cs
@@ -5,14 +5,21 @@ namespace Microsoft.DotNet.Interactive.Commands;
 
 public class RequestInput : KernelCommand
 {
-    public RequestInput(string prompt, bool isPassword = false, string targetKernelName = null)
+    public RequestInput(
+        string prompt,
+        bool isPassword = false,
+        string targetKernelName = null,
+        string inputTypeHint = null)
         : base(targetKernelName)
     {
         Prompt = prompt;
         IsPassword = isPassword;
+        InputTypeHint = inputTypeHint ?? "text";
     }
 
     public string Prompt { get; }
 
     public bool IsPassword { get; }
+
+    public string InputTypeHint { get; }
 }

--- a/src/Microsoft.DotNet.Interactive/Connection/ProxyKernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Connection/ProxyKernel.cs
@@ -218,7 +218,7 @@ public sealed class ProxyKernel : Kernel
 
     private void PatchRoutingSlip(KernelCommand command, KernelCommand commandFromRemoteKernel)
     {
-        foreach (var kernelOrKernelHostUri in commandFromRemoteKernel.RoutingSlip.Skip(command.RoutingSlip.Count()))
+        foreach (var kernelOrKernelHostUri in commandFromRemoteKernel.RoutingSlip.Skip(command.RoutingSlip.Count))
         {
             command.RoutingSlip.TryAdd(kernelOrKernelHostUri);
         }

--- a/src/Microsoft.DotNet.Interactive/KernelInvocationContext.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelInvocationContext.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
+using Microsoft.DotNet.Interactive.Parsing;
 using Microsoft.DotNet.Interactive.Utility;
 using Pocket;
 using CompositeDisposable = Pocket.CompositeDisposable;
@@ -315,6 +316,8 @@ namespace Microsoft.DotNet.Interactive
             Complete(Command);
             TryCancel();
         }
+
+        internal DirectiveNode CurrentlyParsingDirectiveNode { get; set; }
 
         public Task ScheduleAsync(Func<KernelInvocationContext, Task> func) =>
             HandlingKernel.SendAsync(new AnonymousKernelCommand((_, invocationContext) =>

--- a/src/Microsoft.DotNet.Interactive/Parsing/SubmissionParser.cs
+++ b/src/Microsoft.DotNet.Interactive/Parsing/SubmissionParser.cs
@@ -430,15 +430,10 @@ namespace Microsoft.DotNet.Interactive.Parsing
 
                     var c = parseResult.CommandResult.Children.FirstOrDefault(c => c.Tokens.Any(t => t.Value == "REPLACE-ME"));
 
-                    typeHint = c?.Symbol switch
+                    if (c is { Symbol: {} symbol })
                     {
-                        IValueDescriptor<DateTime> => "datetime-local",
-                        IValueDescriptor<int> => "number",
-                        IValueDescriptor<float> => "number",
-                        IValueDescriptor<FileSystemInfo> => "file",
-                        IValueDescriptor<Uri> => "url",
-                        _ => null
-                    };
+                        typeHint = GetTypeHint(symbol);
+                    }
                 }
 
                 var inputRequest = new RequestInput(
@@ -515,6 +510,17 @@ namespace Microsoft.DotNet.Interactive.Parsing
                 return false;
             }
         }
+
+        private static string GetTypeHint(Symbol symbol) =>
+            symbol switch
+            {
+                IValueDescriptor<DateTime> => "datetime-local",
+                IValueDescriptor<int> => "number",
+                IValueDescriptor<float> => "number",
+                IValueDescriptor<FileSystemInfo> => "file",
+                IValueDescriptor<Uri> => "url",
+                _ => null
+            };
 
         public void AddDirective(Command command)
         {

--- a/src/dotnet-interactive-vscode-common/src/extension.ts
+++ b/src/dotnet-interactive-vscode-common/src/extension.ts
@@ -145,7 +145,12 @@ export async function activate(context: vscode.ExtensionContext) {
                 const requestInput = <contracts.RequestInput>commandInvocation.commandEnvelope.command;
                 const prompt = requestInput.prompt;
                 const password = requestInput.isPassword;
-                const value = await vscode.window.showInputBox({ prompt, password });
+
+                const value = (requestInput.inputTypeHint === "file")
+                    ? await vscode.window.showOpenDialog({ canSelectFiles: true, canSelectFolders: false, title: prompt, canSelectMany: false })
+                        .then(v => typeof v?.[0].fsPath === 'undefined' ? null : v[0].fsPath)
+                    : await vscode.window.showInputBox({ prompt, password });
+
                 if (!value) {
                     commandInvocation.context.fail('Input request cancelled');
                 } else {

--- a/src/dotnet-interactive/CommandLine/CommandLineParser.cs
+++ b/src/dotnet-interactive/CommandLine/CommandLineParser.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;

--- a/src/microsoft-dotnet-interactive/src/contracts.ts
+++ b/src/microsoft-dotnet-interactive/src/contracts.ts
@@ -107,6 +107,7 @@ export interface RequestHoverText extends LanguageServiceCommand {
 export interface RequestInput extends KernelCommand {
     prompt: string;
     isPassword: boolean;
+    inputTypeHint: string;
 }
 
 export interface RequestKernelInfo extends KernelCommand {


### PR DESCRIPTION
This adds support for `RequestInput` commands to carry type hints based on the magic command parser's type expectations. One example is implemented here, which is triggering a file dialog when the expected type is `FileSystemInfo`:

![image](https://user-images.githubusercontent.com/547415/187735276-d57b74fa-e676-4849-a186-e8fb5a03f0a5.png)
