### PR TITLE
add cred scan supporession for false positives

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -1,0 +1,9 @@
+{
+  "tool": "Credential Scanner",
+  "suppressions": [
+    {
+      "file": "/src/dotnet-interactive-vscode-ads/src/azdata.d.ts",
+      "_justification": "False positives on lines 602 and 625 in an enum: password = 'password'"
+    }
+  ]
+}


### PR DESCRIPTION
The mirror to the internal git repo is failing because of a false positive in the cred scan tool.  Following the instructions [here](https://strikecommunity.azurewebsites.net/articles/4125/credscan-local-suppression.html) and guidance received via email, we're suppressing items from the affected file because it doesn't actually contain any secrets.