### PR TITLE
handle the case kernelinfo si deserialised as dicittionary

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Documents.Tests/CodeSubmissionFormatTests.dib_file_can_be_round_tripped_through_read_and_write_without_the_content_changing.approved.dib
+++ b/src/Microsoft.DotNet.Interactive.Documents.Tests/CodeSubmissionFormatTests.dib_file_can_be_round_tripped_through_read_and_write_without_the_content_changing.approved.dib
@@ -1,6 +1,6 @@
 #!meta
 
-{"kernelInfo":{"defaultKernelName":"csharp","items":[{"aliases":["cs","C#","c#"],"name":"csharp"},{"aliases":["fs","F#","f#"],"name":"fsharp"},{"aliases":["powershell"],"name":"pwsh"},{"name":"mermaid"},{"name":"javascript"}]}}
+{"kernelInfo":{"defaultKernelName":"csharp","items":[{"name":"csharp","aliases":["cs","C#","c#"]},{"name":"fsharp","aliases":["fs","F#","f#"]},{"name":"pwsh","aliases":["powershell"]},{"name":"mermaid"},{"name":"javascript"}]}}
 
 #!markdown
 

--- a/src/Microsoft.DotNet.Interactive.Documents/CodeSubmission.cs
+++ b/src/Microsoft.DotNet.Interactive.Documents/CodeSubmission.cs
@@ -57,6 +57,7 @@ public static class CodeSubmission
                 if (InteractiveDocument.TryGetKernelInfoFromMetadata(metadata, out var kernelInfoFromMetadata))
                 {
                     InteractiveDocument.MergeKernelInfos(kernelInfo, kernelInfoFromMetadata);
+                    document.Metadata["kernelInfo"] = kernelInfoFromMetadata;
                 }
             }
 
@@ -98,6 +99,7 @@ public static class CodeSubmission
         {
             document.Metadata.MergeWith(metadata);
         }
+
 
         return document;
 

--- a/src/Microsoft.DotNet.Interactive.Documents/CodeSubmission.cs
+++ b/src/Microsoft.DotNet.Interactive.Documents/CodeSubmission.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices.ComTypes;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -63,7 +62,7 @@ public static class CodeSubmission
 
             if (line.StartsWith(MagicCommandPrefix))
             {
-                var cellKernelName = line.Substring(MagicCommandPrefix.Length);
+                var cellKernelName = line[MagicCommandPrefix.Length..];
 
                 if (kernelInfo.TryGetByAlias(cellKernelName, out var name))
                 {


### PR DESCRIPTION
From vscode invocation the document is deserialized and the medatadata now is a dictionary. This fixes saving notebooks