### PR TITLE
use vscode output append apis where possible

### DIFF
--- a/NotebookTestScript.dib
+++ b/NotebookTestScript.dib
@@ -1,3 +1,7 @@
+#!meta
+
+{"kernelInfo":{"defaultKernelName":"csharp","items":[{"name":"csharp","aliases":["c#","C#"],"languageName":"C#"},{"name":".NET","aliases":[]},{"name":"fsharp","aliases":["f#","F#"],"languageName":"F#"},{"name":"html","aliases":[],"languageName":"HTML"},{"name":"javascript","aliases":["js"],"languageName":"JavaScript"},{"name":"kql","aliases":[],"languageName":"KQL"},{"name":"mermaid","aliases":[],"languageName":"Mermaid"},{"name":"pwsh","aliases":["powershell"],"languageName":"PowerShell"},{"name":"sql","aliases":[],"languageName":"SQL"},{"name":"value","aliases":[]},{"name":"webview","aliases":[]},{"name":"vscode","languageName":null,"aliases":["frontend"]}]}}
+
 #!markdown
 
 # Verify execution count.
@@ -18,6 +22,8 @@ You'll notice a counter that appears and starts incrementing.  After a second or
 5
 Command cancelled
 ```
+
+N.b., the old values (e.g., `1`, `2`, `3`, `4`, etc.) should no longer be displayed, but overwritten.
 
 #!csharp
 
@@ -94,7 +100,7 @@ return kernels;
 1234
 ```
 
-And the `POLYGLOT NOTEBOOK: VALUES` window should contain a variable with name `asdf`, value `1234` and kernel Name `csharp`
+And the `POLYGLOT NOTEBOOK: VARIABLES` window should contain a variable with name `asdf`, value `1234` and kernel Name `csharp`
 
 #!javascript
 
@@ -190,7 +196,7 @@ input.Result
 
 This should prompt you for input.
 
-#!fsharp
+#!value
 
 #!value --from-value @input:wat --name value_from_input
 

--- a/src/dotnet-interactive-vscode-common/src/extension.ts
+++ b/src/dotnet-interactive-vscode-common/src/extension.ts
@@ -40,6 +40,7 @@ import { ActiveNotebookTracker } from './activeNotebookTracker';
 import { onKernelInfoUpdates } from './dotnet-interactive';
 import * as metadataUtilities from './metadataUtilities';
 import * as constants from './constants';
+import { ServiceCollection } from './serviceCollection';
 
 export class CachedDotNetPathManager {
     private dotNetPath: string = 'dotnet'; // default to global tool if possible
@@ -231,6 +232,9 @@ export async function activate(context: vscode.ExtensionContext) {
     registerKernelCommands(context, clientMapper);
     registerVariableExplorer(context, clientMapper);
 
+    ServiceCollection.initialize(context, clientMapper);
+    context.subscriptions.push(new ActiveNotebookTracker(clientMapper));
+
     const hostVersionSuffix = vscodeUtilities.isInsidersBuild() ? 'Insiders' : 'Stable';
     diagnosticsChannel.appendLine(`Extension started for VS Code ${hostVersionSuffix}.`);
     const languageServiceDelay = polyglotConfig.get<number>('languageServiceDelay') || 500; // fall back to something reasonable
@@ -253,7 +257,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(vscode.workspace.onDidRenameFiles(e => handleFileRenames(e, clientMapper)));
     context.subscriptions.push(serializerLineAdapter);
-    context.subscriptions.push(new ActiveNotebookTracker(context, clientMapper));
 
     // rebuild notebook grammar
     const compositeKernelToNotebookUri: Map<CompositeKernel, vscodeLike.Uri> = new Map();

--- a/src/dotnet-interactive-vscode-common/src/interactiveClient.ts
+++ b/src/dotnet-interactive-vscode-common/src/interactiveClient.ts
@@ -58,13 +58,11 @@ import { clearDebounce, createOutput } from './utilities';
 
 import * as vscodeLike from './interfaces/vscode-like';
 import { CompositeKernel } from './dotnet-interactive/compositeKernel';
-import { ProxyKernel } from './dotnet-interactive/proxyKernel';
 import { Guid } from './dotnet-interactive/tokenGenerator';
 import { KernelHost } from './dotnet-interactive/kernelHost';
 import { KernelCommandAndEventChannel } from './DotnetInteractiveChannel';
 import * as connection from './dotnet-interactive/connection';
 import { DisposableSubscription } from './dotnet-interactive/disposables';
-import { Logger } from './dotnet-interactive/logger';
 
 export interface ErrorOutputCreator {
     (message: string, outputId?: string): vscodeLike.NotebookCellOutput;
@@ -82,7 +80,6 @@ export class InteractiveClient {
     private nextToken: number = 1;
     private tokenEventObservers: Map<string, Array<KernelEventEnvelopeObserver>> = new Map<string, Array<KernelEventEnvelopeObserver>>();
     private deferredOutput: Array<vscodeLike.NotebookCellOutput> = [];
-    private valueIdMap: Map<string, { idx: number, outputs: Array<vscodeLike.NotebookCellOutput>, observer: { (outputs: Array<vscodeLike.NotebookCellOutput>): void } }> = new Map<string, { idx: number, outputs: Array<vscodeLike.NotebookCellOutput>, observer: { (outputs: Array<vscodeLike.NotebookCellOutput>): void } }>();
     private _kernel: CompositeKernel;
     private _kernelHost: KernelHost;
     constructor(readonly config: InteractiveClientConfiguration) {
@@ -134,20 +131,15 @@ export class InteractiveClient {
         clearDebounce(`sighelp-${requestId}`);
     }
 
-    execute(source: string, language: string, outputObserver: { (outputs: Array<vscodeLike.NotebookCellOutput>): void }, diagnosticObserver: (diags: Array<Diagnostic>) => void, configuration: { token?: string | undefined, id?: string | undefined } | undefined): Promise<boolean> {
+    execute(source: string, language: string, outputReporter: { (output: vscodeLike.NotebookCellOutput): void }, diagnosticObserver: (diags: Array<Diagnostic>) => void, configuration: { token?: string | undefined, id?: string | undefined } | undefined): Promise<boolean> {
         if (configuration !== undefined && configuration.id !== undefined) {
             this.clearExistingLanguageServiceRequests(configuration.id);
         }
         return new Promise((resolve, reject) => {
             let diagnostics: Array<Diagnostic> = [];
-            let outputs: Array<vscodeLike.NotebookCellOutput> = [];
 
             let reportDiagnostics = () => {
                 diagnosticObserver(diagnostics);
-            };
-
-            let reportOutputs = () => {
-                outputObserver(outputs);
             };
 
             let failureReported = false;
@@ -156,7 +148,9 @@ export class InteractiveClient {
             try {
                 return this.submitCode(source, language, eventEnvelope => {
                     if (this.deferredOutput.length > 0) {
-                        outputs.push(...this.deferredOutput);
+                        for (const output of this.deferredOutput) {
+                            outputReporter(output);
+                        }
                         this.deferredOutput = [];
                     }
 
@@ -172,8 +166,7 @@ export class InteractiveClient {
                             {
                                 const err = <CommandFailed>eventEnvelope.event;
                                 const errorOutput = this.config.createErrorOutput(err.message, this.getNextOutputId());
-                                outputs.push(errorOutput);
-                                reportOutputs();
+                                outputReporter(errorOutput);
                                 failureReported = true;
                                 if (eventEnvelope.command?.id === commandId) {
                                     // only complete this promise if it's the root command
@@ -184,8 +177,7 @@ export class InteractiveClient {
                         case ErrorProducedType: {
                             const err = <ErrorProduced>eventEnvelope.event;
                             const errorOutput = this.config.createErrorOutput(err.message, this.getNextOutputId());
-                            outputs.push(errorOutput);
-                            reportOutputs();
+                            outputReporter(errorOutput);
                             failureReported = true;
                         }
                         case DiagnosticsProducedType:
@@ -198,43 +190,19 @@ export class InteractiveClient {
                         case StandardErrorValueProducedType:
                         case StandardOutputValueProducedType:
                             {
-                                let disp = <DisplayEvent>eventEnvelope.event;
+                                const disp = <DisplayEvent>eventEnvelope.event;
                                 const stream = eventEnvelope.eventType === StandardErrorValueProducedType ? 'stderr' : 'stdout';
-                                let output = this.displayEventToCellOutput(disp, stream);
-                                outputs.push(output);
-                                reportOutputs();
+                                const output = this.displayEventToCellOutput(disp, stream);
+                                outputReporter(output);
                             }
                             break;
                         case DisplayedValueProducedType:
                         case DisplayedValueUpdatedType:
                         case ReturnValueProducedType:
                             {
-                                let disp = <DisplayEvent>eventEnvelope.event;
-                                let output = this.displayEventToCellOutput(disp);
-
-                                if (disp.valueId) {
-                                    let valueId = this.valueIdMap.get(disp.valueId);
-                                    if (valueId !== undefined) {
-                                        // update existing value
-                                        valueId.outputs[valueId.idx] = output;
-                                        valueId.observer(valueId.outputs);
-                                        // don't report through regular channels
-                                        break;
-                                    } else {
-                                        // add new tracked value
-                                        this.valueIdMap.set(disp.valueId, {
-                                            idx: outputs.length,
-                                            outputs,
-                                            observer: outputObserver
-                                        });
-                                        outputs.push(output);
-                                    }
-                                } else {
-                                    // raw value, just push it
-                                    outputs.push(output);
-                                }
-
-                                reportOutputs();
+                                const disp = <DisplayEvent>eventEnvelope.event;
+                                const output = this.displayEventToCellOutput(disp);
+                                outputReporter(output);
                             }
                             break;
                     }
@@ -243,8 +211,7 @@ export class InteractiveClient {
                     if (!failureReported) {
                         const errorMessage = typeof e?.message === 'string' ? <string>e.message : '' + e;
                         const errorOutput = this.config.createErrorOutput(errorMessage, this.getNextOutputId());
-                        outputs.push(errorOutput);
-                        reportOutputs();
+                        outputReporter(errorOutput);
                         reject(e);
                     }
                 });
@@ -491,7 +458,7 @@ export class InteractiveClient {
     private displayEventToCellOutput(disp: DisplayEvent, stream?: 'stdout' | 'stderr'): vscodeLike.NotebookCellOutput {
 
         const encoder = new TextEncoder();
-        let outputItems: Array<vscodeLike.NotebookCellOutputItem> = [];
+        const outputItems: Array<vscodeLike.NotebookCellOutputItem> = [];
         if (disp.formattedValues && disp.formattedValues.length > 0) {
             for (let formatted of disp.formattedValues) {
                 let data = this.IsEncodedMimeType(formatted.mimeType)
@@ -508,7 +475,8 @@ export class InteractiveClient {
             }
         }
 
-        const output = createOutput(outputItems, this.getNextOutputId());
+        const outputId = disp.valueId ?? this.getNextOutputId();
+        const output = createOutput(outputItems, outputId);
         return output;
     }
 

--- a/src/dotnet-interactive-vscode-common/src/notebookWatcherService.ts
+++ b/src/dotnet-interactive-vscode-common/src/notebookWatcherService.ts
@@ -1,0 +1,74 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import * as vscode from 'vscode';
+import { ClientMapper } from './clientMapper';
+import { InteractiveClient } from './interactiveClient';
+import { Disposable, Logger } from './dotnet-interactive';
+
+export type NotebookDelegate = { (notebook: vscode.NotebookDocument, client: InteractiveClient): void };
+
+export class NotebookWatcherService {
+    private notebookOpenDelegates: NotebookDelegate[] = [];
+    private notebookCloseDelegates: NotebookDelegate[] = [];
+
+    constructor(context: vscode.ExtensionContext, clientMapper: ClientMapper) {
+        context.subscriptions.push(vscode.workspace.onDidCloseNotebookDocument(async notebook => {
+            const client = await clientMapper.tryGetClient(notebook.uri);
+            if (client) {
+                // if one of ours...
+                this.notebookDocumentClosed(notebook, client);
+            }
+        }));
+        clientMapper.onClientCreate((uri, client) => {
+            const notebooks = vscode.workspace.notebookDocuments.filter(n => n.uri.fsPath === uri.fsPath);
+            if (notebooks.length === 1) {
+                const notebook = notebooks[0];
+                this.notebookDocumentOpened(notebook, client);
+            } else {
+                Logger.default.error(`Unable to find single notebook for URI ${uri.toString()}`);
+            }
+        });
+    }
+
+    onNotebookDocumentOpened(callback: NotebookDelegate): Disposable {
+        this.notebookOpenDelegates.push(callback);
+        return {
+            dispose: () => {
+                this.notebookOpenDelegates = this.notebookOpenDelegates.filter(d => d !== callback);
+            }
+        };
+    }
+
+    onNotebookDocumentClosed(callback: NotebookDelegate): Disposable {
+        this.notebookCloseDelegates.push(callback);
+        return {
+            dispose: () => {
+                this.notebookCloseDelegates = this.notebookCloseDelegates.filter(d => d !== callback);
+            }
+        };
+    }
+
+    private notebookDocumentOpened(notebook: vscode.NotebookDocument, client: InteractiveClient) {
+        for (const callback of this.notebookOpenDelegates) {
+            try {
+                callback(notebook, client);
+            } catch (e) {
+                Logger.default.error(`Error calling notebook open delegate for ${notebook.uri.toString()}: ${e}`);
+            }
+        }
+    }
+
+    private notebookDocumentClosed(notebook: vscode.NotebookDocument, client: InteractiveClient) {
+        for (const callback of this.notebookCloseDelegates) {
+            try {
+                callback(notebook, client);
+            } catch (e) {
+                Logger.default.error(`Error calling notebook close delegate for ${notebook.uri.toString()}: ${e}`);
+            }
+        }
+    }
+
+    dispose() {
+    }
+}

--- a/src/dotnet-interactive-vscode-common/src/serviceCollection.ts
+++ b/src/dotnet-interactive-vscode-common/src/serviceCollection.ts
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import * as vscode from 'vscode';
+import { ClientMapper } from './clientMapper';
+import { NotebookWatcherService } from './notebookWatcherService';
+
+export class ServiceCollection {
+    private notebookWatcherService: NotebookWatcherService;
+
+    static _instance: ServiceCollection;
+
+    static get Instance(): ServiceCollection {
+        if (!ServiceCollection._instance) {
+            throw new Error('ServiceCollection not yet initialized');
+        }
+
+        return ServiceCollection._instance;
+    }
+
+    constructor(context: vscode.ExtensionContext, clientMapper: ClientMapper) {
+        this.notebookWatcherService = new NotebookWatcherService(context, clientMapper);
+        context.subscriptions.push(this);
+    }
+
+    get NotebookWatcher() {
+        return this.notebookWatcherService;
+    }
+
+    static initialize(context: vscode.ExtensionContext, clientMapper: ClientMapper) {
+        ServiceCollection._instance = new ServiceCollection(context, clientMapper);
+    }
+
+    dispose() {
+        this.notebookWatcherService.dispose();
+    }
+}

--- a/src/dotnet-interactive-vscode-common/tests/notebook.test.ts
+++ b/src/dotnet-interactive-vscode-common/tests/notebook.test.ts
@@ -71,9 +71,9 @@ describe('Notebook tests', () => {
             }));
             const clientMapper = new ClientMapper(config);
             const client = await clientMapper.getOrAddClient(createUri('test/path'));
-            let result: Array<vscodeLike.NotebookCellOutput> = [];
-            await client.execute(code, language, outputs => result = outputs, _ => { }, { token });
-            const decodedResults = decodeNotebookCellOutputs(result);
+            const outputs: Array<vscodeLike.NotebookCellOutput> = [];
+            await client.execute(code, language, output => outputs.push(output), _ => { }, { token });
+            const decodedResults = decodeNotebookCellOutputs(outputs);
             expect(decodedResults).to.deep.equal([
                 {
                     id: '1',
@@ -173,9 +173,9 @@ Console.WriteLine(3);
         }));
         const clientMapper = new ClientMapper(config);
         const client = await clientMapper.getOrAddClient(createUri('test/path'));
-        let result: Array<vscodeLike.NotebookCellOutput> = [];
-        await client.execute(code, 'csharp', outputs => result = outputs, _ => { }, { token });
-        const decodedResults = decodeNotebookCellOutputs(result);
+        const outputs: Array<vscodeLike.NotebookCellOutput> = [];
+        await client.execute(code, 'csharp', output => outputs.push(output), _ => { }, { token });
+        const decodedResults = decodeNotebookCellOutputs(outputs);
         expect(decodedResults).to.deep.equal([
             {
                 id: '1',
@@ -216,93 +216,6 @@ Console.WriteLine(3);
                     }
                 ]
             }
-        ]);
-    });
-
-    it('updated values are replaced instead of added', async () => {
-        const token = '123';
-        const code = '#r nuget:Newtonsoft.Json';
-        const config = createChannelConfig(async (_notebookPath) => new TestDotnetInteractiveChannel({
-            'SubmitCode': [
-                {
-                    eventType: CodeSubmissionReceivedType,
-                    event: {
-                        code: code
-                    },
-                    token
-                },
-                {
-                    eventType: CompleteCodeSubmissionReceivedType,
-                    event: {
-                        code: code
-                    },
-                    token
-                },
-                {
-                    eventType: DisplayedValueProducedType,
-                    event: {
-                        valueId: 'newtonsoft.json',
-                        formattedValues: [{
-                            mimeType: "text/plain",
-                            value: "Installing package Newtonsoft.Json..."
-                        }]
-                    },
-                    token
-                },
-                {
-                    eventType: DisplayedValueUpdatedType,
-                    event: {
-                        valueId: 'newtonsoft.json',
-                        formattedValues: [
-                            {
-                                mimeType: "text/plain",
-                                value: "Installed package Newtonsoft.Json version 1.2.3.4"
-                            }]
-                    },
-                    token
-                },
-                {
-                    eventType: DisplayedValueProducedType,
-                    event: {
-                        valueId: null,
-                        formattedValues: [{
-                            mimeType: "text/plain",
-                            value: "sentinel"
-                        }]
-                    },
-                    token
-                },
-                {
-                    eventType: CommandSucceededType,
-                    event: {},
-                    token
-                }
-            ]
-        }));
-        const clientMapper = new ClientMapper(config);
-        const client = await clientMapper.getOrAddClient(createUri('test/path'));
-        let result: Array<vscodeLike.NotebookCellOutput> = [];
-        await client.execute(code, 'csharp', outputs => result = outputs, _ => { }, { token });
-        const decodedResults = decodeNotebookCellOutputs(result);
-        expect(decodedResults).to.deep.equal([
-            {
-                id: '2',
-                items: [
-                    {
-                        mime: 'text/plain',
-                        decodedData: 'Installed package Newtonsoft.Json version 1.2.3.4',
-                    }
-                ]
-            },
-            {
-                id: '3',
-                items: [
-                    {
-                        mime: 'text/plain',
-                        decodedData: 'sentinel',
-                    }
-                ]
-            },
         ]);
     });
 
@@ -347,9 +260,9 @@ Console.WriteLine(3);
         }));
         const clientMapper = new ClientMapper(config);
         const client = await clientMapper.getOrAddClient(createUri('test/path'));
-        let result: Array<vscodeLike.NotebookCellOutput> = [];
-        await client.execute(code, 'csharp', outputs => result = outputs, _ => { }, { token });
-        const decodedResults = decodeNotebookCellOutputs(result);
+        const outputs: Array<vscodeLike.NotebookCellOutput> = [];
+        await client.execute(code, 'csharp', output => outputs.push(output), _ => { }, { token });
+        const decodedResults = decodeNotebookCellOutputs(outputs);
         expect(decodedResults).to.deep.equal([
             {
                 id: '1',

--- a/src/dotnet-interactive-vscode-insiders/src/notebookControllers.ts
+++ b/src/dotnet-interactive-vscode-insiders/src/notebookControllers.ts
@@ -17,8 +17,12 @@ import * as metadataUtilities from './vscode-common/metadataUtilities';
 import * as constants from './vscode-common/constants';
 import * as versionSpecificFunctions from './versionSpecificFunctions';
 import * as semanticTokens from './vscode-common/documentSemanticTokenProvider';
+import { ServiceCollection } from './vscode-common/serviceCollection';
+import { PromiseCompletionSource } from './vscode-common/dotnet-interactive';
 
 const executionTasks: Map<string, vscode.NotebookCellExecution> = new Map();
+const standardOutputMimeType = 'application/vnd.code.notebook.stdout';
+const standardErrorMimeType = 'application/vnd.code.notebook.stderr';
 
 export interface DotNetNotebookKernelConfiguration {
     clientMapper: ClientMapper,
@@ -28,9 +32,14 @@ export interface DotNetNotebookKernelConfiguration {
 
 export class DotNetNotebookKernel {
 
+    private trackedOutputIds: Map<vscode.Uri, Set<string>> = new Map(); // tracks notebookUri => [trackedOutputId]
     private disposables: { dispose(): void }[] = [];
 
     constructor(readonly config: DotNetNotebookKernelConfiguration, readonly tokensProvider: semanticTokens.DocumentSemanticTokensProvider) {
+        // ensure the tracked output ids are always fresh
+        ServiceCollection.Instance.NotebookWatcher.onNotebookDocumentOpened((notebook, _client) => this.trackedOutputIds.delete(notebook.uri));
+        ServiceCollection.Instance.NotebookWatcher.onNotebookDocumentClosed((notebook, _client) => this.trackedOutputIds.delete(notebook.uri));
+
         const preloads = config.preloadUris.map(uri => new vscode.NotebookRendererScript(uri));
 
         // .dib execution
@@ -171,13 +180,15 @@ export class DotNetNotebookKernel {
                 executionTask.start(startTime);
                 executionTask.executionOrder = undefined;
                 await executionTask.clearOutput(cell);
-                const controllerErrors: vscodeLike.NotebookCellOutput[] = [];
 
-                function outputObserver(outputs: Array<vscodeLike.NotebookCellOutput>) {
+                const outputObserver = (output: vscodeLike.NotebookCellOutput) => {
                     outputUpdatePromise = outputUpdatePromise.catch(ex => {
-                        console.error('Failed to update output', ex);
-                    }).finally(() => updateCellOutputs(executionTask!, [...outputs]));
-                }
+                        Logger.default.error(`Failed to update output: ${ex}`);
+                    }).finally(() => this.applyCellOutput(executionTask, output).catch(ex => {
+                        Logger.default.error(`Failed to update output: ${ex}`);
+                    }));
+                };
+
                 const client = await this.config.clientMapper.getOrAddClient(cell.notebook.uri);
                 executionTask.token.onCancellationRequested(() => {
                     client.cancel().catch(async err => {
@@ -209,6 +220,64 @@ export class DotNetNotebookKernel {
                 throw err;
             }
         }
+    }
+
+    private async applyCellOutput(executionTask: vscode.NotebookCellExecution, output: vscodeLike.NotebookCellOutput): Promise<void> {
+        const streamMimetypes = new Set([standardOutputMimeType, standardErrorMimeType]);
+
+        // ensure we're tracking output ids
+        const cell = executionTask.cell;
+        const trackedOutputs = this.trackedOutputIds.get(cell.notebook.uri) ?? new Set<string>();
+        this.trackedOutputIds.set(cell.notebook.uri, trackedOutputs);
+
+        if (trackedOutputs.has(output.id)) {
+            // if already tracking this output, build a new collection and update them all
+            const newOutputs = cell.outputs.map(o => {
+                if (o.metadata?.id === output.id) {
+                    return generateVsCodeNotebookCellOutput(output);
+                } else {
+                    return o;
+                }
+            });
+
+            await executionTask.replaceOutput(newOutputs);
+        } else {
+            // if the very last output item is stdout/stderr, append to it's parent
+            let appendItems = false;
+            if (cell.outputs.length > 0 && output.items.length === 1) {
+                const lastOutput = cell.outputs[cell.outputs.length - 1];
+                if (lastOutput.items.length > 0) {
+                    const lastOutputItem = lastOutput.items[lastOutput.items.length - 1];
+                    const vsCodeMimeType = getVsCodeMimeTypeFromStreamType(output.items[0].stream);
+                    if (streamMimetypes.has(lastOutputItem.mime) && lastOutputItem.mime === vsCodeMimeType) {
+                        // last mime type matches the incomming one; append the items
+                        appendItems = true;
+                    }
+                }
+            }
+
+            const outputItems = output.items.map(i => generateVsCodeNotebookCellOutputItem(i.data, i.mime, i.stream));
+            if (appendItems) {
+                const lastOutput = cell.outputs[cell.outputs.length - 1];
+                await executionTask.appendOutputItems(outputItems, lastOutput);
+            } else {
+                // couldn't append to last output item, so just create a new output and track it
+                const newOutput = createVsCodeNotebookCellOutput(outputItems, output.id);
+                trackedOutputs.add(output.id);
+                await executionTask.appendOutput(newOutput);
+            }
+        }
+    }
+}
+
+function getVsCodeMimeTypeFromStreamType(stream: string | undefined): string | undefined {
+    switch (stream) {
+        case 'stdout':
+            return standardOutputMimeType;
+        case 'stderr':
+            return standardErrorMimeType;
+        default:
+            return undefined;
     }
 }
 
@@ -281,32 +350,6 @@ async function updateCellLanguagesAndKernels(document: vscode.NotebookDocument):
     }));
 }
 
-async function updateCellOutputs(executionTask: vscode.NotebookCellExecution, outputs: Array<vscodeLike.NotebookCellOutput>): Promise<void> {
-    const streamMimetypes = ['application/vnd.code.notebook.stderr', 'application/vnd.code.notebook.stdout'];
-    const reshapedOutputs: vscode.NotebookCellOutput[] = [];
-    outputs.forEach(async (o) => {
-        if (o.items.length > 1) {
-            // multi mimeType outputs should not be processed
-            reshapedOutputs.push(new vscode.NotebookCellOutput(o.items));
-        } else {
-            // If current nad previous items are of the same stream type then append currentItem to previousOutput.
-            const currentItem = generateVsCodeNotebookCellOutputItem(o.items[0].data, o.items[0].mime, o.items[0].stream);
-            const previousOutput = reshapedOutputs.length ? reshapedOutputs[reshapedOutputs.length - 1] : undefined;
-            const previousOutputItem = previousOutput?.items.length === 1 ? previousOutput.items[0] : undefined;
-
-            if (previousOutput && previousOutputItem?.mime && streamMimetypes.includes(previousOutputItem?.mime) && streamMimetypes.includes(currentItem.mime)) {
-                const decoder = new TextDecoder();
-                const newText = `${decoder.decode(previousOutputItem.data)}${decoder.decode(currentItem.data)}`;
-                const newItem = previousOutputItem.mime === 'application/vnd.code.notebook.stderr' ? vscode.NotebookCellOutputItem.stderr(newText) : vscode.NotebookCellOutputItem.stdout(newText);
-                previousOutput.items[previousOutput.items.length - 1] = newItem;
-            } else {
-                reshapedOutputs.push(new vscode.NotebookCellOutput([currentItem]));
-            }
-        }
-    });
-    await executionTask.replaceOutput(reshapedOutputs);
-}
-
 export function endExecution(client: InteractiveClient | undefined, cell: vscode.NotebookCell, success: boolean) {
     const key = cell.document.uri.toString();
     const executionTask = executionTasks.get(key);
@@ -318,7 +361,16 @@ export function endExecution(client: InteractiveClient | undefined, cell: vscode
     }
 }
 
-function generateVsCodeNotebookCellOutputItem(data: Uint8Array, mime: string, stream?: 'stdout' | 'stderr'): vscode.NotebookCellOutputItem {
+function createVsCodeNotebookCellOutput(outputItems: vscode.NotebookCellOutputItem[], id: string): vscode.NotebookCellOutput {
+    return new vscode.NotebookCellOutput(outputItems, { id });
+}
+
+function generateVsCodeNotebookCellOutput(output: vscodeLike.NotebookCellOutput): vscode.NotebookCellOutput {
+    const items = output.items.map(i => generateVsCodeNotebookCellOutputItem(i.data, i.mime, i.stream));
+    return createVsCodeNotebookCellOutput(items, output.id);
+}
+
+function generateVsCodeNotebookCellOutputItem(data: Uint8Array, mime: string, stream: 'stdout' | 'stderr' | undefined): vscode.NotebookCellOutputItem {
     const displayData = reshapeOutputValueForVsCode(data, mime);
     switch (stream) {
         case 'stdout':


### PR DESCRIPTION
The old behavior was for `InteractiveClient.execute()` to build/rebuild and regularly report the entire set of outputs, but this had the unfortunate consequence of us always calling `ExecutionTask.replaceOutput()` which caused the outputs to flicker and was really slow.

The new behavior is to simplify `InteractiveClient.execute()` to report each output event that occurs and move the output muxing code to `notebookControllers.ts` where we could properly call either `replaceOutput()`, `appendOutput()`, or `appendOutputItem()`.  This also resulted in a bunch of tests getting deleted since the muxing code was moved.  While more refactorings could be done to make it unit testable, the result would be really nasty, and we already have proper coverage in `NotebookTestScript.dib` which is run weekly, at a minimum.

I've also added some code to simplify and centralize listening for notebook client creation and closing.

Fixes #2000.