### PR TITLE
`#!import` support in documents API

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Documents.Tests/CodeSubmissionFormatTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Documents.Tests/CodeSubmissionFormatTests.cs
@@ -26,7 +26,7 @@ public class CodeSubmissionFormatTests : DocumentFormatTestsBase
 
     public InteractiveDocument ParseDib(string content)
     {
-        return CodeSubmission.Parse(content, KernelInfos);
+        return CodeSubmission.Parse(content, DefaultKernelInfos);
     }
 
     public string SerializeDib(InteractiveDocument interactive, string newLine)
@@ -386,8 +386,8 @@ var x = 1;
     [Fact]
     public void Default_language_can_be_specified_in_metadata()
     {
-        var kernelInfo = KernelInfos;
-        KernelInfos.DefaultKernelName = "fsharp";
+        var kernelInfo = DefaultKernelInfos;
+        DefaultKernelInfos.DefaultKernelName = "fsharp";
 
         var metadata = new Dictionary<string, object>
         {
@@ -406,7 +406,7 @@ var x = 1;
     [Fact]
     public void Kernel_languages_can_be_specified_in_metadata()
     {
-        var kernelInfo = KernelInfos;
+        var kernelInfo = DefaultKernelInfos;
         kernelInfo.Add(new("mermaid"));
         kernelInfo.Add(new("javascript"));
 
@@ -436,7 +436,7 @@ var x = 1;
     [Fact]
     public void Metadata_section_is_not_added_as_a_document_element()
     {
-        var kernelInfo = KernelInfos;
+        var kernelInfo = DefaultKernelInfos;
         kernelInfo.Add(new("mermaid"));
         kernelInfo.Add(new("javascript"));
 

--- a/src/Microsoft.DotNet.Interactive.Documents.Tests/DocumentFormatTestsBase.cs
+++ b/src/Microsoft.DotNet.Interactive.Documents.Tests/DocumentFormatTestsBase.cs
@@ -9,16 +9,16 @@ public abstract class DocumentFormatTestsBase
 {
     protected DocumentFormatTestsBase()
     {
-        KernelInfos = new KernelInfoCollection
+        DefaultKernelInfos = new KernelInfoCollection
         {
             new("csharp", new[] { "cs", "C#", "c#" }),
             new("fsharp", new[] { "fs", "F#", "f#" }),
             new("pwsh", new[] { "powershell" }),
         };
-        KernelInfos.DefaultKernelName = "csharp";
+        DefaultKernelInfos.DefaultKernelName = "csharp";
     }
 
-    public KernelInfoCollection KernelInfos { get; }
+    public KernelInfoCollection DefaultKernelInfos { get; }
 
     protected static string PathToCurrentSourceFile([CallerFilePath] string path = null)
     {

--- a/src/Microsoft.DotNet.Interactive.Documents.Tests/ImportNotebookTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Documents.Tests/ImportNotebookTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using FluentAssertions;
+using Microsoft.DotNet.Interactive.Documents.Jupyter;
+using Xunit;
+
+namespace Microsoft.DotNet.Interactive.Documents.Tests;
+
+public class ImportNotebookTests : DocumentFormatTestsBase
+{
+    [Theory]
+    [InlineData(".ipynb", ".ipynb")]
+    [InlineData(".ipynb", ".dib")]
+    [InlineData(".dib", ".ipynb")]
+    [InlineData(".dib", ".dib")]
+    public void It_can_import_one_notebook_into_another(
+        string importingNotebookExtension,
+        string importedNotebookExtension)
+    {
+        var importedCode = "// imported code";
+
+        var importedNotebook = new InteractiveDocument
+        {
+            new InteractiveDocumentElement(importedCode, "csharp")
+        };
+
+        var importedNotebookPath = Path.GetTempFileName() + importedNotebookExtension;
+
+        switch (importedNotebookExtension)
+        {
+            case ".dib":
+                File.WriteAllText(importedNotebookPath, importedNotebook.ToCodeSubmissionContent());
+                break;
+            case ".ipynb":
+                File.WriteAllText(importedNotebookPath, importedNotebook.ToJupyterJson());
+                break;
+        }
+
+        var importingNotebook =
+            new InteractiveDocument
+            {
+                new InteractiveDocumentElement($"#!import {importedNotebookPath}"),
+                new InteractiveDocumentElement("// code in importing notebook", "csharp")
+            };
+
+        var importingNotebookText = importingNotebookExtension switch
+        {
+            ".dib" => importingNotebook.ToCodeSubmissionContent(),
+            ".ipynb" => importingNotebook.ToJupyterJson()
+        };
+
+        var document = CodeSubmission.Parse(
+            importingNotebookText, 
+            DefaultKernelInfos);
+
+        document.GetImportedDocuments().Should().ContainSingle()
+                .Which
+                .Elements.Should().ContainSingle()
+                .Which
+                .Contents.Should().Contain(importedCode);
+    }
+
+    [Fact]
+    public void Imported_documents_override_parent_document_kernel_aliases()
+    {
+        
+
+        // TODO (Imported_documents_override_parent_document_kernel_aliases) write test
+        throw new NotImplementedException();
+    }
+
+    [Fact]
+    public void Imported_document_metadata_augments_parent_document_kernel_info()
+    {
+        
+
+        // TODO (Imported_document_metadata_augments_parent_document_kernel_info) write test
+        throw new NotImplementedException();
+    }
+
+    [Fact]
+    public void It_can_import_a_file_that_imports_another_file()
+    {
+        // TODO (It_can_import_a_file_that_imports_another_file) write test
+        throw new NotImplementedException();
+    }
+}

--- a/src/Microsoft.DotNet.Interactive.Documents.Tests/JupyterFormatTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Documents.Tests/JupyterFormatTests.cs
@@ -18,327 +18,327 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
-namespace Microsoft.DotNet.Interactive.Documents.Tests
+namespace Microsoft.DotNet.Interactive.Documents.Tests;
+
+public class JupyterFormatTests : DocumentFormatTestsBase
 {
-    public class JupyterFormatTests : DocumentFormatTestsBase
+    private readonly Configuration _assentConfiguration =
+        new Configuration()
+            .UsingExtension("json")
+            .SetInteractive(Debugger.IsAttached);
+
+    public InteractiveDocument SerializeAndParse(object jupyter)
     {
-        private readonly Configuration _assentConfiguration =
-            new Configuration()
-                .UsingExtension("json")
-                .SetInteractive(Debugger.IsAttached);
+        var content = JsonConvert.SerializeObject(jupyter);
 
-        public InteractiveDocument SerializeAndParse(object jupyter)
+        return Notebook.Parse(content, KernelInfos);
+    }
+
+    [Theory]
+    [InlineData("csharp", "C#", ".cs", "8.0")]
+    [InlineData("fsharp", "F#", ".fs", "5.0")]
+    public void notebook_metadata_default_language_is_honored_in_cells_without_language_specifier_set(string language, string shortLanguage, string extension, string version)
+    {
+        var jupyter = new
         {
-            var content = JsonConvert.SerializeObject(jupyter);
-
-            return Notebook.Parse(content, KernelInfos);
-        }
-
-        [Theory]
-        [InlineData("csharp", "C#", ".cs", "8.0")]
-        [InlineData("fsharp", "F#", ".fs", "5.0")]
-        public void notebook_metadata_default_language_is_honored_in_cells_without_language_specifier_set(string language, string shortLanguage, string extension, string version)
-        {
-            var jupyter = new
+            cells = new object[]
             {
-                cells = new object[]
+                new
                 {
-                    new
-                    {
-                        cell_type = "code",
-                        execution_count = 0,
-                        source = new[] { "// this is the code" }
-                    }
-                },
-                metadata = new
+                    cell_type = "code",
+                    execution_count = 0,
+                    source = new[] { "// this is the code" }
+                }
+            },
+            metadata = new
+            {
+                kernelspec = new
                 {
-                    kernelspec = new
-                    {
-                        display_name = $".NET ({shortLanguage})",
-                        language = shortLanguage,
-                        name = $".net-{language}"
-                    },
-                    language_info = new
-                    {
-                        file_extension = extension,
-                        mimetype = $"text/x-{language}",
-                        name = shortLanguage,
-                        pygments_lexer = language,
-                        version
-                    }
+                    display_name = $".NET ({shortLanguage})",
+                    language = shortLanguage,
+                    name = $".net-{language}"
                 },
-                nbformat = 4,
-                nbformat_minor = 4
-            };
+                language_info = new
+                {
+                    file_extension = extension,
+                    mimetype = $"text/x-{language}",
+                    name = shortLanguage,
+                    pygments_lexer = language,
+                    version
+                }
+            },
+            nbformat = 4,
+            nbformat_minor = 4
+        };
 
-            var notebook = SerializeAndParse(jupyter);
+        var notebook = SerializeAndParse(jupyter);
 
-            notebook.Elements
+        notebook.Elements
                 .Should()
                 .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
                     new InteractiveDocumentElement("// this is the code", language)
                 });
-        }
+    }
 
-        [Fact]
-        public void missing_metadata_defaults_to_csharp_kernel()
+    [Fact]
+    public void missing_metadata_defaults_to_csharp_kernel()
+    {
+        var jupyter = new
         {
-            var jupyter = new
+            cells = new object[]
             {
-                cells = new object[]
+                new
                 {
-                    new
+                    cell_type = "code",
+                    execution_count = 0,
+                    source = new[] { "// this is assumed to be csharp" }
+                },
+                new
+                {
+                    cell_type = "code",
+                    execution_count = 0,
+                    source = new[]
                     {
-                        cell_type = "code",
-                        execution_count = 0,
-                        source = new[] { "// this is assumed to be csharp" }
-                    },
-                    new
+                        "#!csharp\n",
+                        "// this is still assumed to be csharp"
+                    }
+                }
+            }
+        };
+        var notebook = SerializeAndParse(jupyter);
+        notebook.Elements
+                .Should()
+                .BeEquivalentToRespectingRuntimeTypes(new[]
+                {
+                    new InteractiveDocumentElement("// this is assumed to be csharp", "csharp"),
+                    new InteractiveDocumentElement("#!csharp\n// this is still assumed to be csharp", "csharp")
+                });
+    }
+
+    [Fact]
+    public void cell_metadata_can_specify_language_that_overrides_notebook()
+    {
+        var jupyter = new
+        {
+            cells = new object[]
+            {
+                new
+                {
+                    cell_type = "code",
+                    execution_count = 1,
+                    metadata = new
                     {
-                        cell_type = "code",
-                        execution_count = 0,
-                        source = new[]
+                        dotnet_interactive = new
                         {
-                            "#!csharp\n",
-                            "// this is still assumed to be csharp"
+                            language = "fsharp"
                         }
-                    }
-                }
-            };
-            var notebook = SerializeAndParse(jupyter);
-            notebook.Elements
-                    .Should()
-                    .BeEquivalentToRespectingRuntimeTypes(new[]
-                    {
-                        new InteractiveDocumentElement("// this is assumed to be csharp", "csharp"),
-                        new InteractiveDocumentElement("#!csharp\n// this is still assumed to be csharp", "csharp")
-                    });
-        }
-
-        [Fact]
-        public void cell_metadata_can_specify_language_that_overrides_notebook()
-        {
-            var jupyter = new
-            {
-                cells = new object[]
-                {
-                    new
-                    {
-                        cell_type = "code",
-                        execution_count = 1,
-                        metadata = new
-                        {
-                            dotnet_interactive = new
-                            {
-                                language = "fsharp"
-                            }
-                        },
-                        source = new[] { "// this should be F#" }
-                    }
-                },
-                metadata = new
-                {
-                    kernelspec = new
-                    {
-                        display_name = ".NET (C#)",
-                        language = "C#",
-                        name = ".net-csharp"
                     },
-                    language_info = new
-                    {
-                        file_extension = ".cs",
-                        mimetype = "text/x-csharp",
-                        name = "C#",
-                        pygments_lexer = "C#",
-                        version = "8.0"
-                    }
+                    source = new[] { "// this should be F#" }
+                }
+            },
+            metadata = new
+            {
+                kernelspec = new
+                {
+                    display_name = ".NET (C#)",
+                    language = "C#",
+                    name = ".net-csharp"
                 },
-                nbformat = 4,
-                nbformat_minor = 4
-            };
-            var notebook = SerializeAndParse(jupyter);
-            notebook.Elements
+                language_info = new
+                {
+                    file_extension = ".cs",
+                    mimetype = "text/x-csharp",
+                    name = "C#",
+                    pygments_lexer = "C#",
+                    version = "8.0"
+                }
+            },
+            nbformat = 4,
+            nbformat_minor = 4
+        };
+        var notebook = SerializeAndParse(jupyter);
+        notebook.Elements
                 .Should()
                 .ContainSingle()
                 .Which
                 .KernelName
                 .Should()
                 .Be("fsharp");
-        }
+    }
 
-        [Fact]
-        public void cell_language_can_specify_language_when_there_is_no_notebook_default()
+    [Fact]
+    public void cell_language_can_specify_language_when_there_is_no_notebook_default()
+    {
+        var jupyter = new
         {
-            var jupyter = new
+            cells = new object[]
             {
-                cells = new object[]
+                new
                 {
-                    new
+                    cell_type = "code",
+                    execution_count = 1,
+                    metadata = new
                     {
-                        cell_type = "code",
-                        execution_count = 1,
-                        metadata = new
+                        dotnet_interactive = new
                         {
-                            dotnet_interactive = new
-                            {
-                                language = "fsharp"
-                            }
-                        },
-                        source = new[] { "// this should be F#" }
-                    }
+                            language = "fsharp"
+                        }
+                    },
+                    source = new[] { "// this should be F#" }
                 }
-            };
-            var notebook = SerializeAndParse(jupyter);
-            notebook.Elements
+            }
+        };
+        var notebook = SerializeAndParse(jupyter);
+        notebook.Elements
                 .Should()
                 .ContainSingle()
                 .Which
                 .KernelName
                 .Should()
                 .Be("fsharp");
-        }
+    }
 
-        [Fact]
-        public void parsed_cells_do_not_contain_redundant_language_specifier()
+    [Fact]
+    public void parsed_cells_do_not_contain_redundant_language_specifier()
+    {
+        var jupyter = new
         {
-            var jupyter = new
+            cells = new object[]
             {
-                cells = new object[]
+                new
                 {
-                    new
-                    {
-                        cell_type = "code",
-                        execution_count = 0,
-                        source = new[] {"#!csharp\n", "// this is the code"}
-                    }
-                },
-                metadata = new
+                    cell_type = "code",
+                    execution_count = 0,
+                    source = new[] {"#!csharp\n", "// this is the code"}
+                }
+            },
+            metadata = new
+            {
+                kernelspec = new
                 {
-                    kernelspec = new
-                    {
-                        display_name = ".NET (C#)",
-                        language = "C#",
-                        name = ".net-csharp"
-                    },
-                    language_info = new
-                    {
-                        file_extension = ".cs",
-                        mimetype = "text/x-csharp",
-                        name = "C#",
-                        pygments_lexer = "csharp",
-                        version = "8.0"
-                    }
+                    display_name = ".NET (C#)",
+                    language = "C#",
+                    name = ".net-csharp"
                 },
-                nbformat = 4,
-                nbformat_minor = 4
-            };
+                language_info = new
+                {
+                    file_extension = ".cs",
+                    mimetype = "text/x-csharp",
+                    name = "C#",
+                    pygments_lexer = "csharp",
+                    version = "8.0"
+                }
+            },
+            nbformat = 4,
+            nbformat_minor = 4
+        };
 
-            var notebook = SerializeAndParse(jupyter);
+        var notebook = SerializeAndParse(jupyter);
 
-            notebook.Elements
+        notebook.Elements
                 .Should()
                 .BeEquivalentToRespectingRuntimeTypes(new object[]
                 {
                     new InteractiveDocumentElement("#!csharp\n// this is the code", "csharp")
                 });
-        }
+    }
 
-        [Fact]
-        public void kernel_chooser_magic_takes_precedence_over_metadata_language()
+    [Fact]
+    public void kernel_chooser_magic_takes_precedence_over_metadata_language()
+    {
+        var jupyter = new
         {
-            var jupyter = new
+            cells = new object[]
             {
-                cells = new object[]
+                new
                 {
-                    new
+                    cell_type = "code",
+                    execution_count = 1,
+                    metadata = new
                     {
-                        cell_type = "code",
-                        execution_count = 1,
-                        metadata = new
+                        dotnet_interactive = new
                         {
-                            dotnet_interactive = new
-                            {
-                                language = "fsharp"
-                            }
-                        },
-                        source = new[]
-                        {
-                            "#!pwsh\n",
-                            "# this is PowerShell and not F#"
+                            language = "fsharp"
                         }
-                    }
-                },
-                metadata = new
-                {
-                    kernelspec = new
-                    {
-                        display_name = ".NET (C#)",
-                        language = "C#",
-                        name = ".net-csharp"
                     },
-                    language_info = new
+                    source = new[]
                     {
-                        file_extension = ".cs",
-                        mimetype = "text/x-csharp",
-                        name = "C#",
-                        pygments_lexer = "C#",
-                        version = "8.0"
+                        "#!pwsh\n",
+                        "# this is PowerShell and not F#"
                     }
+                }
+            },
+            metadata = new
+            {
+                kernelspec = new
+                {
+                    display_name = ".NET (C#)",
+                    language = "C#",
+                    name = ".net-csharp"
                 },
-                nbformat = 4,
-                nbformat_minor = 4
-            };
+                language_info = new
+                {
+                    file_extension = ".cs",
+                    mimetype = "text/x-csharp",
+                    name = "C#",
+                    pygments_lexer = "C#",
+                    version = "8.0"
+                }
+            },
+            nbformat = 4,
+            nbformat_minor = 4
+        };
 
-            var notebook = SerializeAndParse(jupyter);
+        var notebook = SerializeAndParse(jupyter);
 
-            notebook.Elements
+        notebook.Elements
                 .Should()
                 .ContainSingle()
                 .Which
                 .KernelName
                 .Should()
                 .Be("pwsh");
-        }
+    }
 
-        [Fact]
-        public void parsed_cell_language_aliases_are_normalized()
+    [Fact]
+    public void parsed_cell_language_aliases_are_normalized()
+    {
+        var jupyter = new
         {
-            var jupyter = new
+            cells = new object[]
             {
-                cells = new object[]
+                new
                 {
-                    new
-                    {
-                        cell_type = "code",
-                        source = new[] { "#!c#\n", "// this is csharp 1" }
-                    },
-                    new
-                    {
-                        cell_type = "code",
-                        source = new[] { "#!C#\n", "// this is csharp 2" }
-                    },
-                    new
-                    {
-                        cell_type = "code",
-                        source = new[] { "#!f#\n", "// this is fsharp 1" }
-                    },
-                    new
-                    {
-                        cell_type = "code",
-                        source = new[] { "#!F#\n", "// this is fsharp 2" }
-                    },  
-                    new
-                    {
-                        cell_type = "code",
-                        source = new[] { "#!powershell\n", "# this is pwsh" }
-                    }
+                    cell_type = "code",
+                    source = new[] { "#!c#\n", "// this is csharp 1" }
+                },
+                new
+                {
+                    cell_type = "code",
+                    source = new[] { "#!C#\n", "// this is csharp 2" }
+                },
+                new
+                {
+                    cell_type = "code",
+                    source = new[] { "#!f#\n", "// this is fsharp 1" }
+                },
+                new
+                {
+                    cell_type = "code",
+                    source = new[] { "#!F#\n", "// this is fsharp 2" }
+                },  
+                new
+                {
+                    cell_type = "code",
+                    source = new[] { "#!powershell\n", "# this is pwsh" }
                 }
-            };
+            }
+        };
 
-            var notebook = SerializeAndParse(jupyter);
+        var notebook = SerializeAndParse(jupyter);
 
-            notebook.Elements
+        notebook.Elements
                 .Should()
                 .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
@@ -348,370 +348,370 @@ namespace Microsoft.DotNet.Interactive.Documents.Tests
                     new InteractiveDocumentElement("#!F#\n// this is fsharp 2", "fsharp"),
                     new InteractiveDocumentElement("#!powershell\n# this is pwsh", "pwsh")
                 });
-        }
+    }
 
-        [Fact]
-        public void parsed_cells_can_override_default_language_with_language_specifier()
+    [Fact]
+    public void parsed_cells_can_override_default_language_with_language_specifier()
+    {
+        var jupyter = new
         {
-            var jupyter = new
+            cells = new object[]
             {
-                cells = new object[]
+                new
                 {
-                    new
-                    {
-                        cell_type = "code",
-                        execution_count = 0,
-                        source = new[] { "#!fsharp\n", "// this is the code" }
-                    }
-                },
-                metadata = new
+                    cell_type = "code",
+                    execution_count = 0,
+                    source = new[] { "#!fsharp\n", "// this is the code" }
+                }
+            },
+            metadata = new
+            {
+                kernelspec = new
                 {
-                    kernelspec = new
-                    {
-                        display_name = ".NET (C#)",
-                        language = "C#",
-                        name = ".net-csharp"
-                    },
-                    language_info = new
-                    {
-                        file_extension = ".cs",
-                        mimetype = "text/x-csharp",
-                        name = "C#",
-                        pygments_lexer = "csharp",
-                        version = "8.0"
-                    }
+                    display_name = ".NET (C#)",
+                    language = "C#",
+                    name = ".net-csharp"
                 },
-                nbformat = 4,
-                nbformat_minor = 4
-            };
+                language_info = new
+                {
+                    file_extension = ".cs",
+                    mimetype = "text/x-csharp",
+                    name = "C#",
+                    pygments_lexer = "csharp",
+                    version = "8.0"
+                }
+            },
+            nbformat = 4,
+            nbformat_minor = 4
+        };
 
-            var notebook = SerializeAndParse(jupyter);
+        var notebook = SerializeAndParse(jupyter);
 
-            notebook.Elements
+        notebook.Elements
                 .Should()
                 .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
                     new InteractiveDocumentElement("#!fsharp\n// this is the code", "fsharp")
                 });
-        }
+    }
 
-        [Fact]
-        public void parsed_cells_can_contain_polyglot_blobs_with_appropriate_default_language()
+    [Fact]
+    public void parsed_cells_can_contain_polyglot_blobs_with_appropriate_default_language()
+    {
+        var jupyter = new
         {
-            var jupyter = new
+            cells = new object[]
             {
-                cells = new object[]
+                new
                 {
-                    new
-                    {
-                        cell_type = "code",
-                        execution_count = 0,
-                        source = new[] {"// this is csharp\n", "#!fsharp\n", "// and this is fsharp"}
-                    }
-                },
-                metadata = new
+                    cell_type = "code",
+                    execution_count = 0,
+                    source = new[] {"// this is csharp\n", "#!fsharp\n", "// and this is fsharp"}
+                }
+            },
+            metadata = new
+            {
+                kernelspec = new
                 {
-                    kernelspec = new
-                    {
-                        display_name = ".NET (C#)",
-                        language = "C#",
-                        name = ".net-csharp"
-                    },
-                    language_info = new
-                    {
-                        file_extension = ".cs",
-                        mimetype = "text/x-csharp",
-                        name = "C#",
-                        pygments_lexer = "csharp",
-                        version = "8.0"
-                    }
+                    display_name = ".NET (C#)",
+                    language = "C#",
+                    name = ".net-csharp"
                 },
-                nbformat = 4,
-                nbformat_minor = 4
-            };
+                language_info = new
+                {
+                    file_extension = ".cs",
+                    mimetype = "text/x-csharp",
+                    name = "C#",
+                    pygments_lexer = "csharp",
+                    version = "8.0"
+                }
+            },
+            nbformat = 4,
+            nbformat_minor = 4
+        };
 
-            var notebook = SerializeAndParse(jupyter);
+        var notebook = SerializeAndParse(jupyter);
 
-            notebook.Elements
+        notebook.Elements
                 .Should()
                 .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
                     new InteractiveDocumentElement("// this is csharp\n#!fsharp\n// and this is fsharp", "csharp")
                 });
-        }
+    }
 
-        [Fact]
-        public void parsed_cells_create_non_language_specifier_first_lines_as_magic_commands()
+    [Fact]
+    public void parsed_cells_create_non_language_specifier_first_lines_as_magic_commands()
+    {
+        var jupyter = new
         {
-            var jupyter = new
+            cells = new object[]
             {
-                cells = new object[]
+                new
                 {
-                    new
-                    {
-                        cell_type = "code",
-                        execution_count = 0,
-                        source = new[] {"#!probably-a-magic-command\n// but this is csharp"}
-                    }
-                },
-                metadata = new
-                {
-                    kernelspec = new
-                    {
-                        display_name = ".NET (C#)",
-                        language = "C#",
-                        name = ".net-csharp"
-                    },
-                    language_info = new
-                    {
-                        file_extension = ".cs",
-                        mimetype = "text/x-csharp",
-                        name = "C#",
-                        pygments_lexer = "csharp",
-                        version = "8.0"
-                    }
-                },
-                nbformat = 4,
-                nbformat_minor = 4
-            };
-
-            var notebook = SerializeAndParse(jupyter);
-
-            notebook.Elements
-                    .Should()
-                    .BeEquivalentToRespectingRuntimeTypes(new[]
-                    {
-                        new InteractiveDocumentElement("#!probably-a-magic-command\n// but this is csharp", "csharp")
-                    });
-        }
-
-        [Fact]
-        public void markdown_cells_can_be_parsed_as_a_single_string()
-        {
-            var jupyter = new
-            {
-                cells = new object[]
-                {
-                    new
-                    {
-                        cell_type = "markdown",
-                        source = new[] {"This is `markdown`."}
-                    }
+                    cell_type = "code",
+                    execution_count = 0,
+                    source = new[] {"#!probably-a-magic-command\n// but this is csharp"}
                 }
-            };
-            var notebook = SerializeAndParse(jupyter);
-            notebook.Elements
+            },
+            metadata = new
+            {
+                kernelspec = new
+                {
+                    display_name = ".NET (C#)",
+                    language = "C#",
+                    name = ".net-csharp"
+                },
+                language_info = new
+                {
+                    file_extension = ".cs",
+                    mimetype = "text/x-csharp",
+                    name = "C#",
+                    pygments_lexer = "csharp",
+                    version = "8.0"
+                }
+            },
+            nbformat = 4,
+            nbformat_minor = 4
+        };
+
+        var notebook = SerializeAndParse(jupyter);
+
+        notebook.Elements
+                .Should()
+                .BeEquivalentToRespectingRuntimeTypes(new[]
+                {
+                    new InteractiveDocumentElement("#!probably-a-magic-command\n// but this is csharp", "csharp")
+                });
+    }
+
+    [Fact]
+    public void markdown_cells_can_be_parsed_as_a_single_string()
+    {
+        var jupyter = new
+        {
+            cells = new object[]
+            {
+                new
+                {
+                    cell_type = "markdown",
+                    source = new[] {"This is `markdown`."}
+                }
+            }
+        };
+        var notebook = SerializeAndParse(jupyter);
+        notebook.Elements
                 .Should()
                 .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
                     new InteractiveDocumentElement("This is `markdown`.", "markdown")
                 });
-        }
+    }
 
-        [Fact]
-        public void markdown_cells_can_be_parsed_as_a_string_array()
+    [Fact]
+    public void markdown_cells_can_be_parsed_as_a_string_array()
+    {
+        var jupyter = new
         {
-            var jupyter = new
+            cells = new object[]
             {
-                cells = new object[]
+                new
                 {
-                    new
+                    cell_type = "markdown",
+                    source = new[]
                     {
-                        cell_type = "markdown",
-                        source = new[]
-                        {
-                            "This is `markdown`.\n",
-                            "So is this."
-                        }
+                        "This is `markdown`.\n",
+                        "So is this."
                     }
                 }
-            };
-            var notebook = SerializeAndParse(jupyter);
-            notebook.Elements
+            }
+        };
+        var notebook = SerializeAndParse(jupyter);
+        notebook.Elements
                 .Should()
                 .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
                     new InteractiveDocumentElement("This is `markdown`.\nSo is this.", "markdown")
                 });
-        }
+    }
 
-        [Fact]
-        public void cells_can_specify_source_as_a_string_array()
+    [Fact]
+    public void cells_can_specify_source_as_a_string_array()
+    {
+        var jupyter = new
         {
-            var jupyter = new
+            cells = new object[]
             {
-                cells = new object[]
+                new
                 {
-                    new
+                    cell_type = "code",
+                    execution_count = 0,
+                    source = new[]
                     {
-                        cell_type = "code",
-                        execution_count = 0,
-                        source = new[]
-                        {
-                            // all different newline styles are normalized to `\n`
-                            "line 1\n",
-                            "line 2\n",
-                            "line 3\n",
-                            "line 4",
-                        }
+                        // all different newline styles are normalized to `\n`
+                        "line 1\n",
+                        "line 2\n",
+                        "line 3\n",
+                        "line 4",
                     }
-                },
-                metadata = new
+                }
+            },
+            metadata = new
+            {
+                kernelspec = new
                 {
-                    kernelspec = new
-                    {
-                        display_name = ".NET (C#)",
-                        language = "C#",
-                        name = ".net-csharp"
-                    },
-                    language_info = new
-                    {
-                        file_extension = ".cs",
-                        mimetype = "text/x-csharp",
-                        name = "C#",
-                        pygments_lexer = "csharp",
-                        version = "8.0"
-                    }
+                    display_name = ".NET (C#)",
+                    language = "C#",
+                    name = ".net-csharp"
                 },
-                nbformat = 4,
-                nbformat_minor = 4
-            };
+                language_info = new
+                {
+                    file_extension = ".cs",
+                    mimetype = "text/x-csharp",
+                    name = "C#",
+                    pygments_lexer = "csharp",
+                    version = "8.0"
+                }
+            },
+            nbformat = 4,
+            nbformat_minor = 4
+        };
 
-            var notebook = SerializeAndParse(jupyter);
+        var notebook = SerializeAndParse(jupyter);
             
-            notebook.Elements
+        notebook.Elements
                 .Should()
                 .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
                     new InteractiveDocumentElement("line 1\nline 2\nline 3\nline 4", "csharp")
                 });
-        }
+    }
 
-        [Fact]
-        public void cells_can_specify_source_as_a_single_string()
+    [Fact]
+    public void cells_can_specify_source_as_a_single_string()
+    {
+        var jupyter = new
         {
-            var jupyter = new
+            cells = new object[]
             {
-                cells = new object[]
+                new
                 {
-                    new
-                    {
-                        cell_type = "code",
-                        source = "line 1\nline 2\nline 3\n"
-                    }
-                },
-            };
+                    cell_type = "code",
+                    source = "line 1\nline 2\nline 3\n"
+                }
+            },
+        };
 
-            var notebook = SerializeAndParse(jupyter);
+        var notebook = SerializeAndParse(jupyter);
             
-            notebook.Elements
-                    .Should()
-                    .BeEquivalentToRespectingRuntimeTypes(new[]
-                    {
-                        new InteractiveDocumentElement("line 1\nline 2\nline 3\n", "csharp")
-                    });
-        }
-
-        [Fact]
-        public void cell_with_metadata_but_not_language_can_be_parsed()
-        {
-            var jupyter = new
-            {
-                cells = new object[]
+        notebook.Elements
+                .Should()
+                .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
-                    new
+                    new InteractiveDocumentElement("line 1\nline 2\nline 3\n", "csharp")
+                });
+    }
+
+    [Fact]
+    public void cell_with_metadata_but_not_language_can_be_parsed()
+    {
+        var jupyter = new
+        {
+            cells = new object[]
+            {
+                new
+                {
+                    cell_type = "code",
+                    source = new[]
                     {
-                        cell_type = "code",
-                        source = new[]
+                        "// this is not really fsharp"
+                    },
+                    metadata = new
+                    {
+                        dotnet_interactive = new
                         {
-                            "// this is not really fsharp"
-                        },
-                        metadata = new
-                        {
-                            dotnet_interactive = new
-                            {
-                                not_a_language = "fsharp"
-                            }
+                            not_a_language = "fsharp"
                         }
                     }
                 }
-            };
+            }
+        };
 
-            var notebook = SerializeAndParse(jupyter);
+        var notebook = SerializeAndParse(jupyter);
 
-            notebook.Elements
-                    .Should()
-                    .BeEquivalentToRespectingRuntimeTypes(new[]
+        notebook.Elements
+                .Should()
+                .BeEquivalentToRespectingRuntimeTypes(new[]
+                {
+                    new InteractiveDocumentElement("// this is not really fsharp", "csharp")
                     {
-                        new InteractiveDocumentElement("// this is not really fsharp", "csharp")
+                        Metadata = new Dictionary<string, object>
                         {
-                            Metadata = new Dictionary<string, object>
+                            ["dotnet_interactive"] = new Dictionary<string, object>
                             {
-                                ["dotnet_interactive"] = new Dictionary<string, object>
-                                {
-                                    ["not_a_language"] = "fsharp"
-                                }
+                                ["not_a_language"] = "fsharp"
                             }
                         }
-                    });
-        }
+                    }
+                });
+    }
 
-        [Fact]
-        public void code_cell_without_source_can_be_parsed()
+    [Fact]
+    public void code_cell_without_source_can_be_parsed()
+    {
+        var jupyter = new
         {
-            var jupyter = new
+            cells = new object[]
             {
-                cells = new object[]
+                new
                 {
-                    new
+                    cell_type = "code",
+                    not_source = new[]
                     {
-                        cell_type = "code",
-                        not_source = new[]
-                        {
-                            "// this isn't code"
-                        }
+                        "// this isn't code"
                     }
                 }
-            };
-            var notebook = SerializeAndParse(jupyter);
-            notebook.Elements
+            }
+        };
+        var notebook = SerializeAndParse(jupyter);
+        notebook.Elements
                 .Should()
                 .BeEquivalentToRespectingRuntimeTypes(new[]
                 {
                     new InteractiveDocumentElement(kernelName: "csharp")
                 });
-        }
+    }
 
-        [Fact]
-        public void cell_display_output_with_object_array_can_be_parsed()
+    [Fact]
+    public void cell_display_output_with_object_array_can_be_parsed()
+    {
+        var jupyter = new
         {
-            var jupyter = new
+            cells = new object[]
             {
-                cells = new object[]
+                new
                 {
-                    new
+                    cell_type = "code",
+                    execution_count = 1,
+                    metadata = new { },
+                    source = new[] { "" },
+                    outputs = new[]
                     {
-                        cell_type = "code",
-                        execution_count = 1,
-                        metadata = new { },
-                        source = new[] { "" },
-                        outputs = new[]
+                        new
                         {
-                            new
+                            data = new Dictionary<string, object>
                             {
-                                data = new Dictionary<string, object>
-                                {
-                                    { "text/html", new object[] { "line 1", new { the_answer = 42 } } }
-                                },
-                                metadata = new { },
-                                output_type = "display_data"
-                            }
+                                { "text/html", new object[] { "line 1", new { the_answer = 42 } } }
+                            },
+                            metadata = new { },
+                            output_type = "display_data"
                         }
                     }
                 }
-            };
-            var notebook = SerializeAndParse(jupyter);
-            notebook.Elements
+            }
+        };
+        var notebook = SerializeAndParse(jupyter);
+        notebook.Elements
                 .Should()
                 .ContainSingle()
                 .Which
@@ -737,40 +737,40 @@ namespace Microsoft.DotNet.Interactive.Documents.Tests
                         }
                     }
                 );
-        }
+    }
 
 
-        [Fact]
-        public void cell_display_output_without_data_member_can_be_parsed()
+    [Fact]
+    public void cell_display_output_without_data_member_can_be_parsed()
+    {
+        var jupyter = new
         {
-            var jupyter = new
+            cells = new object[]
             {
-                cells = new object[]
+                new
                 {
-                    new
+                    cell_type = "code",
+                    execution_count = 1,
+                    metadata = new { },
+                    source =new[] {"//"},
+                    outputs = new object[]
                     {
-                        cell_type = "code",
-                        execution_count = 1,
-                        metadata = new { },
-                        source =new[] {"//"},
-                        outputs = new object[]
+                        new
                         {
-                            new
+                            output_type = "display_data",
+                            not_data = new Dictionary<string, string[]>
                             {
-                                output_type = "display_data",
-                                not_data = new Dictionary<string, string[]>
-                                {
-                                    { "text/html", new[]{"<div>this is html</div>"} }
-                                },
-                                execution_count = 1,
-                                metadata = new { }
-                            }
+                                { "text/html", new[]{"<div>this is html</div>"} }
+                            },
+                            execution_count = 1,
+                            metadata = new { }
                         }
                     }
                 }
-            };
-            var notebook = SerializeAndParse(jupyter);
-            notebook.Elements
+            }
+        };
+        var notebook = SerializeAndParse(jupyter);
+        notebook.Elements
                 .Should()
                 .ContainSingle()
                 .Which
@@ -784,39 +784,39 @@ namespace Microsoft.DotNet.Interactive.Documents.Tests
                 .Data
                 .Should()
                 .BeEmpty();
-        }
+    }
 
-        [Fact]
-        public void execute_result_output_without_data_member_can_be_parsed()
+    [Fact]
+    public void execute_result_output_without_data_member_can_be_parsed()
+    {
+        var jupyter = new
         {
-            var jupyter = new
+            cells = new object[]
             {
-                cells = new object[]
+                new
                 {
-                    new
+                    cell_type = "code",
+                    execution_count = 1,
+                    metadata = new { },
+                    source =new[] {"//"},
+                    outputs = new object[]
                     {
-                        cell_type = "code",
-                        execution_count = 1,
-                        metadata = new { },
-                        source =new[] {"//"},
-                        outputs = new object[]
+                        new
                         {
-                            new
+                            output_type = "execute_result",
+                            not_data = new Dictionary<string, string[]>
                             {
-                                output_type = "execute_result",
-                                not_data = new Dictionary<string, string[]>
-                                {
-                                    { "text/html", new[]{"<div>this is html</div>"} }
-                                },
-                                execution_count = 1,
-                                metadata = new { }
-                            }
+                                { "text/html", new[]{"<div>this is html</div>"} }
+                            },
+                            execution_count = 1,
+                            metadata = new { }
                         }
                     }
                 }
-            };
-            var notebook = SerializeAndParse(jupyter);
-            notebook.Elements
+            }
+        };
+        var notebook = SerializeAndParse(jupyter);
+        notebook.Elements
                 .Should()
                 .ContainSingle()
                 .Which
@@ -830,37 +830,37 @@ namespace Microsoft.DotNet.Interactive.Documents.Tests
                 .Data
                 .Should()
                 .BeEmpty();
-        }
+    }
 
-        [Fact]
-        public void cell_stream_output_without_text_member_can_be_parsed()
+    [Fact]
+    public void cell_stream_output_without_text_member_can_be_parsed()
+    {
+        var jupyter = new
         {
-            var jupyter = new
+            cells = new object[]
             {
-                cells = new object[]
+                new
                 {
-                    new
+                    cell_type = "code",
+                    execution_count = 1,
+                    metadata = new { },
+                    source = new[] { "//" },
+                    outputs = new object[]
                     {
-                        cell_type = "code",
-                        execution_count = 1,
-                        metadata = new { },
-                        source = new[] { "//" },
-                        outputs = new object[]
+                        new
                         {
-                            new
-                            {
-                                output_type = "stream",
-                                name = "stdout",
-                                not_text = "this is text"
-                            }
+                            output_type = "stream",
+                            name = "stdout",
+                            not_text = "this is text"
                         }
                     }
                 }
-            };
+            }
+        };
 
-            var notebook = SerializeAndParse(jupyter);
+        var notebook = SerializeAndParse(jupyter);
 
-            notebook.Elements
+        notebook.Elements
                 .Should()
                 .ContainSingle()
                 .Which
@@ -874,40 +874,40 @@ namespace Microsoft.DotNet.Interactive.Documents.Tests
                 .Text
                 .Should()
                 .BeEmpty();
-        }
+    }
 
-        [Fact]
-        public void cell_error_output_without_required_fields_can_be_parsed()
+    [Fact]
+    public void cell_error_output_without_required_fields_can_be_parsed()
+    {
+        var jupyter = new
         {
-            var jupyter = new
+            cells = new object[]
             {
-                cells = new object[]
+                new
                 {
-                    new
+                    cell_type = "code",
+                    execution_count = 1,
+                    metadata = new { },
+                    source =new[] {"//"},
+                    outputs = new object[]
                     {
-                        cell_type = "code",
-                        execution_count = 1,
-                        metadata = new { },
-                        source =new[] {"//"},
-                        outputs = new object[]
+                        new
                         {
-                            new
+                            output_type = "error",
+                            not_ename = "e-name",
+                            not_evalue = "e-value",
+                            not_traceback = new[]
                             {
-                                output_type = "error",
-                                not_ename = "e-name",
-                                not_evalue = "e-value",
-                                not_traceback = new[]
-                                {
-                                    "at func1()",
-                                    "at func2()"
-                                }
+                                "at func1()",
+                                "at func2()"
                             }
                         }
                     }
                 }
-            };
-            var notebook = SerializeAndParse(jupyter);
-            notebook.Elements
+            }
+        };
+        var notebook = SerializeAndParse(jupyter);
+        notebook.Elements
                 .Should()
                 .ContainSingle()
                 .Which
@@ -920,303 +920,303 @@ namespace Microsoft.DotNet.Interactive.Documents.Tests
                 .Which
                 .Should()
                 .BeEquivalentToRespectingRuntimeTypes(new ErrorElement(null, null));
-        }
+    }
 
-        [Fact]
-        public void markdown_cell_missing_source_field_can_be_parsed()
+    [Fact]
+    public void markdown_cell_missing_source_field_can_be_parsed()
+    {
+        var jupyter = new
         {
-            var jupyter = new
+            cells = new object[]
             {
-                cells = new object[]
+                new
                 {
-                    new
-                    {
-                        cell_type = "markdown",
-                        not_source = new[] { "this isn't markdown" }
-                    }
+                    cell_type = "markdown",
+                    not_source = new[] { "this isn't markdown" }
                 }
-            };
-            var notebook = SerializeAndParse(jupyter);
-            notebook.Elements
-                    .Should()
-                    .ContainSingle()
-                    .Which
-                    .Should()
-                    .BeEquivalentToRespectingRuntimeTypes(new InteractiveDocumentElement(kernelName: "markdown"));
-        }
-
-        [Fact]
-        public void serialized_notebook_has_appropriate_metadata()
-        {
-            var notebook = new InteractiveDocument();
-            var serialized = notebook.SerializeToJupyter();
-            var jupyter = JToken.Parse(serialized);
-
-            using var _ = new AssertionScope();
-            jupyter["metadata"]
+            }
+        };
+        var notebook = SerializeAndParse(jupyter);
+        notebook.Elements
                 .Should()
-                .BeEquivalentTo(JToken.Parse(JsonConvert.SerializeObject(new
-                {
-                    kernelspec = new
-                    {
-                        display_name = ".NET (C#)",
-                        language = "C#",
-                        name = ".net-csharp"
-                    },
-                    language_info = new
-                    {
-                        file_extension = ".cs",
-                        mimetype = "text/x-csharp",
-                        name = "C#",
-                        pygments_lexer = "csharp",
-                        version = "8.0"
-                    }
-                })));
-            jupyter["nbformat"]
-                .ToObject<int>()
-                .Should()
-                .Be(4);
-            jupyter["nbformat_minor"]
-                .ToObject<int>()
-                .Should()
-                .BeGreaterOrEqualTo(4);
-        }
-
-        [Fact]
-        public void serialized_code_cells_have_appropriate_shape()
-        {
-            var cells = new List<InteractiveDocumentElement>
-            {
-                new("//", "csharp")
-            };
-            var notebook = new InteractiveDocument(cells);
-            var serialized = notebook.SerializeToJupyter();
-            var jupyter = JToken.Parse(serialized);
-            jupyter["cells"]
-                .Should()
-                .ContainSingleItem()
+                .ContainSingle()
                 .Which
                 .Should()
-                .BeEquivalentTo(JToken.Parse(JsonConvert.SerializeObject(
-                    new
-                    {
-                        cell_type = "code",
-                        execution_count = (int?)null,
-                        metadata = new
-                        {
-                            dotnet_interactive = new
-                            {
-                                language = "csharp"
-                            }
-                        },
-                        outputs = Array.Empty<object>(),
-                        source = new[]
-                        {
-                            "//"
-                        },
-                    }
-                )));
-        }
+                .BeEquivalentToRespectingRuntimeTypes(new InteractiveDocumentElement(kernelName: "markdown"));
+    }
 
-        [Fact]
-        public void serialized_code_cells_with_default_jupyter_kernel_language_dont_have_language_specifier()
-        {
-            var cells = new List<InteractiveDocumentElement>
+    [Fact]
+    public void serialized_notebook_has_appropriate_metadata()
+    {
+        var notebook = new InteractiveDocument();
+        var serialized = notebook.SerializeToJupyter();
+        var jupyter = JToken.Parse(serialized);
+
+        using var _ = new AssertionScope();
+        jupyter["metadata"]
+            .Should()
+            .BeEquivalentTo(JToken.Parse(JsonConvert.SerializeObject(new
             {
-                new("var x = 1;", "csharp")
-            };
-            var notebook = new InteractiveDocument(cells);
-            var serialized = notebook.SerializeToJupyter();
-            var jupyter = JToken.Parse(serialized);
-            jupyter["cells"][0]["source"]
-                .Should()
-                .BeEquivalentTo(JToken.Parse(JsonConvert.SerializeObject(new object[]
+                kernelspec = new
                 {
-                    "var x = 1;"
-                })));
-        }
+                    display_name = ".NET (C#)",
+                    language = "C#",
+                    name = ".net-csharp"
+                },
+                language_info = new
+                {
+                    file_extension = ".cs",
+                    mimetype = "text/x-csharp",
+                    name = "C#",
+                    pygments_lexer = "csharp",
+                    version = "8.0"
+                }
+            })));
+        jupyter["nbformat"]
+            .ToObject<int>()
+            .Should()
+            .Be(4);
+        jupyter["nbformat_minor"]
+            .ToObject<int>()
+            .Should()
+            .BeGreaterOrEqualTo(4);
+    }
 
-        [Fact]
-        public void serialized_code_cells_with_non_default_jupyter_kernel_language_have_language_metadata_and_no_language_specifier()
+    [Fact]
+    public void serialized_code_cells_have_appropriate_shape()
+    {
+        var cells = new List<InteractiveDocumentElement>
         {
-            var cells = new List<InteractiveDocumentElement>
+            new("//", "csharp")
+        };
+        var notebook = new InteractiveDocument(cells);
+        var serialized = notebook.SerializeToJupyter();
+        var jupyter = JToken.Parse(serialized);
+        jupyter["cells"]
+            .Should()
+            .ContainSingleItem()
+            .Which
+            .Should()
+            .BeEquivalentTo(JToken.Parse(JsonConvert.SerializeObject(
+                                             new
+                                             {
+                                                 cell_type = "code",
+                                                 execution_count = (int?)null,
+                                                 metadata = new
+                                                 {
+                                                     dotnet_interactive = new
+                                                     {
+                                                         language = "csharp"
+                                                     }
+                                                 },
+                                                 outputs = Array.Empty<object>(),
+                                                 source = new[]
+                                                 {
+                                                     "//"
+                                                 },
+                                             }
+                                         )));
+    }
+
+    [Fact]
+    public void serialized_code_cells_with_default_jupyter_kernel_language_dont_have_language_specifier()
+    {
+        var cells = new List<InteractiveDocumentElement>
+        {
+            new("var x = 1;", "csharp")
+        };
+        var notebook = new InteractiveDocument(cells);
+        var serialized = notebook.SerializeToJupyter();
+        var jupyter = JToken.Parse(serialized);
+        jupyter["cells"][0]["source"]
+            .Should()
+            .BeEquivalentTo(JToken.Parse(JsonConvert.SerializeObject(new object[]
             {
-                new("let x = 1", "fsharp") { ExecutionOrder = 123 }
-            };
-            var notebook = new InteractiveDocument(cells);
-            var serialized = notebook.SerializeToJupyter();
-            var jupyter = JToken.Parse(serialized);
-            jupyter["cells"][0]
-                .Should()
-                .BeEquivalentTo(JToken.Parse(JsonConvert.SerializeObject(new
+                "var x = 1;"
+            })));
+    }
+
+    [Fact]
+    public void serialized_code_cells_with_non_default_jupyter_kernel_language_have_language_metadata_and_no_language_specifier()
+    {
+        var cells = new List<InteractiveDocumentElement>
+        {
+            new("let x = 1", "fsharp") { ExecutionOrder = 123 }
+        };
+        var notebook = new InteractiveDocument(cells);
+        var serialized = notebook.SerializeToJupyter();
+        var jupyter = JToken.Parse(serialized);
+        jupyter["cells"][0]
+            .Should()
+            .BeEquivalentTo(JToken.Parse(JsonConvert.SerializeObject(new
+            {
+                cell_type = "code",
+                execution_count = 123,
+                metadata = new
+                {
+                    dotnet_interactive = new
+                    {
+                        language = "fsharp"
+                    }
+                },
+                source = new[]
+                {
+                    "let x = 1"
+                },
+                outputs = new object[] { }
+            })));
+    }
+
+    [Fact]
+    public void code_cells_with_multi_line_text_are_serialized_as_an_array()
+    {
+        var cells = new List<InteractiveDocumentElement>
+        {
+            new("var x = 1;\nvar y = 2;", "csharp")
+        };
+        var notebook = new InteractiveDocument(cells);
+        var serialized = notebook.SerializeToJupyter();
+        var jupyter = JToken.Parse(serialized);
+        jupyter["cells"][0]["source"]
+            .Should()
+            .BeEquivalentTo(JToken.Parse(JsonConvert.SerializeObject(new object[]
+            {
+                "var x = 1;\n",
+                "var y = 2;"
+            })));
+    }
+
+    [Fact]
+    public void serialized_markdown_cells_have_appropriate_shape()
+    {
+        var cells = new List<InteractiveDocumentElement>
+        {
+            new("This is `markdown`.\nThis is more `markdown`.", "markdown")
+        };
+        var notebook = new InteractiveDocument(cells);
+        var serialized = notebook.SerializeToJupyter();
+        var jupyter = JToken.Parse(serialized);
+        jupyter["cells"]
+            .Should()
+            .ContainSingleItem()
+            .Which
+            .Should()
+            .BeEquivalentTo(JToken.Parse(JsonConvert.SerializeObject(
+                                             new
+                                             {
+                                                 cell_type = "markdown",
+                                                 metadata = new { },
+                                                 source = new[]
+                                                 {
+                                                     "This is `markdown`.\n",
+                                                     "This is more `markdown`."
+                                                 }
+                                             }
+                                         )));
+    }
+
+    [Fact]
+    public void text_cell_outputs_are_serialized()
+    {
+        var cells = new List<InteractiveDocumentElement>
+        {
+            new("//", "csharp", new[]
+            {
+                new TextElement("this is text", "stdout")
+            })
+        };
+        var notebook = new InteractiveDocument(cells);
+        var serialized = notebook.SerializeToJupyter();
+        var jupyter = JToken.Parse(serialized);
+        jupyter["cells"]
+            .Should()
+            .ContainSingleItem()
+            .Which["outputs"]
+            .Should()
+            .ContainSingleItem()
+            .Which
+            .Should()
+            .BeEquivalentTo(JToken.Parse(JsonConvert.SerializeObject(
+                                             new
+                                             {
+                                                 output_type = "stream",
+                                                 name = "stdout",
+                                                 text = new[] { "this is text" }
+                                             }
+                                         )));
+    }
+
+    [Fact]
+    public void text_cell_outputs_are_parsed_as_string()
+    {
+        var jupyter = new
+        {
+            cells = new object[]
+            {
+                new
                 {
                     cell_type = "code",
-                    execution_count = 123,
-                    metadata = new
+                    source = "//",
+                    outputs = new object[]
                     {
-                        dotnet_interactive = new
+                        new
                         {
-                            language = "fsharp"
-                        }
-                    },
-                    source = new[]
-                    {
-                        "let x = 1"
-                    },
-                    outputs = new object[] { }
-                })));
-        }
-
-        [Fact]
-        public void code_cells_with_multi_line_text_are_serialized_as_an_array()
-        {
-            var cells = new List<InteractiveDocumentElement>
-            {
-                new("var x = 1;\nvar y = 2;", "csharp")
-            };
-            var notebook = new InteractiveDocument(cells);
-            var serialized = notebook.SerializeToJupyter();
-            var jupyter = JToken.Parse(serialized);
-            jupyter["cells"][0]["source"]
-                .Should()
-                .BeEquivalentTo(JToken.Parse(JsonConvert.SerializeObject(new object[]
-                {
-                    "var x = 1;\n",
-                    "var y = 2;"
-                })));
-        }
-
-        [Fact]
-        public void serialized_markdown_cells_have_appropriate_shape()
-        {
-            var cells = new List<InteractiveDocumentElement>
-            {
-                new("This is `markdown`.\nThis is more `markdown`.", "markdown")
-            };
-            var notebook = new InteractiveDocument(cells);
-            var serialized = notebook.SerializeToJupyter();
-            var jupyter = JToken.Parse(serialized);
-            jupyter["cells"]
-                .Should()
-                .ContainSingleItem()
-                .Which
-                .Should()
-                .BeEquivalentTo(JToken.Parse(JsonConvert.SerializeObject(
-                    new
-                    {
-                        cell_type = "markdown",
-                        metadata = new { },
-                        source = new[]
-                        {
-                            "This is `markdown`.\n",
-                            "This is more `markdown`."
-                        }
-                    }
-                )));
-        }
-
-        [Fact]
-        public void text_cell_outputs_are_serialized()
-        {
-            var cells = new List<InteractiveDocumentElement>
-            {
-                new("//", "csharp", new[]
-                {
-                    new TextElement("this is text", "stdout")
-                })
-            };
-            var notebook = new InteractiveDocument(cells);
-            var serialized = notebook.SerializeToJupyter();
-            var jupyter = JToken.Parse(serialized);
-            jupyter["cells"]
-                .Should()
-                .ContainSingleItem()
-                .Which["outputs"]
-                .Should()
-                .ContainSingleItem()
-                .Which
-                .Should()
-                .BeEquivalentTo(JToken.Parse(JsonConvert.SerializeObject(
-                    new
-                    {
-                        output_type = "stream",
-                        name = "stdout",
-                        text = new[] { "this is text" }
-                    }
-                )));
-        }
-
-        [Fact]
-        public void text_cell_outputs_are_parsed_as_string()
-        {
-            var jupyter = new
-            {
-                cells = new object[]
-                {
-                    new
-                    {
-                        cell_type = "code",
-                        source = "//",
-                        outputs = new object[]
-                        {
-                            new
-                            {
-                                output_type = "stream",
-                                name = "stdout",
-                                text = "this is text"
-                            }
+                            output_type = "stream",
+                            name = "stdout",
+                            text = "this is text"
                         }
                     }
                 }
-            };
+            }
+        };
 
-            var notebook = SerializeAndParse(jupyter);
+        var notebook = SerializeAndParse(jupyter);
             
-            notebook.Elements
-                    .Should()
-                    .ContainSingle()
-                    .Which
-                    .Outputs
-                    .Should()
-                    .ContainSingle()
-                    .Which
-                    .Should()
-                    .BeEquivalentToRespectingRuntimeTypes(new TextElement("this is text", "stdout"));
-        }
+        notebook.Elements
+                .Should()
+                .ContainSingle()
+                .Which
+                .Outputs
+                .Should()
+                .ContainSingle()
+                .Which
+                .Should()
+                .BeEquivalentToRespectingRuntimeTypes(new TextElement("this is text", "stdout"));
+    }
 
-        [Fact]
-        public void text_cell_outputs_are_parsed_as_string_array()
+    [Fact]
+    public void text_cell_outputs_are_parsed_as_string_array()
+    {
+        var jupyter = new
         {
-            var jupyter = new
+            cells = new object[]
             {
-                cells = new object[]
+                new
                 {
-                    new
+                    cell_type = "code",
+                    execution_count = 1,
+                    metadata = new { },
+                    source = new[] { "//" },
+                    outputs = new object[]
                     {
-                        cell_type = "code",
-                        execution_count = 1,
-                        metadata = new { },
-                        source = new[] { "//" },
-                        outputs = new object[]
+                        new
                         {
-                            new
+                            output_type = "stream",
+                            name = "stdout",
+                            text = new[]
                             {
-                                output_type = "stream",
-                                name = "stdout",
-                                text = new[]
-                                {
-                                    "this is text\n",
-                                    "so is this"
-                                }
+                                "this is text\n",
+                                "so is this"
                             }
                         }
                     }
                 }
-            };
+            }
+        };
 
-            var notebook = SerializeAndParse(jupyter);
+        var notebook = SerializeAndParse(jupyter);
 
-            notebook.Elements
+        notebook.Elements
                 .Should()
                 .ContainSingle()
                 .Which
@@ -1226,74 +1226,74 @@ namespace Microsoft.DotNet.Interactive.Documents.Tests
                 .Which
                 .Should()
                 .BeEquivalentToRespectingRuntimeTypes(new TextElement("this is text\nso is this", "stdout"));
-        }
+    }
 
-        [Fact]
-        public void rich_cell_outputs_are_serialized()
+    [Fact]
+    public void rich_cell_outputs_are_serialized()
+    {
+        var cells = new List<InteractiveDocumentElement>
         {
-            var cells = new List<InteractiveDocumentElement>
+            new("//", "csharp", new[]
             {
-                new("//", "csharp", new[]
+                new DisplayElement(new Dictionary<string, object>
                 {
-                    new DisplayElement(new Dictionary<string, object>
-                    {
-                        { "text/html", new[] { "<div>this is html</div>" } }
-                    })
+                    { "text/html", new[] { "<div>this is html</div>" } }
                 })
-            };
-            var notebook = new InteractiveDocument(cells);
-            var serialized = notebook.SerializeToJupyter();
-            var jupyter = JToken.Parse(serialized);
-            jupyter["cells"]
-                .Should()
-                .ContainSingleItem()
-                .Which["outputs"]
-                .Should()
-                .ContainSingleItem()
-                .Which
-                .Should()
-                .BeEquivalentTo(JToken.Parse(JsonConvert.SerializeObject(
-                                                 new
+            })
+        };
+        var notebook = new InteractiveDocument(cells);
+        var serialized = notebook.SerializeToJupyter();
+        var jupyter = JToken.Parse(serialized);
+        jupyter["cells"]
+            .Should()
+            .ContainSingleItem()
+            .Which["outputs"]
+            .Should()
+            .ContainSingleItem()
+            .Which
+            .Should()
+            .BeEquivalentTo(JToken.Parse(JsonConvert.SerializeObject(
+                                             new
+                                             {
+                                                 output_type = "display_data",
+                                                 data = new Dictionary<string, string[]>
                                                  {
-                                                     output_type = "display_data",
-                                                     data = new Dictionary<string, string[]>
-                                                     {
-                                                         { "text/html", new[] { "<div>this is html</div>" } }
-                                                     },
-                                                     metadata = new{}
-                                                 }
-                                             )));
-        }
+                                                     { "text/html", new[] { "<div>this is html</div>" } }
+                                                 },
+                                                 metadata = new{}
+                                             }
+                                         )));
+    }
 
-        [Fact]
-        public void rich_cell_outputs_are_parsed()
+    [Fact]
+    public void rich_cell_outputs_are_parsed()
+    {
+        var jupyter = new
         {
-            var jupyter = new
+            cells = new object[]
             {
-                cells = new object[]
+                new
                 {
-                    new
+                    cell_type = "code",
+                    execution_count = 1,
+                    metadata = new { },
+                    source = new[] { "//" },
+                    outputs = new object[]
                     {
-                        cell_type = "code",
-                        execution_count = 1,
-                        metadata = new { },
-                        source = new[] { "//" },
-                        outputs = new object[]
+                        new
                         {
-                            new
+                            output_type = "display_data",
+                            data = new Dictionary<string, string[]>
                             {
-                                output_type = "display_data",
-                                data = new Dictionary<string, string[]>
-                                {
-                                    { "text/html", new[] { "<div>this is html</div>" } }
-                                },
-                            }
+                                { "text/html", new[] { "<div>this is html</div>" } }
+                            },
                         }
                     }
                 }
-            };
-            var notebook = SerializeAndParse(jupyter);
-            notebook.Elements
+            }
+        };
+        var notebook = SerializeAndParse(jupyter);
+        notebook.Elements
                 .Should()
                 .ContainSingle()
                 .Which
@@ -1306,76 +1306,76 @@ namespace Microsoft.DotNet.Interactive.Documents.Tests
                 {
                     { "text/html", new[]{"<div>this is html</div>"} }
                 }));
-        }
+    }
 
-        [Fact]
-        public void error_cell_outputs_are_serialized()
+    [Fact]
+    public void error_cell_outputs_are_serialized()
+    {
+        var cells = new List<InteractiveDocumentElement>
         {
-            var cells = new List<InteractiveDocumentElement>
+            new("//", "csharp", new[]
             {
-                new("//", "csharp", new[]
-                {
-                    new ErrorElement("e-value", "e-name", new[] { "at func1()", "at func2()" })
-                })
-            };
-            var notebook = new InteractiveDocument(cells);
-            var serialized = (string)notebook.SerializeToJupyter();
-            var jupyter = JToken.Parse(serialized);
-            jupyter["cells"]
-                .Should()
-                .ContainSingleItem()
-                .Which["outputs"]
-                .Should()
-                .ContainSingleItem()
-                .Which
-                .Should()
-                .BeEquivalentTo(JToken.Parse(JsonConvert.SerializeObject(
-                    new
-                    {
-                        output_type = "error",
-                        ename = "e-name",
-                        evalue = "e-value",
-                        traceback = new[]
-                        {
-                            "at func1()",
-                            "at func2()"
-                        }
-                    }
-                )));
-        }
+                new ErrorElement("e-value", "e-name", new[] { "at func1()", "at func2()" })
+            })
+        };
+        var notebook = new InteractiveDocument(cells);
+        var serialized = (string)notebook.SerializeToJupyter();
+        var jupyter = JToken.Parse(serialized);
+        jupyter["cells"]
+            .Should()
+            .ContainSingleItem()
+            .Which["outputs"]
+            .Should()
+            .ContainSingleItem()
+            .Which
+            .Should()
+            .BeEquivalentTo(JToken.Parse(JsonConvert.SerializeObject(
+                                             new
+                                             {
+                                                 output_type = "error",
+                                                 ename = "e-name",
+                                                 evalue = "e-value",
+                                                 traceback = new[]
+                                                 {
+                                                     "at func1()",
+                                                     "at func2()"
+                                                 }
+                                             }
+                                         )));
+    }
 
-        [Fact]
-        public void error_cell_outputs_are_parsed()
+    [Fact]
+    public void error_cell_outputs_are_parsed()
+    {
+        var jupyter = new
         {
-            var jupyter = new
+            cells = new object[]
             {
-                cells = new object[]
+                new
                 {
-                    new
+                    cell_type = "code",
+                    execution_count = 1,
+                    metadata = new { },
+                    source = new[] { "//" },
+                    outputs = new object[]
                     {
-                        cell_type = "code",
-                        execution_count = 1,
-                        metadata = new { },
-                        source = new[] { "//" },
-                        outputs = new object[]
+                        new
                         {
-                            new
+                            output_type = "error",
+                            ename = "e-name",
+                            evalue = "e-value",
+                            traceback = new[]
                             {
-                                output_type = "error",
-                                ename = "e-name",
-                                evalue = "e-value",
-                                traceback = new[]
-                                {
-                                    "at func1()",
-                                    "at func2()"
-                                }
+                                "at func1()",
+                                "at func2()"
                             }
                         }
                     }
                 }
-            };
-            var notebook = SerializeAndParse(jupyter);
-            notebook.Elements
+            }
+        };
+        var notebook = SerializeAndParse(jupyter);
+        notebook.Elements
                 .Should()
                 .ContainSingle()
                 .Which
@@ -1389,80 +1389,79 @@ namespace Microsoft.DotNet.Interactive.Documents.Tests
                     "at func1()",
                     "at func2()"
                 }));
-        }
-
-        [Theory]
-        [InlineData("", new string[] {  })]
-        [InlineData("one", new[] { "one" })]
-        [InlineData("one\n", new[] { "one\n" })]
-        [InlineData("one\r\n", new[] { "one\r\n" })]
-        [InlineData("one\ntwo", new[] { "one\n", "two" })]
-        [InlineData("one\r\ntwo", new[] { "one\r\n", "two" })]
-        public void SplitIntoJupyterFileArray_performs_expected_split_for_ipynb_array_values(string input, string[] expected)
-        {
-            var lines = input.SplitIntoJupyterFileArray();
-
-            lines.Should().BeEquivalentTo(expected, c => c.WithStrictOrdering());
-        }
-
-        [Fact]
-        public async Task ipynb_from_Jupyter_can_be_round_tripped_through_read_and_write_without_the_content_changing()
-        {
-            var path = GetNotebookFilePath();
-
-            this.Assent(await RoundTripIpynb(path), _assentConfiguration);
-        }
-
-        [Fact]
-        public async Task ipynb_from_VSCode_can_be_round_tripped_through_read_and_write_without_the_content_changing()
-        {
-            var path = GetNotebookFilePath();
-
-            this.Assent(await RoundTripIpynb(path), _assentConfiguration);
-        }
-
-        [Fact]
-        public void Input_tokens_are_parsed_from_ipynb_files()
-        {
-            var ipynbJson = new InteractiveDocument
-            {
-                new("#!value --from-file @input:filename --name myfile")
-            }.SerializeToJupyter();
-
-            var document = Notebook.Parse(ipynbJson);
-
-            document.GetInputFields()
-                    .Should()
-                    .ContainSingle()
-                    .Which
-                    .ValueName
-                    .Should()
-                    .Be("filename");
-        }
-
-        private async Task<string> RoundTripIpynb(string notebookFile)
-        {
-            var expectedContent = await File.ReadAllTextAsync(notebookFile);
-            
-            var inputDoc = Notebook.Parse(expectedContent);
-
-            var resultContent = inputDoc.SerializeToJupyter(enforceJupyterMetadata: false);
-
-            if (expectedContent.EndsWith("\r\n"))
-            {
-                resultContent += "\r\n";
-            }
-            else if (expectedContent.EndsWith("\n"))
-            {
-                resultContent += "\n";
-            }
-
-            return resultContent;
-        }
-
-        private string GetNotebookFilePath([CallerMemberName] string testName = null) =>
-            Path.Combine(
-                Path.GetDirectoryName(PathToCurrentSourceFile()),
-                $"{GetType().Name}.{testName}.approved.json");
     }
+
+    [Theory]
+    [InlineData("", new string[] {  })]
+    [InlineData("one", new[] { "one" })]
+    [InlineData("one\n", new[] { "one\n" })]
+    [InlineData("one\r\n", new[] { "one\r\n" })]
+    [InlineData("one\ntwo", new[] { "one\n", "two" })]
+    [InlineData("one\r\ntwo", new[] { "one\r\n", "two" })]
+    public void SplitIntoJupyterFileArray_performs_expected_split_for_ipynb_array_values(string input, string[] expected)
+    {
+        var lines = input.SplitIntoJupyterFileArray();
+
+        lines.Should().BeEquivalentTo(expected, c => c.WithStrictOrdering());
+    }
+
+    [Fact]
+    public async Task ipynb_from_Jupyter_can_be_round_tripped_through_read_and_write_without_the_content_changing()
+    {
+        var path = GetNotebookFilePath();
+
+        this.Assent(await RoundTripIpynb(path), _assentConfiguration);
+    }
+
+    [Fact]
+    public async Task ipynb_from_VSCode_can_be_round_tripped_through_read_and_write_without_the_content_changing()
+    {
+        var path = GetNotebookFilePath();
+
+        this.Assent(await RoundTripIpynb(path), _assentConfiguration);
+    }
+
+    [Fact]
+    public void Input_tokens_are_parsed_from_ipynb_files()
+    {
+        var ipynbJson = new InteractiveDocument
+        {
+            new("#!value --from-file @input:filename --name myfile")
+        }.SerializeToJupyter();
+
+        var document = Notebook.Parse(ipynbJson);
+
+        document.GetInputFields()
+                .Should()
+                .ContainSingle()
+                .Which
+                .ValueName
+                .Should()
+                .Be("filename");
+    }
+
+    private async Task<string> RoundTripIpynb(string notebookFile)
+    {
+        var expectedContent = await File.ReadAllTextAsync(notebookFile);
+            
+        var inputDoc = Notebook.Parse(expectedContent);
+
+        var resultContent = inputDoc.SerializeToJupyter(enforceJupyterMetadata: false);
+
+        if (expectedContent.EndsWith("\r\n"))
+        {
+            resultContent += "\r\n";
+        }
+        else if (expectedContent.EndsWith("\n"))
+        {
+            resultContent += "\n";
+        }
+
+        return resultContent;
+    }
+
+    private string GetNotebookFilePath([CallerMemberName] string testName = null) =>
+        Path.Combine(
+            Path.GetDirectoryName(PathToCurrentSourceFile()),
+            $"{GetType().Name}.{testName}.approved.json");
 }

--- a/src/Microsoft.DotNet.Interactive.Documents.Tests/JupyterFormatTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Documents.Tests/JupyterFormatTests.cs
@@ -31,7 +31,7 @@ public class JupyterFormatTests : DocumentFormatTestsBase
     {
         var content = JsonConvert.SerializeObject(jupyter);
 
-        return Notebook.Parse(content, KernelInfos);
+        return Notebook.Parse(content, DefaultKernelInfos);
     }
 
     [Theory]
@@ -949,7 +949,7 @@ public class JupyterFormatTests : DocumentFormatTestsBase
     public void serialized_notebook_has_appropriate_metadata()
     {
         var notebook = new InteractiveDocument();
-        var serialized = notebook.SerializeToJupyter();
+        var serialized = notebook.ToJupyterJson();
         var jupyter = JToken.Parse(serialized);
 
         using var _ = new AssertionScope();
@@ -990,7 +990,7 @@ public class JupyterFormatTests : DocumentFormatTestsBase
             new("//", "csharp")
         };
         var notebook = new InteractiveDocument(cells);
-        var serialized = notebook.SerializeToJupyter();
+        var serialized = notebook.ToJupyterJson();
         var jupyter = JToken.Parse(serialized);
         jupyter["cells"]
             .Should()
@@ -1026,7 +1026,7 @@ public class JupyterFormatTests : DocumentFormatTestsBase
             new("var x = 1;", "csharp")
         };
         var notebook = new InteractiveDocument(cells);
-        var serialized = notebook.SerializeToJupyter();
+        var serialized = notebook.ToJupyterJson();
         var jupyter = JToken.Parse(serialized);
         jupyter["cells"][0]["source"]
             .Should()
@@ -1044,7 +1044,7 @@ public class JupyterFormatTests : DocumentFormatTestsBase
             new("let x = 1", "fsharp") { ExecutionOrder = 123 }
         };
         var notebook = new InteractiveDocument(cells);
-        var serialized = notebook.SerializeToJupyter();
+        var serialized = notebook.ToJupyterJson();
         var jupyter = JToken.Parse(serialized);
         jupyter["cells"][0]
             .Should()
@@ -1075,7 +1075,7 @@ public class JupyterFormatTests : DocumentFormatTestsBase
             new("var x = 1;\nvar y = 2;", "csharp")
         };
         var notebook = new InteractiveDocument(cells);
-        var serialized = notebook.SerializeToJupyter();
+        var serialized = notebook.ToJupyterJson();
         var jupyter = JToken.Parse(serialized);
         jupyter["cells"][0]["source"]
             .Should()
@@ -1094,7 +1094,7 @@ public class JupyterFormatTests : DocumentFormatTestsBase
             new("This is `markdown`.\nThis is more `markdown`.", "markdown")
         };
         var notebook = new InteractiveDocument(cells);
-        var serialized = notebook.SerializeToJupyter();
+        var serialized = notebook.ToJupyterJson();
         var jupyter = JToken.Parse(serialized);
         jupyter["cells"]
             .Should()
@@ -1126,7 +1126,7 @@ public class JupyterFormatTests : DocumentFormatTestsBase
             })
         };
         var notebook = new InteractiveDocument(cells);
-        var serialized = notebook.SerializeToJupyter();
+        var serialized = notebook.ToJupyterJson();
         var jupyter = JToken.Parse(serialized);
         jupyter["cells"]
             .Should()
@@ -1242,7 +1242,7 @@ public class JupyterFormatTests : DocumentFormatTestsBase
             })
         };
         var notebook = new InteractiveDocument(cells);
-        var serialized = notebook.SerializeToJupyter();
+        var serialized = notebook.ToJupyterJson();
         var jupyter = JToken.Parse(serialized);
         jupyter["cells"]
             .Should()
@@ -1319,7 +1319,7 @@ public class JupyterFormatTests : DocumentFormatTestsBase
             })
         };
         var notebook = new InteractiveDocument(cells);
-        var serialized = (string)notebook.SerializeToJupyter();
+        var serialized = (string)notebook.ToJupyterJson();
         var jupyter = JToken.Parse(serialized);
         jupyter["cells"]
             .Should()
@@ -1427,7 +1427,7 @@ public class JupyterFormatTests : DocumentFormatTestsBase
         var ipynbJson = new InteractiveDocument
         {
             new("#!value --from-file @input:filename --name myfile")
-        }.SerializeToJupyter();
+        }.ToJupyterJson();
 
         var document = Notebook.Parse(ipynbJson);
 
@@ -1446,7 +1446,7 @@ public class JupyterFormatTests : DocumentFormatTestsBase
             
         var inputDoc = Notebook.Parse(expectedContent);
 
-        var resultContent = inputDoc.SerializeToJupyter(enforceJupyterMetadata: false);
+        var resultContent = inputDoc.ToJupyterJson(enforceJupyterMetadata: false);
 
         if (expectedContent.EndsWith("\r\n"))
         {

--- a/src/Microsoft.DotNet.Interactive.Documents.Tests/NotebookParserServerTests_ObjectInterface.cs
+++ b/src/Microsoft.DotNet.Interactive.Documents.Tests/NotebookParserServerTests_ObjectInterface.cs
@@ -8,87 +8,86 @@ using FluentAssertions;
 using Microsoft.DotNet.Interactive.Documents.ParserServer;
 using Xunit;
 
-namespace Microsoft.DotNet.Interactive.Documents.Tests
+namespace Microsoft.DotNet.Interactive.Documents.Tests;
+
+public class NotebookParserServerTests_ObjectInterface
 {
-    public class NotebookParserServerTests_ObjectInterface
+    [Theory]
+    [InlineData(DocumentSerializationType.Dib, "#!csharp\nvar x = 1;")]
+    [InlineData(DocumentSerializationType.Ipynb, @"{""cells"":[{""cell_type"":""code"",""source"":[""var x = 1;""]}]}")]
+    public void Notebook_parser_server_can_parse_file_based_on_document_type(DocumentSerializationType serializationType, string contents)
     {
-        [Theory]
-        [InlineData(DocumentSerializationType.Dib, "#!csharp\nvar x = 1;")]
-        [InlineData(DocumentSerializationType.Ipynb, @"{""cells"":[{""cell_type"":""code"",""source"":[""var x = 1;""]}]}")]
-        public void Notebook_parser_server_can_parse_file_based_on_document_type(DocumentSerializationType serializationType, string contents)
-        {
-            var request = new NotebookParseRequest(
-                "the-id",
-                serializationType,
-                defaultLanguage: "csharp",
-                rawData: Encoding.UTF8.GetBytes(contents));
+        var request = new NotebookParseRequest(
+            "the-id",
+            serializationType,
+            defaultLanguage: "csharp",
+            rawData: Encoding.UTF8.GetBytes(contents));
 
-            var response = NotebookParserServer.HandleRequest(request);
+        var response = NotebookParserServer.HandleRequest(request);
             
-            response
-                .Should()
-                .BeOfType<NotebookParseResponse>()
-                .Which
-                .Document
-                .Elements
-                .Should()
-                .ContainSingle()
-                .Which
-                .Contents
-                .Should()
-                .Be("var x = 1;");
-        }
-
-        [Theory]
-        [InlineData(DocumentSerializationType.Dib, "#!csharp")]
-        [InlineData(DocumentSerializationType.Ipynb, @"""cell_type""")]
-        public void Notebook_parser_server_can_serialize_file_based_on_document_type(DocumentSerializationType serializationType, string expected)
-        {
-            var request = new NotebookSerializeRequest(
-                "the-id",
-                serializationType,
-                defaultLanguage: "csharp",
-                newLine: "\n",
-                document: new InteractiveDocument(new List<InteractiveDocumentElement>
-                {
-                    new("var x = 1;", "csharp")
-                })
-            );
-            var response = NotebookParserServer.HandleRequest(request);
-            response
-                .Should()
-                .BeOfType<NotebookSerializeResponse>()
-                .Which
-                .RawData
-                .AsUtf8String()
-                .Should()
-                .Contain(expected);
-        }
-
-        [Fact]
-        public void Notebook_parser_server_returns_an_error_on_unsupported_document_type()
-        {
-            var request = new NotebookParseRequest(
-                "the-id",
-                serializationType: (DocumentSerializationType)42,
-                defaultLanguage: "csharp",
-                rawData: Array.Empty<byte>());
-            var response = NotebookParserServer.HandleRequest(request);
-            response
-                .Should()
-                .BeOfType<NotebookErrorResponse>()
-                .Which
-                .ErrorMessage
-                .Should()
-                .Contain($"Unable to parse an interactive document with type '{(int)request.SerializationType}'");
-        }
+        response
+            .Should()
+            .BeOfType<NotebookParseResponse>()
+            .Which
+            .Document
+            .Elements
+            .Should()
+            .ContainSingle()
+            .Which
+            .Contents
+            .Should()
+            .Be("var x = 1;");
     }
 
-    internal static class NotebookParseServerTestExtension
+    [Theory]
+    [InlineData(DocumentSerializationType.Dib, "#!csharp")]
+    [InlineData(DocumentSerializationType.Ipynb, @"""cell_type""")]
+    public void Notebook_parser_server_can_serialize_file_based_on_document_type(DocumentSerializationType serializationType, string expected)
     {
-        public static string AsUtf8String(this byte[] data)
-        {
-            return Encoding.UTF8.GetString(data);
-        }
+        var request = new NotebookSerializeRequest(
+            "the-id",
+            serializationType,
+            defaultLanguage: "csharp",
+            newLine: "\n",
+            document: new InteractiveDocument(new List<InteractiveDocumentElement>
+            {
+                new("var x = 1;", "csharp")
+            })
+        );
+        var response = NotebookParserServer.HandleRequest(request);
+        response
+            .Should()
+            .BeOfType<NotebookSerializeResponse>()
+            .Which
+            .RawData
+            .AsUtf8String()
+            .Should()
+            .Contain(expected);
+    }
+
+    [Fact]
+    public void Notebook_parser_server_returns_an_error_on_unsupported_document_type()
+    {
+        var request = new NotebookParseRequest(
+            "the-id",
+            serializationType: (DocumentSerializationType)42,
+            defaultLanguage: "csharp",
+            rawData: Array.Empty<byte>());
+        var response = NotebookParserServer.HandleRequest(request);
+        response
+            .Should()
+            .BeOfType<NotebookErrorResponse>()
+            .Which
+            .ErrorMessage
+            .Should()
+            .Contain($"Unable to parse an interactive document with type '{(int)request.SerializationType}'");
+    }
+}
+
+internal static class NotebookParseServerTestExtension
+{
+    public static string AsUtf8String(this byte[] data)
+    {
+        return Encoding.UTF8.GetString(data);
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Documents.Tests/NotebookParserServerTests_TextInterface.cs
+++ b/src/Microsoft.DotNet.Interactive.Documents.Tests/NotebookParserServerTests_TextInterface.cs
@@ -12,160 +12,159 @@ using Nerdbank.Streams;
 using Pocket;
 using Xunit;
 
-namespace Microsoft.DotNet.Interactive.Documents.Tests
+namespace Microsoft.DotNet.Interactive.Documents.Tests;
+
+public class NotebookParserServerTests_TextInterface : IDisposable
 {
-    public class NotebookParserServerTests_TextInterface : IDisposable
+    private readonly CompositeDisposable _disposables = new();
+
+    [Theory]
+    [InlineData("\n")]
+    [InlineData("\r\n")]
+    public async Task Notebook_parser_server_takes_request_until_newline_and_returns_response_on_a_single_line(string newline)
     {
-        private readonly CompositeDisposable _disposables = new();
+        var request = new NotebookParseRequest(
+            "the-id",
+            serializationType: DocumentSerializationType.Dib,
+            defaultLanguage: "csharp",
+            rawData: Encoding.UTF8.GetBytes("#!csharp\nvar x = 1;"));
+        var requestJson = request.ToJson();
 
-        [Theory]
-        [InlineData("\n")]
-        [InlineData("\r\n")]
-        public async Task Notebook_parser_server_takes_request_until_newline_and_returns_response_on_a_single_line(string newline)
-        {
-            var request = new NotebookParseRequest(
-                "the-id",
-                serializationType: DocumentSerializationType.Dib,
-                defaultLanguage: "csharp",
-                rawData: Encoding.UTF8.GetBytes("#!csharp\nvar x = 1;"));
-            var requestJson = request.ToJson();
+        var asyncEnumerator = GetResponseObjectsEnumerable(requestJson + newline).GetAsyncEnumerator();
 
-            var asyncEnumerator = GetResponseObjectsEnumerable(requestJson + newline).GetAsyncEnumerator();
+        var response = await asyncEnumerator.GetNextAsync();
+        response
+            .Should()
+            .BeOfType<NotebookParseResponse>()
+            .Which
+            .Should()
+            .BeEquivalentTo(new NotebookParseResponse(
+                                "the-id",
+                                document: new InteractiveDocument(
+                                    new List<InteractiveDocumentElement>
+                                    {
+                                        new("var x = 1;", "csharp")
+                                    })));
+    }
 
-            var response = await asyncEnumerator.GetNextAsync();
-            response
-                .Should()
-                .BeOfType<NotebookParseResponse>()
-                .Which
-                .Should()
-                .BeEquivalentTo(new NotebookParseResponse(
-                    "the-id",
-                    document: new InteractiveDocument(
-                   new List<InteractiveDocumentElement>
-                    {
-                        new("var x = 1;", "csharp")
-                    })));
-        }
-
-        [Theory]
-        [InlineData("\n")]
-        [InlineData("\r\n")]
-        public async Task Notebook_parser_server_can_handle_repeated_requests_with_different_newlines(string newline)
-        {
-            var request1 = new NotebookParseRequest(
-                "the-id",
-                serializationType: DocumentSerializationType.Dib,
-                defaultLanguage: "csharp",
-                rawData: Encoding.UTF8.GetBytes("#!csharp\nvar x = 1;"));
-            var request2 = new NotebookSerializeRequest(
-                "the-second-id",
-                serializationType: DocumentSerializationType.Dib,
-                defaultLanguage: "csharp",
-                newLine: "\n",
-                document: new InteractiveDocument
-              (
-                   new List<InteractiveDocumentElement>
-                    {
+    [Theory]
+    [InlineData("\n")]
+    [InlineData("\r\n")]
+    public async Task Notebook_parser_server_can_handle_repeated_requests_with_different_newlines(string newline)
+    {
+        var request1 = new NotebookParseRequest(
+            "the-id",
+            serializationType: DocumentSerializationType.Dib,
+            defaultLanguage: "csharp",
+            rawData: Encoding.UTF8.GetBytes("#!csharp\nvar x = 1;"));
+        var request2 = new NotebookSerializeRequest(
+            "the-second-id",
+            serializationType: DocumentSerializationType.Dib,
+            defaultLanguage: "csharp",
+            newLine: "\n",
+            document: new InteractiveDocument
+            (
+                new List<InteractiveDocumentElement>
+                {
                     new("let y = 2", "fsharp")
                 }));
-            var fullRequestText = string.Concat(
-                request1.ToJson(),
-                newline,
-                request2.ToJson(),
-                newline);
+        var fullRequestText = string.Concat(
+            request1.ToJson(),
+            newline,
+            request2.ToJson(),
+            newline);
 
-            var asyncEnumerator = GetResponseObjectsEnumerable(fullRequestText).GetAsyncEnumerator();
+        var asyncEnumerator = GetResponseObjectsEnumerable(fullRequestText).GetAsyncEnumerator();
 
-            var result1 = await asyncEnumerator.GetNextAsync();
-            result1
-                .Should()
-                .BeOfType<NotebookParseResponse>()
-                .Which
-                .Id
-                .Should()
-                .Be("the-id");
+        var result1 = await asyncEnumerator.GetNextAsync();
+        result1
+            .Should()
+            .BeOfType<NotebookParseResponse>()
+            .Which
+            .Id
+            .Should()
+            .Be("the-id");
 
-            var result2 = await asyncEnumerator.GetNextAsync();
-            result2
-                .Should()
-                .BeOfType<NotebookSerializeResponse>()
-                .Which
-                .Id
-                .Should()
-                .Be("the-second-id");
-        }
+        var result2 = await asyncEnumerator.GetNextAsync();
+        result2
+            .Should()
+            .BeOfType<NotebookSerializeResponse>()
+            .Which
+            .Id
+            .Should()
+            .Be("the-second-id");
+    }
 
-        [Fact]
-        public async Task Notebook_parser_server_does_nothing_with_garbage_input_and_skips_to_the_next_line_to_process()
+    [Fact]
+    public async Task Notebook_parser_server_does_nothing_with_garbage_input_and_skips_to_the_next_line_to_process()
+    {
+        var validRequest = new NotebookParseRequest(
+            "the-id",
+            serializationType: DocumentSerializationType.Dib,
+            defaultLanguage: "csharp",
+            rawData: Array.Empty<byte>());
+
+        var requestJson = string.Concat(
+            "this is a request that can't be handled in any meaningful way, including returning an error",
+            "\n",
+            validRequest.ToJson(),
+            "\n");
+
+        var asyncEnumerator = GetResponseObjectsEnumerable(requestJson).GetAsyncEnumerator();
+
+        var result = await asyncEnumerator.GetNextAsync();
+        result
+            .Should()
+            .BeOfType<NotebookParseResponse>()
+            .Which
+            .Id
+            .Should()
+            .Be("the-id");
+    }
+
+    private async IAsyncEnumerable<NotebookParserServerResponse> GetResponseObjectsEnumerable(string inputText)
+    {
+        using var input = new StringReader(inputText);
+        var stream = new SimplexStream();
+        var output = new StreamWriter(stream);
+        var server = new NotebookParserServer(input, output);
+        _disposables.Add(server);
+
+        var _ = Task.Run(() => server.RunAsync()); // start server listener in the background
+
+        var outputReader = new StreamReader(stream);
+
+        while (true)
         {
-            var validRequest = new NotebookParseRequest(
-                "the-id",
-                serializationType: DocumentSerializationType.Dib,
-                defaultLanguage: "csharp",
-                rawData: Array.Empty<byte>());
-
-            var requestJson = string.Concat(
-                "this is a request that can't be handled in any meaningful way, including returning an error",
-                "\n",
-                validRequest.ToJson(),
-                "\n");
-
-            var asyncEnumerator = GetResponseObjectsEnumerable(requestJson).GetAsyncEnumerator();
-
-            var result = await asyncEnumerator.GetNextAsync();
-            result
-                .Should()
-                .BeOfType<NotebookParseResponse>()
-                .Which
-                .Id
-                .Should()
-                .Be("the-id");
-        }
-
-        private async IAsyncEnumerable<NotebookParserServerResponse> GetResponseObjectsEnumerable(string inputText)
-        {
-            using var input = new StringReader(inputText);
-            var stream = new SimplexStream();
-            var output = new StreamWriter(stream);
-            var server = new NotebookParserServer(input, output);
-            _disposables.Add(server);
-
-            var _ = Task.Run(() => server.RunAsync()); // start server listener in the background
-
-            var outputReader = new StreamReader(stream);
-
-            while (true)
+            var responseText = await outputReader.ReadLineAsync();
+            if (responseText is { })
             {
-                var responseText = await outputReader.ReadLineAsync();
-                if (responseText is { })
-                {
-                    var responseObject = NotebookParserServerResponse.FromJson(responseText);
-                    yield return responseObject;
-                }
-                else
-                {
-                    break;
-                }
+                var responseObject = NotebookParserServerResponse.FromJson(responseText);
+                yield return responseObject;
             }
-        }
-
-        public void Dispose()
-        {
-            _disposables.Dispose();
+            else
+            {
+                break;
+            }
         }
     }
 
-    internal static class IAsyncEnumeratorExtensions
+    public void Dispose()
     {
-        public static async Task<T> GetNextAsync<T>(this IAsyncEnumerator<T> collection)
-        {
-            var itemsRemain = await collection.MoveNextAsync();
-            if (itemsRemain)
-            {
-                return collection.Current;
-            }
+        _disposables.Dispose();
+    }
+}
 
-            throw new InvalidOperationException("No more items");
+internal static class IAsyncEnumeratorExtensions
+{
+    public static async Task<T> GetNextAsync<T>(this IAsyncEnumerator<T> collection)
+    {
+        var itemsRemain = await collection.MoveNextAsync();
+        if (itemsRemain)
+        {
+            return collection.Current;
         }
+
+        throw new InvalidOperationException("No more items");
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Documents/CodeSubmission.cs
+++ b/src/Microsoft.DotNet.Interactive.Documents/CodeSubmission.cs
@@ -82,8 +82,6 @@ namespace Microsoft.DotNet.Interactive.Documents
                     {
                         // unrecognized language, probably a magic command
                         currentElementLines.Add(line);
-
-                        document.AddMagicCommandLine(line);
                     }
                 }
                 else

--- a/src/Microsoft.DotNet.Interactive.Documents/InteractiveDocument.cs
+++ b/src/Microsoft.DotNet.Interactive.Documents/InteractiveDocument.cs
@@ -40,7 +40,7 @@ public class InteractiveDocument : IEnumerable
     public IDictionary<string, object> Metadata =>
         _metadata ??= new Dictionary<string, object>();
 
-    public async IAsyncEnumerable<InteractiveDocument> GetImportedDocumentsAsync()
+    public async IAsyncEnumerable<InteractiveDocument> GetImportsAsync(bool recursive = false)
     {
         EnsureImportFieldParserIsInitialized();
 
@@ -57,7 +57,17 @@ public class InteractiveDocument : IEnumerable
             {
                 var file = parseResult.GetValueForArgument(_importedFileArgument);
 
-                yield return await LoadAsync(file, kernelInfos);
+                var interactiveDocument = await LoadAsync(file, kernelInfos);
+
+                yield return interactiveDocument;
+
+                if (recursive)
+                {
+                    await foreach (var import in interactiveDocument.GetImportsAsync(recursive))
+                    {
+                        yield return import;
+                    }
+                }    
             }
         }
     }

--- a/src/Microsoft.DotNet.Interactive.Documents/Jupyter/InteractiveDocumentConverter.cs
+++ b/src/Microsoft.DotNet.Interactive.Documents/Jupyter/InteractiveDocumentConverter.cs
@@ -29,7 +29,10 @@ internal class InteractiveDocumentConverter : JsonConverter<InteractiveDocument>
 
                         if (cells is not null)
                         {
-                            document.Elements = cells;
+                            foreach (var cell in cells)
+                            {
+                                document.Add(cell);
+                            }
                         }
 
                         break;

--- a/src/Microsoft.DotNet.Interactive.Documents/Jupyter/Notebook.cs
+++ b/src/Microsoft.DotNet.Interactive.Documents/Jupyter/Notebook.cs
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.Interactive.Documents.Jupyter
             writer.Flush();
         }
 
-        public static string SerializeToJupyter(
+        public static string ToJupyterJson(
             this InteractiveDocument document,
             bool enforceJupyterMetadata = true)
         {
@@ -102,7 +102,7 @@ namespace Microsoft.DotNet.Interactive.Documents.Jupyter
 
         public static void Write(InteractiveDocument document, TextWriter writer)
         {
-            var content = document.SerializeToJupyter();
+            var content = document.ToJupyterJson();
             writer.Write(content);
         }
     }

--- a/src/Microsoft.DotNet.Interactive.Documents/ParserServer/InteractiveDocumentConverter.cs
+++ b/src/Microsoft.DotNet.Interactive.Documents/ParserServer/InteractiveDocumentConverter.cs
@@ -29,7 +29,10 @@ internal class InteractiveDocumentConverter : JsonConverter<InteractiveDocument>
 
                         if (cells is not null)
                         {
-                            document.Elements = cells;
+                            foreach (var cell in cells)
+                            {
+                                document.Elements.Add(cell);
+                            }
                         }
 
                         break;

--- a/src/Microsoft.DotNet.Interactive.Tests/ImportNotebookTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/ImportNotebookTests.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Microsoft.AspNetCore.Http;
 using Microsoft.DotNet.Interactive.CSharp;
 using Microsoft.DotNet.Interactive.Documents;
 using Microsoft.DotNet.Interactive.Documents.Jupyter;
@@ -22,7 +21,7 @@ namespace Microsoft.DotNet.Interactive.Tests
         [Theory]
         [InlineData(".ipynb")]
         [InlineData(".dib")]
-        public async Task It_imports_and_runs(string notebookExt)
+        public async Task It_imports_and_runs_well_known_polyglot_file_formats(string notebookExt)
         {
             using var kernel = new CompositeKernel { 
                 new CSharpKernel(),
@@ -60,15 +59,16 @@ namespace Microsoft.DotNet.Interactive.Tests
                 }
             };
 
-            string filePath = $@".\testnotebook{notebookExt}";
-            string notebookContents = notebookExt switch
+            var notebookContents = notebookExt switch
             {
-                ".ipynb" => document.SerializeToJupyter(),
+                ".ipynb" => document.ToJupyterJson(),
                 ".dib" => document.ToCodeSubmissionContent(),
                 _ => throw new InvalidOperationException($"Unrecognized extension for a notebook: {notebookExt}")
             };
+            
+            var filePath = $@".\testnotebook{notebookExt}";
 
-            File.WriteAllText(filePath, notebookContents);
+            await File.WriteAllTextAsync(filePath, notebookContents);
 
             using var events = kernel.KernelEvents.ToSubscribedList();
 

--- a/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
@@ -139,21 +139,21 @@ namespace Microsoft.DotNet.Interactive
             return kernel.SendAsync(new SubmitCode(code), CancellationToken.None);
         }
 
-        public static T UseImportMagicCommand<T>(this T kernel) 
+        public static T UseImportMagicCommand<T>(this T kernel)
             where T : Kernel
         {
             var command = new Command("#!import", "Imports and runs another notebook.");
             command.AddArgument(new Argument<FileInfo>("notebookFile").ExistingOnly());
             command.Handler = CommandHandler.Create(
-                async (FileInfo notebookFile, KernelInvocationContext context)
-                =>
+                async (FileInfo notebookFile, KernelInvocationContext _) =>
                 {
-                    var document = await InteractiveDocument.LoadInteractiveDocumentAsync(notebookFile,
-                        CreateKernelInfos(kernel.RootKernel as CompositeKernel));
+                    var document = await InteractiveDocument.LoadAsync(
+                                       notebookFile,
+                                       CreateKernelInfos(kernel.RootKernel as CompositeKernel));
+
                     foreach (var element in document.Elements)
                     {
-                        var command = new SubmitCode(element.Contents, element.KernelName);
-                        await kernel.RootKernel.SendAsync(command);
+                        await kernel.RootKernel.SendAsync(new SubmitCode(element.Contents, element.KernelName));
                     }
                 });
 


### PR DESCRIPTION
This adds support to `InteractiveDocument` for reading documents linked via `#!import` magic commands.