### PR TITLE
sort kernel picker values by name

### DIFF
--- a/src/dotnet-interactive-vscode-common/src/kernelSelectorUtilities.ts
+++ b/src/dotnet-interactive-vscode-common/src/kernelSelectorUtilities.ts
@@ -41,8 +41,11 @@ export function getKernelSelectorOptions(kernel: CompositeKernel, document: vsco
         kernelInfos.set(childKernel.name, childKernel.kernelInfo);
     }
 
+    // ...order by kernel name...
+    const orderedKernels = [...kernelInfos.values()].sort((a, b) => a.localName.localeCompare(b.localName));
+
     // ...filter to only kernels that can handle `requiredSupportedCommandType`...
-    const filteredKernels = [...kernelInfos.values()].filter(k => k.supportedKernelCommands.findIndex(kci => kci.name === requiredSupportedCommandType) >= 0);
+    const filteredKernels = orderedKernels.filter(k => k.supportedKernelCommands.findIndex(kci => kci.name === requiredSupportedCommandType) >= 0);
 
     // ...and pull out just the information necessary
     const selectorOptions: KernelSelectorOption[] = filteredKernels.map(kernelInfo => {


### PR DESCRIPTION
Newly added kernels (like SQL, Perl, etc.) were getting added to the end of the kernel picker list and the result was a mess of trying to find your kernel.  The fix is to simply order by kernel name for a more consistent experience.