### PR TITLE
Add environment variables to enable service logging in the MSSQL and Kusto kernels

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Kql/KqlKernelConnector.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql/KqlKernelConnector.cs
@@ -35,8 +35,8 @@ public class KqlKernelConnector : IKernelConnector
 
         var connectionDetails = await BuildConnectionDetailsAsync();
 
-        var logPath = Environment.GetEnvironmentVariable("DOTNET_KUSTOSERVICE_LOGPATH");
-        string extraArgs = logPath != null ? $" --log-path {logPath} --trace-level Verbose" : string.Empty;
+        var logFile = Environment.GetEnvironmentVariable("DOTNET_KUSTOSERVICE_LOGFILE");
+        string extraArgs = logFile != null ? $" --log-path \"{logFile}\" --trace-level Verbose" : string.Empty;
 
         var client = new ToolsServiceClient(PathToService, $"--parent-pid {Environment.ProcessId}{extraArgs}");
 

--- a/src/Microsoft.DotNet.Interactive.Kql/KqlKernelConnector.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql/KqlKernelConnector.cs
@@ -36,7 +36,7 @@ public class KqlKernelConnector : IKernelConnector
         var connectionDetails = await BuildConnectionDetailsAsync();
 
         var logFile = Environment.GetEnvironmentVariable("DOTNET_KUSTOSERVICE_LOGFILE");
-        string extraArgs = logFile != null ? $" --log-path \"{logFile}\" --trace-level Verbose" : string.Empty;
+        string extraArgs = logFile != null ? $" --log-file \"{logFile}\" --tracing-level Verbose" : string.Empty;
 
         var client = new ToolsServiceClient(PathToService, $"--parent-pid {Environment.ProcessId}{extraArgs}");
 

--- a/src/Microsoft.DotNet.Interactive.Kql/KqlKernelConnector.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql/KqlKernelConnector.cs
@@ -35,7 +35,10 @@ public class KqlKernelConnector : IKernelConnector
 
         var connectionDetails = await BuildConnectionDetailsAsync();
 
-        var client = new ToolsServiceClient(PathToService);
+        var logPath = Environment.GetEnvironmentVariable("DOTNET_KUSTOSERVICE_LOGPATH");
+        string extraArgs = logPath != null ? $" --log-path {logPath} --trace-level Verbose" : string.Empty;
+
+        var client = new ToolsServiceClient(PathToService, $"--parent-pid {Environment.ProcessId}{extraArgs}");
 
         var kernel = new MsKqlKernel(
                 $"kql-{kernelName}",

--- a/src/Microsoft.DotNet.Interactive.Kql/KqlKernelConnector.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql/KqlKernelConnector.cs
@@ -35,10 +35,15 @@ public class KqlKernelConnector : IKernelConnector
 
         var connectionDetails = await BuildConnectionDetailsAsync();
 
+        var serviceArgs = $"--parent-pid {Environment.ProcessId}";
         var logFile = Environment.GetEnvironmentVariable("DOTNET_KUSTOSERVICE_LOGFILE");
-        string extraArgs = logFile != null ? $" --log-file \"{logFile}\" --tracing-level Verbose" : string.Empty;
+        if (!string.IsNullOrWhiteSpace(logFile))
+        {
+            var logArgs = $" --log-file \"{logFile}\" --tracing-level Verbose";
+            serviceArgs += logArgs;
+        }
 
-        var client = new ToolsServiceClient(PathToService, $"--parent-pid {Environment.ProcessId}{extraArgs}");
+        var client = new ToolsServiceClient(PathToService, serviceArgs);
 
         var kernel = new MsKqlKernel(
                 $"kql-{kernelName}",

--- a/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelConnector.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelConnector.cs
@@ -28,7 +28,10 @@ public class MsSqlKernelConnector : IKernelConnector
             throw new InvalidOperationException($"{nameof(PathToService)} cannot be null or whitespace.");
         }
 
-        var client = new ToolsServiceClient(PathToService, $"--parent-pid {Environment.ProcessId}");
+        var logPath = Environment.GetEnvironmentVariable("DOTNET_SQLTOOLSSERVICE_LOGPATH");
+        string extraArgs = logPath != null ? $" --log-path {logPath} --trace-level Verbose" : string.Empty;
+
+        var client = new ToolsServiceClient(PathToService, $"--parent-pid {Environment.ProcessId}{extraArgs}");
 
         var kernel = new MsSqlKernel(
                 $"sql-{kernelName}",

--- a/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelConnector.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelConnector.cs
@@ -29,7 +29,7 @@ public class MsSqlKernelConnector : IKernelConnector
         }
 
         var logFile = Environment.GetEnvironmentVariable("DOTNET_SQLTOOLSSERVICE_LOGFILE");
-        string extraArgs = logFile != null ? $" --log-path \"{logFile}\" --trace-level Verbose" : string.Empty;
+        string extraArgs = logFile != null ? $" --log-file \"{logFile}\" --tracing-level Verbose" : string.Empty;
 
         var client = new ToolsServiceClient(PathToService, $"--parent-pid {Environment.ProcessId}{extraArgs}");
 

--- a/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelConnector.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelConnector.cs
@@ -28,10 +28,15 @@ public class MsSqlKernelConnector : IKernelConnector
             throw new InvalidOperationException($"{nameof(PathToService)} cannot be null or whitespace.");
         }
 
+        var serviceArgs = $"--parent-pid {Environment.ProcessId}";
         var logFile = Environment.GetEnvironmentVariable("DOTNET_SQLTOOLSSERVICE_LOGFILE");
-        string extraArgs = logFile != null ? $" --log-file \"{logFile}\" --tracing-level Verbose" : string.Empty;
+        if (!string.IsNullOrWhiteSpace(logFile))
+        {
+            var logArgs = $" --log-file \"{logFile}\" --tracing-level Verbose";
+            serviceArgs += logArgs;
+        }
 
-        var client = new ToolsServiceClient(PathToService, $"--parent-pid {Environment.ProcessId}{extraArgs}");
+        var client = new ToolsServiceClient(PathToService, serviceArgs);
 
         var kernel = new MsSqlKernel(
                 $"sql-{kernelName}",

--- a/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelConnector.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelConnector.cs
@@ -28,8 +28,8 @@ public class MsSqlKernelConnector : IKernelConnector
             throw new InvalidOperationException($"{nameof(PathToService)} cannot be null or whitespace.");
         }
 
-        var logPath = Environment.GetEnvironmentVariable("DOTNET_SQLTOOLSSERVICE_LOGPATH");
-        string extraArgs = logPath != null ? $" --log-path {logPath} --trace-level Verbose" : string.Empty;
+        var logFile = Environment.GetEnvironmentVariable("DOTNET_SQLTOOLSSERVICE_LOGFILE");
+        string extraArgs = logFile != null ? $" --log-path \"{logFile}\" --trace-level Verbose" : string.Empty;
 
         var client = new ToolsServiceClient(PathToService, $"--parent-pid {Environment.ProcessId}{extraArgs}");
 


### PR DESCRIPTION
Currently we don't have any way to collect logs from the SQL and Kusto service processes if there are any issues. This change adds an environment variable to provide a log file to dump traces to for those services. Tracing is only enabled if the environment variables are set.