### PR TITLE
attempt to show variables when first activated

### DIFF
--- a/src/dotnet-interactive-vscode-common/src/variableExplorer.ts
+++ b/src/dotnet-interactive-vscode-common/src/variableExplorer.ts
@@ -217,6 +217,9 @@ class WatchWindowTableViewProvider implements vscode.WebviewViewProvider {
         </html>
         `;
         this.webview.html = html;
+
+        const currentNotebookUri = vscode.window.activeNotebookEditor?.notebook.uri;
+        this.showNotebookVariables(currentNotebookUri);
     }
 
     private setRows(rows: VariableGridRow[]) {


### PR DESCRIPTION
If a notebook is opened and code is executed and only then does the user activate the variable explorer, we don't show anything, just set the initial HTML.

This makes an attempt to populate the variable explorer immediately.  If no notebook is currently active, the uri will be `undefined` and it'll display the normal empty table.