### PR TITLE
add github issues notebook

### DIFF
--- a/issues-review.github-issues
+++ b/issues-review.github-issues
@@ -1,0 +1,7 @@
+[
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "// install extension id ms-vscode.vscode-github-issue-notebooks\r\nrepo:dotnet/interactive is:issue is:open -label:external -label:enhancement -label:impact-medium -label:impact-low -label:impact-high -label:plan -label:question -label:Urgency-High -label:Maintainability"
+  }
+]


### PR DESCRIPTION
I copied the normal issues review query from the meeting invite and added it to a GitHub Issues Notebook.

I'm open to suggestions as to what to actually name this file and where to put it.

Example:
<img width="606" alt="image" src="https://user-images.githubusercontent.com/926281/193155405-5b347461-1209-4d23-bbed-4bc10c2fdf6b.png">
