### PR TITLE
only allow the exact version of the backing tool

### DIFF
--- a/eng/package/PackVSCodeExtension.ps1
+++ b/eng/package/PackVSCodeExtension.ps1
@@ -17,7 +17,7 @@ function Build-VsCodeExtension([string] $packageDirectory, [string] $outputSubDi
     # set tool version
     if ($kernelVersionNumber -Ne "") {
         Write-Host "Setting tool version to $kernelVersionNumber"
-        $packageJsonContents.contributes.configuration.properties."dotnet-interactive.minimumInteractiveToolVersion"."default" = $kernelVersionNumber
+        $packageJsonContents.contributes.configuration.properties."dotnet-interactive.requiredInteractiveToolVersion"."default" = $kernelVersionNumber
     }
 
     SaveJson -packageJsonPath $packagejsonPath -packageJsonContents $packageJsonContents

--- a/eng/publish/VerifyVSCodeExtension.ps1
+++ b/eng/publish/VerifyVSCodeExtension.ps1
@@ -1,4 +1,4 @@
-[CmdletBinding(PositionalBinding=$false)]
+[CmdletBinding(PositionalBinding = $false)]
 param (
     [string]$extensionPath
 )
@@ -28,7 +28,7 @@ try {
     $availableVersions = ($packageQueryResults."data" | Select-Object -First 1)."versions" | ForEach-Object { $_."version" }
 
     # ensure package exists
-    $expectedVersion = $packageJsonContents."contributes"."configuration"."properties"."dotnet-interactive.minimumInteractiveToolVersion"."default"
+    $expectedVersion = $packageJsonContents."contributes"."configuration"."properties"."dotnet-interactive.requiredInteractiveToolVersion"."default"
     $exists = $availableVersions -contains $expectedVersion
 
     # cleanup unpacked extension
@@ -36,7 +36,8 @@ try {
 
     if ($exists) {
         Write-Host "Package version $expectedVersion exists on feed $toolFeed"
-    } else {
+    }
+    else {
         Write-Host "Package version $expectedVersion not found on feed $toolFeed"
         exit 1
     }

--- a/src/dotnet-interactive-vscode-common/src/acquisition.ts
+++ b/src/dotnet-interactive-vscode-common/src/acquisition.ts
@@ -5,12 +5,12 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { InstallInteractiveTool, InstallInteractiveArgs, CreateToolManifest, GetCurrentInteractiveVersion, InteractiveLaunchOptions, ReportInstallationStarted, ReportInstallationFinished } from './interfaces';
 
-import { isVersionSufficient } from './utilities';
+import { isVersionExactlyEqual } from './utilities';
 
 // The acquisition function.  Uses predefined callbacks for external command invocations to make testing easier.
 export async function acquireDotnetInteractive(
     args: InstallInteractiveArgs,
-    minDotNetInteractiveVersion: string,
+    requiredDotNetInteractiveVersion: string,
     globalStoragePath: string,
     getInteractiveVersion: GetCurrentInteractiveVersion,
     createToolManifest: CreateToolManifest,
@@ -34,14 +34,14 @@ export async function acquireDotnetInteractive(
     };
 
     // determine if acquisition is necessary
-    const requiredVersion = args.toolVersion ?? minDotNetInteractiveVersion;
+    const requiredVersion = args.toolVersion ?? requiredDotNetInteractiveVersion;
     const currentVersion = await getInteractiveVersion(args.dotnetPath, globalStoragePath);
-    if (currentVersion && isVersionSufficient(currentVersion, requiredVersion)) {
+    if (currentVersion && isVersionExactlyEqual(currentVersion, requiredVersion)) {
         // current is acceptable
         return launchOptions;
     }
 
-    // no current version installed or it's out of date
+    // no current version installed or it's incorrect
     reportInstallationStarted(requiredVersion);
     await installInteractive({
         dotnetPath: args.dotnetPath,

--- a/src/dotnet-interactive-vscode-common/src/commands.ts
+++ b/src/dotnet-interactive-vscode-common/src/commands.ts
@@ -19,13 +19,16 @@ import { PromiseCompletionSource } from './dotnet-interactive/promiseCompletionS
 
 import * as constants from './constants';
 
-export function registerAcquisitionCommands(context: vscode.ExtensionContext, diagnosticChannel: ReportChannel) {
+export async function registerAcquisitionCommands(context: vscode.ExtensionContext, diagnosticChannel: ReportChannel): Promise<void> {
     const dotnetConfig = vscode.workspace.getConfiguration(constants.DotnetConfigurationSectionName);
     const requiredDotNetInteractiveVersion = dotnetConfig.get<string>('requiredInteractiveToolVersion');
     const interactiveToolSource = dotnetConfig.get<string>('interactiveToolSource');
 
     if (!requiredDotNetInteractiveVersion) {
-        throw new Error(`Missing or incorrect required configuration setting "${constants.DotnetConfigurationSectionName}.requiredInteractiveToolVersion"`);
+        const errorTitle = 'Polyglot Notebooks extension will not work.';
+        const errorDetails = `Incorrect value for option "${constants.DotnetConfigurationSectionName}.requiredInteractiveToolVersion" in settings.json.  Please remove this value and restart VS Code.`;
+        await vscode.window.showErrorMessage(errorTitle, { modal: true, detail: errorDetails });
+        throw new Error(errorDetails);
     }
 
     let cachedInstallArgs: InstallInteractiveArgs | undefined = undefined;

--- a/src/dotnet-interactive-vscode-common/src/commands.ts
+++ b/src/dotnet-interactive-vscode-common/src/commands.ts
@@ -21,8 +21,12 @@ import * as constants from './constants';
 
 export function registerAcquisitionCommands(context: vscode.ExtensionContext, diagnosticChannel: ReportChannel) {
     const dotnetConfig = vscode.workspace.getConfiguration(constants.DotnetConfigurationSectionName);
-    const minDotNetInteractiveVersion = dotnetConfig.get<string>('minimumInteractiveToolVersion');
+    const requiredDotNetInteractiveVersion = dotnetConfig.get<string>('requiredInteractiveToolVersion');
     const interactiveToolSource = dotnetConfig.get<string>('interactiveToolSource');
+
+    if (!requiredDotNetInteractiveVersion) {
+        throw new Error(`Missing or incorrect required configuration setting "${constants.DotnetConfigurationSectionName}.requiredInteractiveToolVersion"`);
+    }
 
     let cachedInstallArgs: InstallInteractiveArgs | undefined = undefined;
     let acquirePromise: Promise<InteractiveLaunchOptions> | undefined = undefined;
@@ -44,7 +48,7 @@ export function registerAcquisitionCommands(context: vscode.ExtensionContext, di
                 const installationPromiseCompletionSource = new PromiseCompletionSource<void>();
                 acquirePromise = acquireDotnetInteractive(
                     installArgs,
-                    minDotNetInteractiveVersion!,
+                    requiredDotNetInteractiveVersion,
                     context.globalStorageUri.fsPath,
                     getInteractiveVersion,
                     createToolManifest,

--- a/src/dotnet-interactive-vscode-common/src/extension.ts
+++ b/src/dotnet-interactive-vscode-common/src/extension.ts
@@ -20,7 +20,7 @@ import { registerAcquisitionCommands, registerKernelCommands, registerFileComman
 import { languageToCellKind } from './interactiveNotebook';
 import { InteractiveLaunchOptions, InstallInteractiveArgs } from './interfaces';
 
-import { createOutput, debounce, getDotNetVersionOrThrow, getWorkingDirectoryForNotebook, isVersionSufficient, processArguments } from './utilities';
+import { createOutput, debounce, getDotNetVersionOrThrow, getWorkingDirectoryForNotebook, isVersionGreaterOrEqual, processArguments } from './utilities';
 import { OutputChannelAdapter } from './OutputChannelAdapter';
 
 import * as notebookControllers from '../notebookControllers';
@@ -94,7 +94,7 @@ export async function activate(context: vscode.ExtensionContext) {
     let showHelpPage = false;
     try {
         const dotnetVersion = await getDotNetVersionOrThrow(DotNetPathManager.getDotNetPath(), diagnosticsChannel);
-        if (!isVersionSufficient(dotnetVersion, minDotNetSdkVersion)) {
+        if (!isVersionGreaterOrEqual(dotnetVersion, minDotNetSdkVersion)) {
             showHelpPage = true;
             const message = `The .NET SDK version ${dotnetVersion} is not sufficient. The minimum required version is ${minDotNetSdkVersion}.`;
             diagnosticsChannel.appendLine(message);

--- a/src/dotnet-interactive-vscode-common/src/extension.ts
+++ b/src/dotnet-interactive-vscode-common/src/extension.ts
@@ -88,7 +88,7 @@ export async function activate(context: vscode.ExtensionContext) {
     await waitForSdkPackExtension();
 
     // this must happen early, because some following functions use the acquisition command
-    registerAcquisitionCommands(context, diagnosticsChannel);
+    await registerAcquisitionCommands(context, diagnosticsChannel);
 
     // check sdk version
     let showHelpPage = false;

--- a/src/dotnet-interactive-vscode-common/src/utilities.ts
+++ b/src/dotnet-interactive-vscode-common/src/utilities.ts
@@ -274,7 +274,15 @@ export function getVersionNumber(output: string): string {
     return lines[lines.length - 1];
 }
 
-export function isVersionSufficient(firstVersion: string, secondVersion: string): boolean {
+export function isVersionExactlyEqual(firstVersion: string, secondVersion: string): boolean {
+    try {
+        return compareVersions.compare(firstVersion, secondVersion, '=');
+    } catch (_) {
+        return false;
+    }
+}
+
+export function isVersionGreaterOrEqual(firstVersion: string, secondVersion: string): boolean {
     try {
         return compareVersions.compare(firstVersion, secondVersion, '>=');
     } catch (_) {

--- a/src/dotnet-interactive-vscode-insiders/package.json
+++ b/src/dotnet-interactive-vscode-insiders/package.json
@@ -173,10 +173,10 @@
           "default": "7.0",
           "description": "The minimum required version of the .NET SDK."
         },
-        "dotnet-interactive.minimumInteractiveToolVersion": {
+        "dotnet-interactive.requiredInteractiveToolVersion": {
           "type": "string",
           "default": "1.0.406101",
-          "description": "The minimum required version of the .NET Interactive tool."
+          "description": "The required version of the .NET Interactive tool."
         }
       }
     },

--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -172,10 +172,10 @@
           "default": "7.0",
           "description": "The minimum required version of the .NET SDK."
         },
-        "dotnet-interactive.minimumInteractiveToolVersion": {
+        "dotnet-interactive.requiredInteractiveToolVersion": {
           "type": "string",
           "default": "1.0.406101",
-          "description": "The minimum required version of the .NET Interactive tool."
+          "description": "The required version of the .NET Interactive tool."
         }
       }
     },

--- a/src/dotnet-interactive-vscode/update-versions.ps1
+++ b/src/dotnet-interactive-vscode/update-versions.ps1
@@ -27,13 +27,13 @@ try {
             $newToolVersion = ($packageQueryResults."data" | Select-Object -First 1)."version"
 
             # ...compare to existing...
-            $existingToolVersion = $packageJsonContents."contributes"."configuration"."properties"."dotnet-interactive.minimumInteractiveToolVersion"."default"
+            $existingToolVersion = $packageJsonContents."contributes"."configuration"."properties"."dotnet-interactive.requiredInteractiveToolVersion"."default"
             if ($existingToolVersion -eq $newToolVersion) {
                 Write-Host "Existing tool version $existingToolVersion is up to date."
             }
             else {
                 Write-Host "Updating tool version from $existingToolVersion to $newToolVersion"
-                $packageJsonContents."contributes"."configuration"."properties"."dotnet-interactive.minimumInteractiveToolVersion"."default" = $newToolVersion
+                $packageJsonContents."contributes"."configuration"."properties"."dotnet-interactive.requiredInteractiveToolVersion"."default" = $newToolVersion
             }
         }
 


### PR DESCRIPTION
This renames the configuration option `minimumInteractiveToolVersion` to `requiredInteractiveToolVersion` and changes the version check from `>=` to `=`.  This ensures that if the user installs a different version of the extension (e.g., if they downgrade) then they'll get the exact matching tool as well.

Fixes #2398.