### PR TITLE
improve stability of test

### DIFF
--- a/src/dotnet-interactive.Tests/StdIoBehaviorTests.cs
+++ b/src/dotnet-interactive.Tests/StdIoBehaviorTests.cs
@@ -49,7 +49,7 @@ public class StdIoBehaviorTests
         var kernelReadyEventTaskCompletionSource = new TaskCompletionSource();
         process.OutputDataReceived += (_, args) =>
         {
-            if (args?.Data.Contains(nameof(KernelReady)) == true)
+            if (args?.Data?.Contains(nameof(KernelReady)) == true)
             {
                 kernelReadyEventTaskCompletionSource.SetResult();
             }


### PR DESCRIPTION
This seems to periodically throw a nullref, probably because the underlying process has exited.