### PR TITLE
keep `GetValueDeclarer()` public

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
@@ -131,6 +131,7 @@ Microsoft.DotNet.Interactive
      KernelScheduler<Microsoft.DotNet.Interactive.Commands.KernelCommand,KernelCommandResult> get_Scheduler()
      System.Collections.Generic.IEnumerable<System.CommandLine.Parsing.Parser> GetDirectiveParsersForCompletion(Microsoft.DotNet.Interactive.Parsing.DirectiveNode directiveNode, System.Int32 requestPosition)
      Kernel GetHandlingKernel(Microsoft.DotNet.Interactive.Commands.KernelCommand command, KernelInvocationContext context)
+    public Microsoft.DotNet.Interactive.ValueSharing.IKernelValueDeclarer GetValueDeclarer()
     public System.Threading.Tasks.Task HandleAsync(Microsoft.DotNet.Interactive.Commands.RequestKernelInfo command, KernelInvocationContext context)
      System.Boolean HasDynamicHandlerFor(Microsoft.DotNet.Interactive.Commands.KernelCommand command)
      System.Void PublishEvent(Microsoft.DotNet.Interactive.Events.KernelEvent kernelEvent)
@@ -545,6 +546,7 @@ Microsoft.DotNet.Interactive.Connection
     public System.Void Dispose()
   public class ProxyKernel : Microsoft.DotNet.Interactive.Kernel, Microsoft.DotNet.Interactive.IKernelCommandHandler<Microsoft.DotNet.Interactive.Commands.RequestKernelInfo>, System.IDisposable
     .ctor(System.String name, IKernelCommandAndEventSender sender, IKernelCommandAndEventReceiver receiver, System.Uri remoteUri = null)
+    public Microsoft.DotNet.Interactive.ValueSharing.IKernelValueDeclarer GetValueDeclarer()
     public System.Threading.Tasks.Task HandleAsync(Microsoft.DotNet.Interactive.Commands.RequestKernelInfo command, Microsoft.DotNet.Interactive.KernelInvocationContext context)
   public delegate ReadCommandOrEvent : System.MulticastDelegate, System.ICloneable, System.Runtime.Serialization.ISerializable
     .ctor(System.Object object, System.IntPtr method)

--- a/src/Microsoft.DotNet.Interactive/Connection/ProxyKernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Connection/ProxyKernel.cs
@@ -117,7 +117,7 @@ public sealed class ProxyKernel : Kernel
         {
             if (!task.GetIsCompletedSuccessfully())
             {
-                if (task.Exception is {} ex)
+                if (task.Exception is { } ex)
                 {
                     completionSource.TrySetException(ex);
                 }
@@ -127,7 +127,7 @@ public sealed class ProxyKernel : Kernel
         return completionSource.Task.ContinueWith(te =>
         {
             command.TargetKernelName = targetKernelName;
-          
+
             if (te.Result is CommandFailed cf)
             {
                 context.Fail(command, cf.Exception, cf.Message);
@@ -248,5 +248,5 @@ public sealed class ProxyKernel : Kernel
         set => _valueDeclarer = value;
     }
 
-    internal override IKernelValueDeclarer GetValueDeclarer() => _valueDeclarer ?? KernelValueDeclarer.Default;
+    public override IKernelValueDeclarer GetValueDeclarer() => _valueDeclarer ?? KernelValueDeclarer.Default;
 }

--- a/src/Microsoft.DotNet.Interactive/Kernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Kernel.cs
@@ -535,7 +535,7 @@ namespace Microsoft.DotNet.Interactive
                             }
 
                             return inner.IsChildCommand(outer);
-                          
+
                         }
                         );
                     RegisterForDisposal(scheduler);
@@ -879,7 +879,7 @@ namespace Microsoft.DotNet.Interactive
             return false;
         }
 
-        internal virtual IKernelValueDeclarer GetValueDeclarer() => KernelValueDeclarer.Default;
+        public virtual IKernelValueDeclarer GetValueDeclarer() => KernelValueDeclarer.Default;
 
         public override string ToString()
         {


### PR DESCRIPTION
Regressed in #2228.  If this method is `internal` then third-party kernels that inherit the `Kernel` class can't set their own value declarers.