### PR TITLE
put http request kernel behind "--preview" flag

### DIFF
--- a/src/dotnet-interactive-vscode-insiders/package.json
+++ b/src/dotnet-interactive-vscode-insiders/package.json
@@ -144,7 +144,8 @@
             "[vscode]",
             "stdio",
             "--working-dir",
-            "{working_dir}"
+            "{working_dir}",
+            "--preview"
           ],
           "description": "Command and arguments used to start a notebook session."
         },

--- a/src/dotnet-interactive-vscode-insiders/tests/package.json.test.ts
+++ b/src/dotnet-interactive-vscode-insiders/tests/package.json.test.ts
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import * as chai from 'chai';
+chai.use(require('chai-as-promised'));
+const expect = chai.expect;
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+chai.use(require('chai-fs'));
+
+describe('package.json values tests', () => {
+
+    it(`command line arguments contain "--preview" flag`, () => {
+        const packageJsonPath = path.join(__dirname, '..', '..', 'package.json');
+        const packageJsonContents = fs.readFileSync(packageJsonPath, 'utf8');
+        const packageJson = JSON.parse(packageJsonContents);
+        expect(packageJson.contributes.configuration.properties['dotnet-interactive.kernelTransportArgs'].default).to.contain('--preview');
+    });
+
+});

--- a/src/dotnet-interactive-vscode/UPDATING-TO-NEW-VERSION-OF-STABLE.md
+++ b/src/dotnet-interactive-vscode/UPDATING-TO-NEW-VERSION-OF-STABLE.md
@@ -1,10 +1,10 @@
 Updating to new version of stable
 =================================
 
-1. Copy `<root>/src/dotnet-interactive-vscode-insiders/package.json` to `<root>/src/dotnet-interactive-vscode/`
-2. Copy `<root>/src/dotnet-interactive-vscode-insiders/help/*` to `<root>/src/dotnet-interactive-vscode/help/`
-3. Copy `<root>/src/dotnet-interactive-vscode-insiders/src/*` to `<root>/src/dotnet-interactive-vscode/src/` **EXCEPT** for the `vscode-common` symlinked directory.
-4. Increment verion number in `vscodeStableVersion.txt` to match the upcoming stable release of VS Code.
+1. Copy `<root>/src/dotnet-interactive-vscode-insiders/help/*` to `<root>/src/dotnet-interactive-vscode/help/`
+2. Copy `<root>/src/dotnet-interactive-vscode-insiders/src/*` to `<root>/src/dotnet-interactive-vscode/src/` **EXCEPT** for the `vscode-common` symlinked directory.
+3. Increment verion number in `vscodeStableVersion.txt` to match the upcoming stable release of VS Code.
+4. `.\copy-package-json.ps1`
 5. `.\update-api.ps1`
 6. `.\update-versions.ps1 -updateAll`
 7. For each directory:

--- a/src/dotnet-interactive-vscode/copy-package-json.ps1
+++ b/src/dotnet-interactive-vscode/copy-package-json.ps1
@@ -1,0 +1,18 @@
+Set-StrictMode -version 2.0
+$ErrorActionPreference = "Stop"
+
+try {
+    $stablePackageJsonPath = Join-Path $PSScriptRoot "package.json"
+    $insidersPackageJsonPath = Join-Path $PSScriptRoot "..\dotnet-interactive-vscode-insiders\package.json"
+    $packageJsonContents = (Get-Content $insidersPackageJsonPath | Out-String | ConvertFrom-Json)
+    $commandLineArguments = $packageJsonContents.contributes.configuration.properties."dotnet-interactive.kernelTransportArgs".default
+    $updatedCommandLineArguments = $commandLineArguments | Where-Object { $_ -ne "--preview" }
+    $packagejsonContents.contributes.configuration.properties."dotnet-interactive.kernelTransportArgs".default = $updatedCommandLineArguments
+    $packageJsonContents | ConvertTo-Json -depth 100 | Out-File $stablePackageJsonPath
+}
+catch {
+    Write-Host $_
+    Write-Host $_.Exception
+    Write-Host $_.ScriptStackTrace
+    exit 1
+}

--- a/src/dotnet-interactive-vscode/tests/package.json.test.ts
+++ b/src/dotnet-interactive-vscode/tests/package.json.test.ts
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import * as chai from 'chai';
+chai.use(require('chai-as-promised'));
+const expect = chai.expect;
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+chai.use(require('chai-fs'));
+
+describe('package.json values tests', () => {
+
+    it(`command line arguments don't contain "--preview" flag`, () => {
+        const packageJsonPath = path.join(__dirname, '..', '..', 'package.json');
+        const packageJsonContents = fs.readFileSync(packageJsonPath, 'utf8');
+        const packageJson = JSON.parse(packageJsonContents);
+        expect(packageJson.contributes.configuration.properties['dotnet-interactive.kernelTransportArgs'].default).to.not.contain('--preview');
+    });
+
+});

--- a/src/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
+++ b/src/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
@@ -350,6 +350,34 @@ public class CommandLineParserTests : IDisposable
     }
 
     [Fact]
+    public void stdio_command_preview_option_defaults_to_false()
+    {
+        var result = _parser.Parse("stdio");
+
+        var binder = new ModelBinder<StartupOptions>();
+
+        var options = (StartupOptions)binder.CreateInstance(new InvocationContext(result).BindingContext);
+
+        options.Preview
+            .Should()
+            .BeFalse();
+    }
+
+    [Fact]
+    public void stdio_command_preview_option_can_be_set()
+    {
+        var result = _parser.Parse("stdio --preview");
+
+        var binder = new ModelBinder<StartupOptions>();
+
+        var options = (StartupOptions)binder.CreateInstance(new InvocationContext(result).BindingContext);
+
+        options.Preview
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
     public void stdio_command_working_dir_defaults_to_process_current()
     {
         var result = _parser.Parse("stdio");

--- a/src/dotnet-interactive/CommandLine/CommandLineParser.cs
+++ b/src/dotnet-interactive/CommandLine/CommandLineParser.cs
@@ -293,6 +293,8 @@ public static class CommandLineParser
                 isDefault: true,
                 description: "Name of the kernel host.");
 
+            var previewOption = new Option<bool>("--preview", description: "Enable preview kernel features.");
+
             var workingDirOption = new Option<DirectoryInfo>(
                 "--working-dir",
                 () => new DirectoryInfo(Environment.CurrentDirectory),
@@ -306,6 +308,7 @@ public static class CommandLineParser
                 httpPortRangeOption,
                 httpPortOption,
                 kernelHostOption,
+                previewOption,
                 workingDirOption
             };
 
@@ -351,8 +354,11 @@ public static class CommandLineParser
                         var vscodeSetup = new VSCodeClientKernelExtension();
                         await vscodeSetup.OnLoadAsync(kernel);
 
-                        var http = new HttpRequestKernelExtension();
-                        await http.OnLoadAsync(kernel);
+                        if (startupOptions.Preview)
+                        {
+                            var http = new HttpRequestKernelExtension();
+                            await http.OnLoadAsync(kernel);
+                        }
                     }
                        
                     if (startupOptions.EnableHttpApi)

--- a/src/dotnet-interactive/CommandLine/StartupOptions.cs
+++ b/src/dotnet-interactive/CommandLine/StartupOptions.cs
@@ -15,6 +15,7 @@ public class StartupOptions
         HttpPortRange httpPortRange = null,
         HttpPort httpPort = null,
         Uri kernelHost = null,
+        bool preview = false,
         DirectoryInfo workingDir = null)
     {
         LogPath = logPath;
@@ -22,6 +23,7 @@ public class StartupOptions
         HttpPortRange = httpPortRange;
         HttpPort = httpPort;
         KernelHost = kernelHost;
+        Preview = preview;
         WorkingDir = workingDir;
     }
 
@@ -34,6 +36,8 @@ public class StartupOptions
     public HttpPortRange HttpPortRange { get; internal set; }
         
     public Uri KernelHost { get; }
+
+    public bool Preview { get; }
 
     public DirectoryInfo WorkingDir { get; internal set; }
 


### PR DESCRIPTION
The http request kernel is now only enabled if `--preview` is specified on the command line.  The insiders version of the extension has had the new option added to the transport args, unit tests have been added in each to ensure the flag is appropriately present/absent, and a new script has been added to reduce errors when preparing for a stable release.

The end result is that the only insiders version of the extension will get preview features, even if they exist over a stable release boundary.