### PR TITLE
add cell execution count

### DIFF
--- a/NotebookTestScript.dib
+++ b/NotebookTestScript.dib
@@ -1,5 +1,15 @@
 #!markdown
 
+# Verify execution count.
+
+The next code cell should have empty square brackets on the left, e.g., "`[ ]`".  Execute the cell and upon completion there should be a number there; probably "`[1]`".  Execute the cell again and verify that the number in the brackets increments by one, e.g., "`[2]`".
+
+#!csharp
+
+1+1
+
+#!markdown
+
 # Execute the following cell.
 
 You'll notice a counter that appears and starts incrementing.  After a second or two, stop the cell.  Your output should look similar to:

--- a/src/dotnet-interactive-vscode-common/src/commands.ts
+++ b/src/dotnet-interactive-vscode-common/src/commands.ts
@@ -131,7 +131,12 @@ export function registerKernelCommands(context: vscode.ExtensionContext, clientM
 
         if (notebook) {
             for (const cell of notebook.getCells()) {
-                notebookControllers.endExecution(cell, false);
+                notebookControllers.endExecution(undefined, cell, false);
+            }
+
+            const client = await clientMapper.tryGetClient(notebook.uri);
+            if (client) {
+                client.resetExecutionCount();
             }
 
             clientMapper.closeClient(notebook.uri);

--- a/src/dotnet-interactive-vscode-common/src/interactiveClient.ts
+++ b/src/dotnet-interactive-vscode-common/src/interactiveClient.ts
@@ -70,6 +70,7 @@ export interface InteractiveClientConfiguration {
 }
 
 export class InteractiveClient {
+    private nextExecutionCount = 1;
     private nextOutputId: number = 1;
     private nextToken: number = 1;
     private tokenEventObservers: Map<string, Array<KernelEventEnvelopeObserver>> = new Map<string, Array<KernelEventEnvelopeObserver>>();
@@ -488,6 +489,16 @@ export class InteractiveClient {
     private IsEncodedMimeType(mimeType: string): boolean {
         const encdodedMimetypes = new Set<string>(["image/png", "image/jpeg", "image/gif"]);
         return encdodedMimetypes.has(mimeType);
+    }
+
+    resetExecutionCount() {
+        this.nextExecutionCount = 1;
+    }
+
+    getNextExecutionCount(): number {
+        const next = this.nextExecutionCount;
+        this.nextExecutionCount++;
+        return next;
     }
 
     private getNextOutputId(): string {

--- a/src/dotnet-interactive-vscode-insiders/src/notebookControllers.ts
+++ b/src/dotnet-interactive-vscode-insiders/src/notebookControllers.ts
@@ -11,7 +11,7 @@ import { getSimpleLanguage, isDotnetInteractiveLanguage, jupyterViewType, notebo
 import { getCellLanguage, getDotNetMetadata, getLanguageInfoMetadata, isDotNetNotebookMetadata, withDotNetKernelMetadata } from './vscode-common/ipynbUtilities';
 import { reshapeOutputValueForVsCode } from './vscode-common/interfaces/utilities';
 import { selectDotNetInteractiveKernelForJupyter } from './vscode-common/commands';
-import { ErrorOutputCreator } from './vscode-common/interactiveClient';
+import { ErrorOutputCreator, InteractiveClient } from './vscode-common/interactiveClient';
 import { LogEntry, Logger } from './vscode-common/dotnet-interactive/logger';
 import * as notebookMessageHandler from './vscode-common/notebookMessageHandler';
 import { KernelCommandOrEventEnvelope } from './vscode-common/dotnet-interactive/connection';
@@ -84,7 +84,8 @@ export class DotNetNotebookKernel {
         this.disposables.push(vscode.workspace.onDidOpenNotebookDocument(async notebook => {
             if (isDotNetNotebook(notebook)) {
                 // eagerly spin up the backing process
-                const _client = await config.clientMapper.getOrAddClient(notebook.uri);
+                const client = await config.clientMapper.getOrAddClient(notebook.uri);
+                client.resetExecutionCount();
 
                 if (notebook.notebookType === jupyterViewType) {
                     jupyterController.updateNotebookAffinity(notebook, vscode.NotebookControllerAffinity.Preferred);
@@ -103,6 +104,7 @@ export class DotNetNotebookKernel {
 
     private commonControllerInit(controller: vscode.NotebookController) {
         controller.supportedLanguages = notebookCellLanguages;
+        controller.supportsExecutionOrder = true;
         this.disposables.push(controller.onDidReceiveMessage(e => {
             const notebookUri = e.editor.notebook.uri;
             const notebookUriString = notebookUri.toString();
@@ -144,6 +146,7 @@ export class DotNetNotebookKernel {
             try {
                 const startTime = Date.now();
                 executionTask.start(startTime);
+                executionTask.executionOrder = undefined;
                 await executionTask.clearOutput(cell);
                 const controllerErrors: vscodeLike.NotebookCellOutput[] = [];
 
@@ -170,16 +173,16 @@ export class DotNetNotebookKernel {
 
                 return client.execute(source, getSimpleLanguage(cell.document.languageId), outputObserver, diagnosticObserver, { id: cell.document.uri.toString() }).then(async () => {
                     await outputUpdatePromise;
-                    endExecution(cell, true);
+                    endExecution(client, cell, true);
                 }).catch(async () => {
                     await outputUpdatePromise;
-                    endExecution(cell, false);
+                    endExecution(client, cell, false);
                 });
             } catch (err) {
                 const errorOutput = new vscode.NotebookCellOutput(this.config.createErrorOutput(`Error executing cell: ${err}`).items.map(oi => generateVsCodeNotebookCellOutputItem(oi.data, oi.mime, oi.stream)));
                 await executionTask.appendOutput(errorOutput);
                 await outputUpdatePromise;
-                endExecution(cell, false);
+                endExecution(undefined, cell, false);
                 throw err;
             }
         }
@@ -241,11 +244,12 @@ async function updateCellOutputs(executionTask: vscode.NotebookCellExecution, ou
     await executionTask.replaceOutput(reshapedOutputs);
 }
 
-export function endExecution(cell: vscode.NotebookCell, success: boolean) {
+export function endExecution(client: InteractiveClient | undefined, cell: vscode.NotebookCell, success: boolean) {
     const key = cell.document.uri.toString();
     const executionTask = executionTasks.get(key);
     if (executionTask) {
         executionTasks.delete(key);
+        executionTask.executionOrder = client?.getNextExecutionCount();
         const endTime = Date.now();
         executionTask.end(success, endTime);
     }

--- a/src/dotnet-interactive-vscode/src/notebookControllers.ts
+++ b/src/dotnet-interactive-vscode/src/notebookControllers.ts
@@ -11,7 +11,7 @@ import { getSimpleLanguage, isDotnetInteractiveLanguage, jupyterViewType, notebo
 import { getCellLanguage, getDotNetMetadata, getLanguageInfoMetadata, isDotNetNotebookMetadata, withDotNetKernelMetadata } from './vscode-common/ipynbUtilities';
 import { reshapeOutputValueForVsCode } from './vscode-common/interfaces/utilities';
 import { selectDotNetInteractiveKernelForJupyter } from './vscode-common/commands';
-import { ErrorOutputCreator } from './vscode-common/interactiveClient';
+import { ErrorOutputCreator, InteractiveClient } from './vscode-common/interactiveClient';
 import { LogEntry, Logger } from './vscode-common/dotnet-interactive/logger';
 import * as notebookMessageHandler from './vscode-common/notebookMessageHandler';
 import { KernelCommandOrEventEnvelope } from './vscode-common/dotnet-interactive/connection';
@@ -84,7 +84,8 @@ export class DotNetNotebookKernel {
         this.disposables.push(vscode.workspace.onDidOpenNotebookDocument(async notebook => {
             if (isDotNetNotebook(notebook)) {
                 // eagerly spin up the backing process
-                const _client = await config.clientMapper.getOrAddClient(notebook.uri);
+                const client = await config.clientMapper.getOrAddClient(notebook.uri);
+                client.resetExecutionCount();
 
                 if (notebook.notebookType === jupyterViewType) {
                     jupyterController.updateNotebookAffinity(notebook, vscode.NotebookControllerAffinity.Preferred);
@@ -103,6 +104,7 @@ export class DotNetNotebookKernel {
 
     private commonControllerInit(controller: vscode.NotebookController) {
         controller.supportedLanguages = notebookCellLanguages;
+        controller.supportsExecutionOrder = true;
         this.disposables.push(controller.onDidReceiveMessage(e => {
             const notebookUri = e.editor.notebook.uri;
             const notebookUriString = notebookUri.toString();
@@ -144,6 +146,7 @@ export class DotNetNotebookKernel {
             try {
                 const startTime = Date.now();
                 executionTask.start(startTime);
+                executionTask.executionOrder = undefined;
                 await executionTask.clearOutput(cell);
                 const controllerErrors: vscodeLike.NotebookCellOutput[] = [];
 
@@ -170,16 +173,16 @@ export class DotNetNotebookKernel {
 
                 return client.execute(source, getSimpleLanguage(cell.document.languageId), outputObserver, diagnosticObserver, { id: cell.document.uri.toString() }).then(async () => {
                     await outputUpdatePromise;
-                    endExecution(cell, true);
+                    endExecution(client, cell, true);
                 }).catch(async () => {
                     await outputUpdatePromise;
-                    endExecution(cell, false);
+                    endExecution(client, cell, false);
                 });
             } catch (err) {
                 const errorOutput = new vscode.NotebookCellOutput(this.config.createErrorOutput(`Error executing cell: ${err}`).items.map(oi => generateVsCodeNotebookCellOutputItem(oi.data, oi.mime, oi.stream)));
                 await executionTask.appendOutput(errorOutput);
                 await outputUpdatePromise;
-                endExecution(cell, false);
+                endExecution(undefined, cell, false);
                 throw err;
             }
         }
@@ -241,11 +244,12 @@ async function updateCellOutputs(executionTask: vscode.NotebookCellExecution, ou
     await executionTask.replaceOutput(reshapedOutputs);
 }
 
-export function endExecution(cell: vscode.NotebookCell, success: boolean) {
+export function endExecution(client: InteractiveClient | undefined, cell: vscode.NotebookCell, success: boolean) {
     const key = cell.document.uri.toString();
     const executionTask = executionTasks.get(key);
     if (executionTask) {
         executionTasks.delete(key);
+        executionTask.executionOrder = client?.getNextExecutionCount();
         const endTime = Date.now();
         executionTask.end(success, endTime);
     }


### PR DESCRIPTION
Fixes #1852.

The VS Code APIs only allow us to change a cell's execution order number while it's running which means we have no way of resetting all values, etc. when the backing kernel is restarted.