### PR TITLE
remove redundant keyword tags from extension

### DIFF
--- a/src/dotnet-interactive-vscode-insiders/package.json
+++ b/src/dotnet-interactive-vscode-insiders/package.json
@@ -28,16 +28,12 @@
     "Visualization"
   ],
   "keywords": [
-    ".NET Core",
     ".NET",
     "interactive",
-    ".NET Interactive",
-    "dotnet interactive",
     "C#",
     "data science",
     "dotnet",
     "F#",
-    "interactive programming",
     "ipynb",
     "Jupyter",
     "notebooks",

--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -28,16 +28,12 @@
     "Visualization"
   ],
   "keywords": [
-    ".NET Core",
     ".NET",
     "interactive",
-    ".NET Interactive",
-    "dotnet interactive",
     "C#",
     "data science",
     "dotnet",
     "F#",
-    "interactive programming",
     "ipynb",
     "Jupyter",
     "notebooks",


### PR DESCRIPTION
Publishing the extension to the VS Code marketplace is now failing with "You exceeded the number of allowed tags of 10." and according to [this](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#i-get-a-you-exceeded-the-number-of-allowed-tags-of-10-error-when-i-try-to-publish-my-extension) we need to reduce the number of entries in the `keywords` element to 10.  All items removed exist in their single-word form, with the exception of ".NET Core" which isn't the proper branding anyways.