### PR TITLE
JS implementation for SendValue command

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
@@ -92,9 +92,10 @@ Microsoft.DotNet.Interactive
     public System.Collections.Generic.IEnumerable<System.String> FormatAsPlainTextLines()
   public abstract class IStaticContentSource
     public System.String Name { get;}
-  public class JavaScriptKernel : Kernel, IKernelCommandHandler<Microsoft.DotNet.Interactive.Commands.RequestKernelInfo>, IKernelCommandHandler<Microsoft.DotNet.Interactive.Commands.SubmitCode>, System.IDisposable
+  public class JavaScriptKernel : Kernel, IKernelCommandHandler<Microsoft.DotNet.Interactive.Commands.RequestKernelInfo>, IKernelCommandHandler<Microsoft.DotNet.Interactive.Commands.SendValue>, IKernelCommandHandler<Microsoft.DotNet.Interactive.Commands.SubmitCode>, System.IDisposable
     .ctor(Microsoft.DotNet.Interactive.Connection.KernelClientBase client = null)
     protected Func<TCommand,KernelInvocationContext,System.Threading.Tasks.Task> CreateDefaultHandlerForCommandType<TCommand>()
+    public System.Threading.Tasks.Task HandleAsync(Microsoft.DotNet.Interactive.Commands.SendValue command, KernelInvocationContext context)
   public abstract class JsonConverter<T> : JsonConverter<T>
     protected System.Void EnsureStartObject(System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert)
     protected System.Void OnWrite(System.Text.Json.Utf8JsonWriter writer, T value, System.Text.Json.JsonSerializerOptions options)

--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.cs
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.cs
@@ -29,42 +29,42 @@ public class ApiCompatibilityTests
                          .UsingExtension("txt");
     }
 
-    [FactSkipLinux]
+    [FactSkipLinux("Testing api contract changes, not needed on Linux too")]
     public void Interactive_api_is_not_changed()
     {
         var contract = ApiContract.GenerateContract<Kernel>();
         this.Assent(contract, _configuration);
     }
 
-    [FactSkipLinux]
+    [FactSkipLinux("Testing api contract changes, not needed on Linux too")]
     public void Formatting_api_is_not_changed()
     {
         var contract = ApiContract.GenerateContract<FormatContext>();
         this.Assent(contract, _configuration);
     }
 
-    [FactSkipLinux]
+    [FactSkipLinux("Testing api contract changes, not needed on Linux too")]
     public void Document_api_is_not_changed()
     {
         var contract = ApiContract.GenerateContract<InteractiveDocument>();
         this.Assent(contract, _configuration);
     }
 
-    [FactSkipLinux]
+    [FactSkipLinux("Testing api contract changes, not needed on Linux too")]
     public void PackageManagement_api_is_not_changed()
     {
         var contract = ApiContract.GenerateContract<PackageRestoreContext>();
         this.Assent(contract, _configuration);
     }
 
-    [FactSkipLinux]
+    [FactSkipLinux("Testing api contract changes, not needed on Linux too")]
     public void Journey_api_is_not_changed()
     {
         var contract = ApiContract.GenerateContract<Lesson>();
         this.Assent(contract, _configuration);
     }
 
-    [FactSkipLinux]
+    [FactSkipLinux("Testing api contract changes, not needed on Linux too")]
     public void csharp_api_is_not_changed()
     {
         var contract = ApiContract.GenerateContract<CSharpKernel>();
@@ -85,28 +85,28 @@ public class ApiCompatibilityTests
         this.Assent(contract, _configuration);
     }
 
-    [FactSkipLinux]
+    [FactSkipLinux("Testing api contract changes, not needed on Linux too")]
     public void powershell_api_is_not_changed()
     {
         var contract = ApiContract.GenerateContract<PowerShellKernel>();
         this.Assent(contract, _configuration);
     }
 
-    [FactSkipLinux]
+    [FactSkipLinux("Testing api contract changes, not needed on Linux too")]
     public void mssql_api_is_not_changed()
     {
         var contract = ApiContract.GenerateContract<MsSqlKernelConnector>();
         this.Assent(contract, _configuration);
     }
 
-    [FactSkipLinux]
+    [FactSkipLinux("Testing api contract changes, not needed on Linux too")]
     public void kql_api_is_not_changed()
     {
         var contract = ApiContract.GenerateContract<KqlKernelConnector>();
         this.Assent(contract, _configuration);
     }
 
-    [FactSkipLinux]
+    [FactSkipLinux("Testing api contract changes, not needed on Linux too")]
     public void mermaid_api_is_not_changed()
     {
         var contract = ApiContract.GenerateContract<MermaidKernel>();

--- a/src/Microsoft.DotNet.Interactive.Browser.Tests/HtmlKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Browser.Tests/HtmlKernelTests.cs
@@ -32,7 +32,7 @@ public class HtmlKernelTests : IDisposable
 
     public void Dispose() => _disposables.Dispose();
 
-    [Fact]
+    [FactSkipLinux("Requires Playwright installed")]
     public async Task It_can_share_the_underlying_Playwright_page_object()
     {
         using var kernel = await CreateHtmlProxyKernelAsync();
@@ -50,7 +50,7 @@ public class HtmlKernelTests : IDisposable
             .BeAssignableTo<ILocator>();
     }
 
-    [Fact]
+    [FactSkipLinux("Requires Playwright installed")]
     public async Task It_can_share_the_underlying_page_HTML()
     {
         using var kernel = await CreateHtmlProxyKernelAsync();
@@ -72,7 +72,7 @@ public class HtmlKernelTests : IDisposable
             .Contain("<div>hello</div>");
     }
 
-    [Fact]
+    [FactSkipLinux("Requires Playwright installed")]
     public async Task It_can_share_the_underlying_page_content()
     {
         using var kernel = await CreateHtmlProxyKernelAsync();
@@ -94,7 +94,7 @@ public class HtmlKernelTests : IDisposable
             .Be("hello");
     }
 
-    [Fact]
+    [FactSkipLinux("Requires Playwright installed")]
     public async Task It_can_capture_a_PNG_using_a_selector()
     {
         using var kernel = await CreateHtmlProxyKernelAsync();
@@ -121,7 +121,7 @@ public class HtmlKernelTests : IDisposable
              .NotThrow();
     }
 
-    [Fact]
+    [FactSkipLinux("Requires Playwright installed")]
     public async Task It_can_capture_a_Jpeg_using_a_selector()
     {
         using var kernel = await CreateHtmlProxyKernelAsync();
@@ -148,7 +148,7 @@ public class HtmlKernelTests : IDisposable
              .NotThrow();
     }
 
-    [Fact]
+    [FactSkipLinux("Requires Playwright installed")]
     public async Task It_has_shareable_values()
     {
         using var kernel = await CreateHtmlProxyKernelAsync();
@@ -166,7 +166,7 @@ public class HtmlKernelTests : IDisposable
             .ContainSingle(i => i.Name == ":root");
     }
 
-    [Fact]
+    [FactSkipLinux("Requires Playwright installed")]
     public async Task HTML_kernel_can_see_DOM_changes_made_by_JavaScript_kernel()
     {
         var connector = new PlaywrightKernelConnector(!Debugger.IsAttached);
@@ -189,7 +189,7 @@ public class HtmlKernelTests : IDisposable
             .Contain("<div>howdy</div>");
     }
 
-    [Fact]
+    [FactSkipLinux("Requires Playwright installed")]
     public async Task JavaScript_kernel_can_see_DOM_changes_made_by_HTML_kernel()
     {
         var connector = new PlaywrightKernelConnector(!Debugger.IsAttached);

--- a/src/Microsoft.DotNet.Interactive.Browser.Tests/HtmlKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Browser.Tests/HtmlKernelTests.cs
@@ -14,6 +14,8 @@ using Pocket.For.Xunit;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.Formats.Png;
+
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.Interactive.Browser.Tests;
@@ -30,7 +32,7 @@ public class HtmlKernelTests : IDisposable
 
     public void Dispose() => _disposables.Dispose();
 
-    [FactSkipLinux]
+    [Fact]
     public async Task It_can_share_the_underlying_Playwright_page_object()
     {
         using var kernel = await CreateHtmlProxyKernelAsync();
@@ -48,7 +50,7 @@ public class HtmlKernelTests : IDisposable
             .BeAssignableTo<ILocator>();
     }
 
-    [FactSkipLinux]
+    [Fact]
     public async Task It_can_share_the_underlying_page_HTML()
     {
         using var kernel = await CreateHtmlProxyKernelAsync();
@@ -70,7 +72,7 @@ public class HtmlKernelTests : IDisposable
             .Contain("<div>hello</div>");
     }
 
-    [FactSkipLinux]
+    [Fact]
     public async Task It_can_share_the_underlying_page_content()
     {
         using var kernel = await CreateHtmlProxyKernelAsync();
@@ -92,7 +94,7 @@ public class HtmlKernelTests : IDisposable
             .Be("hello");
     }
 
-    [FactSkipLinux]
+    [Fact]
     public async Task It_can_capture_a_PNG_using_a_selector()
     {
         using var kernel = await CreateHtmlProxyKernelAsync();
@@ -119,7 +121,7 @@ public class HtmlKernelTests : IDisposable
              .NotThrow();
     }
 
-    [FactSkipLinux]
+    [Fact]
     public async Task It_can_capture_a_Jpeg_using_a_selector()
     {
         using var kernel = await CreateHtmlProxyKernelAsync();
@@ -146,7 +148,7 @@ public class HtmlKernelTests : IDisposable
              .NotThrow();
     }
 
-    [FactSkipLinux]
+    [Fact]
     public async Task It_has_shareable_values()
     {
         using var kernel = await CreateHtmlProxyKernelAsync();
@@ -164,7 +166,7 @@ public class HtmlKernelTests : IDisposable
             .ContainSingle(i => i.Name == ":root");
     }
 
-    [FactSkipLinux]
+    [Fact]
     public async Task HTML_kernel_can_see_DOM_changes_made_by_JavaScript_kernel()
     {
         var connector = new PlaywrightKernelConnector(!Debugger.IsAttached);
@@ -187,7 +189,7 @@ public class HtmlKernelTests : IDisposable
             .Contain("<div>howdy</div>");
     }
 
-    [FactSkipLinux]
+    [Fact]
     public async Task JavaScript_kernel_can_see_DOM_changes_made_by_HTML_kernel()
     {
         var connector = new PlaywrightKernelConnector(!Debugger.IsAttached);

--- a/src/Microsoft.DotNet.Interactive.Browser.Tests/JavaScriptKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Browser.Tests/JavaScriptKernelTests.cs
@@ -28,7 +28,7 @@ public class JavaScriptKernelTests : IDisposable
 
     public void Dispose() => _disposables.Dispose();
 
-    [Fact]
+    [FactSkipLinux("Requires Playwright installed")]
     public async Task It_can_execute_code()
     {
         using var kernel = await CreateJavaScriptProxyKernelAsync();
@@ -40,7 +40,7 @@ public class JavaScriptKernelTests : IDisposable
         events.Should().NotContainErrors();
     }
 
-    [Fact]
+    [FactSkipLinux("Requires Playwright installed")]
     public async Task It_can_get_a_return_value()
     {
         using var kernel = await CreateJavaScriptProxyKernelAsync();
@@ -57,7 +57,7 @@ public class JavaScriptKernelTests : IDisposable
                                   v.Value == "123");
     }
 
-    [Fact]
+    [FactSkipLinux("Requires Playwright installed")]
     public async Task It_can_get_console_log_output()
     {
         using var kernel = await CreateJavaScriptProxyKernelAsync();
@@ -74,7 +74,7 @@ public class JavaScriptKernelTests : IDisposable
                                   v.Value == "123");
     }
 
-    [Fact]
+    [FactSkipLinux("Requires Playwright installed")]
     public async Task It_can_import_value_from_another_kernel()
     {
         using var kernel = await CreateJavaScriptProxyKernelAsync();
@@ -103,7 +103,7 @@ console.log(x);", targetKernelName: kernel.Name));
                                 v.Value == "123");
     }
 
-    [Fact]
+    [FactSkipLinux("Requires Playwright installed")]
     public async Task It_can_share_value_with_another_kernel()
     {
         using var kernel = await CreateJavaScriptProxyKernelAsync();

--- a/src/Microsoft.DotNet.Interactive.Browser.Tests/JavaScriptKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Browser.Tests/JavaScriptKernelTests.cs
@@ -11,6 +11,7 @@ using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Tests.Utility;
 using Pocket;
 using Pocket.For.Xunit;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.Interactive.Browser.Tests;
@@ -27,7 +28,7 @@ public class JavaScriptKernelTests : IDisposable
 
     public void Dispose() => _disposables.Dispose();
 
-    [FactSkipLinux]
+    [Fact]
     public async Task It_can_execute_code()
     {
         using var kernel = await CreateJavaScriptProxyKernelAsync();
@@ -39,7 +40,7 @@ public class JavaScriptKernelTests : IDisposable
         events.Should().NotContainErrors();
     }
 
-    [FactSkipLinux]
+    [Fact]
     public async Task It_can_get_a_return_value()
     {
         using var kernel = await CreateJavaScriptProxyKernelAsync();
@@ -56,7 +57,7 @@ public class JavaScriptKernelTests : IDisposable
                                   v.Value == "123");
     }
 
-    [FactSkipLinux]
+    [Fact]
     public async Task It_can_get_console_log_output()
     {
         using var kernel = await CreateJavaScriptProxyKernelAsync();
@@ -73,7 +74,7 @@ public class JavaScriptKernelTests : IDisposable
                                   v.Value == "123");
     }
 
-    [FactSkipLinux]
+    [Fact]
     public async Task It_can_import_value_from_another_kernel()
     {
         using var kernel = await CreateJavaScriptProxyKernelAsync();
@@ -102,7 +103,7 @@ console.log(x);", targetKernelName: kernel.Name));
                                 v.Value == "123");
     }
 
-    [FactSkipLinux]
+    [Fact]
     public async Task It_can_share_value_with_another_kernel()
     {
         using var kernel = await CreateJavaScriptProxyKernelAsync();

--- a/src/Microsoft.DotNet.Interactive.Browser/PlaywrightKernelConnector.cs
+++ b/src/Microsoft.DotNet.Interactive.Browser/PlaywrightKernelConnector.cs
@@ -117,7 +117,11 @@ public class PlaywrightKernelConnector : IKernelConnector
                 break;
 
             case "javascript":
-
+                proxy.KernelInfo.SupportedKernelCommands.Add(new(nameof(SubmitCode)));
+                proxy.KernelInfo.SupportedKernelCommands.Add(new(nameof(RequestValue)));
+                proxy.KernelInfo.SupportedKernelCommands.Add(new(nameof(RequestValueInfos)));
+                proxy.KernelInfo.SupportedKernelCommands.Add(new(nameof(SendValue)));
+                proxy.UseValueSharing();
                 break;
         }
 

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/SqlKernelUtils.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/SqlKernelUtils.cs
@@ -3,36 +3,34 @@
 
 using System.Collections.Generic;
 
-namespace Microsoft.DotNet.Interactive.ExtensionLab
+namespace Microsoft.DotNet.Interactive.ExtensionLab;
+
+internal static class SqlKernelUtils
 {
-    internal static class SqlKernelUtils
+    /// <summary>
+    /// Appends a number to the end of duplicate column names in the provided
+    /// string array. Some column names in SQL query results can be duplicates
+    /// either from deliberate aliasing with the AS keyword, or from being
+    /// unnamed columns, but column names have to be unique in a Table Schema.
+    /// </summary>
+    /// <param name="columnNames">
+    /// The array of column names to be aliased. Note: The provided array will
+    /// be modified by this method.
+    /// </param>
+    internal static void AliasDuplicateColumnNames(string[] columnNames)
     {
-        /// <summary>
-        /// Appends a number to the end of duplicate column names in the provided
-        /// string array. Some column names in SQL query results can be duplicates
-        /// either from deliberate aliasing with the AS keyword, or from being
-        /// unnamed columns, but column names have to be unique in a Table Schema.
-        /// </summary>
-        /// <param name="columnNames">
-        /// The array of column names to be aliased. Note: The provided array will
-        /// be modified by this method.
-        /// </param>
-        internal static void AliasDuplicateColumnNames(string[] columnNames)
+        var nameCounts = new Dictionary<string, int>(capacity: columnNames.Length);
+        for (var i = 0; i < columnNames.Length; i++)
         {
-            var nameCounts = new Dictionary<string, int>(capacity: columnNames.Length);
-            for (int i = 0; i < columnNames.Length; i++)
+            var columnName = columnNames[i];
+            if (nameCounts.TryGetValue(columnName, out var count))
             {
-                string columnName = columnNames[i];
-                int count;
-                if (nameCounts.TryGetValue(columnName, out count))
-                {
-                    nameCounts[columnName] = ++count;
-                    columnNames[i] = columnName + $" ({count})";
-                }
-                else
-                {
-                    nameCounts[columnName] = 1;
-                }
+                nameCounts[columnName] = ++count;
+                columnNames[i] = columnName + $" ({count})";
+            }
+            else
+            {
+                nameCounts[columnName] = 1;
             }
         }
     }

--- a/src/Microsoft.DotNet.Interactive.SqlServer.Tests/MsSqlConnectionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer.Tests/MsSqlConnectionTests.cs
@@ -106,7 +106,7 @@ select top 10 AddressLine1, AddressLine2 from Person.Address
 
             events.ShouldDisplayTabularDataResourceWhich()
                 .Data
-                .Select(row => row.Where(r => r.Key == "AddressLine2").Select(r => r.Value))
+                .SelectMany(row => row.Where(r => r.Key == "AddressLine2").Select(r => r.Value))
                 .Should()
                 .AllBeEquivalentTo((object)null);
         }

--- a/src/Microsoft.DotNet.Interactive.SqlServer/ToolsServiceKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/ToolsServiceKernel.cs
@@ -250,15 +250,28 @@ namespace Microsoft.DotNet.Interactive.SqlServer
             var dataRows = new List<List<KeyValuePair<string, object>>>();
             var columnNames = columnInfos.Select(info => info.ColumnName).ToArray();
 
+            var columnNameCounters = new Dictionary<string, int>();
+
             SqlKernelUtils.AliasDuplicateColumnNames(columnNames);
 
             foreach (var columnInfo in columnInfos)
             {
+                var columnName = columnInfo.ColumnName;
+                if (columnNameCounters.TryGetValue(columnName, out var count))
+                {
+                    columnNameCounters[columnName] = count + 1;
+                    columnName = $"{columnName}_{count}";
+                }
+                else
+                {
+                    columnNameCounters[columnName] = 1;
+                }
+                
                 var expectedType = Type.GetType(columnInfo.DataType);
-                schema.Fields.Add(new TableSchemaFieldDescriptor(columnInfo.ColumnName, expectedType.ToTableSchemaFieldType()));
+                schema.Fields.Add(new TableSchemaFieldDescriptor(columnName, expectedType.ToTableSchemaFieldType()));
                 if (columnInfo.IsKey == true)
                 {
-                    schema.PrimaryKey.Add(columnInfo.ColumnName);
+                    schema.PrimaryKey.Add(columnName);
                 }
             }
             

--- a/src/Microsoft.DotNet.Interactive.SqlServer/ToolsServiceKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/ToolsServiceKernel.cs
@@ -15,6 +15,8 @@ using Microsoft.DotNet.Interactive.ExtensionLab;
 using Microsoft.DotNet.Interactive.Formatting.TabularData;
 using Microsoft.DotNet.Interactive.ValueSharing;
 
+using static Azure.Core.HttpHeader;
+
 namespace Microsoft.DotNet.Interactive.SqlServer
 {
     public abstract class ToolsServiceKernel :
@@ -248,25 +250,15 @@ namespace Microsoft.DotNet.Interactive.SqlServer
         {
             var schema = new TableSchema();
             var dataRows = new List<List<KeyValuePair<string, object>>>();
-            var columnNames = columnInfos.Select(info => info.ColumnName).ToArray();
-
-            var columnNameCounters = new Dictionary<string, int>();
+            var columnNames = columnInfos.Select(c => c.ColumnName).ToArray();
 
             SqlKernelUtils.AliasDuplicateColumnNames(columnNames);
 
-            foreach (var columnInfo in columnInfos)
+            for (var i = 0; i <  columnInfos.Length; i++)
             {
-                var columnName = columnInfo.ColumnName;
-                if (columnNameCounters.TryGetValue(columnName, out var count))
-                {
-                    columnNameCounters[columnName] = count + 1;
-                    columnName = $"{columnName}_{count}";
-                }
-                else
-                {
-                    columnNameCounters[columnName] = 1;
-                }
-                
+                var columnInfo = columnInfos[i];
+                var columnName = columnNames[i];
+
                 var expectedType = Type.GetType(columnInfo.DataType);
                 schema.Fields.Add(new TableSchemaFieldDescriptor(columnName, expectedType.ToTableSchemaFieldType()));
                 if (columnInfo.IsKey == true)

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/CompletionTests.MagicCommands.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/CompletionTests.MagicCommands.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Interactive.Tests.LanguageServices
             // commands
             [InlineData("#!sha[||]", "Get a value from one kernel and create a copy (or a reference if the kernels are in the same process) in another.")]
             // options
-            [InlineData("#!share --fr[||]", "--from*csharp*The name of the kernel")]
+            [InlineData("#!share --fr[||]", "--from*ValueSource*The name of the kernel")]
             // subcommands
             [InlineData("#!connect signa[||]", "Connects to a kernel using SignalR*--hub-url*The URL of the SignalR hub")]
             public async Task Completion_documentation_is_available_for_magic_commands(
@@ -73,7 +73,11 @@ namespace Microsoft.DotNet.Interactive.Tests.LanguageServices
                 string expected)
             {
                 var kernel = CreateKernel();
-
+                var fakeKernel = new FakeKernel("ValueSource");
+                fakeKernel.KernelInfo.SupportedKernelCommands.Add(new(nameof(RequestValue)));
+                fakeKernel.KernelInfo.SupportedKernelCommands.Add(new(nameof(RequestValueInfos)));
+                
+                kernel.Add(fakeKernel);
                 kernel.AddKernelConnector(new ConnectSignalRCommand());
 
                 var completions = await markupCode

--- a/src/Microsoft.DotNet.Interactive.Tests/Utility/FactSkipLinux.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Utility/FactSkipLinux.cs
@@ -8,11 +8,11 @@ namespace Microsoft.DotNet.Interactive.Tests.Utility;
 
 public sealed class FactSkipLinux : FactAttribute
 {
-    public FactSkipLinux()
+    public FactSkipLinux(string reason = null)
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            Skip = "Ignored on Linux";
+            Skip = string.IsNullOrWhiteSpace(reason) ? "Ignored on Linux" : reason;
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Tests/Utility/FactSkipWindows.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Utility/FactSkipWindows.cs
@@ -8,11 +8,11 @@ namespace Microsoft.DotNet.Interactive.Tests.Utility;
 
 public sealed class FactSkipWindows : FactAttribute
 {
-    public FactSkipWindows()
+    public FactSkipWindows(string reason = null)
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            Skip = "Ignored on Windows";
+            Skip = string.IsNullOrWhiteSpace(reason) ? "Ignored on Windows" : reason;
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Tests/VariableSharingTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/VariableSharingTests.cs
@@ -228,11 +228,11 @@ namespace Microsoft.DotNet.Interactive.Tests
             events.Should().NotContainErrors();
 
             remoteCommands.Should()
-                          .ContainSingle<SubmitCode>()
+                          .ContainSingle<SendValue>()
                           .Which
-                          .Code
+                          .FormattedValue.Value
                           .Should()
-                          .Be("csharpVariable = 123;");
+                          .Be("123");
         }
         
         [Fact]
@@ -525,7 +525,8 @@ y");
             var remoteKernel = new FakeKernel("remote-javascript", "javascript");
             remoteKernel.RegisterCommandType<RequestValue>();
             remoteKernel.RegisterCommandType<RequestValueInfos>();
-            
+            remoteKernel.RegisterCommandType<SendValue>();
+
             remoteCompositeKernel.Add(remoteKernel);
 
             ConnectHost.ConnectInProcessHost(
@@ -542,7 +543,7 @@ y");
                           remoteKernelUri);
 
             javascriptKernel.UseValueSharing();
-
+            javascriptKernel.RegisterCommandType<SendValue>();
             await localCompositeKernel.SendAsync(new RequestKernelInfo(remoteKernelUri));
 
             _disposables.Add(localCompositeKernel);

--- a/src/Microsoft.DotNet.Interactive.Tests/VariableSharingTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/VariableSharingTests.cs
@@ -543,7 +543,7 @@ y");
                           remoteKernelUri);
 
             javascriptKernel.UseValueSharing();
-            javascriptKernel.RegisterCommandType<SendValue>();
+            
             await localCompositeKernel.SendAsync(new RequestKernelInfo(remoteKernelUri));
 
             _disposables.Add(localCompositeKernel);

--- a/src/Microsoft.DotNet.Interactive.VSCode/VSCodeClientKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.VSCode/VSCodeClientKernelExtension.cs
@@ -34,6 +34,8 @@ public class VSCodeClientKernelExtension : IKernelExtension
             jsKernel.KernelInfo.SupportedKernelCommands.Add(new(nameof(RequestValueInfos)));
             jsKernel.KernelInfo.SupportedKernelCommands.Add(new(nameof(SendValue)));
 
+            jsKernel.UseValueSharing();
+
             root.VisitSubkernels(subkernel =>
             {
                 if (subkernel is PowerShellKernel powerShellKernel)

--- a/src/Microsoft.DotNet.Interactive.VSCode/VSCodeClientKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.VSCode/VSCodeClientKernelExtension.cs
@@ -3,7 +3,10 @@
 
 using System;
 using System.Threading.Tasks;
+using System.Xml.Linq;
+
 using Microsoft.DotNet.Interactive.Commands;
+using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.PowerShell;
 
 namespace Microsoft.DotNet.Interactive.VSCode;
@@ -29,6 +32,7 @@ public class VSCodeClientKernelExtension : IKernelExtension
             jsKernel.KernelInfo.SupportedKernelCommands.Add(new(nameof(SubmitCode)));
             jsKernel.KernelInfo.SupportedKernelCommands.Add(new(nameof(RequestValue)));
             jsKernel.KernelInfo.SupportedKernelCommands.Add(new(nameof(RequestValueInfos)));
+            jsKernel.KernelInfo.SupportedKernelCommands.Add(new(nameof(SendValue)));
 
             root.VisitSubkernels(subkernel =>
             {

--- a/src/Microsoft.DotNet.Interactive/Commands/SendValue.cs
+++ b/src/Microsoft.DotNet.Interactive/Commands/SendValue.cs
@@ -24,7 +24,7 @@ public class SendValue : KernelCommand
         FormattedValue = formattedValue;
     }
 
-    public FormattedValue FormattedValue { get; }
+    public FormattedValue FormattedValue { get; internal set; }
 
     public string Name { get; }
 

--- a/src/Microsoft.DotNet.Interactive/Commands/SendValue.cs
+++ b/src/Microsoft.DotNet.Interactive/Commands/SendValue.cs
@@ -24,7 +24,7 @@ public class SendValue : KernelCommand
         FormattedValue = formattedValue;
     }
 
-    public FormattedValue FormattedValue { get; internal set; }
+    public FormattedValue FormattedValue { get; }
 
     public string Name { get; }
 

--- a/src/Microsoft.DotNet.Interactive/JavaScriptKernel.cs
+++ b/src/Microsoft.DotNet.Interactive/JavaScriptKernel.cs
@@ -2,39 +2,50 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Connection;
+using Microsoft.DotNet.Interactive.Events;
+using Microsoft.DotNet.Interactive.ValueSharing;
 
-namespace Microsoft.DotNet.Interactive
+namespace Microsoft.DotNet.Interactive;
+
+public class JavaScriptKernel :
+    Kernel,
+    IKernelCommandHandler<SubmitCode>,
+    IKernelCommandHandler<SendValue>
 {
-    public class JavaScriptKernel :
-        Kernel,
-        IKernelCommandHandler<SubmitCode>
+    private readonly KernelClientBase _client;
+    public const string DefaultKernelName = "javascript";
+
+    public JavaScriptKernel(KernelClientBase client = null) : base(DefaultKernelName)
     {
-        private readonly KernelClientBase _client;
-        public const string DefaultKernelName = "javascript";
+        _client = client;
+    }
 
-        public JavaScriptKernel(KernelClientBase client = null) : base(DefaultKernelName)
-        {
-            _client = client;
-        }
+    Task IKernelCommandHandler<SubmitCode>.HandleAsync(
+        SubmitCode command,
+        KernelInvocationContext context)
+    {
+        return FrontendEnvironment.ExecuteClientScript(command.Code, context);
+    }
 
-        Task IKernelCommandHandler<SubmitCode>.HandleAsync(
-            SubmitCode command,
-            KernelInvocationContext context)
-        {
-            return FrontendEnvironment.ExecuteClientScript(command.Code, context);
-        }
+    protected override Func<TCommand, KernelInvocationContext, Task> CreateDefaultHandlerForCommandType<TCommand>()
+    {
+        return (kernelCommand, _) => ForwardCommand(kernelCommand);
+    }
 
-        protected override Func<TCommand, KernelInvocationContext, Task> CreateDefaultHandlerForCommandType<TCommand>()
-        {
-            return (kernelCommand, _) => ForwardCommand(kernelCommand);
-        }
+    private Task ForwardCommand(KernelCommand command)
+    {
+        return _client?.SendAsync(command) ?? Task.CompletedTask;
+    }
 
-        private Task ForwardCommand(KernelCommand command)
+    public async Task HandleAsync(SendValue command, KernelInvocationContext context)
+    {
+        if (JavaScriptValueDeclarer.TryGetValueDeclaration(command.Value, command.Name, out var code))
         {
-            return _client?.SendAsync(command) ?? Task.CompletedTask;
+            await FrontendEnvironment.ExecuteClientScript(code, context);
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
@@ -210,7 +210,9 @@ namespace Microsoft.DotNet.Interactive
                 if (kernel.ParentKernel is { } composite)
                 {
                     var valueInfos = new ConcurrentQueue<ValueInfosProduced>();
-                    var getValueTasks = composite.ChildKernels.Where(k => k.KernelInfo.SupportsCommand(nameof(RequestValueInfos)))
+                    var getValueTasks = composite.ChildKernels.Where(
+                                 k => k != kernel &&
+                                 k.KernelInfo.SupportsCommand(nameof(RequestValueInfos)))
                         .Select(async k =>
                         {
                             var result = await k.SendAsync(new RequestValueInfos());
@@ -237,8 +239,10 @@ namespace Microsoft.DotNet.Interactive
                 if (kernel.ParentKernel is { } composite)
                 {
                     return composite.ChildKernels
-                                    .Where(k => k.KernelInfo.SupportsCommand(nameof(RequestValueInfos)) &&
-                                                k.KernelInfo.SupportsCommand(nameof(RequestValue)))
+                                    .Where(k =>
+                                        k != kernel &&
+                                        k.KernelInfo.SupportsCommand(nameof(RequestValueInfos)) &&
+                                        k.KernelInfo.SupportsCommand(nameof(RequestValue)))
                                     .Select(k => new CompletionItem(k.Name));
                 }
 

--- a/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
@@ -321,13 +321,6 @@ namespace Microsoft.DotNet.Interactive
                             value,
                             valueProduced.FormattedValue));
                 }
-                else if (toKernel.KernelInfo.LanguageName?.ToLowerInvariant() == "javascript")
-                {
-                    if (new JavaScriptValueDeclarer().TryGetValueDeclaration(valueProduced, toName, out var submitCode))
-                    {
-                        await toKernel.SendAsync(submitCode);
-                    }
-                }
                 else
                 {
                     throw new CommandNotSupportedException(typeof(SendValue), toKernel);

--- a/src/Microsoft.DotNet.Interactive/ValueSharing/JavaScriptValueDeclarer.cs
+++ b/src/Microsoft.DotNet.Interactive/ValueSharing/JavaScriptValueDeclarer.cs
@@ -5,7 +5,6 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.DotNet.Interactive.Commands;
-using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Formatting.TabularData;
 
 namespace Microsoft.DotNet.Interactive.ValueSharing;
@@ -34,21 +33,18 @@ internal class JavaScriptValueDeclarer
         };
     }
 
-    public bool TryGetValueDeclaration(
-        ValueProduced valueProduced,
-        string declareAsName,
-        out SubmitCode command)
+    public static bool TryGetValueDeclaration(object referenceValue, string declareAsName, out string code)
     {
-        if (valueProduced.Value is { } value)
+        if (referenceValue is { } value)
         {
-            var code = $"{valueProduced.Name} = {JsonSerializer.Serialize(value, _serializerOptions)};";
-            command = new SubmitCode(code);
+            code = $"{declareAsName} = {JsonSerializer.Serialize(value, _serializerOptions)};";
+            new SubmitCode(code);
             return true;
         }
 
         // FIX: (TryGetValueDeclaration) handle application/json
 
-        command = null;
+        code = null;
         return false;
     }
 }

--- a/src/Microsoft.DotNet.Interactive/ValueSharing/JavaScriptValueDeclarer.cs
+++ b/src/Microsoft.DotNet.Interactive/ValueSharing/JavaScriptValueDeclarer.cs
@@ -38,7 +38,6 @@ internal class JavaScriptValueDeclarer
         if (referenceValue is { } value)
         {
             code = $"{declareAsName} = {JsonSerializer.Serialize(value, _serializerOptions)};";
-            new SubmitCode(code);
             return true;
         }
 

--- a/src/dotnet-interactive/CommandLine/CommandLineParser.cs
+++ b/src/dotnet-interactive/CommandLine/CommandLineParser.cs
@@ -356,7 +356,7 @@ public static class CommandLineParser
                         else
                         {
                             kernel.Add(
-                                new JavaScriptKernel(clientSideKernelClient),
+                                new JavaScriptKernel(clientSideKernelClient).UseValueSharing(),
                                 new[] { "js" });
                         }
 

--- a/src/microsoft-dotnet-interactive/src/javascriptKernel.ts
+++ b/src/microsoft-dotnet-interactive/src/javascriptKernel.ts
@@ -16,8 +16,27 @@ export class JavascriptKernel extends Kernel {
         this.registerCommandHandler({ commandType: contracts.SubmitCodeType, handle: invocation => this.handleSubmitCode(invocation) });
         this.registerCommandHandler({ commandType: contracts.RequestValueInfosType, handle: invocation => this.handleRequestValueInfos(invocation) });
         this.registerCommandHandler({ commandType: contracts.RequestValueType, handle: invocation => this.handleRequestValue(invocation) });
+        this.registerCommandHandler({ commandType: contracts.SendValueType, handle: invocation => this.handleSendValue(invocation) });
 
         this.capture = new ConsoleCapture();
+    }
+
+    private handleSendValue(invocation: IKernelCommandInvocation): Promise<void> {
+        const sendValue = <contracts.SendValue>invocation.commandEnvelope.command;
+        if (sendValue.formattedValue) {
+            switch (sendValue.formattedValue.mimeType) {
+                case 'application/json':
+                    (<any>globalThis)[sendValue.name] = JSON.parse(sendValue.formattedValue.value);
+                    break;
+                case 'text/plain':
+                    (<any>globalThis)[sendValue.name] = sendValue.formattedValue.value;
+                    break;
+                default:
+                    throw new Error(`mimetype ${sendValue.formattedValue.mimeType} not supported`);
+            }
+            return Promise.resolve();
+        }
+        throw new Error("formattedValue is required");
     }
 
     private async handleSubmitCode(invocation: IKernelCommandInvocation): Promise<void> {
@@ -73,7 +92,7 @@ export class JavascriptKernel extends Kernel {
         return Promise.resolve();
     }
 
-    private allLocalVariableNames(): string[] {
+    public allLocalVariableNames(): string[] {
         const result: string[] = [];
         try {
             for (const key in globalThis) {
@@ -92,7 +111,7 @@ export class JavascriptKernel extends Kernel {
         return result;
     }
 
-    private getLocalVariable(name: string): any {
+    public getLocalVariable(name: string): any {
         return (<any>globalThis)[name];
     }
 }

--- a/src/microsoft-dotnet-interactive/src/javascriptKernel.ts
+++ b/src/microsoft-dotnet-interactive/src/javascriptKernel.ts
@@ -28,9 +28,6 @@ export class JavascriptKernel extends Kernel {
                 case 'application/json':
                     (<any>globalThis)[sendValue.name] = JSON.parse(sendValue.formattedValue.value);
                     break;
-                case 'text/plain':
-                    (<any>globalThis)[sendValue.name] = sendValue.formattedValue.value;
-                    break;
                 default:
                     throw new Error(`mimetype ${sendValue.formattedValue.mimeType} not supported`);
             }

--- a/src/microsoft-dotnet-interactive/src/javascriptKernel.ts
+++ b/src/microsoft-dotnet-interactive/src/javascriptKernel.ts
@@ -11,7 +11,7 @@ export class JavascriptKernel extends Kernel {
     private capture: ConsoleCapture;
 
     constructor(name?: string) {
-        super(name ?? "javascript", "Javascript");
+        super(name ?? "javascript", "JavaScript");
         this.suppressedLocals = new Set<string>(this.allLocalVariableNames());
         this.registerCommandHandler({ commandType: contracts.SubmitCodeType, handle: invocation => this.handleSubmitCode(invocation) });
         this.registerCommandHandler({ commandType: contracts.RequestValueInfosType, handle: invocation => this.handleRequestValueInfos(invocation) });

--- a/src/microsoft-dotnet-interactive/tests/frontEndHost.test.ts
+++ b/src/microsoft-dotnet-interactive/tests/frontEndHost.test.ts
@@ -89,7 +89,8 @@ describe("frontEndHost", () => {
                         [{ name: 'RequestKernelInfo' },
                         { name: 'SubmitCode' },
                         { name: 'RequestValueInfos' },
-                        { name: 'RequestValue' }],
+                        { name: 'RequestValue' },
+                        { name: 'SendValue' }],
                     uri: 'kernel://testKernel/javascript'
                 }
             },

--- a/src/microsoft-dotnet-interactive/tests/frontEndHost.test.ts
+++ b/src/microsoft-dotnet-interactive/tests/frontEndHost.test.ts
@@ -81,7 +81,7 @@ describe("frontEndHost", () => {
                 kernelInfo:
                 {
                     aliases: ['js'],
-                    languageName: 'Javascript',
+                    languageName: 'JavaScript',
                     languageVersion: undefined,
                     localName: 'javascript',
                     supportedDirectives: [],

--- a/src/microsoft-dotnet-interactive/tests/javascriptKernel.test.ts
+++ b/src/microsoft-dotnet-interactive/tests/javascriptKernel.test.ts
@@ -26,6 +26,51 @@ describe("javascriptKernel", () => {
         expect(events.find(e => e.eventType === contracts.CommandSucceededType)).to.not.be.undefined;
     });
 
+    it("can handle SendValue with application/json", async () => {
+        let events: contracts.KernelEventEnvelope[] = [];
+        const kernel = new JavascriptKernel();
+        kernel.subscribeToKernelEvents((e) => {
+            events.push(e);
+        });
+
+        await kernel.send({
+            commandType: contracts.SendValueType, command: <contracts.SendValue>{
+                formattedValue: {
+                    value: JSON.stringify({ a: 1 }),
+                    mimeType: "application/json",
+                },
+                name: "x0"
+            }
+        });
+
+        expect(events.find(e => e.eventType === contracts.CommandSucceededType)).to.not.be.undefined;
+        let value: any = kernel.getLocalVariable("x0");
+        expect(value).to.deep.equal({ a: 1 });
+    });
+
+
+    it("can handle SendValue with text/plain", async () => {
+        let events: contracts.KernelEventEnvelope[] = [];
+        const kernel = new JavascriptKernel();
+        kernel.subscribeToKernelEvents((e) => {
+            events.push(e);
+        });
+
+        await kernel.send({
+            commandType: contracts.SendValueType, command: <contracts.SendValue>{
+                formattedValue: {
+                    value: "string value",
+                    mimeType: "text/plain",
+                },
+                name: "x1"
+            }
+        });
+
+        expect(events.find(e => e.eventType === contracts.CommandSucceededType)).to.not.be.undefined;
+        let value: any = kernel.getLocalVariable("x1");
+        expect(value).to.deep.equal("string value");
+    });
+
     it("does not return built-in values from RequestValueInfos", async () => {
         const events: contracts.KernelEventEnvelope[] = [];
         const kernel = new JavascriptKernel();

--- a/src/microsoft-dotnet-interactive/tests/javascriptKernel.test.ts
+++ b/src/microsoft-dotnet-interactive/tests/javascriptKernel.test.ts
@@ -48,29 +48,6 @@ describe("javascriptKernel", () => {
         expect(value).to.deep.equal({ a: 1 });
     });
 
-
-    it("can handle SendValue with text/plain", async () => {
-        let events: contracts.KernelEventEnvelope[] = [];
-        const kernel = new JavascriptKernel();
-        kernel.subscribeToKernelEvents((e) => {
-            events.push(e);
-        });
-
-        await kernel.send({
-            commandType: contracts.SendValueType, command: <contracts.SendValue>{
-                formattedValue: {
-                    value: "string value",
-                    mimeType: "text/plain",
-                },
-                name: "x1"
-            }
-        });
-
-        expect(events.find(e => e.eventType === contracts.CommandSucceededType)).to.not.be.undefined;
-        let value: any = kernel.getLocalVariable("x1");
-        expect(value).to.deep.equal("string value");
-    });
-
     it("does not return built-in values from RequestValueInfos", async () => {
         const events: contracts.KernelEventEnvelope[] = [];
         const kernel = new JavascriptKernel();

--- a/src/microsoft-dotnet-interactive/tests/kernelInfo.test.ts
+++ b/src/microsoft-dotnet-interactive/tests/kernelInfo.test.ts
@@ -35,7 +35,8 @@ describe("kernelInfo", () => {
                     [{ name: 'RequestKernelInfo' },
                     { name: 'SubmitCode' },
                     { name: 'RequestValueInfos' },
-                    { name: 'RequestValue' }]
+                    { name: 'RequestValue' },
+                    { name: 'SendValue' }]
             },
             {
                 aliases: ['child2Js'],
@@ -47,7 +48,8 @@ describe("kernelInfo", () => {
                     [{ name: 'RequestKernelInfo' },
                     { name: 'SubmitCode' },
                     { name: 'RequestValueInfos' },
-                    { name: 'RequestValue' }]
+                    { name: 'RequestValue' },
+                    { name: 'SendValue' }]
             }]);
         });
 
@@ -91,12 +93,11 @@ describe("kernelInfo", () => {
                         localName: 'child1',
                         supportedDirectives: [],
                         supportedKernelCommands:
-                            [
-                                { name: 'RequestKernelInfo' },
-                                { name: 'SubmitCode' },
-                                { name: 'RequestValueInfos' },
-                                { name: 'RequestValue' }
-                            ]
+                            [{ name: 'RequestKernelInfo' },
+                            { name: 'SubmitCode' },
+                            { name: 'RequestValueInfos' },
+                            { name: 'RequestValue' },
+                            { name: 'SendValue' }]
                     }
                 },
                 eventType: 'KernelInfoProduced'
@@ -289,7 +290,8 @@ describe("kernelInfo", () => {
                     { name: 'RequestKernelInfo' },
                     { name: 'SubmitCode' },
                     { name: 'RequestValueInfos' },
-                    { name: 'RequestValue' }
+                    { name: 'RequestValue' },
+                    { name: 'SendValue' }
                 ]);
         });
 
@@ -332,6 +334,7 @@ describe("kernelInfo", () => {
                 { name: 'SubmitCode' },
                 { name: 'RequestValueInfos' },
                 { name: 'RequestValue' },
+                { name: 'SendValue' },
                 { name: 'TestCommand1' },
                 { name: 'TestCommand2' },
                 { name: 'TestCommand3' }]);

--- a/src/microsoft-dotnet-interactive/tests/kernelInfo.test.ts
+++ b/src/microsoft-dotnet-interactive/tests/kernelInfo.test.ts
@@ -27,7 +27,7 @@ describe("kernelInfo", () => {
             expect(kernelInfos.length).to.equal(2);
             expect(kernelInfos).to.deep.equal([{
                 aliases: ['child1Js'],
-                languageName: 'Javascript',
+                languageName: 'JavaScript',
                 languageVersion: undefined,
                 localName: 'child1',
                 supportedDirectives: [],
@@ -40,7 +40,7 @@ describe("kernelInfo", () => {
             },
             {
                 aliases: ['child2Js'],
-                languageName: 'Javascript',
+                languageName: 'JavaScript',
                 languageVersion: undefined,
                 localName: 'child2',
                 supportedDirectives: [],
@@ -88,7 +88,7 @@ describe("kernelInfo", () => {
                     kernelInfo:
                     {
                         aliases: ['child1Js'],
-                        languageName: 'Javascript',
+                        languageName: 'JavaScript',
                         languageVersion: undefined,
                         localName: 'child1',
                         supportedDirectives: [],
@@ -303,7 +303,7 @@ describe("kernelInfo", () => {
             await kernel.send({ commandType: contracts.RequestKernelInfoType, command: {} });
             sub.dispose();
             const kernelInfoProduced = <contracts.KernelInfoProduced>events.find(e => e.eventType === contracts.KernelInfoProducedType)?.event;
-            expect(kernelInfoProduced?.kernelInfo.languageName).to.equal("Javascript");
+            expect(kernelInfoProduced?.kernelInfo.languageName).to.equal("JavaScript");
 
         });
 


### PR DESCRIPTION
Value sharing is now handled on the js kernel
![image](https://user-images.githubusercontent.com/375556/196279418-6fed962d-fdf1-4191-9bf5-59a518c30e71.png)


the kernel with `#!share` is not listed as a completion for the `--from` option
<img width="654" alt="image" src="https://user-images.githubusercontent.com/375556/196279371-a39fa270-e0b6-481d-91fc-a00fcd4754cd.png">
