### PR TITLE
disable completion documentation for C#

### DIFF
--- a/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
@@ -448,10 +448,12 @@ public class CSharpKernel :
         }
 
         var items = new List<CompletionItem>();
-        foreach (var item in completionList.ItemsList)
+
+        foreach (CodeAnalysis.Completion.CompletionItem item in completionList.ItemsList)
         {
-            var description = await service.GetDescriptionAsync(document, item, contextCancellationToken);
-            var completionItem = item.ToModel(description);
+            // TODO: Getting a description for each item significantly slows this overall operation. We should look into caching approaches but shouldn't block completions here.
+           // var description = await service.GetDescriptionAsync(document, item, contextCancellationToken);
+            var completionItem = item.ToModel(CompletionDescription.Empty);
             items.Add(completionItem);
         }
 

--- a/src/Microsoft.DotNet.Interactive.CSharp/InteractiveWorkspace.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/InteractiveWorkspace.cs
@@ -59,14 +59,14 @@ internal class InteractiveWorkspace : Workspace
             if (Directory.Exists(appRefDir))
             {
                 var latestRuntimeDirAndVersion =
-                    Directory.GetDirectories(appRefDir)
-                        .Select(dir => Path.GetFileName(dir))
+                    Directory
+                        .GetDirectories(appRefDir)
+                        .Select(Path.GetFileName)
                         .Select(dir => new { Directory = dir, Version = TryParseVersion(dir, out var version) ? version : new Version() })
                         .Where(dir => dir.Version <= runtimeVersion)
                         .OrderByDescending(dirPair => dirPair.Version)
                         .Select(dirInfo => Path.Combine(appRefDir, dirInfo.Directory, "ref", $"net{dirInfo.Version.Major}.{dirInfo.Version.Minor}"))
-                        .Where(candidateRefDir => Directory.Exists(candidateRefDir))
-                        .FirstOrDefault();
+                        .FirstOrDefault(Directory.Exists);
                 if (latestRuntimeDirAndVersion is { })
                 {
                     refAssemblyDir = latestRuntimeDirAndVersion;

--- a/src/Microsoft.DotNet.Interactive.Formatting/HtmlFormatter.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/HtmlFormatter.cs
@@ -132,13 +132,6 @@ public static class HtmlFormatter
             return true;
         }),
 
-        //new HtmlFormatter<decimal>((d, context) =>
-        //{
-        //    FormatAndStyleAsPlainText(d, context);
-        //    return true;
-        //}),
-
-
         new HtmlFormatter<TimeSpan>((timespan, context) =>
         {
             PocketView view = span(timespan.ToString());
@@ -217,12 +210,12 @@ public static class HtmlFormatter
             return true;
         }),
 
-        // decimal should be displayed as plain text
-        new HtmlFormatter<decimal>((value, context) =>
-        {
-            FormatAndStyleAsPlainText(value, context);
-            return true;
-        }),
+        // // decimal should be displayed as plain text
+        // new HtmlFormatter<decimal>((value, context) =>
+        // {
+        //     FormatAndStyleAsPlainText(value, context);
+        //     return true;
+        // }),
 
         // Try to display object results as tables. This will return false for nested tables.
         new HtmlFormatter<object>((value, context) =>

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/CompletionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/CompletionTests.cs
@@ -318,7 +318,7 @@ var y = x + 2;
     }
 
     [Theory]
-    [InlineData(Language.CSharp, "System.Environment.Command$$Line", "Gets the command line for this process.")]
+    [InlineData(Language.CSharp, "System.Environment.Command$$Line", "Gets the command line for this process.", Skip = "Disabled pending https://github.com/dotnet/interactive/issues/2637")]
     public async Task completion_doc_comments_can_be_loaded_from_bcl_types(Language language, string markupCode, string expectedCompletionSubstring)
     {
         using var kernel = CreateKernel(language);
@@ -336,7 +336,7 @@ var y = x + 2;
     }
 
     [Theory]
-    [InlineData(Language.CSharp, "/// <summary>Adds two numbers.</summary>\nint Add(int a, int b) => a + b;", "Ad$$", "Adds two numbers.")]
+    [InlineData(Language.CSharp, "/// <summary>Adds two numbers.</summary>\nint Add(int a, int b) => a + b;", "Ad$$", "Adds two numbers.", Skip = "Disabled pending https://github.com/dotnet/interactive/issues/2637")]
     [InlineData(Language.FSharp, "/// Adds two numbers.\nlet add a b = a + b", "ad$$", "Adds two numbers.")]
     public async Task completion_doc_comments_can_be_loaded_from_source_in_a_previous_submission(Language language, string previousSubmission, string markupCode, string expectedCompletionSubString)
     {
@@ -357,7 +357,7 @@ var y = x + 2;
     }
 
     [Theory]
-    [InlineData(Language.CSharp)]
+    [InlineData(Language.CSharp, Skip = "Disabled pending https://github.com/dotnet/interactive/issues/2637")]
     [InlineData(Language.FSharp)]
     public async Task completion_contains_doc_comments_from_individually_referenced_assemblies_with_xml_files(Language language)
     {
@@ -394,7 +394,7 @@ public class C
             .ContainSingle(ci => !string.IsNullOrEmpty(ci.Documentation) && ci.Documentation.Contains("This is the answer."));
     }
 
-    [Fact]
+    [Fact(Skip = "Disabled pending https://github.com/dotnet/interactive/issues/2637")]
     public async Task csharp_completions_can_read_doc_comments_from_nuget_packages_after_forcing_the_assembly_to_load()
     {
         using var kernel = CreateKernel(Language.CSharp);


### PR DESCRIPTION
In many cases, completion documentation isn't used. It's a slightly hidden feature in VS Code and even when you know about it, you're not likely to read it for every completion item. A lazy evaluation or caching strategy can be used in the future to put this functionality back (#2637) but in the meantime, the performance improvement gained by removing it should benefit everyone.