### PR TITLE
show help page if dotnet sdk version is insufficient

### DIFF
--- a/src/dotnet-interactive-vscode-common/src/extension.ts
+++ b/src/dotnet-interactive-vscode-common/src/extension.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import * as contracts from './dotnet-interactive/contracts';
+import * as helpService from './helpService';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -87,17 +88,23 @@ export async function activate(context: vscode.ExtensionContext) {
     registerAcquisitionCommands(context, diagnosticsChannel);
 
     // check sdk version
+    let showHelpPage = false;
     try {
         const dotnetVersion = await getDotNetVersionOrThrow(DotNetPathManager.getDotNetPath(), diagnosticsChannel);
         if (!isVersionSufficient(dotnetVersion, minDotNetSdkVersion)) {
+            showHelpPage = true;
             const message = `The .NET SDK version ${dotnetVersion} is not sufficient. The minimum required version is ${minDotNetSdkVersion}.`;
             diagnosticsChannel.appendLine(message);
             vscode.window.showErrorMessage(message);
-            throw new Error(message);
         }
     } catch (e) {
+        showHelpPage = true;
         vscode.window.showErrorMessage(`Please install the .NET SDK version ${minDotNetSdkVersion} from https://dotnet.microsoft.com/en-us/download`);
-        throw e;
+    }
+
+    if (showHelpPage) {
+        const helpServiceInstance = new helpService.HelpService(context);
+        await helpServiceInstance.showHelpPageAndThrow(helpService.DotNetVersion);
     }
 
     async function kernelChannelCreator(notebookUri: vscodeLike.Uri): Promise<KernelCommandAndEventChannel> {

--- a/src/dotnet-interactive-vscode-common/src/helpService.ts
+++ b/src/dotnet-interactive-vscode-common/src/helpService.ts
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+export const DotNetVersion = 'DotNetVersion';
+
+export type HelpPage =
+    typeof DotNetVersion;
+
+export class HelpService {
+    constructor(private readonly context: vscode.ExtensionContext) {
+    }
+
+    async showHelpPageAndThrow(page: HelpPage): Promise<void> {
+        const helpPagePath = getHelpPagePath(this.context, page);
+        const helpPageUri = vscode.Uri.file(helpPagePath);
+        await vscode.commands.executeCommand('markdown.showPreview', helpPageUri);
+        throw new Error('Error activating extension, see the displayed help page for more details.');
+    }
+}
+
+function getHelpPagePath(context: vscode.ExtensionContext, page: HelpPage) {
+    const basePath = path.join(context.extensionPath, 'help');
+    const helpPagePath = path.join(basePath, `${page}.md`);
+    return helpPagePath;
+}

--- a/src/dotnet-interactive-vscode-insiders/help/DotNetVersion.md
+++ b/src/dotnet-interactive-vscode-insiders/help/DotNetVersion.md
@@ -1,0 +1,4 @@
+Install supported dotnet SDK
+============================
+
+The Polyglot Notebok extension requires the dotnet SDK version 7.0 or later, and it can be installed from [here](https://dotnet.microsoft.com/en-us/download).  Once installed please restart VS Code.

--- a/src/dotnet-interactive-vscode-insiders/help/DotNetVersion.md
+++ b/src/dotnet-interactive-vscode-insiders/help/DotNetVersion.md
@@ -1,4 +1,6 @@
-Install supported dotnet SDK
-============================
+# .NET 7 SDK **REQUIRED**
 
-The Polyglot Notebok extension requires the dotnet SDK version 7.0 or later, and it can be installed from [here](https://dotnet.microsoft.com/en-us/download).  Once installed please restart VS Code.
+## The Polyglot Notebooks extension now requires .NET SDK Version 7.0 or higher.
+
+## 1. Install [here](https://dotnet.microsoft.com/en-us/download)
+## 2. Restart VS Code

--- a/src/dotnet-interactive-vscode/UPDATING-TO-NEW-VERSION-OF-STABLE.md
+++ b/src/dotnet-interactive-vscode/UPDATING-TO-NEW-VERSION-OF-STABLE.md
@@ -2,17 +2,18 @@ Updating to new version of stable
 =================================
 
 1. Copy `<root>/src/dotnet-interactive-vscode-insiders/package.json` to `<root>/src/dotnet-interactive-vscode/`
-2. Copy `<root>/src/dotnet-interactive-vscode-insiders/src/*` to `<root>/src/dotnet-interactive-vscode/src/` **EXCEPT** for the `vscode-common` symlinked directory.
-3. Increment verion number in `vscodeStableVersion.txt` to match the upcoming stable release of VS Code.
-4. `.\update-api.ps1`
-5. `.\update-versions.ps1 -updateAll`
-6. For each directory:
+2. Copy `<root>/src/dotnet-interactive-vscode-insiders/help/*` to `<root>/src/dotnet-interactive-vscode/help/`
+3. Copy `<root>/src/dotnet-interactive-vscode-insiders/src/*` to `<root>/src/dotnet-interactive-vscode/src/` **EXCEPT** for the `vscode-common` symlinked directory.
+4. Increment verion number in `vscodeStableVersion.txt` to match the upcoming stable release of VS Code.
+5. `.\update-api.ps1`
+6. `.\update-versions.ps1 -updateAll`
+7. For each directory:
    - `<root>/src/dotnet-interactive-vscode`
    - `<root>/src/dotnet-interactive-vscode-insiders`
      - `npm i`
      - `npm run compile`
      - `npm run test`
-7. `git add .`, `git commit`
+8. `git add .`, `git commit`
 
 Validating
 ==========

--- a/src/dotnet-interactive-vscode/help/DotNetVersion.md
+++ b/src/dotnet-interactive-vscode/help/DotNetVersion.md
@@ -1,0 +1,4 @@
+Install supported dotnet SDK
+============================
+
+The Polyglot Notebok extension requires the dotnet SDK version 7.0 or later, and it can be installed from [here](https://dotnet.microsoft.com/en-us/download).  Once installed please restart VS Code.

--- a/src/dotnet-interactive-vscode/help/DotNetVersion.md
+++ b/src/dotnet-interactive-vscode/help/DotNetVersion.md
@@ -1,4 +1,6 @@
-Install supported dotnet SDK
-============================
+# .NET 7 SDK **REQUIRED**
 
-The Polyglot Notebok extension requires the dotnet SDK version 7.0 or later, and it can be installed from [here](https://dotnet.microsoft.com/en-us/download).  Once installed please restart VS Code.
+## The Polyglot Notebooks extension now requires .NET SDK Version 7.0 or higher.
+
+## 1. Install [here](https://dotnet.microsoft.com/en-us/download)
+## 2. Restart VS Code


### PR DESCRIPTION
If the user's SDK version wasn't sufficient an error toast is shown indicating that, but it can go unnoticed and isn't really actionable.  This PR will show a rendered markdown file that is more visible, has more information, and has actionable links.  Eventually this feature can be expanded to include a host of various fixes.

This will be particularly useful given that we're about to ship a version of the extension that will require a newer SDK.

Example:
<img width="764" alt="image" src="https://user-images.githubusercontent.com/926281/202799987-8d817cda-78dc-4fe5-9ae1-c9aef552bdaf.png">

Future work will be to detect multiple different issues and dynamically build a help page that can be used as a check list, but since the only issue we currently detect is a bad SDK, I opted to not add that complexity just yet.
