### PR TITLE
update docker files to use dotnet 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/base-notebook:ubuntu-20.04
+FROM jupyter/base-notebook:ubuntu-22.04
 
 # Install .NET CLI dependencies
 
@@ -30,27 +30,19 @@ RUN apt-get update \
   libc6 \
   libgcc1 \
   libgssapi-krb5-2 \
-  libicu66 \
-  libssl1.1 \
+  libicu70 \
+  libssl3 \
   libstdc++6 \
   zlib1g \
   && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core SDK
+# Install the appropriate dotnet SDK
+ENV DOTNET_SDK_VERSION 7.0.100
+RUN curl -L https://dot.net/v1/dotnet-install.sh | bash -e -s -- --install-dir /usr/share/dotnet --version $DOTNET_SDK_VERSION \
+  && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
-# When updating the SDK version, the sha512 value a few lines down must also be updated.
-ENV DOTNET_SDK_VERSION 6.0.100
-
-RUN dotnet_sdk_version=6.0.100 \
-  && curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-  && dotnet_sha512='cb0d174a79d6294c302261b645dba6a479da8f7cf6c1fe15ae6998bc09c5e0baec810822f9e0104e84b0efd51fdc0333306cb2a0a6fcdbaf515a8ad8cf1af25b' \
-  && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
-  && mkdir -p /usr/share/dotnet \
-  && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
-  && rm dotnet.tar.gz \
-  && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-  # Trigger first run experience by running arbitrary cmd
-  && dotnet help
+# Trigger first run experience by running arbitrary command
+RUN dotnet help
 
 # Copy notebooks
 COPY ./samples/notebooks/ ${HOME}/Notebooks/
@@ -82,7 +74,7 @@ USER ${USER}
 RUN pip install nteract_on_jupyter
 
 # Install lastest build of Microsoft.DotNet.Interactive
-RUN dotnet tool install -g Microsoft.dotnet-interactive --add-source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json"
+RUN dotnet tool install -g Microsoft.dotnet-interactive --add-source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
 
 ENV PATH="${PATH}:${HOME}/.dotnet/tools"
 RUN echo "$PATH"

--- a/samples/my binder/Dockerfile
+++ b/samples/my binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/base-notebook:ubuntu-20.04
+FROM jupyter/base-notebook:ubuntu-22.04
 
 # Install .NET CLI dependencies
 
@@ -30,27 +30,19 @@ RUN apt-get update \
   libc6 \
   libgcc1 \
   libgssapi-krb5-2 \
-  libicu66 \
-  libssl1.1 \
+  libicu70 \
+  libssl3 \
   libstdc++6 \
   zlib1g \
   && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core SDK
+# Install the appropriate dotnet SDK
+ENV DOTNET_SDK_VERSION 7.0.100
+RUN curl -L https://dot.net/v1/dotnet-install.sh | bash -e -s -- --install-dir /usr/share/dotnet --version $DOTNET_SDK_VERSION \
+  && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
-# When updating the SDK version, the sha512 value a few lines down must also be updated.
-ENV DOTNET_SDK_VERSION 6.0.100
-
-RUN dotnet_sdk_version=6.0.100 \
-  && curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-  && dotnet_sha512='cb0d174a79d6294c302261b645dba6a479da8f7cf6c1fe15ae6998bc09c5e0baec810822f9e0104e84b0efd51fdc0333306cb2a0a6fcdbaf515a8ad8cf1af25b' \
-  && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
-  && mkdir -p /usr/share/dotnet \
-  && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
-  && rm dotnet.tar.gz \
-  && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-  # Trigger first run experience by running arbitrary cmd
-  && dotnet help
+# Trigger first run experience by running arbitrary command
+RUN dotnet help
 
 # Copy notebooks
 
@@ -84,7 +76,7 @@ USER ${USER}
 RUN pip install nteract_on_jupyter
 
 # Install lastest build of Microsoft.DotNet.Interactive
-RUN dotnet tool install -g Microsoft.dotnet-interactive --add-source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json"
+RUN dotnet tool install -g Microsoft.dotnet-interactive --add-source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
 
 # Latest stable from nuget.org
 #RUN dotnet tool install -g Microsoft.dotnet-interactive --add-source "https://api.nuget.org/v3/index.json"


### PR DESCRIPTION
Since we're now producing dotnet 7 assemblies, we need to update the docker files.  We're also switching to use the semi-official `dotnet-install.sh` because it handles a bunch of stuff for us.