### PR TITLE
cache variable explorer rows

### DIFF
--- a/src/dotnet-interactive-vscode-common/src/commands.ts
+++ b/src/dotnet-interactive-vscode-common/src/commands.ts
@@ -144,9 +144,6 @@ export function registerKernelCommands(context: vscode.ExtensionContext, clientM
     context.subscriptions.push(vscode.commands.registerCommand('polyglot-notebook.restartCurrentNotebookKernel', async (notebook?: vscode.NotebookDocument | undefined) => {
         notebook = notebook || getCurrentNotebookDocument();
         if (notebook) {
-            // clear the value explorer view
-            await vscode.commands.executeCommand('polyglot-notebook.clearValueExplorer');
-
             // notifty the client that the kernel is about to restart
             const restartCompletionSource = new PromiseCompletionSource<void>();
             vscode.window.withProgress({
@@ -160,9 +157,6 @@ export function registerKernelCommands(context: vscode.ExtensionContext, clientM
             restartCompletionSource.resolve();
             await vscode.commands.executeCommand('workbench.notebook.layout.webview.reset', notebook.uri);
             vscode.window.showInformationMessage('Kernel restarted.');
-
-            // notify the ValueExplorer that the kernel has restarted
-            await vscode.commands.executeCommand('polyglot-notebook.resetValueExplorerSubscriptions');
         }
     }));
 


### PR DESCRIPTION
Only kernels from which we've seen `CommandSucceeded` (or failed or cancelled) events will ever be queried, and we also cache the values so that on active notebook change we don't re-query everything, we simply regurgitate what we've previously saved.

Fixes #2384.