### PR TITLE
move test retry logic into separate script

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -132,9 +132,11 @@ stages:
             TRYDOTNET_PACKAGES_PATH: $(TryDotNetPackagesPath)
             DOTNET_INTERACTIVE_FRONTEND_NAME: CI
 
-        - script: dotnet test -l trx --no-build --blame-hang-timeout 15m --blame-hang-dump-type full --blame-crash -c $(_BuildConfig) --results-directory $(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)
+        - pwsh: ./test-retry-runner.ps1 -buildConfig $env:BUILDCONFIG
           displayName: Test / Blame
           workingDirectory: $(Build.SourcesDirectory)
+          env:
+            BUILDCONFIG: $(_BuildConfig)
           condition: ne(variables['SkipTests'], 'true')
 
         - pwsh: Get-ChildItem *.dmp -Recurse | Remove-Item
@@ -277,107 +279,11 @@ stages:
             TRYDOTNET_PACKAGES_PATH: $(TryDotNetPackagesPath)
             DOTNET_INTERACTIVE_FRONTEND_NAME: CI
 
-        - pwsh: |
-            $retryCount = 5
-            $normalTestAssemblies = @(
-              "Microsoft.DotNet.Interactive.ApiCompatibility.Tests",
-              "Microsoft.DotNet.Interactive.AspNetCore.Tests",
-              "Microsoft.DotNet.Interactive.Browser.Tests",
-              "Microsoft.DotNet.Interactive.CSharp.Tests",
-              "Microsoft.DotNet.Interactive.CSharpProject.Tests",
-              "Microsoft.DotNet.Interactive.Documents.Tests",
-              "Microsoft.DotNet.Interactive.ExtensionLab.Tests",
-              "Microsoft.DotNet.Interactive.FSharp.Tests",
-              "Microsoft.DotNet.Interactive.Formatting.Tests",
-              "Microsoft.DotNet.Interactive.Journey.Tests",
-              "Microsoft.DotNet.Interactive.Jupyter.Tests",
-              "Microsoft.DotNet.Interactive.Kql.Tests",
-              "Microsoft.DotNet.Interactive.Mermaid.Tests",
-              "Microsoft.DotNet.Interactive.PowerShell.Tests",
-              "Microsoft.DotNet.Interactive.SqlServer.Tests",
-              "Microsoft.DotNet.Interactive.Telemetry.Tests",
-              "dotnet-interactive.Tests"
-            )
-            foreach ($testAssembly in $normalTestAssemblies) {
-              for ($i=1; $i -le $retryCount; $i++) {
-                Write-Host "Testing assembly $testAssembly, attempt $i"
-                dotnet test $env:BUILDSOURCESDIRECTORY/src/$testAssembly/ -l trx --no-build --blame-hang-timeout 15m --blame-hang-dump-type full --blame-crash -c $env:BUILDCONFIG --results-directory $env:BUILDSOURCESDIRECTORY/artifacts/TestResults/$env:BUILDCONFIG
-                if ($LASTEXITCODE -eq 0) {
-                  break
-                }
-              }
-              if ($LASTEXITCODE -ne 0) {
-                exit $LASTEXITCODE
-              }
-            }
-
-            #
-            # this one frequently crashes; running tests one class at a time
-            #
-            $flakyTestAssembly = "Microsoft.DotNet.Interactive.Tests"
-            $testClasses = @(
-              "Microsoft.DotNet.Interactive.Tests.CompositeKernelTests",
-              "Microsoft.DotNet.Interactive.Tests.ConnectDirectiveTests",
-              "Microsoft.DotNet.Interactive.Tests.DataExplorerTests",
-              "Microsoft.DotNet.Interactive.Tests.DirectiveTests",
-              "Microsoft.DotNet.Interactive.Tests.HtmlKernelTests",
-              "Microsoft.DotNet.Interactive.Tests.ImportantNotebookTests",
-              "Microsoft.DotNet.Interactive.Tests.InputsWithinMagicCommandsTests",
-              "Microsoft.DotNet.Interactive.Tests.JavaScriptKernelTests",
-              "Microsoft.DotNet.Interactive.Tests.KernelCommandNestingTests",
-              "Microsoft.DotNet.Interactive.Tests.KernelExtensionsTests",
-              "Microsoft.DotNet.Interactive.Tests.KernelInfoTests",
-              "Microsoft.DotNet.Interactive.Tests.KernelInvocationContextTests",
-              "Microsoft.DotNet.Interactive.Tests.KernelRoutingTests",
-              "Microsoft.DotNet.Interactive.Tests.KernelSchedulerTests",
-              "Microsoft.DotNet.Interactive.Tests.KernelTests",
-              "Microsoft.DotNet.Interactive.Tests.KeyValueStoreKernelTests",
-              "Microsoft.DotNet.Interactive.Tests.LanguageKernelAssemblyReferenceTests",
-              "Microsoft.DotNet.Interactive.Tests.LanguageKernelExtensionLoadingTests",
-              "Microsoft.DotNet.Interactive.Tests.LanguageKernelFormattingTests",
-              "Microsoft.DotNet.Interactive.Tests.LanguageKernelPackageTests",
-              "Microsoft.DotNet.Interactive.Tests.LanguageKernelScriptReferenceTests",
-              "Microsoft.DotNet.Interactive.Tests.LanguageKernelTests",
-              "Microsoft.DotNet.Interactive.Tests.LogDirectiveTests",
-              "Microsoft.DotNet.Interactive.Tests.NamedPipeConnectionTests",
-              "Microsoft.DotNet.Interactive.Tests.PackageReferenceTests",
-              "Microsoft.DotNet.Interactive.Tests.PackageRestoreContextTests",
-              "Microsoft.DotNet.Interactive.Tests.QuitCommandTests",
-              "Microsoft.DotNet.Interactive.Tests.SqlDiscoverabilityKernelTests",
-              "Microsoft.DotNet.Interactive.Tests.VariableSharingTests",
-              "Microsoft.DotNet.Interactive.Tests.VariableSharingWithinMagicCommandsTests",
-              "Microsoft.DotNet.Interactive.Tests.Connection.KernelCommandAndEventSenderTests",
-              "Microsoft.DotNet.Interactive.Tests.Connection.KernelCommandEnvelopeTests",
-              "Microsoft.DotNet.Interactive.Tests.Connection.KernelEventEnvelopeTests",
-              "Microsoft.DotNet.Interactive.Tests.Connection.KernelHostTests",
-              "Microsoft.DotNet.Interactive.Tests.Connection.ObservableCommandAndEventReceiverTests",
-              "Microsoft.DotNet.Interactive.Tests.Connection.SerializationTests",
-              "Microsoft.DotNet.Interactive.Tests.Connection.TokenTests",
-              "Microsoft.DotNet.Interactive.Tests.LanguageServices.CompletionTests",
-              "Microsoft.DotNet.Interactive.Tests.LanguageServices.HoverTextTests",
-              "Microsoft.DotNet.Interactive.Tests.LanguageServices.SignatureHelpTests",
-              "Microsoft.DotNet.Interactive.Tests.Parsing.DirectiveTokenTests",
-              "Microsoft.DotNet.Interactive.Tests.Parsing.SubmissionParserTests",
-              "Microsoft.DotNet.Interactive.Tests.Utility.AsyncContextTests",
-              "Microsoft.DotNet.Interactive.Tests.Utility.MultiplexingTextWriterTests",
-              "Microsoft.DotNet.Interactive.Tests.Utility.UtilityTests"
-            )
-            foreach ($testClass in $testClasses) {
-              for ($i=1; $i -le $retryCount; $i++) {
-                Write-Host "Testing assembly $flakyTestAssembly::$testClass, attempt $i"
-                dotnet test $env:BUILDSOURCESDIRECTORY/src/$flakyTestAssembly/ --filter FullyQualifiedName~$testClass -l trx --no-build --blame-hang-timeout 15m --blame-hang-dump-type full --blame-crash -c $env:BUILDCONFIG --results-directory $env:BUILDSOURCESDIRECTORY/artifacts/TestResults/$env:BUILDCONFIG
-                if ($LASTEXITCODE -eq 0) {
-                  break
-                }
-              }
-            }
-
-            exit $LASTEXITCODE
+        - pwsh: ./test-retry-runner.ps1 -buildConfig $env:BUILDCONFIG
           displayName: Test / Blame
           workingDirectory: $(Build.SourcesDirectory)
           env:
             BUILDCONFIG: $(_BuildConfig)
-            BUILDSOURCESDIRECTORY: $(Build.SourcesDirectory)
           condition: ne(variables['SkipTests'], 'true')
 
         - pwsh: Get-ChildItem *.dmp -Recurse | Remove-Item

--- a/test-retry-runner.ps1
+++ b/test-retry-runner.ps1
@@ -1,0 +1,58 @@
+[CmdletBinding(PositionalBinding = $false)]
+param (
+    [int]$retryCount = 5,
+    [string]$buildConfig = "Debug"
+)
+
+Set-StrictMode -version 2.0
+$ErrorActionPreference = "Stop"
+
+function ExecuteTestDirectory([string]$testDirectory, [string]$extraArgs = "") {
+    $testCommand = "dotnet test $testDirectory/ $extraArgs -l trx --no-restore --no-build --blame-hang-timeout 15m --blame-hang-dump-type full --blame-crash -c $buildConfig --results-directory $repoRoot/artifacts/TestResults/$buildConfig"
+    Write-Host "Executing $testCommand"
+    Invoke-Expression $testCommand
+}
+
+try {
+    $repoRoot = Resolve-Path $PSScriptRoot
+    $flakyTestAssemblyDirectory = "Microsoft.DotNet.Interactive.Tests"
+    $normalTestAssemblyDirectories = Get-ChildItem -Path "$repoRoot/src" -Directory -Filter *.Tests -Recurse | Where-Object { $_.Name -ne $flakyTestAssemblyDirectory }
+
+    foreach ($testAssemblyDirectory in $normalTestAssemblyDirectories) {
+        $assemblyName = $testAssemblyDirectory.Name
+        for ($i = 1; $i -le $retryCount; $i++) {
+            Write-Host "Testing assembly $assemblyName, attempt $i"
+            ExecuteTestDirectory -testDirectory $testAssemblyDirectory
+            if ($LASTEXITCODE -eq 0) {
+                break
+            }
+        }
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
+    }
+
+    $testNamePattern = "    ([^(]+)" # skip 4 spaces then get everything that's not a left paren because test names start with 4 spaces and [Theory] tests have a parenthesized argument list
+    $testNames = dotnet test "$repoRoot/src/$flakyTestAssemblyDirectory/" --no-restore --no-build --configuration $buildConfig --list-tests | Select-String -Pattern $testNamePattern | ForEach-Object { $_.Matches[0].Groups[1].Value }
+    $testClasses = $testNames | ForEach-Object { $_.Substring(0, $_.LastIndexOf([char]".")) } # trim off the test name, just get the class
+    $distinctTestClasses = $testClasses | Get-Unique
+
+    foreach ($testClass in $distinctTestClasses) {
+        for ($i = 1; $i -le $retryCount; $i++) {
+            Write-Host "Testing class $testClass, attempt $i"
+            ExecuteTestDirectory -testDirectory "$repoRoot/src/$flakyTestAssemblyDirectory" -extraArgs "--filter FullyQualifiedName~$testClass"
+            if ($LASTEXITCODE -eq 0) {
+                break
+            }
+        }
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
+    }
+}
+catch {
+    Write-Host $_
+    Write-Host $_.Exception
+    Write-Host $_.ScriptStackTrace
+    exit 1
+}


### PR DESCRIPTION
Move test retry stuff into a separate script for easy usage.

Also dynamically detect the list of test classes by calling `dotnet --list-tests`.

Confirmed that all tests were run (in fact, more tests were run than before because new test classes were added.)