### PR TITLE
Temporarily remove parent-pid launch argument for Kusto

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Kql/KqlKernelConnector.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql/KqlKernelConnector.cs
@@ -35,7 +35,7 @@ public class KqlKernelConnector : IKernelConnector
 
         var connectionDetails = await BuildConnectionDetailsAsync();
 
-        var serviceArgs = $"--parent-pid {Environment.ProcessId}";
+        var serviceArgs = string.Empty; // $"--parent-pid {Environment.ProcessId}";
         var logFile = Environment.GetEnvironmentVariable("DOTNET_KUSTOSERVICE_LOGFILE");
         if (!string.IsNullOrWhiteSpace(logFile))
         {


### PR DESCRIPTION
This parent-pid argument has been in the Kusto service for almost half a year now, but the dotnet tool version of the Kusto service that we use in Interactive was created slightly before then so it doesn't recognize the argument. I'm temporarily disabling it here while I work on publishing an updated version of the Kusto nuget package.