### PR TITLE
Switched to AsyncKeyedLock

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <solution>
     <add key="disableSourceControlIntegration" value="true" />
@@ -11,6 +11,7 @@
     <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
     <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
     <add key="MachineLearning" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/MachineLearning/nuget/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/src/Microsoft.DotNet.Interactive.CSharpProject/Microsoft.DotNet.Interactive.CSharpProject.csproj
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/Microsoft.DotNet.Interactive.CSharpProject.csproj
@@ -39,6 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AsyncKeyedLock" Version="6.0.5" />
     <PackageReference Include="Buildalyzer" Version="5.0.0" />
     <PackageReference Include="Buildalyzer.Workspaces" Version="5.0.0" />
     <PackageReference Include="Markdig.Signed" Version="0.30.4" />

--- a/src/Microsoft.DotNet.Interactive.CSharpProject/Packaging/Package.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/Packaging/Package.cs
@@ -1,32 +1,30 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Concurrent;
-using System.IO;
-using System.Linq;
-using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
-using System.Reactive.Subjects;
-using System.Text;
-using System.Threading.Tasks;
-using System.Xml.Linq;
-using System.Xml.XPath;
+using AsyncKeyedLock;
 using Buildalyzer;
 using Buildalyzer.Workspaces;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
-using System.Reactive.Linq;
-using System.Runtime.CompilerServices;
-using System.Threading;
+using Microsoft.DotNet.Interactive.CSharpProject.Servers.Roslyn;
 using Microsoft.DotNet.Interactive.Utility;
 using Pocket;
-using Microsoft.DotNet.Interactive.CSharpProject.Servers.Roslyn;
+using System;
+using System.IO;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using System.Xml.XPath;
 using static Pocket.Logger<Microsoft.DotNet.Interactive.CSharpProject.Packaging.Package>;
-using Disposable = System.Reactive.Disposables.Disposable;
-using AsyncKeyedLock;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject.Packaging;
 


### PR DESCRIPTION
I made these changes because I'm seeing some concurrent dictionaries being filled up with semaphoreslims but I don't understand if and when they're being cleared. I have switched the code to make use of my library which adds a dependency that is not in the official NuGet package sources, so I had to modify NuGet.config just so that this could build, but if it gets approved then that change would need to be dropped and I'm not sure what the procedure is to get added to the official NuGet package sources.