### PR TITLE
fix importing notebooks

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Tests/ImportNotebookTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/ImportNotebookTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.CSharp;
 using Microsoft.DotNet.Interactive.Documents;
 using Microsoft.DotNet.Interactive.Documents.Jupyter;
@@ -83,5 +84,65 @@ public class ImportNotebookTests
         {
             ((ReturnValueProduced)returnedValues[i]).Value.Should().Be(results[i]);
         }
+    }
+
+    [Theory]
+    [InlineData(".ipynb")]
+    [InlineData(".dib")]
+    public async Task It_produces_DisplayedValueProduced_events_for_markdown_cells(string notebookExt)
+    {
+        
+        using var kernel = new CompositeKernel {
+                new CSharpKernel(),
+                new FSharpKernel(),
+                new HtmlKernel(),
+            }
+            .UseImportMagicCommand();
+
+        var document = new InteractiveDocument
+        {
+            new InteractiveDocumentElement
+            {
+                Contents = "6+5",
+                KernelName = "csharp"
+            },
+            new InteractiveDocumentElement
+            {
+                Contents = "5+11",
+                KernelName = "markdown" //should not evaluate to 8
+            },
+            new InteractiveDocumentElement
+            {
+                Contents = "5+3",
+                KernelName = "html" //should not evaluate to 8
+            },
+            new InteractiveDocumentElement
+            {
+                Contents = "11*2",
+                KernelName = "fsharp"
+            },
+            new InteractiveDocumentElement
+            {
+                Contents = "11*3",
+                KernelName = "csharp"
+            }
+        };
+
+        var notebookContents = notebookExt switch
+        {
+            ".ipynb" => document.ToJupyterJson(),
+            ".dib" => document.ToCodeSubmissionContent(),
+            _ => throw new InvalidOperationException($"Unrecognized extension for a notebook: {notebookExt}")
+        };
+
+        var filePath = $@".\testnotebook{notebookExt}";
+
+        await File.WriteAllTextAsync(filePath, notebookContents);
+
+        using var events = kernel.KernelEvents.ToSubscribedList();
+
+        await kernel.SubmitCodeAsync($"#!import {filePath}");
+
+        events.Should().ContainSingle<DisplayedValueProduced>(v => v.FormattedValues.Any(f => f.MimeType == "text/markdown"));
     }
 }

--- a/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
@@ -104,7 +104,11 @@ public static class KernelExtensions
                     switch (element.KernelName?.ToLowerInvariant())
                     {
                         case "markdown":
-                            var @event = new DisplayedValueProduced(element.Contents, context.Command, new[] { new FormattedValue("text/markdown", element.Contents) });
+                            var @event = new DisplayedValueProduced(element.Contents, context.Command, new[]
+                            {
+                                new FormattedValue("text/markdown", element.Contents),
+                                new FormattedValue(PlainTextFormatter.MimeType, element.Contents)
+                            });
                             context.Publish(@event);
                             break;
                         default:


### PR DESCRIPTION
importing notebooks with markdown cells adds those to the ui.

<img width="734" alt="image" src="https://user-images.githubusercontent.com/375556/208494523-7c3d9dc0-c165-4871-94c0-535439562dac.png">

This will add all markdown cells after the cell executing the import and all outputs that the imported notebook will generate