### PR TITLE
Input type hints for SQL connection strings

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
@@ -717,6 +717,7 @@ Microsoft.DotNet.Interactive.Parsing
     public System.Collections.Generic.IReadOnlyList<System.CommandLine.Command> Directives { get;}
     public System.Void AddDirective(System.CommandLine.Command command)
     public PolyglotSyntaxTree Parse(System.String code, System.String language = null)
+    public System.Void SetInputTypeHint(System.Type expectedType, System.String inputTypeHint)
     public System.Collections.Generic.IReadOnlyList<Microsoft.DotNet.Interactive.Commands.KernelCommand> SplitSubmission(Microsoft.DotNet.Interactive.Commands.SubmitCode submitCode)
     public System.Collections.Generic.IReadOnlyList<Microsoft.DotNet.Interactive.Commands.KernelCommand> SplitSubmission(Microsoft.DotNet.Interactive.Commands.RequestDiagnostics requestDiagnostics)
   public abstract class SyntaxNode : SyntaxNodeOrToken

--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.mssql_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.mssql_api_is_not_changed.approved.txt
@@ -87,7 +87,6 @@ Microsoft.DotNet.Interactive.SqlServer
     public System.String UserName { get; set;}
   public class ConnectMsSqlCommand : Microsoft.DotNet.Interactive.Connection.ConnectKernelCommand, System.Collections.Generic.IEnumerable<System.CommandLine.Symbol>, System.Collections.IEnumerable, System.CommandLine.Completions.ICompletionSource
     .ctor(System.String resolvedToolsServicePath)
-    public System.CommandLine.Argument<System.String> ConnectionStringArgument { get;}
     public System.Threading.Tasks.Task<Microsoft.DotNet.Interactive.Kernel> ConnectKernelAsync(Microsoft.DotNet.Interactive.KernelInvocationContext context, System.CommandLine.Invocation.InvocationContext commandLineContext)
   public class ConnectParams
     .ctor()

--- a/src/Microsoft.DotNet.Interactive.Kql.Tests/KqlConnectionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql.Tests/KqlConnectionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Interactive.Kql.Tests
 {
     public class KqlConnectionTests : IDisposable
     {
-        private static async Task<CompositeKernel> CreateKernel()
+        private static async Task<CompositeKernel> CreateKernelAsync()
         {
             Formatter.SetPreferredMimeTypesFor(typeof(TabularDataResource), HtmlFormatter.MimeType, CsvFormatter.MimeType);
             var csharpKernel = new CSharpKernel().UseNugetDirective();
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.Interactive.Kql.Tests
         public async Task It_can_connect_and_query_data()
         {
             var cluster = KqlFactAttribute.GetClusterForTests();
-            using var kernel = await CreateKernel();
+            using var kernel = await CreateKernelAsync();
             var result = await kernel.SubmitCodeAsync(
                 $"#!connect kql --kernel-name KustoHelp --cluster \"{cluster}\" --database \"Samples\"");
 
@@ -76,7 +76,7 @@ StormEvents | take 10
         public async Task It_can_store_result_set_with_a_name()
         {
             var cluster = KqlFactAttribute.GetClusterForTests();
-            using var kernel = await CreateKernel();
+            using var kernel = await CreateKernelAsync();
             var result = await kernel.SubmitCodeAsync(
                 $"#!connect kql --kernel-name KustoHelp --cluster \"{cluster}\" --database \"Samples\"");
 
@@ -99,7 +99,7 @@ StormEvents | take 10
         public async Task sending_query_to_kusto_will_generate_suggestions()
         {
             var cluster = KqlFactAttribute.GetClusterForTests();
-            using var kernel = await CreateKernel();
+            using var kernel = await CreateKernelAsync();
             var result = await kernel.SubmitCodeAsync(
                 $"#!connect kql --kernel-name KustoHelp --cluster \"{cluster}\" --database \"Samples\"");
 
@@ -133,7 +133,7 @@ StormEvents | take 10
         public async Task Field_types_are_deserialized_correctly()
         {
             var cluster = KqlFactAttribute.GetClusterForTests();
-            using var kernel = await CreateKernel();
+            using var kernel = await CreateKernelAsync();
             var result = await kernel.SubmitCodeAsync(
                 $"#!connect kql --kernel-name KustoHelp --cluster \"{cluster}\" --database \"Samples\"");
 
@@ -164,7 +164,7 @@ StormEvents | take 10
         public async Task query_produces_expected_formatted_values()
         {
             var cluster = KqlFactAttribute.GetClusterForTests();
-            using var kernel = await CreateKernel();
+            using var kernel = await CreateKernelAsync();
             var result = await kernel.SubmitCodeAsync(
                 $"#!connect kql --kernel-name KustoHelp --cluster \"{cluster}\" --database \"Samples\"");
 
@@ -194,7 +194,7 @@ StormEvents | take 10
         public async Task Empty_results_are_displayed_correctly()
         {
             var cluster = KqlFactAttribute.GetClusterForTests();
-            using var kernel = await CreateKernel();
+            using var kernel = await CreateKernelAsync();
             var result = await kernel.SubmitCodeAsync(
                 $"#!connect kql --kernel-name KustoHelp --cluster \"{cluster}\" --database \"Samples\"");
 
@@ -239,7 +239,7 @@ StormEvents | take 0
         public async Task Shared_variable_can_be_used_to_parameterize_a_kql_query(string csharpVariableDeclaration, object expectedValue)
         {
             var cluster = KqlFactAttribute.GetClusterForTests();
-            using var kernel = await CreateKernel();
+            using var kernel = await CreateKernelAsync();
             var result = await kernel.SubmitCodeAsync(
                 $"#!connect kql --kernel-name KustoHelp --cluster \"{cluster}\" --database \"Samples\"");
 
@@ -278,7 +278,7 @@ print testVar";
         public async Task Invalid_shared_variables_are_handled_correctly(string csharpVariableDeclaration)
         {
             var cluster = KqlFactAttribute.GetClusterForTests();
-            using var kernel = await CreateKernel();
+            using var kernel = await CreateKernelAsync();
 
             var result = await kernel.SubmitCodeAsync(
                 $"#!connect kql --kernel-name KustoHelp --cluster \"{cluster}\" --database \"Samples\"");

--- a/src/Microsoft.DotNet.Interactive.Kql/ConnectKqlCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql/ConnectKqlCommand.cs
@@ -21,13 +21,11 @@ namespace Microsoft.DotNet.Interactive.Kql
         }
 
         public Option<string> ClusterOption { get; } =
-            new(
-                "--cluster",
+            new("--cluster",
                 "The cluster used to connect") { IsRequired = true };
 
         public Option<string> DatabaseOption { get; } =
-            new(
-                "--database",
+            new("--database",
                 "The database to query");
 
         public override async Task<Kernel> ConnectKernelAsync(

--- a/src/Microsoft.DotNet.Interactive.Kql/KqlKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql/KqlKernelExtension.cs
@@ -2,12 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
-using Microsoft.DotNet.Interactive.SqlServer;
 using Microsoft.DotNet.Interactive.Utility;
 
 namespace Microsoft.DotNet.Interactive.Kql

--- a/src/Microsoft.DotNet.Interactive.SqlServer.Tests/MsSqlConnectionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer.Tests/MsSqlConnectionTests.cs
@@ -388,7 +388,7 @@ select @x, @y";
                   .ContainValues(new object[] { "Hello world!", 123 });
         }
 
-        [Fact]
+        [MsSqlFact]
         public async Task An_input_type_hint_is_set_for_connection_strings()
         {
             using var kernel = await CreateKernelAsync();

--- a/src/Microsoft.DotNet.Interactive.SqlServer/ConnectMsSqlCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/ConnectMsSqlCommand.cs
@@ -22,13 +22,11 @@ namespace Microsoft.DotNet.Interactive.SqlServer
         }
 
         private static Option<bool> CreateDbContextOption { get; } =
-            new Option<bool>(
-                "--create-dbcontext",
+            new("--create-dbcontext",
                 "Scaffold a DbContext in the C# kernel.");
 
-        public Argument<string> ConnectionStringArgument { get; } =
-            new Argument<string>(
-                "connectionString",
+        public Argument<MsSqlConnectionString> ConnectionStringArgument { get; } =
+            new("connectionString",
                 "The connection string used to connect to the database");
 
         public override async Task<Kernel> ConnectKernelAsync(

--- a/src/Microsoft.DotNet.Interactive.SqlServer/ConnectMsSqlCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/ConnectMsSqlCommand.cs
@@ -3,6 +3,8 @@
 
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.Connection;
 using Microsoft.DotNet.Interactive.CSharp;
@@ -25,9 +27,10 @@ namespace Microsoft.DotNet.Interactive.SqlServer
             new("--create-dbcontext",
                 "Scaffold a DbContext in the C# kernel.");
 
-        public Argument<MsSqlConnectionString> ConnectionStringArgument { get; } =
+        private Argument<MsSqlConnectionString> ConnectionStringArgument { get; } =
             new("connectionString",
-                "The connection string used to connect to the database");
+                description: "The connection string used to connect to the database",
+                parse: s => new(s.Tokens.Single().Value));
 
         public override async Task<Kernel> ConnectKernelAsync(
             KernelInvocationContext context,
@@ -35,8 +38,7 @@ namespace Microsoft.DotNet.Interactive.SqlServer
         {
             var connector = new MsSqlKernelConnector(
                 commandLineContext.ParseResult.GetValueForOption(CreateDbContextOption),
-                commandLineContext.ParseResult.GetValueForArgument(ConnectionStringArgument)
-            );
+                commandLineContext.ParseResult.GetValueForArgument(ConnectionStringArgument).Value);
             connector.PathToService = ResolvedToolsServicePath;
 
             var localName = commandLineContext.ParseResult.GetValueForOption(KernelNameOption);

--- a/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlConnectionString.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlConnectionString.cs
@@ -3,8 +3,4 @@
 
 namespace Microsoft.DotNet.Interactive.SqlServer;
 
-internal class MsSqlConnectionString
-{
-
-
-}
+internal readonly record struct MsSqlConnectionString(string Value);

--- a/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlConnectionString.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlConnectionString.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Interactive.SqlServer;
+
+internal class MsSqlConnectionString
+{
+
+
+}

--- a/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelExtension.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
-using System.Runtime.InteropServices;
 using Microsoft.DotNet.Interactive.Utility;
 
 namespace Microsoft.DotNet.Interactive.SqlServer
@@ -29,7 +27,11 @@ namespace Microsoft.DotNet.Interactive.SqlServer
                 }
 
                 compositeKernel
-                .AddKernelConnector(new ConnectMsSqlCommand(sqlToolName));
+                    .AddKernelConnector(new ConnectMsSqlCommand(sqlToolName));
+
+                compositeKernel
+                    .SubmissionParser
+                    .SetInputTypeHint(typeof(MsSqlConnectionString), "connectionstring-mssql");
 
                 KernelInvocationContext.Current?.Display(
                     new HtmlString(@"<details><summary>Query Microsoft SQL Server databases.</summary>

--- a/src/Microsoft.DotNet.Interactive.Tests/InputsWithinMagicCommandsTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/InputsWithinMagicCommandsTests.cs
@@ -91,9 +91,6 @@ public class InputsWithinMagicCommandsTests : IDisposable
             .Be("Please enter a value for field \"input-please\".");
     }
 
-    // FIX: (InputsWithinMagicCommandsTests) other default type hints
-    // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input
-
     [Fact]
     public async Task An_input_type_hint_is_set_for_file_inputs()
     {
@@ -102,6 +99,16 @@ public class InputsWithinMagicCommandsTests : IDisposable
         await kernel.SendAsync(new SubmitCode("#!shim --file @input:file-please\n// some more stuff", "csharp"));
 
         _receivedRequestInput.InputTypeHint.Should().Be("file");
+    }
+
+    [Fact]
+    public async Task Unknown_types_return_type_hint_of_text()
+    {
+        _shimCommand.Add(new Option<CompositeKernel>("--unknown"));
+
+        await kernel.SendAsync(new SubmitCode("#!shim --file @input:file-please\n// some more stuff", "csharp"));
+
+        _receivedRequestInput.InputTypeHint.Should().Be("text");
     }
 
     private static CompositeKernel CreateKernel() =>


### PR DESCRIPTION
This adds support for custom input type hints (`SubmissionParser.SetInputTypeHint`), and makes use of this API to provide a custom type hint `"connectionstring-sql"` for MSSQL connection strings requested by the `#!connect mssql` magic command.