### PR TITLE
Bump dotnet tool versions for SQL Tools and Kusto services. Re-enable Kusto parent-PID launch argument.

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Kql/KqlKernelConnector.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql/KqlKernelConnector.cs
@@ -35,7 +35,7 @@ public class KqlKernelConnector : IKernelConnector
 
         var connectionDetails = await BuildConnectionDetailsAsync();
 
-        var serviceArgs = string.Empty; // $"--parent-pid {Environment.ProcessId}";
+        var serviceArgs = $"--parent-pid {Environment.ProcessId}";
         var logFile = Environment.GetEnvironmentVariable("DOTNET_KUSTOSERVICE_LOGFILE");
         if (!string.IsNullOrWhiteSpace(logFile))
         {

--- a/src/Microsoft.DotNet.Interactive.Kql/KqlKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql/KqlKernelExtension.cs
@@ -22,7 +22,7 @@ public class KqlKernelExtension : IKernelExtension
             bool kqlToolInstalled = installedGlobalTools.Any(tool => string.Equals(tool, kqlToolName, StringComparison.InvariantCultureIgnoreCase));
             if (!kqlToolInstalled)
             {
-                var commandLineResult = await dotnet.ToolInstall("Microsoft.SqlServer.KustoServiceLayer.Tool", null, null, "1.0.0");
+                var commandLineResult = await dotnet.ToolInstall("Microsoft.SqlServer.KustoServiceLayer.Tool", null, null, "1.1.0");
                 commandLineResult.ThrowOnFailure();
             }
 

--- a/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelExtension.cs
@@ -22,7 +22,7 @@ public class MsSqlKernelExtension : IKernelExtension
             bool sqlToolInstalled = installedGlobalTools.Any(tool => string.Equals(tool, sqlToolName, StringComparison.InvariantCultureIgnoreCase));
             if (!sqlToolInstalled)
             {
-                var commandLineResult = await dotnet.ToolInstall("Microsoft.SqlServer.SqlToolsServiceLayer.Tool", null, null, "1.0.0");
+                var commandLineResult = await dotnet.ToolInstall("Microsoft.SqlServer.SqlToolsServiceLayer.Tool", null, null, "1.1.0");
                 commandLineResult.ThrowOnFailure();
             }
 


### PR DESCRIPTION
I published new versions of the dotnet tool packages for the SQL Tools and Kusto services, so I'm bumping the versions used by each of the kernels. This new package also enables the parent-pid argument for the Kusto service (used to check when parent process exits), so I'm re-enabling that in the KQL kernel connector.