### PR TITLE
FAQ and docs updates plus support for single-language file formats for `#!import`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ There are several ways to get started using .NET Interactive with Jupyter, inclu
 
 .NET Interactive can be used as the execution engine for REPLs. For an example using a CLI, see [.NET REPL](https://github.com/jonsequitur/dotnet-repl). In addition, .NET REPL can actually be used to set up automation for your Polyglot Notebooks. 
 
+## FAQ
+
+For more information, please refer to our [FAQ](./docs/FAQ.md). 
+
 ### Small factor devices
 
 We support running on devices like Raspberry Pi and [pi-top [4]](https://github.com/pi-top/pi-top-4-.NET-Core-API). You can find instructions [here](small-factor-devices.md).
@@ -73,7 +77,7 @@ Telemetry is collected when .NET Interactive is started. Once .NET Interactive i
 * `dotnet interactive http`
 * `dotnet interactive stdio`
 
-### How to opt out of telemetry
+### How to opt out
 
 The .NET Interactive telemetry feature is enabled by default. To opt out of the telemetry feature, set the `DOTNET_INTERACTIVE_CLI_TELEMETRY_OPTOUT` environment variable to `1` or `true`.
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,6 @@ There are several ways to get started using .NET Interactive with Jupyter, inclu
 
 .NET Interactive can be used as the execution engine for REPLs. For an example using a CLI, see [.NET REPL](https://github.com/jonsequitur/dotnet-repl). In addition, .NET REPL can actually be used to set up automation for your Polyglot Notebooks. 
 
-## FAQ
-
-For more information, please refer to our [FAQ](./docs/FAQ.md). 
-
 ### Small factor devices
 
 We support running on devices like Raspberry Pi and [pi-top [4]](https://github.com/pi-top/pi-top-4-.NET-Core-API). You can find instructions [here](small-factor-devices.md).

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -330,11 +330,6 @@ You can also use `#!import` to run single-language files within a notebook, incl
 
 You can read more about `#!import` [here](import-magic-command.md).
 
-
-Yes. The .NET Interactive [extensibility APIs](extending-dotnet-interactive.md) allows for NuGet packages to add new subkernels at runtime. This is how SQL and KQL support are implemented.
-
-Yes. You can use the `#!import` magic command to load and run a number of different file types within a notebook, including `.ipynb` and `.dib`. Both of these file formats support polyglot, so notebooks imported this way can include cells in various languages. 
-
 ### How can I add other languages to a notebook?
 
 Yes. The .NET Interactive [extensibility APIs](extending-dotnet-interactive.md) allows for NuGet packages to add new subkernels at runtime. This is how SQL and KQL support are implemented.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -78,7 +78,7 @@ await Kernel.Root.SendAsync(
         "javascript"));
 ```
 
-### What's the difference between a .dib file and an .ipynb file?
+### What's the difference between a `.dib` file and an `.ipynb` file?
 
 The `.ipynb` file extension is the standard Jupyter notebook format. Despite the name, it's no longer specific to IPython, and can be used for many different languages. It's a JSON-based format and it can store content and metadata for code cells, Markdown cells, and cell outputs, which store the results of code execution for display. Multiple outputs can be stored for each code cell, as long as they differ by MIME type. There are many tools available for diffing, converting, and displaying `.ipynb` files. In GitHub,`.ipynb` files are displayed using a notebook-style layout.
 
@@ -99,6 +99,8 @@ A "read-eval-print loop", or [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93e
 ### What is .NET REPL?
 
 .NET Repl is a [.NET tool](https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools) ([`dotnet-repl`](https://github.com/jonsequitur/dotnet-repl)) that uses the .NET Interactive engine to provide a terminal-based REPL supporting the same general features that you can find in Polyglot Notebooks, including support for combining multiple languages in one session and support for the `.ipynb` and `.dib` file formats. It also provides some additional features, including the ability to execute notebooks without a UI, allowing for testing notebook files or using them as automation scripts with built-in log capture.
+
+[_This is an experimental feature that might be added to the core .NET Interactive product in the future._]
 
 ### What is the C# Interactive Window?
 
@@ -304,7 +306,21 @@ await Kernel.Root.FindKernelByName("csharp")
 
 ### Is there a way to run a notebook from the command line?
 
-The [.NET REPL](https://github.com/jonsequitur/dotnet-repl) has a number of features relating to command line automation with notebooks. The GitHub project page has more details. 
+The [.NET REPL](https://github.com/jonsequitur/dotnet-repl) has a number of features relating to command line automation with notebooks. The GitHub [project page](https://github.com/jonsequitur/dotnet-repl) has more details. 
+
+[_This is an experimental feature that might be added to the core .NET Interactive product in the future._]
+
+### How can I test my notebooks?
+
+One approach to automated testing of notebooks is to use [.NET REPL](https://github.com/jonsequitur/dotnet-repl). The following example shows how to run a notebook headlessly and output a `.trx` file containing the results:
+
+```console
+dotnet repl --run /path/to/notebook.ipynb --output-format trx --output-path /path/to/results.trx --exit-after-run 
+```
+
+More details can be found on the GitHub [project page](https://github.com/jonsequitur/dotnet-repl).
+
+[_This is an experimental feature that might be added to the core .NET Interactive product in the future._]
 
 ### Can I call one notebook from within another?
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -310,6 +310,11 @@ The [.NET REPL](https://github.com/jonsequitur/dotnet-repl) has a number of feat
 
 Yes. You can use the `#!import` magic command to load and run a number of different file types within a notebook, including `.ipynb` and `.dib`. Both of these file formats support polyglot, so notebooks imported this way can include cells in various languages. 
 
+
+Yes. The .NET Interactive [extensibility APIs](extending-dotnet-interactive.md) allows for NuGet packages to add new subkernels at runtime. This is how SQL and KQL support are implemented.
+
+Yes. You can use the `#!import` magic command to load and run a number of different file types within a notebook, including `.ipynb` and `.dib`. Both of these file formats support polyglot, so notebooks imported this way can include cells in various languages. 
+
 ### How can I add other languages to a notebook?
 
 Yes. The .NET Interactive [extensibility APIs](extending-dotnet-interactive.md) allows for NuGet packages to add new subkernels at runtime. This is how SQL and KQL support are implemented.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -324,7 +324,11 @@ More details can be found on the GitHub [project page](https://github.com/jonseq
 
 ### Can I call one notebook from within another?
 
-Yes. You can use the `#!import` magic command to load and run a number of different file types within a notebook, including `.ipynb` and `.dib`. Both of these file formats support polyglot, so notebooks imported this way can include cells in various languages. 
+Yes. You can use the `#!import` magic command to load and run a number of different file types within a notebook, including `.ipynb` and `.dib`. Both of these file formats support polyglot, so notebooks imported this way can include cells in various languages.
+
+You can also use `#!import` to run single-language files within a notebook, including `.cs`, `.csx`, `.js`, and `.ps1` files. 
+
+You can read more about `#!import` [here](import-magic-command.md).
 
 
 Yes. The .NET Interactive [extensibility APIs](extending-dotnet-interactive.md) allows for NuGet packages to add new subkernels at runtime. This is how SQL and KQL support are implemented.

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,17 +25,11 @@ As a powerful and versatile engine, .NET Interactive can be used to create and p
 - REPLs
 - Embeddable script enginges
 
-## Polyglot Notebooks
+### Polyglot Notebooks
 
-Since .NET Interactive is capable of behaving as a kernel for notebooks, it enables a polyglot (multi-language) notebook experience. 
+Since .NET Interactive is capable of running as a kernel for notebooks, it enables a polyglot (multi-language) notebook experience. When using the .NET Interactive kernel, you can use different languages from one cell to the next, share variables between languages, and dynamically connect new languages and remote kernels within a notebook. There's no need to install different Jupyter kernels, use wrapper libraries, or install different tools to get the best experience for the language of your choice. You can always use the best language for the job and seamlessly transition between different stages of your workflow, all within one notebook.
 
-In Polyglot Notebooks, you can use multiple languages and share variables between them. No more installing different Jupyter kernels, using wrapper libraries, or different tools to get the best language server support for the language of your choice. Always use the best language for the job and seamlessly transition between different states of your workflow, all within one notebook.
-
-### Visual Studio Code
-
-For the best experience when working with multi-language notebooks, we recommend installing the [Polyglot Notebooks Extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode).  
-
-
+For the best experience when working with multi-language notebooks, we recommend installing the [Polyglot Notebooks](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode) extension for Visual Studio Code. While the full .NET Interactive feature set is available in Jupyter, many features are only usable via code, whereas the Polyglot Notebooks extension provides additional features including a language/kernel picker for each cell, enhanced language services, a multi-kernel variable viewer, and more.
 
 ### Jupyter and nteract
 
@@ -45,19 +39,16 @@ There are several ways to get started using .NET Interactive with Jupyter, inclu
 * [Create and run .NET notebooks on your machine](NotebookswithJupyter.md).
 * [Share .NET notebooks online using Binder](CreateBinder.md).
 
+### REPLs
 
-## REPLs
-
-.NET Interactive can be used as the execution engine for REPLs. For an example using a CLI, see [.NET REPL](https://github.com/jonsequitur/dotnet-repl). In addition, .NET REPL can actually be used to set up automation for your Polyglot Notebooks. 
- 
+.NET Interactive can be used as the execution engine for REPLs as well. The experimental [.NET REPL](https://github.com/jonsequitur/dotnet-repl) is one example of a command line REPL built on .NET Interactive. In addition, .NET REPL can actually be used to set up automation for your Polyglot Notebooks. 
 
 ## Acknowledgements 
 
 The multi-language experience of .NET Interactive is truly a collaborative effort amongst other groups at Microsoft. We'd like to thank the following teams for contributing their time and expertise to helping light up functionality for other languages. 
 
-- **PowerShell Team:** PowerShell
-- **Azure Data/SQL Team:** SQL, KQL
-
+- **PowerShell Team:** PowerShell support
+- **Azure Data Team:** SQL and KQL support
 
 ## Other
 
@@ -90,13 +81,13 @@ The .NET Core tools collect usage data in order to help us improve your experien
 
 To disable this message and the .NET Core welcome message, set the `DOTNET_INTERACTIVE_CLI_TELEMETRY_OPTOUT` environment variable to `true`. Note that this variable has no effect on telemetry opt out.
 
-## Features
+## Using notebooks
 
 * [Support for multiple languages](polyglot.md)
 * Display output ([C#](display-output-csharp.md) | F# | PowerShell)
-* Create plots with with [Xplot](https://fslab.org/XPlot/)
 * ["Magic commands"](./magic-commands.md)
 * [Import NuGet packages](nuget-overview.md)
+* [Running code from other notebooks and source files using `#!import`](import-magic-command.md)
 * Language-specific features
     * C#
         * The [C# scripting](https://docs.microsoft.com/en-us/archive/msdn-magazine/2016/january/essential-net-csharp-scripting) dialect
@@ -108,23 +99,17 @@ To disable this message and the .NET Core welcome message, set the `DOTNET_INTER
         * [PowerShell profile support](../samples/notebooks/powershell/Docs/Profile%20Support.ipynb)
         * [PowerShell host support](../samples/notebooks/powershell/Docs/Interactive-Host-Experience.ipynb)
         * [AzShell support](../samples/notebooks/powershell/Docs/Interact-With-Azure-Cloud-Shell.ipynb)
-* Getting input from the user
+* [Getting input from the user](input-prompts.md)
+* [Formatter APIs](formatting.md)
+    * [PocketView](pocketview.md)
 * [Multi-language notebooks](polyglot.md)
-    * Switching between languages
-        * Per-cell
-        * Within a single cell
     * [.NET variable sharing](variable-sharing.md)
     * [Accessing kernel variables from the client with JavaScript](javascript-overview.md) 
 
-## Technical details
+## Technical overview
 
 * [Architecture](kernels-overview.md)
 * How Jupyter kernel installation works
-
-## Visualization
-
-* XPlot
-* Visualization with JavaScript libraries
 
 ## .NET Interactive API Guides
 
@@ -133,13 +118,10 @@ To disable this message and the .NET Core welcome message, set the `DOTNET_INTER
 ### .NET API Guide ([TODO](https://github.com/dotnet/interactive/issues/815))
 
 * Commands and events
-* [Formatter APIs](formatting.md)
-    * Working with MIME types 
-* PocketView
+    * Message protocol ([TODO](https://github.com/dotnet/interactive/issues/813))
 * Magic commands
 * Kernel APIs
     * Variable sharing
-* JSON API for Standard I/O and HTTP modes ([TODO](https://github.com/dotnet/interactive/issues/813))
 
 ### JavaScript API Guide ([TODO](https://github.com/dotnet/interactive/issues/814))
 
@@ -150,9 +132,6 @@ To disable this message and the .NET Core welcome message, set the `DOTNET_INTER
  
 ## Extending .NET Interactive
 
-* [Overview](extending-dotnet-interactive.md)
 * [Building your own extension](extending-dotnet-interactive.md)
   * [Adding magic commands](extending-dotnet-interactive.md#adding-magic-commands)
 * Publishing your extension using NuGet
-
-

--- a/docs/import-magic-command.md
+++ b/docs/import-magic-command.md
@@ -1,0 +1,33 @@
+# The `#!import` magic command
+
+Often when working in a notebook, there's code in another file that you'd like to be able to use without copying it into the notebook. Notebook and scripting tools typically include ways to run code from an external file, and .NET Interactive is no different. The `#!import` magic command provides this capability. When run, the `#!import` command will read the file from the specified path and immediately execute the code found within it.
+
+```console
+#!import /path/to/file
+```
+
+For imported notebook files containing multiple cells, the cells will be run in the order in which they occur in the file.
+
+## `#!import` and polyglot
+
+Since .NET Interactive is polyglot, the `#!import` magic command recognizes multiple languages. If the specified file is in a format that supports polyglot, such as `.ipynb` or `.dib`, then the different code snippets within the file will be run using their appropriate subkernels, as long as the importing kernel has subkernels that correspond to those languages.
+
+But `#!import` isn't limited to importing other notebook files. It can also directly load source code files for known languages, including:
+
+|File extension | Details                                                                 |
+|---------------|-------------------------------------------------------------------------|
+| `.cs`         | Common C# <br> _(Note: These will be compiled using the C# Script compiler.)_
+| `.csx`        | C# Script
+| `.fs`         | Common F#
+| `.fsx`        | F# script
+| `.html`       | HTML
+| `.js`         | JavaScript
+| `.ps1`        | PowerShell 
+
+Note that `.cs` and `.fs` files will be run using .NET Interactive's default scripting implementations, so some language constructs might not be supported. 
+
+## .NET Projects
+
+Importing or referencing full .NET projects, or source files in the context of a .NET project, is not currently supported. If you have functionality in a .NET project that you would like to use from within a notebook, you can compile it and then reference the assembly directly using `#r "/path/to/assembly.dll"`, or package it and reference the NuGet package using [`#r nuget`](nuget-overview.md).
+
+Improved integration with .NET projects is being considered, however. For more information, see issue [#890](https://github.com/dotnet/interactive/issues/890).

--- a/docs/input-prompts.md
+++ b/docs/input-prompts.md
@@ -1,0 +1,98 @@
+# Input prompts
+
+In a notebook, it's often useful to have certain values provided from outside. Query parameters, authentication tokens, and file paths are common examples of information used to parameterize a notebook in order to reuse it for different data or among different users. 
+
+There are a few different ways to avoid having to hard-code such values in your notebooks.
+
+## Input prompts within magic commands
+
+Within any magic command, you can prompt for input by prefixing a token with `@input:`. For example, `@input:xyz` will prompt the user with the text `xyz`. The input will replace the text `@input:prompt_text` (The following examples use the `#!value` command but this syntax works with any magic command. For more information about using `#!value`, you can read about the value kernel [here](value-kernel.md)).
+
+In most cases, the input prompt will be a text field. Here's an example showing an input prompt in Polyglot Notebooks:
+
+<img width="60%" alt="image" src="https://user-images.githubusercontent.com/547415/211088346-bb944997-c79b-4d71-96b3-bf7be8747d8d.png">
+
+Input prompts look a little different JupyterLab, but they work the same way:
+
+<img width="55%" alt="image" src="https://user-images.githubusercontent.com/547415/211088510-fc31eed8-8ac6-4fbf-af1c-7ef61c826eab.png">
+
+In some cases, input prompts can present UI that's more specific to the type that the magic command is expecting for a given argument. One example is `#!value --from-file`. Since it expects a file input, the Polyglot Notebooks UI will show a file chooser instead of a text box:
+
+<img alt="image" src="https://user-images.githubusercontent.com/547415/210602472-22bbf35c-316b-4c32-b891-58b226853301.png" width="60%" >
+
+## Input prompts via .NET code
+
+There are also methods that can be called directly in .NET code to prompt users for input. Here's one example in C#:
+
+```csharp
+using Microsoft.DotNet.Interactive;
+
+var input = await Kernel.GetInputAsync("Pick a number.");
+```
+
+The resulting prompt looks the same as the one that's shown when using the `@input:` prefix in a magic command:
+
+<img alt="image" src="https://user-images.githubusercontent.com/547415/210603522-8738fa01-105d-4d0f-93cd-976da0a73a6c.png" width="60%" >
+
+You can also provide a type hint using this API, which the frontend can choose to use to provide more specific UI.
+
+```csharp
+using Microsoft.DotNet.Interactive;
+
+var input = await Kernel.GetInputAsync(
+    "Please provide a connection string.",
+    typeHint: "file");
+```
+
+If the type hint is one that's understood by the frontend, you'll see the appropriate UI:
+
+<img width="60%" alt="image" src="https://user-images.githubusercontent.com/547415/211090654-efdab0dc-6f1e-4c93-9fdd-4fbaf3c37ec7.png">
+
+Otherwise, it will fall back to the simple text input:
+
+<img width="60%" alt="image" src="https://user-images.githubusercontent.com/547415/211090750-f01a8379-b506-46aa-8b6b-4c22d57abfbf.png">
+
+## Passwords and other secrets
+
+Some notebook inputs are sensitive and you don't want them to be saved in a readable form in your notebook's code cells or outputs. 
+
+You can prompt for input using `Kernel.GetPasswordAsync` 
+
+```csharp
+using Microsoft.DotNet.Interactive;
+
+var input = await Kernel.GetPasswordAsync("Please provide a connection string.");
+```
+
+The resulting prompt masks the text that the user types:
+
+<img width="60%" alt="image" src="https://user-images.githubusercontent.com/547415/211089804-3807d3cb-b050-49dd-a4ef-e38accd7773b.png">
+
+## Inputs from command line parameters
+
+[_This is an experimental feature that might be added to the core .NET Interactive product in the future._]
+
+The capability for a notebook to prompt a user for input solves a number of problems. But in automation scenarios (such as using a notebook as an automation tool or running tests of notebooks), there is no user present to respond to the prompt.
+
+The [.NET REPL](https://github.com/jonsequitur/dotnet-repl) has features for running notebooks from the command line, with no UI or user present. In order to be able to provide values for known inputs, .NET REPL can identify `@input:`-prefixed tokens in magics and allows you to pass values for these inputs at the command line. 
+
+You can find out what parameters are required by a notebook by running the following command and passing the path to the notebook. (This works for both `.ipynb` and `.dib` files.)
+
+```console
+ dotnet repl describe /path/to/notebook.ipynb
+```
+
+The `dotnet repl describe` command will display the parameters needed by the notebook and show examples of how to pass them using command line options:
+
+<img width="60%" alt="image" src="https://user-images.githubusercontent.com/547415/211161842-39437eba-5da2-4b02-b13a-3a0848fe4d45.png">
+
+The following command will run a notebook (called `parameters.ipynb`) and write the results to a new notebook (called `parameters-output.ipynb`). 
+
+```console
+ dotnet-repl --run .\parameters.ipynb --exit-after-run --output-path parameters-output.ipynb --input parameter1="value one" --input parameter2="value two"
+```
+
+Note that the `--input` option is specified more than once.
+
+For more information about usng .NET REPL, see the GitHub [project](https://github.com/jonsequitur/dotnet-repl) page.
+

--- a/docs/magic-commands.md
+++ b/docs/magic-commands.md
@@ -16,22 +16,24 @@ The following is a list of magic commands supported by .NET Interactive:
 
 ## .NET Kernel
 
-The following magic commands are available globally.
+The following are some useful magic commands that are available in all or nearly all subkernels within .NET Interactive:
 
 
-| Command                                 | Behavior                               
-|-----------------------------------------|----------------------------------------------------------------------
-| `#!csharp` (also: `#!c#`, `#!C#`)       | Indicates that the code that follows is C#. Specifically, it is the [C# scripting](https://docs.microsoft.com/en-us/archive/msdn-magazine/2016/january/essential-net-csharp-scripting) dialect. 
-| `#!fsharp` (also: `#!f#`, `#!F#`)       | Indicates that the code that follows is F#.
-| `#!pwsh` (also: `#!powershell`)         | Indicates that the code that follows is PowerShell.
-| `#!javascript` (also: `#!js`)           | Indicates that the code that follows is JavaScript, to be executed in the browser.
-| `#!html`                                | Indicates that the code that follows is HTML, which can then be directly rendered in the browser.
-| `#!lsmagic`                             | Lists the available magic commands, including those that might have been installed via an extension. 
-| `#!markdown`                            | Indicates that the code that follows is Markdown, which can then be directly rendered as HTML in the browser.
-| `#!log`                                 | Enables logging for the session. Once it has been run, detailed log information from .NET Interactive will be published along with other code outputs. 
-| `#!about`                               | Displays information about the current version of .NET Interactive:<br />![image](https://user-images.githubusercontent.com/547415/81481060-42f1ca00-91e2-11ea-92f7-c4ffae904961.png)
-| `#!time`                                | Measures the execution time of the code submission.
-| `#!value`                               | Stores a value (from entered text, a file, or a URL), which can be accessed using `#!share`.
+| Command                               | Behavior                               
+|---------------------------------------|----------------------------------------------------------------------
+| `#!csharp` (also: `#!c#`, `#!C#`)     | Indicates that the code that follows is C#. (Specifically, the [C# Script](https://docs.microsoft.com/en-us/archive/msdn-magazine/2016/january/essential-net-csharp-scripting) dialect.) 
+| `#!fsharp` (also: `#!f#`, `#!F#`)     | Indicates that the code that follows is F#.
+| `#!pwsh` (also: `#!powershell`)       | Indicates that the code that follows is PowerShell.
+| `#!javascript` (also: `#!js`)         | Indicates that the code that follows is JavaScript, to be executed in the browser.
+| `#!html`                              | Indicates that the code that follows is HTML, which can then be directly rendered in the browser.
+| `#!lsmagic`                           | Lists the available magic commands, including those that might have been installed via an extension. 
+| `#!markdown`                          | Indicates that the code that follows is Markdown, which can then be directly rendered as HTML in the browser.
+| `#!mermaid`                           | Indicates that the code that follows is [Mermaid](https://mermaid.js.org/intro/). Output is rendered visually.
+| `#!about`                             | Displays information about the current version of .NET Interactive:<br />![image](https://user-images.githubusercontent.com/547415/81481060-42f1ca00-91e2-11ea-92f7-c4ffae904961.png)
+| [`#!import`](import-magic-command.md) | Runs code from another notebook or source code file.
+| [`#!share`](variable-sharing.md)      | Shares a variable from another specified subkernel (including one stored using `#!value`).
+| `#!time`                              | Measures the execution time of the code submission.
+| `#!value`                             | Stores a value (from entered text, a file, or a URL), which can be accessed using `#!share`.
 
 ## C# Kernel
 
@@ -41,7 +43,6 @@ The following magic commands are available within a C# language context.
 |-----------------------------------------|----------------------------------------------------------------------
 | `#i`                                    | Adds a NuGet source to the session. Subsequent `#r nuget` commands will include the specified source when resolving packages.
 | `#r`                                    | In C# Interactive, the `#r` directive adds a reference to a specified assembly, e.g. `#r "/path/to/a.dll"`, or system assembly, e.g. `#r "System.Net.Http.Json.dll"`.  In .NET Interactive, this capability has been expanded to provide the ability to reference NuGet packages.<br />![image](https://user-images.githubusercontent.com/547415/81502691-362dae80-9294-11ea-94a4-266f4edc0d5e.png)<br />You cannot reference two different versions of the same package. If you try to do so, you'll receive an error:<br />![image](https://user-images.githubusercontent.com/547415/81502694-3cbc2600-9294-11ea-92d4-9151ad1bc805.png)
-| `#!share`                               | Shares a variable from another specified subkernel (including one stored using `#!value`).
 | `#!who`                                 | Displays the names of the top-level variables within the C# subkernel.
 | `#!whos`                                | Displays the top-level variables within the C# subkernel, including their name, type, and value.<br />![image](https://user-images.githubusercontent.com/547415/81481511-87329980-91e5-11ea-9a4b-b025435553ff.png)
 
@@ -53,7 +54,6 @@ The following magic commands are available within an F# language context.
 |-----------------------------------------|----------------------------------------------------------------------
 | `#i`                                    | Adds a NuGet source to the session. Subsequent `#r nuget` commands will include the specified source when resolving packages.
 | `#r`                                    | In F# Interactive, the `#r` directive adds a reference to a specified assembly, e.g. `#r "/path/to/a.dll"`.  In F# 5, which is used by .NET Interactive, this capability has been expanded to provide the ability to reference NuGet packages.<br />![image](https://user-images.githubusercontent.com/547415/81502691-362dae80-9294-11ea-94a4-266f4edc0d5e.png)<br />You cannot reference two different versions of the same package. If you try to do so, you'll receive an error:<br />![image](https://user-images.githubusercontent.com/547415/81502694-3cbc2600-9294-11ea-92d4-9151ad1bc805.png)
-| `#!share`                               | Shares a variable from another specified subkernel (including one stored using `#!value`).
 | `#!who`                                 | Displays the names of the top-level variables within the F# subkernel.
 | `#!whos`                                | Displays the top-level variables within the F# subkernel, including their name, type, and value.<br />![image](https://user-images.githubusercontent.com/547415/81481474-636f5380-91e5-11ea-92ce-07336b201db0.png)
 

--- a/docs/polyglot.md
+++ b/docs/polyglot.md
@@ -1,6 +1,6 @@
 # Multi-language notebooks
 
-With .NET Interactive you can create notebooks that use different languages together. A notebook has a default language. Any cell whose language isn't set specifically will use the default language. In JupyterLab, the default language is chosen when you create a new notebook:
+With .NET Interactive you can create notebooks that use different languages together. A notebook has a default language, and in frontends with no per-cell language picker (e.g. JupyterLab), any cell whose language isn't set will use the default language. In JupyterLab, the default language is chosen when you create a new notebook:
 
 <img src="https://user-images.githubusercontent.com/547415/78056370-ddd0cc00-7339-11ea-9379-c40f8b5c1ae5.png" width="70%">
 
@@ -12,9 +12,15 @@ But every .NET Interactive notebook is capable of running multiple languages. Yo
 
 <img src="https://user-images.githubusercontent.com/547415/81730391-4f745d80-9442-11ea-9f17-244471f6af83.png" width="70%">
 
-If you're editing a notebook in Visual Studio Code, you can also choose the language for a submission by clicking the language selector in a cell's lower right corner.
+If you're editing a notebook in Visual Studio Code, you can also choose the language for a submission by clicking the language selector in a cell's lower right corner. The following screen shot show a C# cell and then an F# cell. 
 
-![Language Picker](/images/LanguagePicker.png)
+<img width="60%" alt="image" src="https://user-images.githubusercontent.com/547415/211166094-036d5277-9c56-40c2-b9b4-392b7f18d603.png">
 
-The language-selection magic commands will still work in Visual Studio Code as well.
+The language picker sets the language for the cell in the `.ipynb` metadata so that if the notebook is later opened in JupyterLab, the correct language will be used even though no magic command is present to specify it.
+
+But language selection magic commands work in Visual Studio Code as well, and take precedence over the language picker selection. You can use the language selection magic commands to combine more than one language within a single cell. In the following example, you can see how the `#!fsharp` magic allows you to switch languages in a single cell and override the cell's language picker.
+
+<img width="60%" alt="image" src="https://user-images.githubusercontent.com/547415/
+211166072-3c0ad7a8-4885-428d-b56d-79cf63bdcd1c.png">
+
 

--- a/src/Microsoft.DotNet.Interactive.Documents.Tests/CodeSubmissionFormatTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Documents.Tests/CodeSubmissionFormatTests.cs
@@ -622,9 +622,9 @@ Console.Write(""hello"");
                 .BeEquivalentTo(new InputField("the-password", "password"));
     }
 
-    private async Task<string> RoundTripDib(string notebookFile)
+    private async Task<string> RoundTripDib(string filePath)
     {
-        var expectedContent = await File.ReadAllTextAsync(notebookFile);
+        var expectedContent = await File.ReadAllTextAsync(filePath);
 
         var inputDoc = CodeSubmission.Parse(expectedContent);
 

--- a/src/Microsoft.DotNet.Interactive.Documents.Tests/JupyterFormatTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Documents.Tests/JupyterFormatTests.cs
@@ -1625,9 +1625,9 @@ public class JupyterFormatTests : DocumentFormatTestsBase
                 .Be("filename");
     }
 
-    private async Task<string> RoundTripIpynb(string notebookFile)
+    private async Task<string> RoundTripIpynb(string filePath)
     {
-        var expectedContent = await File.ReadAllTextAsync(notebookFile);
+        var expectedContent = await File.ReadAllTextAsync(filePath);
 
         var inputDoc = Notebook.Parse(expectedContent);
 

--- a/src/Microsoft.DotNet.Interactive.Documents/InteractiveDocument.cs
+++ b/src/Microsoft.DotNet.Interactive.Documents/InteractiveDocument.cs
@@ -158,12 +158,20 @@ public class InteractiveDocument : IEnumerable
 
         return file.Extension.ToLowerInvariant() switch
         {
+            // polyglot formats
             ".ipynb" => Notebook.Parse(fileContents, kernelInfos),
             ".dib" => CodeSubmission.Parse(fileContents, kernelInfos),
 
+            // single-language formats
+            ".cs" => new InteractiveDocument { new InteractiveDocumentElement(fileContents, "csharp") },
+            ".csx" => new InteractiveDocument { new InteractiveDocumentElement(fileContents, "csharp") },
+            ".fs" => new InteractiveDocument { new InteractiveDocumentElement(fileContents, "fsharp") },
+            ".fsx" => new InteractiveDocument { new InteractiveDocumentElement(fileContents, "fsharp") },
+            ".ps1" => new InteractiveDocument { new InteractiveDocumentElement(fileContents, "pwsh") },
+            ".html" => new InteractiveDocument { new InteractiveDocumentElement(fileContents, "html") },
+            ".js" => new InteractiveDocument { new InteractiveDocumentElement(fileContents, "javascript") },
 
-
-            _ => throw new InvalidOperationException($"Unrecognized extension for a notebook: {file.Extension}"),
+            _ => throw new InvalidOperationException($"Unrecognized extension for a notebook: {file.Extension}")
         };
     }
 

--- a/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
@@ -101,7 +101,7 @@ public static class KernelExtensions
                 var kernelInfoCollection = CreateKernelInfos(kernel.RootKernel as CompositeKernel);
                 var document = await InteractiveDocument.LoadAsync(
                     file,
-                    CreateKernelInfos(kernel.RootKernel as CompositeKernel));
+                    kernelInfoCollection);
 
                 foreach (var element in document.Elements)
                 {

--- a/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
@@ -102,7 +102,7 @@ public static class KernelExtensions
                 var document = await InteractiveDocument.LoadAsync(
                     file,
                     kernelInfoCollection);
-
+var lookup = kernelInfoCollection.ToDictionary(k => k.Name, StringComparer.OrdinalIgnoreCase);
                 foreach (var element in document.Elements)
                 {
                     if (lookup.TryGetValue(element.KernelName!, out var kernelInfo) && StringComparer.OrdinalIgnoreCase.Equals(kernelInfo.LanguageName, "markdown"))

--- a/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
@@ -93,16 +93,16 @@ public static class KernelExtensions
     public static TKernel UseImportMagicCommand<TKernel>(this TKernel kernel)
         where TKernel : Kernel
     {
-        var command = new Command("#!import", "Imports and runs another notebook.");
-        command.AddArgument(new Argument<FileInfo>("notebookFile").ExistingOnly());
+        var command = new Command("#!import", "Runs another notebook or source code file inline.");
+        command.AddArgument(new Argument<FileInfo>("file").ExistingOnly());
         command.Handler = CommandHandler.Create(
-            async (FileInfo notebookFile, KernelInvocationContext context) =>
+            async (FileInfo file, KernelInvocationContext _) =>
             {
                 var kernelInfoCollection = CreateKernelInfos(kernel.RootKernel as CompositeKernel);
                 var document = await InteractiveDocument.LoadAsync(
-                    notebookFile,
-                    kernelInfoCollection);
-                var lookup = kernelInfoCollection.ToDictionary(k => k.Name, StringComparer.OrdinalIgnoreCase);
+                    file,
+                    CreateKernelInfos(kernel.RootKernel as CompositeKernel));
+
                 foreach (var element in document.Elements)
                 {
                     if (lookup.TryGetValue(element.KernelName!, out var kernelInfo) && StringComparer.OrdinalIgnoreCase.Equals(kernelInfo.LanguageName, "markdown"))

--- a/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
@@ -96,7 +96,7 @@ public static class KernelExtensions
         var command = new Command("#!import", "Runs another notebook or source code file inline.");
         command.AddArgument(new Argument<FileInfo>("file").ExistingOnly());
         command.Handler = CommandHandler.Create(
-            async (FileInfo file, KernelInvocationContext _) =>
+            async (FileInfo notebookFile, KernelInvocationContext context) =>
             {
                 var kernelInfoCollection = CreateKernelInfos(kernel.RootKernel as CompositeKernel);
                 var document = await InteractiveDocument.LoadAsync(

--- a/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
@@ -96,7 +96,7 @@ public static class KernelExtensions
         var command = new Command("#!import", "Runs another notebook or source code file inline.");
         command.AddArgument(new Argument<FileInfo>("file").ExistingOnly());
         command.Handler = CommandHandler.Create(
-            async (FileInfo notebookFile, KernelInvocationContext context) =>
+            async (FileInfo file, KernelInvocationContext context) =>
             {
                 var kernelInfoCollection = CreateKernelInfos(kernel.RootKernel as CompositeKernel);
                 var document = await InteractiveDocument.LoadAsync(

--- a/src/dotnet-interactive/CommandLine/readme.md
+++ b/src/dotnet-interactive/CommandLine/readme.md
@@ -1,28 +1,8 @@
 # Command line API
 
-## Configuring the HTTP API
-
-A number of APIs are available over HTTP in `dotnet-interactive`. You can enable the API and specify which port it is enabled on in a number of ways:
-
-  Command                                                      | HTTP behavior
----------------------------------------------------------------|--------------------------------
-`dotnet interactive http`                                      | Enabled on auto-selected port
-`dotnet interactive http --http-port *`                        | Enabled on auto-selected port
-`dotnet interactive http --http-port 1234`                     | Enabled on port 1234
-`dotnet interactive stdio`                                     | Disabled
-`dotnet interactive jupyter`                                   | Enabled on autoselected port between 1000 and 3000
-`dotnet interactive jupyter --http-port-range 8001-9000`       | Enabled on autoselected port between 8001 and 9000
-
-When installing `dotnet-interactive` as a Jupyter kernel, you can also configure the HTTP API's availability when the kernel is started, as follows: 
-
-  Command                                                          | HTTP behavior of kernel 
--------------------------------------------------------------------|--------------------------------
-`dotnet interactive jupyter install`                               | Enabled on autoselected port between 1000 and 3000
-`dotnet interactive jupyter install --http-port-range 8001-9000`   | Enabled on autoselected port between 8001 and 9000                      
-
 ## Installing kernels
 
-When installing `dotnet-interactive` you can provide a path where the kernelspec  files used by Jupyter to configure a kernel will be installed. The provided path must be an existing directory.
+When installing `dotnet-interactive` you can provide a path where the kernelspec files used by Jupyter to configure a kernel will be installed. The provided path must be an existing directory.
 
   Command                                                      | Destination path
 ---------------------------------------------------------------|--------------------------------


### PR DESCRIPTION
More docs updates.

Also, add the ability for `#!import` to support additional file types:

* `.cs`
* `.csx`
* `.fs`
* `.fsx`
* `.ps1`
* `.html`
* `.js`