### PR TITLE
docs and samples updates

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -93,7 +93,7 @@ A magic command is a special code command that can be run in a notebook cell, ty
 
 In IPython, magic commands are prefixed with `%`. Since this is not a valid operator in common Python, it allows IPython to easily identify magic commands.
 
-In .NET Interactive, magics are instead prefixed with `#!`, since the `#` character indicates a comment or preprocessor directive in all of the major .NET languages. Magics must come at the beginning of the line and, while multiple magics can be used in a single cell, a single magic cannot span more than one line.
+In .NET Interactive, magics are instead prefixed with `#!`, since the `#` character indicates a comment or preprocessor directive in all of the major .NET languages. Magics must come at the beginning of the line and, while multiple magics can be used in a single cell, a single magic cannot span more than one line. In .NET Interactive, there is no distinction between a "cell magic" and a "line magic". 
 
 ### What is a REPL?
 

--- a/docs/extending-dotnet-interactive.md
+++ b/docs/extending-dotnet-interactive.md
@@ -1,27 +1,45 @@
 # Extending .NET Interactive
 
-You can create extensions for .NET Interactive in order to create custom experiences including custom visualizations, new magic commands, new subkernels supporting additional languages, and more. Extensions can be distributed using NuGet packages installed using [`#r nuget`](nuget-overview.md).
+You can create extensions for .NET Interactive in order to create custom experiences including custom visualizations, new magic commands, new subkernels supporting additional languages, and more. Extensions can be distributed using NuGet packages. The extension is activated when the package is loaded by .NET Interactive using [`#r nuget`](nuget-overview.md).
 
-If you want to look at some example code first, a great place to start is the [ClockExtension](../samples/extensions/ClockExtension) sample. And we have a walkthrough that shows you how to build and install it [in the form of a notebook](../samples/extensions/ClockExtension.ipynb).
+The simplest way to create an extension is to add a file called `extension.dib` into a NuGet package and build the package so that `extension.dib` is placed in a folder inside the package called `interactive-extensions\dotnet`. 
 
-Let's walk through the steps involved.
+When a package is loaded using `#r nuget`, if that file is found inside the package, then it will be run the code in `extension.dib` after referencing your packages library (assuming the package contains a library). Because `.dib` files support multiple languages, your extension can run code using any of the supported .NET Interactive languages, or even load new kernels with additional languages. The most common approach, though, and the one detailed below, is to use `extension.dib` to simply call a method in your library.
 
-## Implement `IKernelExtension`
+## Sample project
 
-The `IKernelExtension` interface is simple:
+The [ClockExtension](../samples/extensions/ClockExtension) sample illustrates this approach. There's also walkthrough [in the form of a notebook](../samples/extensions/ClockExtension.ipynb) that shows you how to build and install it.
 
-```csharp
-public interface IKernelExtension
-{
-    Task OnLoadAsync(Kernel kernel);
-}
-```
+Here are most important details of the sample project:
 
-When your extension is loaded, this method will be called and a kernel will be passed to it. Typically, in `dotnet-interactive`, this will be a `CompositeKernel` containing the standard language-specific subkernels. Keep in mind though that configurations without a `CompositeKernel` are possible, and your extension should anticipate this. You can read more about about kernels [here](kernels-overview.md).
+* The project contains a public [`Load` method](../samples/extensions/ClockExtension/ClockKernelExtension.cs) containing code to extend .NET Interactive. This can be any public method. Taking a `Kernel` parameter makes it straightforward to write [tests](../samples/extensions/SampleExtensions.Tests/ClockExtensionTests.cs) for your extension code.
 
-## Adding magic commands
+* The [`extension.dib`](../samples/extensions/ClockExtension/extension.dib) file contains code to call this method, passing in the root kernel. (Note that this code doesn't contain `using` directives so as not to clutter up the notebook user's IntelliSense.)
+    ```csharp
+    #!csharp
 
-You can add to the set of magic commands available in your notebooks. Here's an example from the `ClockExtension`:
+    ClockExtension.ClockKernelExtension.Load(Microsoft.DotNet.Interactive.KernelInvocationContext.Current.HandlingKernel.RootKernel);
+    ```
+
+* [`ClockExtension.csproj`](../samples/extensions/ClockExtension/ClockExtension.csproj) includes a reference to the `extension.dib` file that places it in the correct location in the NuGet package:
+
+    ```xml
+    <ItemGroup>
+        <None Include="extension.dib" Pack="true" PackagePath="interactive-extensions/dotnet" />
+    </ItemGroup>
+    ```
+
+Give the [sample notebook](../samples/extensions/ClockExtension.ipynb) a try to see it working end to end on your machine.
+
+## What can you do with an extension?
+
+Here are some of the more common things you might want to do when extending .NET Interactive.
+
+## Add magic commands
+
+You can add to the set of magic commands available in your notebooks. A magic command is defined using [System.CommandLine](https://learn.microsoft.com/en-us/dotnet/standard/commandline/) to parse the user's input as well as provide help and completions. A `System.CommandLine.Command` is used to define a magic command. The handler you define for the command will be invoked when the user runs the magic command.
+
+Here's an example from the `ClockExtension` sample, showing how to define the `#!clock` magic command:
 
 ```csharp
 public class ClockKernelExtension : IKernelExtension
@@ -55,23 +73,36 @@ public class ClockKernelExtension : IKernelExtension
 
 Once the `Command` has been added using `Kernel.AddDirective`, it's available in the kernel and ready to be used.
 
-The magic command syntax is a command line syntax. It's implemented using the `System.CommandLine` command line [library](https://nuget.org/packages/System.CommandLine). You can get help for a magic command in the same way you can typically get help from a command line tool. Here's the help for the `#!clock` magic command that the previous code produces: 
+System.CommandLine allows users to get help for a magic command just like they can get help on in a command line app. For example, to get help for the `#!clock` magic command, you can run `#!clock -h`. That produces the following output:
 
-<img src="https://user-images.githubusercontent.com/547415/82130770-3db4f200-9783-11ea-9912-537127e4ba15.png" width="60%">
+```console
+Description:
+  Displays a clock showing the current or specified time.
+
+Usage:
+  #!clock [options]
+
+Options:
+  -o, --hour <hour>      The position of the hour hand
+  -m, --minute <minute>  The position of the minute hand
+  -s, --second <second>  The position of the second hand
+  -?, -h, --help         Show help and usage information
+```
 
 By calling the `#!clock` magic command, you can draw a lovely purple clock using SVG with the hands at the positions specified:
 
-<img src="https://user-images.githubusercontent.com/547415/82130789-75239e80-9783-11ea-9bf0-6e17c196148c.png" width="60%">
+<img width="513" alt="image" src="https://user-images.githubusercontent.com/547415/213597279-a5bf64b4-f6de-4f78-a29c-af3c6052677c.png">
+
 
 The extension also changes the default formatting for the `System.DateTime` type. This feature is the basis for creating custom visualizations for any .NET type. Before installing the extension, the default output just used the `DateTime.ToString` method:
 
-<img src="https://user-images.githubusercontent.com/547415/82130856-e2373400-9783-11ea-9582-56bde34f38eb.png" width="60%">
+<img width="60%" alt="image" src="https://user-images.githubusercontent.com/547415/213597570-aecf2aa1-65bb-46ea-bb09-bd998e0b8fff.png">
 
 After installing the extension, we get the much more appealing clock drawing, with the hands set to the current time:
 
-<img src="https://user-images.githubusercontent.com/547415/82130861-f11de680-9783-11ea-8159-eeef916db92e.png" width="60%">
+<img width="60%" alt="image" src="https://user-images.githubusercontent.com/547415/213597609-cf5f946b-a6d4-4780-940c-c7cdda1c6017.png">
 
-The code that does this is also found in the sample's `OnLoadAsync` method:
+The code that does this is also found in the sample's `Load` method:
 
 ```csharp
 Formatter.Register<DateTime>((date, writer) =>
@@ -81,15 +112,3 @@ Formatter.Register<DateTime>((date, writer) =>
 ```
 
 The `Formatter` API can be used to customize the output for a given .NET type (`System.DateTime`) for a mime type (`"txt/html"`).
-
-## Script-based extensions
-
-As an alternative to implementing `IKernelExtension`, extensions can also be script-based. This enables a NuGet package to not have any direct dependency on the
-`Microsoft.DotNet.Interactive` libraries or tools which means that any other projects that normally reference that
-NuGet package also will not have a dependency on .NET Interactive. 
-
-NuGet packages that are loaded via `#r "nuget:..."` are probed for a well-known file, `interactive-extensions/dotnet/extension.dib`.
-If that file is found, then it is read in its entirety and executed. The script can add new commands, register
-formatters, load packages, and run code in multiple languages using kernel chooser magic commands (e.g. `#!csharp`, `#!fsharp`, `#!pwsh`, `#!javascript`, and so on).  
-
-See the [RandomNumber](../samples/extensions/RandomNumber/README.md) extension to see this in action.

--- a/docs/magic-commands.md
+++ b/docs/magic-commands.md
@@ -1,39 +1,50 @@
 # Magic Commands
 
-A magic command is a scriptable shortcut to a more complex behavior. The magic command concept is familiar to Jupyter users. With a slight change in syntax to accommodate the .NET languages, they're also available in .NET Interactive. 
+A magic command is a special code command that can be run in an interactive code submission. The magic command concept is familiar to Jupyter users. With a slight change in syntax to accommodate the .NET languages, they're also available in .NET Interactive.
 
-Magic commands must always occur at the beginning of a line and are prefixed with either `#!` or, less commonly, `#`. The latter occurs only when unifying behaviors with language-specific compiler directives such as `#r`, a compiler directive that's implemented in both C# and F# script. Another difference from Jupyter's magic commands is that in .NET Interactive there is no distinction between a "cell magic" and a "line magic". 
+Magic commands must always start at the beginning of a line, cannot span more than one line, and are prefixed with either `#!` or, less commonly, `#`. The latter occurs only when unifying behaviors with language-specific compiler directives such as `#r`, a compiler directive that's implemented in both C# and F# script. Unlike Jupyter's magic commands, .NET Interactive there is no distinction between a "cell magic" and a "line magic". 
 
 Here's an example using the `#!time` magic command:
 
-<img src="https://user-images.githubusercontent.com/547415/81481309-ec858b00-91e3-11ea-9f80-36f02ab64e32.png" />
+<img width="60%" alt="image" src="https://user-images.githubusercontent.com/547415/213319133-9c03bbad-09f6-43a9-9981-1a82826f06aa.png">
 
 Magic commands use a command line-style syntax, including options and arguments similar to a command line tool. For every magic command, you can get help using `-h`:
 
-![image](https://user-images.githubusercontent.com/547415/81481559-f3ad9880-91e5-11ea-909a-f969525bda8d.png)
+<img width="60%" alt="image" src="https://user-images.githubusercontent.com/547415/213322348-f9754fd3-aa39-49bc-9f97-d7d765f9177c.png">
 
 The following is a list of magic commands supported by .NET Interactive:
 
-## .NET Kernel
+## Global magic commands
 
-The following are some useful magic commands that are available in all or nearly all subkernels within .NET Interactive:
+The following are some useful magic commands that are available in all or nearly all subkernels within the .NET Interactive kernel:
 
+| Command                               | Behavior                               
+|---------------------------------------|----------------------------------------------------------------------
+| `#!about`                             | Displays information about the version of the kernel.
+| [`#!import`](import-magic-command.md) | Runs code from another notebook or source code file.
+| `#!lsmagic`                           | Lists the available magic commands, including those that might have been installed via an extension. 
+| `#!markdown`                          | Indicates that the code that follows is Markdown, which can then be directly rendered as HTML in the browser.
+| [`#!share`](variable-sharing.md)      | Shares a variable from another specified subkernel (including one stored using `#!value`).
+| `#!time`                              | Measures the execution time of the code submission.
+| `#!connect`                           | Enables connection of additional kernels.
+
+## Kernel chooser magic commands
+
+Each subkernel in .NET Interactive, including subkernels added dynamically at runtime, has a name which is unique within the kernel. This name can be used to send code to that subkernel. In the default .NET Interactive kernel, the following kernel chooser magic commands are available. 
 
 | Command                               | Behavior                               
 |---------------------------------------|----------------------------------------------------------------------
 | `#!csharp` (also: `#!c#`, `#!C#`)     | Indicates that the code that follows is C#. (Specifically, the [C# Script](https://docs.microsoft.com/en-us/archive/msdn-magazine/2016/january/essential-net-csharp-scripting) dialect.) 
 | `#!fsharp` (also: `#!f#`, `#!F#`)     | Indicates that the code that follows is F#.
-| `#!pwsh` (also: `#!powershell`)       | Indicates that the code that follows is PowerShell.
-| `#!javascript` (also: `#!js`)         | Indicates that the code that follows is JavaScript, to be executed in the browser.
 | `#!html`                              | Indicates that the code that follows is HTML, which can then be directly rendered in the browser.
-| `#!lsmagic`                           | Lists the available magic commands, including those that might have been installed via an extension. 
-| `#!markdown`                          | Indicates that the code that follows is Markdown, which can then be directly rendered as HTML in the browser.
+| `#!javascript` (also: `#!js`)         | Indicates that the code that follows is JavaScript, to be executed in the browser.
+| `#!kql`                               | Provides information on how to add connection-specific KQL (Kusto Query Language) kernels to your interactive session.
 | `#!mermaid`                           | Indicates that the code that follows is [Mermaid](https://mermaid.js.org/intro/). Output is rendered visually.
-| `#!about`                             | Displays information about the current version of .NET Interactive:<br />![image](https://user-images.githubusercontent.com/547415/81481060-42f1ca00-91e2-11ea-92f7-c4ffae904961.png)
-| [`#!import`](import-magic-command.md) | Runs code from another notebook or source code file.
-| [`#!share`](variable-sharing.md)      | Shares a variable from another specified subkernel (including one stored using `#!value`).
-| `#!time`                              | Measures the execution time of the code submission.
+| `#!pwsh` (also: `#!powershell`)       | Indicates that the code that follows is PowerShell.
+| `#!sql`                               | Provides information on how to add connection-specific SQL kernels to your interactive session.
 | `#!value`                             | Stores a value (from entered text, a file, or a URL), which can be accessed using `#!share`.
+
+Note that in the Polyglot Notebooks extension for VS Code, you can also click on the kernel name in the lower right-hand corner of each cell to choose a kernel, so it's not necessary to use these magics. But in Jupyter and other frontends that don't have UI to allow you to choose a kernel, these magics give you access to the same capabilities.
 
 ## C# Kernel
 
@@ -42,9 +53,9 @@ The following magic commands are available within a C# language context.
 | Command                                 | Behavior                               
 |-----------------------------------------|----------------------------------------------------------------------
 | `#i`                                    | Adds a NuGet source to the session. Subsequent `#r nuget` commands will include the specified source when resolving packages.
-| `#r`                                    | In C# Interactive, the `#r` directive adds a reference to a specified assembly, e.g. `#r "/path/to/a.dll"`, or system assembly, e.g. `#r "System.Net.Http.Json.dll"`.  In .NET Interactive, this capability has been expanded to provide the ability to reference NuGet packages.<br />![image](https://user-images.githubusercontent.com/547415/81502691-362dae80-9294-11ea-94a4-266f4edc0d5e.png)<br />You cannot reference two different versions of the same package. If you try to do so, you'll receive an error:<br />![image](https://user-images.githubusercontent.com/547415/81502694-3cbc2600-9294-11ea-92d4-9151ad1bc805.png)
+| `#r`                                    | In C# Interactive, the `#r` compiler directive adds a reference to a specified assembly, e.g. `#r "/path/to/a.dll"`, or system assembly, e.g. `#r "System.Net.Http.Json.dll"`.  In .NET Interactive, this capability has been expanded to provide the ability to reference NuGet packages using the syntax `#r "nuget:PackageName,1.0.0-beta"`.<br />You cannot reference two different versions of the same package. If you try to do so, you'll receive an error.
 | `#!who`                                 | Displays the names of the top-level variables within the C# subkernel.
-| `#!whos`                                | Displays the top-level variables within the C# subkernel, including their name, type, and value.<br />![image](https://user-images.githubusercontent.com/547415/81481511-87329980-91e5-11ea-9a4b-b025435553ff.png)
+| `#!whos`                                | Displays the top-level variables within the C# subkernel, including their name, type, and value.
 
 ## F# Kernel
 
@@ -53,9 +64,9 @@ The following magic commands are available within an F# language context.
 | Command                                 | Behavior                               
 |-----------------------------------------|----------------------------------------------------------------------
 | `#i`                                    | Adds a NuGet source to the session. Subsequent `#r nuget` commands will include the specified source when resolving packages.
-| `#r`                                    | In F# Interactive, the `#r` directive adds a reference to a specified assembly, e.g. `#r "/path/to/a.dll"`.  In F# 5, which is used by .NET Interactive, this capability has been expanded to provide the ability to reference NuGet packages.<br />![image](https://user-images.githubusercontent.com/547415/81502691-362dae80-9294-11ea-94a4-266f4edc0d5e.png)<br />You cannot reference two different versions of the same package. If you try to do so, you'll receive an error:<br />![image](https://user-images.githubusercontent.com/547415/81502694-3cbc2600-9294-11ea-92d4-9151ad1bc805.png)
+| `#r`                                    | In F# Interactive, the `#r` compiler directive adds a reference to a specified assembly, e.g. `#r "/path/to/a.dll"`. <br/> When used with the `nuget` qualifier, it can also reference NuGet packages using the syntax `#r "nuget:PackageName,1.0.0-beta"`.<br />You cannot reference two different versions of the same package. If you try to do so, you'll receive an error.
 | `#!who`                                 | Displays the names of the top-level variables within the F# subkernel.
-| `#!whos`                                | Displays the top-level variables within the F# subkernel, including their name, type, and value.<br />![image](https://user-images.githubusercontent.com/547415/81481474-636f5380-91e5-11ea-92ce-07336b201db0.png)
+| `#!whos`                                | Displays the top-level variables within the F# subkernel, including their name, type, and value.
 
 ## Extensibility
 

--- a/samples/extensions/ClockExtension.ipynb
+++ b/samples/extensions/ClockExtension.ipynb
@@ -1,12 +1,22 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    }
+   },
    "source": [
     "# The `ClockExtension` Sample\n",
     "\n",
-    "The `ClockExtension` sample walks you through how to create a simple .NET Interactive extension and package it using NuGet.\n",
+    "The `ClockExtension` sample walks you through how to create a simple .NET Interactive extension and then package it using NuGet.\n",
+    "\n",
+    "## 1. Build the project\n",
     "\n",
     "If you opened this notebook so that its working directory is in the `ClockExtension` project directory, then the following cell will work. Otherwise, you should first switch your working directory to the directory containing this notebook."
    ]
@@ -19,7 +29,7 @@
      "language": "pwsh"
     },
     "vscode": {
-     "languageId": "dotnet-interactive.pwsh"
+     "languageId": "polyglot-notebook"
     }
    },
    "outputs": [
@@ -27,93 +37,184 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MSBuild version 17.3.0-preview-22329-01+77c72dd0f for .NET\r\n",
-      "  Determining projects to restore...\r\n",
-      "  Restored C:\\dev\\interactive\\samples\\extensions\\RandomNumber\\RandomNumber.csproj (in 152 ms).\r\n",
-      "  5 of 6 projects are up-to-date for restore.\r\n",
-      "  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview\r\n",
-      "  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview\r\n",
-      "  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview\r\n",
-      "  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview\r\n",
-      "  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview\r\n",
-      "  Library -> C:\\dev\\interactive\\samples\\extensions\\Library\\bin\\Debug\\net6.0\\Library.dll\r\n",
-      "  ClockExtension -> C:\\dev\\interactive\\samples\\extensions\\ClockExtension\\bin\\Debug\\net6.0\\ClockExtension.dll\r\n",
-      "  Library.InteractiveExtension -> C:\\dev\\interactive\\samples\\extensions\\Library.InteractiveExtension\\bin\\Debug\\net6.0\\Library.InteractiveExtension.dll\r\n",
-      "  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview\r\n",
-      "  Library.nuget -> C:\\dev\\interactive\\samples\\extensions\\Library.nuget\\bin\\Debug\\net6.0\\Library.nuget.dll\r\n",
-      "  SampleExtensions.Tests -> C:\\dev\\interactive\\samples\\extensions\\SampleExtensions.Tests\\bin\\Debug\\net6.0\\SampleExtensions.Tests.dll\r\n",
-      "  RandomNumber -> C:\\dev\\interactive\\samples\\extensions\\RandomNumber\\bin\\Debug\\netstandard2.0\\RandomNumber.dll\r\n",
-      "\r\n",
-      "Build succeeded.\r\n",
-      "    0 Warning(s)\r\n",
-      "    0 Error(s)\r\n",
-      "\r\n",
-      "Time Elapsed 00:00:01.02\r\n",
-      "MSBuild version 17.3.0-preview-22329-01+77c72dd0f for .NET\r\n",
-      "  Determining projects to restore...\r\n",
-      "  Restored C:\\dev\\interactive\\samples\\extensions\\RandomNumber\\RandomNumber.csproj (in 153 ms).\r\n",
-      "  5 of 6 projects are up-to-date for restore.\r\n",
-      "  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview\r\n",
-      "  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview\r\n",
-      "  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview\r\n",
-      "  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview\r\n",
-      "  Library -> C:\\dev\\interactive\\samples\\extensions\\Library\\bin\\Debug\\net6.0\\Library.dll\r\n",
-      "  ClockExtension -> C:\\dev\\interactive\\samples\\extensions\\ClockExtension\\bin\\Debug\\net6.0\\ClockExtension.dll\r\n",
-      "  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview\r\n",
-      "  Library.InteractiveExtension -> C:\\dev\\interactive\\samples\\extensions\\Library.InteractiveExtension\\bin\\Debug\\net6.0\\Library.InteractiveExtension.dll\r\n",
-      "  Library.nuget -> C:\\dev\\interactive\\samples\\extensions\\Library.nuget\\bin\\Debug\\net6.0\\Library.nuget.dll\r\n",
-      "  RandomNumber -> C:\\dev\\interactive\\samples\\extensions\\RandomNumber\\bin\\Debug\\netstandard2.0\\RandomNumber.dll\r\n",
-      "\r\n",
-      "    Directory: C:\\dev\\interactive\\samples\\extensions\\ClockExtension\\bin\\Debug\r\n",
-      "\r\n",
-      "\u001b[32;1mMode                 LastWriteTime         Length Name\u001b[0m\r\n",
-      "\u001b[32;1m----                 -------------         ------ ----\u001b[0m\r\n",
-      "-a---           8/11/2022  9:59 AM          15906 ClockExtension.1.0.0.nupkg\r\n",
-      "-a---            6/7/2022  5:47 PM          15798 ClockExtension.1.3.5.nupkg\r\n",
-      "-a---           8/11/2022  9:44 AM          15909 ClockExtension.1.3.6.nupkg\r\n",
-      "\r\n"
+      "MSBuild version 17.5.0-preview-22620-02+a6f6699d1 for .NET\n",
+      "  Determining projects to restore...\n",
+      "  All projects are up-to-date for restore.\n",
+      "C:\\Program Files\\dotnet\\sdk\\7.0.200-preview.22628.1\\Sdks\\Microsoft.NET.Sdk\\targets\\Microsoft.NET.RuntimeIdentifierInference.targets(287,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [C:\\dev\\interactive\\samples\\extensions\\ClockExtension\\ClockExtension.csproj]\n",
+      "  ClockExtension -> C:\\dev\\interactive\\samples\\extensions\\ClockExtension\\bin\\Debug\\net7.0\\ClockExtension.dll\n",
+      "\n",
+      "Build succeeded.\n",
+      "    0 Warning(s)\n",
+      "    0 Error(s)\n",
+      "\n",
+      "Time Elapsed 00:00:00.97\n",
+      "MSBuild version 17.5.0-preview-22620-02+a6f6699d1 for .NET\n",
+      "  Determining projects to restore...\n",
+      "  All projects are up-to-date for restore.\n",
+      "C:\\Program Files\\dotnet\\sdk\\7.0.200-preview.22628.1\\Sdks\\Microsoft.NET.Sdk\\targets\\Microsoft.NET.RuntimeIdentifierInference.targets(287,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [C:\\dev\\interactive\\samples\\extensions\\ClockExtension\\ClockExtension.csproj]\n",
+      "  ClockExtension -> C:\\dev\\interactive\\samples\\extensions\\ClockExtension\\bin\\Debug\\net7.0\\ClockExtension.dll\n",
+      "\n",
+      "    Directory: C:\\dev\\interactive\\samples\\extensions\\ClockExtension\\bin\\Debug\n",
+      "\n",
+      "\u001b[32;1mMode                 LastWriteTime         Length Name\u001b[0m\n",
+      "\u001b[32;1m----                 -------------         ------ ----\u001b[0m\n",
+      "-a---           1/19/2023  3:34 PM           9214 \u001b[31;1mClockExtension.1.0.0.nupkg\u001b[0m\n",
+      "-a---           1/19/2023  3:41 PM           9210 \u001b[31;1mClockExtension.1.0.1.nupkg\u001b[0m\n",
+      "\n"
      ]
     }
    ],
    "source": [
     "# 1. Build the project\n",
-    "dotnet build\n",
+    "dotnet build ClockExtension\n",
     "\n",
     "# Clear any older versions of this extension package from your NuGet cache\n",
     "rm ~/.nuget/packages/ClockExtension -Force -Recurse -ErrorAction Ignore\n",
     "\n",
     "# Pack up the NuGet package. \n",
-    "dotnet pack /p:PackageVersion=1.0.0\n",
+    "dotnet pack ClockExtension /p:PackageVersion=1.0.0\n",
     "\n",
     "# 3. Check that the package is there\n",
-    "Get-ChildItem -Recurse ClockExtension*.nupkg"
+    "Get-ChildItem -Recurse ClockExtension*.nupkg\n"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we're ready to install the extension. We can use `#i` to add the build output folder where the package is to our NuGet sources, and then `#r` to install the package. Because we didn't specify a package version to install, it will choose the highest version available, which is why you should increment the version in the cell above if you experiment with making changes to the extension. (*You can find out more about the `#i` and `#r` directives [here](https://github.com/dotnet/interactive/blob/main/docs/nuget-overview.md).*)\n",
-    "\n",
-    "You'll need to change the file path in the `#i` directive in this next cell to directory on your machine where `ClockExtension.1.3.5.nupkg` was created."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    }
+   },
+   "source": [
+    "## 2. Load the NuGet package \n",
+    "\n",
+    "Now we're ready to install the extension that packaged up in the NuGet package we just built. We can use the [`#i` directive](https://github.com/dotnet/interactive/blob/main/docs/nuget-overview.md) to add the build output folder to our NuGet sources.\n",
+    "\n",
+    "First, let's make sure the file is there like we expect after the build.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
     "vscode": {
-     "languageId": "dotnet-interactive.csharp"
+     "languageId": "polyglot-notebook"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "✅ The package is there!"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "using System.IO;\n",
+    "\n",
+    "// Create an absolute path since #i doesn't like \n",
+    "var debugOutputFolder = new DirectoryInfo(@\".\\ClockExtension\\bin\\Debug\\\").FullName;\n",
+    "\n",
+    "if (File.Exists(Path.Combine(debugOutputFolder, \"ClockExtension.1.0.0.nupkg\")))\n",
+    "{\n",
+    "    \"✅ The package is there!\".Display();\n",
+    "} \n",
+    "else\n",
+    "{\n",
+    "    \"❌ Something must have gone wrong with the build. The package isn't there.\".Display();\n",
+    "}\n",
+    "\n",
+    "var nugetSource = $\"nuget:{debugOutputFolder}\";"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    }
+   },
+   "source": [
+    "If the package is there, we can include its location as a NuGet source using the `#i` directive. The following syntax shares the `#i` argument including the `nuget:` prefix and the computed fully-qualified path."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "vscode": {
+     "languageId": "polyglot-notebook"
     }
    },
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<div><div><strong>Restore sources</strong><ul><li><span>C:\\dev\\interactive\\samples\\extensions\\ClockExtension\\bin\\Debug\\</span></li></ul></div><div></div><div><strong>Installed Packages</strong><ul><li><span>ClockExtension, 1.0.0</span></li></ul></div></div>"
+       "<div><div><strong>Restore sources</strong><ul><li><span>c:\\dev\\interactive\\samples\\extensions\\ClockExtension\\bin\\Debug\\</span></li></ul></div><div></div><div></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#i @csharp:nugetSource"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    }
+   },
+   "source": [
+    "Now that the package source is added, we can use `#r` to install the package. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "polyglot-notebook"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><div><strong>Restore sources</strong><ul><li><span>c:\\dev\\interactive\\samples\\extensions\\ClockExtension\\bin\\Debug\\</span></li></ul></div><div></div><div><strong>Installed Packages</strong><ul><li><span>ClockExtension, 1.0.0</span></li></ul></div></div>"
       ]
      },
      "metadata": {},
@@ -121,8 +222,8 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "Loading extensions from `ClockExtension.dll`"
+      "text/plain": [
+       "Loading extension script from `C:\\Users\\josequ\\.nuget\\packages\\clockextension\\1.0.0\\interactive-extensions\\dotnet\\extension.dib`"
       ]
      },
      "metadata": {},
@@ -131,7 +232,7 @@
     {
      "data": {
       "text/html": [
-       "<div><code>ClockExtension</code> is loaded. It adds visualizations for <code><span><a href=\"https://docs.microsoft.com/dotnet/api/system.datetime?view=net-5.0\">System.DateTime</a></span></code> and <code><span><a href=\"https://docs.microsoft.com/dotnet/api/system.datetimeoffset?view=net-5.0\">System.DateTimeOffset</a></span></code>. Try it by running: <code>DateTime.Now</code> or <code>#!clock -h</code></div>"
+       "<div><code>ClockExtension</code> is loaded. It adds visualizations for <code><span><a href=\"https://docs.microsoft.com/dotnet/api/system.datetime?view=net-7.0\">System.DateTime</a></span></code> and <code><span><a href=\"https://docs.microsoft.com/dotnet/api/system.datetimeoffset?view=net-7.0\">System.DateTimeOffset</a></span></code>. Try it by running: <code>DateTime.Now</code> or <code>#!clock -h</code></div>"
       ]
      },
      "metadata": {},
@@ -139,14 +240,23 @@
     }
    ],
    "source": [
-    "#i nuget:C:\\dev\\interactive\\samples\\extensions\\ClockExtension\\bin\\Debug\\\n",
     "#r \"nuget:ClockExtension,1.0.0\""
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    }
+   },
    "source": [
+    "## Try the extension\n",
+    "\n",
     "As you can see from the output above, the extension is able to explain a bit about what it does. So now we can try it out.\n",
     "\n",
     "It adds a custom formatter for `System.DateTime`:"
@@ -154,102 +264,102 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "vscode": {
-     "languageId": "dotnet-interactive.csharp"
+     "languageId": "polyglot-notebook"
     }
    },
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<div id=\"clockExtensionde901ed10e3b43f69cce3007a09e430a\"><svg viewBox=\"0 0 40 40\"><defs><radialGradient id=\"grad1\" cx=\"50%\" cy=\"50%\" r=\"50%\" fx=\"50%\" fy=\"50%\"><stop offset=\"0%\" style=\"stop-color:#512bd4;stop-opacity:0\"></stop><stop offset=\"100%\" style=\"stop-color:#512bd4;stop-opacity:.5\"></stop></radialGradient></defs><circle cx=\"20\" cy=\"20\" r=\"19\" fill=\"#dedede\"></circle><circle cx=\"20\" cy=\"20\" r=\"19\" fill=\"url(#grad1)\"></circle><g class=\"marks\"><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line></g><text x=\"0\" y=\"0\" class=\"text\">.NET Interactive</text><line x1=\"0\" y1=\"0\" x2=\"9\" y2=\"0\" class=\"hour\"></line><line x1=\"0\" y1=\"0\" x2=\"13\" y2=\"0\" class=\"minute\"></line><line x1=\"0\" y1=\"0\" x2=\"16\" y2=\"0\" class=\"seconds\"></line><circle cx=\"20\" cy=\"20\" r=\"0.7\" class=\"pin\"></circle></svg><style type=\"text/css\">\r\n",
-       "#clockExtensionde901ed10e3b43f69cce3007a09e430a svg {\r\n",
+       "<div id=\"clockExtensionef1783851d7f474598827a61832e099e\"><svg viewBox=\"0 0 40 40\"><defs><radialGradient id=\"grad1\" cx=\"50%\" cy=\"50%\" r=\"50%\" fx=\"50%\" fy=\"50%\"><stop offset=\"0%\" style=\"stop-color:#512bd4;stop-opacity:0\"></stop><stop offset=\"100%\" style=\"stop-color:#512bd4;stop-opacity:.5\"></stop></radialGradient></defs><circle cx=\"20\" cy=\"20\" r=\"19\" fill=\"#dedede\"></circle><circle cx=\"20\" cy=\"20\" r=\"19\" fill=\"url(#grad1)\"></circle><g class=\"marks\"><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line></g><text x=\"0\" y=\"0\" class=\"text\">.NET Interactive</text><line x1=\"0\" y1=\"0\" x2=\"9\" y2=\"0\" class=\"hour\"></line><line x1=\"0\" y1=\"0\" x2=\"13\" y2=\"0\" class=\"minute\"></line><line x1=\"0\" y1=\"0\" x2=\"16\" y2=\"0\" class=\"seconds\"></line><circle cx=\"20\" cy=\"20\" r=\"0.7\" class=\"pin\"></circle></svg><style type=\"text/css\">\r\n",
+       "#clockExtensionef1783851d7f474598827a61832e099e svg {\r\n",
        "  width: 400px;\r\n",
        "  fill: white;\r\n",
        "  stroke: black;\r\n",
        "  stroke-width: 1;\r\n",
        "  stroke-linecap: round;\r\n",
        "  transform: rotate(-90deg);\r\n",
-       "  --start-seconds: 3;\r\n",
-       "  --start-minutes: 3;\r\n",
-       "  --start-hours: 10;\r\n",
+       "  --start-seconds: 17;\r\n",
+       "  --start-minutes: 40;\r\n",
+       "  --start-hours: 4;\r\n",
        "}\r\n",
        "\r\n",
-       "#clockExtensionde901ed10e3b43f69cce3007a09e430a .marks {\r\n",
+       "#clockExtensionef1783851d7f474598827a61832e099e .marks {\r\n",
        "  transform: translate(20px, 20px);\r\n",
        "  stroke-width: 0.2;\r\n",
        "}\r\n",
-       "#clockExtensionde901ed10e3b43f69cce3007a09e430a .marks > line:nth-child(1) {\r\n",
+       "#clockExtensionef1783851d7f474598827a61832e099e .marks > line:nth-child(1) {\r\n",
        "  transform: rotate(30deg); \r\n",
        "}\r\n",
-       "#clockExtensionde901ed10e3b43f69cce3007a09e430a .marks > line:nth-child(2) {\r\n",
+       "#clockExtensionef1783851d7f474598827a61832e099e .marks > line:nth-child(2) {\r\n",
        "  transform: rotate(calc(2 * 30deg));\r\n",
        "}\r\n",
-       "#clockExtensionde901ed10e3b43f69cce3007a09e430a .marks > line:nth-child(3) {\r\n",
+       "#clockExtensionef1783851d7f474598827a61832e099e .marks > line:nth-child(3) {\r\n",
        "  transform: rotate(calc(3 * 30deg));\r\n",
        "  stroke-width: 0.5;\r\n",
        "}\r\n",
-       "#clockExtensionde901ed10e3b43f69cce3007a09e430a .marks > line:nth-child(4) {\r\n",
+       "#clockExtensionef1783851d7f474598827a61832e099e .marks > line:nth-child(4) {\r\n",
        "  transform: rotate(calc(4 * 30deg));\r\n",
        "}\r\n",
-       "#clockExtensionde901ed10e3b43f69cce3007a09e430a .marks > line:nth-child(5) {\r\n",
+       "#clockExtensionef1783851d7f474598827a61832e099e .marks > line:nth-child(5) {\r\n",
        "  transform: rotate(calc(5 * 30deg));\r\n",
        "}\r\n",
-       "#clockExtensionde901ed10e3b43f69cce3007a09e430a .marks > line:nth-child(6) {\r\n",
+       "#clockExtensionef1783851d7f474598827a61832e099e .marks > line:nth-child(6) {\r\n",
        "  transform: rotate(calc(6 * 30deg));\r\n",
        "  stroke-width: 0.5;\r\n",
        "}\r\n",
-       "#clockExtensionde901ed10e3b43f69cce3007a09e430a .marks > line:nth-child(7) {\r\n",
+       "#clockExtensionef1783851d7f474598827a61832e099e .marks > line:nth-child(7) {\r\n",
        "  transform: rotate(calc(7 * 30deg));\r\n",
        "}\r\n",
-       "#clockExtensionde901ed10e3b43f69cce3007a09e430a .marks > line:nth-child(8) {\r\n",
+       "#clockExtensionef1783851d7f474598827a61832e099e .marks > line:nth-child(8) {\r\n",
        "  transform: rotate(calc(8 * 30deg));\r\n",
        "}\r\n",
-       "#clockExtensionde901ed10e3b43f69cce3007a09e430a .marks > line:nth-child(9) {\r\n",
+       "#clockExtensionef1783851d7f474598827a61832e099e .marks > line:nth-child(9) {\r\n",
        "  transform: rotate(calc(9 * 30deg));\r\n",
        "  stroke-width: 0.5;\r\n",
        "}\r\n",
-       "#clockExtensionde901ed10e3b43f69cce3007a09e430a .marks > line:nth-child(10) {\r\n",
+       "#clockExtensionef1783851d7f474598827a61832e099e .marks > line:nth-child(10) {\r\n",
        "  transform: rotate(calc(10 * 30deg));\r\n",
        "}\r\n",
-       "#clockExtensionde901ed10e3b43f69cce3007a09e430a .marks > line:nth-child(11) {\r\n",
+       "#clockExtensionef1783851d7f474598827a61832e099e .marks > line:nth-child(11) {\r\n",
        "  transform: rotate(calc(11 * 30deg));\r\n",
        "}\r\n",
-       "#clockExtensionde901ed10e3b43f69cce3007a09e430a .marks > line:nth-child(12) {\r\n",
+       "#clockExtensionef1783851d7f474598827a61832e099e .marks > line:nth-child(12) {\r\n",
        "  transform: rotate(calc(12 * 30deg));\r\n",
        "  stroke-width: 0.5;\r\n",
        "}\r\n",
-       "#clockExtensionde901ed10e3b43f69cce3007a09e430a .seconds,\r\n",
-       "#clockExtensionde901ed10e3b43f69cce3007a09e430a .minute,\r\n",
-       "#clockExtensionde901ed10e3b43f69cce3007a09e430a .hour\r\n",
+       "#clockExtensionef1783851d7f474598827a61832e099e .seconds,\r\n",
+       "#clockExtensionef1783851d7f474598827a61832e099e .minute,\r\n",
+       "#clockExtensionef1783851d7f474598827a61832e099e .hour\r\n",
        "{\r\n",
        "  transform: translate(20px, 20px) rotate(0deg);\r\n",
        "}\r\n",
-       "#clockExtensionde901ed10e3b43f69cce3007a09e430a .seconds {\r\n",
+       "#clockExtensionef1783851d7f474598827a61832e099e .seconds {\r\n",
        "  stroke-width: 0.3;\r\n",
        "  stroke: #d00505;\r\n",
        "  transform: translate(20px, 20px) rotate(calc(var(--start-seconds) * 6deg));\r\n",
        "\r\n",
        "}\r\n",
-       "#clockExtensionde901ed10e3b43f69cce3007a09e430a .minute {\r\n",
+       "#clockExtensionef1783851d7f474598827a61832e099e .minute {\r\n",
        "  stroke-width: 0.6;\r\n",
        "  transform: translate(20px, 20px) rotate(calc(var(--start-minutes) * 6deg));\r\n",
        "}\r\n",
-       "#clockExtensionde901ed10e3b43f69cce3007a09e430a .hour {\r\n",
+       "#clockExtensionef1783851d7f474598827a61832e099e .hour {\r\n",
        "  stroke: #512bd4;\r\n",
        "  stroke-width: 1;\r\n",
        "  transform: translate(20px, 20px) rotate(calc(var(--start-hours) * 30deg));\r\n",
        "}\r\n",
-       "#clockExtensionde901ed10e3b43f69cce3007a09e430a .pin {\r\n",
+       "#clockExtensionef1783851d7f474598827a61832e099e .pin {\r\n",
        "  stroke: #d00505;\r\n",
        "  stroke-width: 0.2;\r\n",
        "}\r\n",
-       "#clockExtensionde901ed10e3b43f69cce3007a09e430a .text {\r\n",
+       "#clockExtensionef1783851d7f474598827a61832e099e .text {\r\n",
        "  font-size: 2px;\r\n",
        "  font-family: \"Segoe UI\",Helvetica,Arial,sans-serif;\r\n",
        "  transform: rotate(90deg) translate(13.5px, -12px);\r\n",
@@ -270,20 +380,27 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    }
+   },
    "source": [
     "The extension output also advised us to run `#!clock -h`. Extensions can add magic commands and all magic commands can provide help."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "vscode": {
-     "languageId": "dotnet-interactive.csharp"
+     "languageId": "polyglot-notebook"
     }
    },
    "outputs": [
@@ -313,109 +430,116 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    }
+   },
    "source": [
     "The `#!clock` magic command help explains how to use options to set the position of the hands on the clock:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "vscode": {
-     "languageId": "dotnet-interactive.csharp"
+     "languageId": "polyglot-notebook"
     }
    },
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<div id=\"clockExtension38be268e022e41e296d93de673b0faf9\"><svg viewBox=\"0 0 40 40\"><defs><radialGradient id=\"grad1\" cx=\"50%\" cy=\"50%\" r=\"50%\" fx=\"50%\" fy=\"50%\"><stop offset=\"0%\" style=\"stop-color:#512bd4;stop-opacity:0\"></stop><stop offset=\"100%\" style=\"stop-color:#512bd4;stop-opacity:.5\"></stop></radialGradient></defs><circle cx=\"20\" cy=\"20\" r=\"19\" fill=\"#dedede\"></circle><circle cx=\"20\" cy=\"20\" r=\"19\" fill=\"url(#grad1)\"></circle><g class=\"marks\"><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line></g><text x=\"0\" y=\"0\" class=\"text\">.NET Interactive</text><line x1=\"0\" y1=\"0\" x2=\"9\" y2=\"0\" class=\"hour\"></line><line x1=\"0\" y1=\"0\" x2=\"13\" y2=\"0\" class=\"minute\"></line><line x1=\"0\" y1=\"0\" x2=\"16\" y2=\"0\" class=\"seconds\"></line><circle cx=\"20\" cy=\"20\" r=\"0.7\" class=\"pin\"></circle></svg><style type=\"text/css\">\r\n",
-       "#clockExtension38be268e022e41e296d93de673b0faf9 svg {\r\n",
+       "<div id=\"clockExtension7ed68c90369e44e1be2f122ddc94acc7\"><svg viewBox=\"0 0 40 40\"><defs><radialGradient id=\"grad1\" cx=\"50%\" cy=\"50%\" r=\"50%\" fx=\"50%\" fy=\"50%\"><stop offset=\"0%\" style=\"stop-color:#512bd4;stop-opacity:0\"></stop><stop offset=\"100%\" style=\"stop-color:#512bd4;stop-opacity:.5\"></stop></radialGradient></defs><circle cx=\"20\" cy=\"20\" r=\"19\" fill=\"#dedede\"></circle><circle cx=\"20\" cy=\"20\" r=\"19\" fill=\"url(#grad1)\"></circle><g class=\"marks\"><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line><line x1=\"15\" y1=\"0\" x2=\"16\" y2=\"0\"></line></g><text x=\"0\" y=\"0\" class=\"text\">.NET Interactive</text><line x1=\"0\" y1=\"0\" x2=\"9\" y2=\"0\" class=\"hour\"></line><line x1=\"0\" y1=\"0\" x2=\"13\" y2=\"0\" class=\"minute\"></line><line x1=\"0\" y1=\"0\" x2=\"16\" y2=\"0\" class=\"seconds\"></line><circle cx=\"20\" cy=\"20\" r=\"0.7\" class=\"pin\"></circle></svg><style type=\"text/css\">\r\n",
+       "#clockExtension7ed68c90369e44e1be2f122ddc94acc7 svg {\r\n",
        "  width: 400px;\r\n",
        "  fill: white;\r\n",
        "  stroke: black;\r\n",
        "  stroke-width: 1;\r\n",
        "  stroke-linecap: round;\r\n",
        "  transform: rotate(-90deg);\r\n",
-       "  --start-seconds: 3;\r\n",
-       "  --start-minutes: 2;\r\n",
-       "  --start-hours: 1;\r\n",
+       "  --start-seconds: 56;\r\n",
+       "  --start-minutes: 34;\r\n",
+       "  --start-hours: 12;\r\n",
        "}\r\n",
        "\r\n",
-       "#clockExtension38be268e022e41e296d93de673b0faf9 .marks {\r\n",
+       "#clockExtension7ed68c90369e44e1be2f122ddc94acc7 .marks {\r\n",
        "  transform: translate(20px, 20px);\r\n",
        "  stroke-width: 0.2;\r\n",
        "}\r\n",
-       "#clockExtension38be268e022e41e296d93de673b0faf9 .marks > line:nth-child(1) {\r\n",
+       "#clockExtension7ed68c90369e44e1be2f122ddc94acc7 .marks > line:nth-child(1) {\r\n",
        "  transform: rotate(30deg); \r\n",
        "}\r\n",
-       "#clockExtension38be268e022e41e296d93de673b0faf9 .marks > line:nth-child(2) {\r\n",
+       "#clockExtension7ed68c90369e44e1be2f122ddc94acc7 .marks > line:nth-child(2) {\r\n",
        "  transform: rotate(calc(2 * 30deg));\r\n",
        "}\r\n",
-       "#clockExtension38be268e022e41e296d93de673b0faf9 .marks > line:nth-child(3) {\r\n",
+       "#clockExtension7ed68c90369e44e1be2f122ddc94acc7 .marks > line:nth-child(3) {\r\n",
        "  transform: rotate(calc(3 * 30deg));\r\n",
        "  stroke-width: 0.5;\r\n",
        "}\r\n",
-       "#clockExtension38be268e022e41e296d93de673b0faf9 .marks > line:nth-child(4) {\r\n",
+       "#clockExtension7ed68c90369e44e1be2f122ddc94acc7 .marks > line:nth-child(4) {\r\n",
        "  transform: rotate(calc(4 * 30deg));\r\n",
        "}\r\n",
-       "#clockExtension38be268e022e41e296d93de673b0faf9 .marks > line:nth-child(5) {\r\n",
+       "#clockExtension7ed68c90369e44e1be2f122ddc94acc7 .marks > line:nth-child(5) {\r\n",
        "  transform: rotate(calc(5 * 30deg));\r\n",
        "}\r\n",
-       "#clockExtension38be268e022e41e296d93de673b0faf9 .marks > line:nth-child(6) {\r\n",
+       "#clockExtension7ed68c90369e44e1be2f122ddc94acc7 .marks > line:nth-child(6) {\r\n",
        "  transform: rotate(calc(6 * 30deg));\r\n",
        "  stroke-width: 0.5;\r\n",
        "}\r\n",
-       "#clockExtension38be268e022e41e296d93de673b0faf9 .marks > line:nth-child(7) {\r\n",
+       "#clockExtension7ed68c90369e44e1be2f122ddc94acc7 .marks > line:nth-child(7) {\r\n",
        "  transform: rotate(calc(7 * 30deg));\r\n",
        "}\r\n",
-       "#clockExtension38be268e022e41e296d93de673b0faf9 .marks > line:nth-child(8) {\r\n",
+       "#clockExtension7ed68c90369e44e1be2f122ddc94acc7 .marks > line:nth-child(8) {\r\n",
        "  transform: rotate(calc(8 * 30deg));\r\n",
        "}\r\n",
-       "#clockExtension38be268e022e41e296d93de673b0faf9 .marks > line:nth-child(9) {\r\n",
+       "#clockExtension7ed68c90369e44e1be2f122ddc94acc7 .marks > line:nth-child(9) {\r\n",
        "  transform: rotate(calc(9 * 30deg));\r\n",
        "  stroke-width: 0.5;\r\n",
        "}\r\n",
-       "#clockExtension38be268e022e41e296d93de673b0faf9 .marks > line:nth-child(10) {\r\n",
+       "#clockExtension7ed68c90369e44e1be2f122ddc94acc7 .marks > line:nth-child(10) {\r\n",
        "  transform: rotate(calc(10 * 30deg));\r\n",
        "}\r\n",
-       "#clockExtension38be268e022e41e296d93de673b0faf9 .marks > line:nth-child(11) {\r\n",
+       "#clockExtension7ed68c90369e44e1be2f122ddc94acc7 .marks > line:nth-child(11) {\r\n",
        "  transform: rotate(calc(11 * 30deg));\r\n",
        "}\r\n",
-       "#clockExtension38be268e022e41e296d93de673b0faf9 .marks > line:nth-child(12) {\r\n",
+       "#clockExtension7ed68c90369e44e1be2f122ddc94acc7 .marks > line:nth-child(12) {\r\n",
        "  transform: rotate(calc(12 * 30deg));\r\n",
        "  stroke-width: 0.5;\r\n",
        "}\r\n",
-       "#clockExtension38be268e022e41e296d93de673b0faf9 .seconds,\r\n",
-       "#clockExtension38be268e022e41e296d93de673b0faf9 .minute,\r\n",
-       "#clockExtension38be268e022e41e296d93de673b0faf9 .hour\r\n",
+       "#clockExtension7ed68c90369e44e1be2f122ddc94acc7 .seconds,\r\n",
+       "#clockExtension7ed68c90369e44e1be2f122ddc94acc7 .minute,\r\n",
+       "#clockExtension7ed68c90369e44e1be2f122ddc94acc7 .hour\r\n",
        "{\r\n",
        "  transform: translate(20px, 20px) rotate(0deg);\r\n",
        "}\r\n",
-       "#clockExtension38be268e022e41e296d93de673b0faf9 .seconds {\r\n",
+       "#clockExtension7ed68c90369e44e1be2f122ddc94acc7 .seconds {\r\n",
        "  stroke-width: 0.3;\r\n",
        "  stroke: #d00505;\r\n",
        "  transform: translate(20px, 20px) rotate(calc(var(--start-seconds) * 6deg));\r\n",
        "\r\n",
        "}\r\n",
-       "#clockExtension38be268e022e41e296d93de673b0faf9 .minute {\r\n",
+       "#clockExtension7ed68c90369e44e1be2f122ddc94acc7 .minute {\r\n",
        "  stroke-width: 0.6;\r\n",
        "  transform: translate(20px, 20px) rotate(calc(var(--start-minutes) * 6deg));\r\n",
        "}\r\n",
-       "#clockExtension38be268e022e41e296d93de673b0faf9 .hour {\r\n",
+       "#clockExtension7ed68c90369e44e1be2f122ddc94acc7 .hour {\r\n",
        "  stroke: #512bd4;\r\n",
        "  stroke-width: 1;\r\n",
        "  transform: translate(20px, 20px) rotate(calc(var(--start-hours) * 30deg));\r\n",
        "}\r\n",
-       "#clockExtension38be268e022e41e296d93de673b0faf9 .pin {\r\n",
+       "#clockExtension7ed68c90369e44e1be2f122ddc94acc7 .pin {\r\n",
        "  stroke: #d00505;\r\n",
        "  stroke-width: 0.2;\r\n",
        "}\r\n",
-       "#clockExtension38be268e022e41e296d93de673b0faf9 .text {\r\n",
+       "#clockExtension7ed68c90369e44e1be2f122ddc94acc7 .text {\r\n",
        "  font-size: 2px;\r\n",
        "  font-family: \"Segoe UI\",Helvetica,Arial,sans-serif;\r\n",
        "  transform: rotate(90deg) translate(13.5px, -12px);\r\n",
@@ -431,7 +555,7 @@
     }
    ],
    "source": [
-    "#!clock --hour 1 -m 2 -s 3"
+    "#!clock --hour 12 -m 34 -s 56"
    ]
   }
  ],
@@ -441,14 +565,71 @@
    "language": "C#",
    "name": ".net-csharp"
   },
-  "language_info": {
-   "file_extension": ".cs",
-   "mimetype": "text/x-csharp",
-   "name": "C#",
-   "pygments_lexer": "csharp",
-   "version": "8.0"
+  "polyglot_notebook": {
+   "kernelInfo": {
+    "defaultKernelName": "csharp",
+    "items": [
+     {
+      "aliases": [
+       "c#",
+       "C#"
+      ],
+      "languageName": "C#",
+      "name": "csharp"
+     },
+     {
+      "aliases": [],
+      "name": ".NET"
+     },
+     {
+      "aliases": [
+       "f#",
+       "F#"
+      ],
+      "languageName": "F#",
+      "name": "fsharp"
+     },
+     {
+      "aliases": [],
+      "languageName": "HTML",
+      "name": "html"
+     },
+     {
+      "aliases": [],
+      "languageName": "KQL",
+      "name": "kql"
+     },
+     {
+      "aliases": [],
+      "languageName": "Mermaid",
+      "name": "mermaid"
+     },
+     {
+      "aliases": [
+       "powershell"
+      ],
+      "languageName": "PowerShell",
+      "name": "pwsh"
+     },
+     {
+      "aliases": [],
+      "languageName": "SQL",
+      "name": "sql"
+     },
+     {
+      "aliases": [],
+      "name": "value"
+     },
+     {
+      "aliases": [
+       "frontend"
+      ],
+      "name": "vscode"
+     }
+    ]
+   }
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 2
 }

--- a/samples/extensions/ClockExtension/ClockExtension.csproj
+++ b/samples/extensions/ClockExtension/ClockExtension.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <IncludeBuildOutput>true</IncludeBuildOutput>
     <IsPackable>true</IsPackable>
-    <PackageDescription>Renders a clock in dotnet-interactive using SVG</PackageDescription>
+    <PackageDescription>Formats dates as an SVG clock in .NET Interactive</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,12 +15,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="microsoft.dotnet.interactive" Version="1.0.0-beta.22405.1" />
-    <PackageReference Include="microsoft.dotnet.interactive.csharp" Version="1.0.0-beta.22405.1" />
+    <PackageReference Include="microsoft.dotnet.interactive" Version="1.0.0-beta.22606.2" />
+    <PackageReference Include="microsoft.dotnet.interactive.csharp" Version="1.0.0-beta.22606.2" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="$(OutputPath)/ClockExtension.dll" Pack="true" PackagePath="interactive-extensions/dotnet" />
+    <None Include="extension.dib" Pack="true" PackagePath="interactive-extensions/dotnet" />
   </ItemGroup>
-
+  
 </Project>

--- a/samples/extensions/ClockExtension/ClockKernelExtension.cs
+++ b/samples/extensions/ClockExtension/ClockKernelExtension.cs
@@ -3,27 +3,22 @@
 
 using System;
 using System.CommandLine;
-using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive;
 using Microsoft.DotNet.Interactive.Formatting;
 using static Microsoft.DotNet.Interactive.Formatting.PocketViewTags;
 
 namespace ClockExtension;
 
-public class ClockKernelExtension : IKernelExtension
+public static class ClockKernelExtension
 {
-    public Task OnLoadAsync(Kernel kernel)
+    public static void Load(Kernel kernel)
     {
-        Formatter.Register<DateTime>((date, writer) =>
-        {
-            writer.Write(date.DrawSvgClock());
-        }, "text/html");
+        // Register formatters that will change the default output when formatting DateTime and DateTimeOffset instances as text/html.
+        Formatter.Register<DateTime>((date, writer) => writer.Write(date.DrawSvgClock()), "text/html");
 
-        Formatter.Register<DateTimeOffset>((date, writer) =>
-        {
-            writer.Write(date.DrawSvgClock());
-        }, "text/html");
+        Formatter.Register<DateTimeOffset>((date, writer) => writer.Write(date.DrawSvgClock()), "text/html");
 
+        // Next, define a magic command that will render a clock.
         var hourOption = new Option<int>(new[] { "-o", "--hour" },
                                          "The position of the hour hand");
         var minuteOption = new Option<int>(new[] { "-m", "--minute" },
@@ -39,33 +34,26 @@ public class ClockKernelExtension : IKernelExtension
         };
 
         clockCommand.SetHandler(
-            (int hour, int minute, int second) =>
-            {
-                KernelInvocationContext.Current.Display(SvgClock.DrawSvgClock(hour, minute, second));
-            }, 
+            (hour, minute, second) => KernelInvocationContext.Current.Display(SvgClock.DrawSvgClock(hour, minute, second)),
             hourOption,
             minuteOption,
             secondOption);
 
         kernel.AddDirective(clockCommand);
 
-        if (KernelInvocationContext.Current is { } context)
-        {
-            PocketView view = div(
-                code(nameof(ClockExtension)),
-                " is loaded. It adds visualizations for ",
-                code(typeof(DateTime)),
-                " and ",
-                code(typeof(DateTimeOffset)),
-                ". Try it by running: ",
-                code("DateTime.Now"),
-                " or ",
-                code("#!clock -h")
-            );
+        // Finally, display some information to the user so they can see how to use the extension.
+        PocketView view = div(
+            code(nameof(ClockExtension)),
+            " is loaded. It adds visualizations for ",
+            code(typeof(DateTime)),
+            " and ",
+            code(typeof(DateTimeOffset)),
+            ". Try it by running: ",
+            code("DateTime.Now"),
+            " or ",
+            code("#!clock -h")
+        );
 
-            context.Display(view);
-        }
-
-        return Task.CompletedTask;
+        KernelInvocationContext.Current?.Display(view);
     }
 }

--- a/samples/extensions/ClockExtension/extension.dib
+++ b/samples/extensions/ClockExtension/extension.dib
@@ -1,0 +1,3 @@
+#!csharp
+
+ClockExtension.ClockKernelExtension.Load(Microsoft.DotNet.Interactive.KernelInvocationContext.Current.HandlingKernel.RootKernel);

--- a/samples/extensions/SampleExtensions.Tests/ClockExtensionTests.cs
+++ b/samples/extensions/SampleExtensions.Tests/ClockExtensionTests.cs
@@ -3,11 +3,11 @@
 
 using System;
 using System.Threading.Tasks;
+using ClockExtension;
 using FluentAssertions;
 using Microsoft.DotNet.Interactive;
 using Microsoft.DotNet.Interactive.CSharp;
 using Microsoft.DotNet.Interactive.Events;
-using ClockExtension;
 using Microsoft.DotNet.Interactive.Tests.Utility;
 using Xunit;
 
@@ -24,8 +24,7 @@ namespace SampleExtensions.Tests
                 new CSharpKernel()
             };
 
-            Task.Run(() => new ClockKernelExtension().OnLoadAsync(_kernel))
-                .Wait();
+            ClockKernelExtension.Load(_kernel);
 
             KernelEvents = _kernel.KernelEvents.ToSubscribedList();
         }

--- a/samples/extensions/SampleExtensions.Tests/SampleExtensions.Tests.csproj
+++ b/samples/extensions/SampleExtensions.Tests/SampleExtensions.Tests.csproj
@@ -11,12 +11,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="microsoft.dotnet.interactive.csharp" Version="1.0.0-beta.22405.1" />
-    <PackageReference Include="microsoft.dotnet.interactive.fsharp" Version="1.0.0-beta.22405.1" />
+    <PackageReference Include="microsoft.dotnet.interactive.csharp" Version="1.0.0-beta.22606.2" />
+    <PackageReference Include="microsoft.dotnet.interactive.fsharp" Version="1.0.0-beta.22606.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="xunit" Version="$(xunitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(xunitrunnervisualstudioVersion)">
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -24,7 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="FluentAssertions" Version="6.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Interactive.Jupyter/KernelExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/KernelExtensions.cs
@@ -209,7 +209,10 @@ using static {typeof(TopLevelMethods).FullName};
             {
                 var context = cmdLineContext.GetService<KernelInvocationContext>();
 
-                var commands =  kernel.Directives.Where(d => !d.IsHidden).ToArray();
+                var commands =  kernel.Directives
+                                      .Where(d => !d.IsHidden)
+                                      .OrderBy(d => d.Name)
+                                      .ToArray();
 
                 var supportedDirectives = new SupportedDirectives(kernel.Name, commands);
 

--- a/src/Microsoft.DotNet.Interactive.Tests/KernelRoutingTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/KernelRoutingTests.cs
@@ -269,7 +269,6 @@ await Kernel.Root.SendAsync(command);", targetKernelName: "csharp");
         public RemoteCommand(string targetKernelName) : base(targetKernelName)
         {
         }
-        
     }
 
     [Fact]

--- a/src/Microsoft.DotNet.Interactive.VSCode/VSCodeClientKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.VSCode/VSCodeClientKernelExtension.cs
@@ -19,6 +19,7 @@ public class VSCodeClientKernelExtension : IKernelExtension
                 "vscode",
                 new Uri("kernel://vscode"),
                 new[] { "frontend" });
+            hostKernel.ChooseKernelDirective.IsHidden = true;
             hostKernel.KernelInfo.SupportedKernelCommands.Add(new(nameof(RequestInput)));
             root.SetDefaultTargetKernelNameForCommand(typeof(RequestInput), "vscode");
             hostKernel.KernelInfo.SupportedKernelCommands.Add(new(nameof(SendEditableCode)));


### PR DESCRIPTION
There are updates here to the ClockExtension sample and to the docs for magic commands and building extensions.

Also a tweak to make `#!lsmagic` output alphabetical and hide the `vscode` kernel selector magic.