### PR TITLE
Setting text in JSON formatter to align to the right instead of left

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Formatting/HtmlFormatter.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/HtmlFormatter.cs
@@ -316,6 +316,7 @@ namespace Microsoft.DotNet.Interactive.Formatting
 
 .dni-treeview td {
     vertical-align: top;
+    text-align: start;
 }
 
 details.dni-treeview {


### PR DESCRIPTION
Fixes: https://github.com/dotnet/interactive/issues/2190

How it looks after the fix:
![image](https://user-images.githubusercontent.com/18668118/188500296-f88591ec-8144-4cfb-a37b-7de5b6caeb6d.png)
How it have looked before:
![image](https://user-images.githubusercontent.com/18668118/188500359-827f9a3b-7cdd-44fc-a57a-2d7bb608a375.png)

Json file used: https://jsonplaceholder.typicode.com/posts/1/comments

Let me know if I need to do anything more