### PR TITLE
Throw more informative exception if tools service process exits before a connection is established.

### DIFF
--- a/src/Microsoft.DotNet.Interactive.SqlServer/ToolsServiceClient.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/ToolsServiceClient.cs
@@ -116,7 +116,21 @@ public class ToolsServiceClient : IDisposable
 
     public async Task<bool> ConnectAsync(ConnectParams connectParams)
     {
-        return await _rpc.InvokeWithParameterObjectAsync<bool>("connection/connect", connectParams);
+        try
+        {
+            return await _rpc.InvokeWithParameterObjectAsync<bool>("connection/connect", connectParams);
+        }
+        catch (ConnectionLostException ex)
+        {
+            if (_process.HasExited)
+            {
+                throw new InvalidOperationException($"{_serviceExePath} failed to start properly. Exit code: {_process.ExitCode}.", ex);
+            }
+            else
+            {
+                throw;
+            }
+        }
     }
 
     public async Task<bool> DisconnectAsync(Uri ownerUri)


### PR DESCRIPTION
When StreamJsonRpc throws a ConnectionLostException, it isn't immediately obvious what the underlying issue is. This change adds an extra wrapping exception if the process exited abruptly before a connection was established, since in that case we probably won't be able to get any logs from the tools service exiting so close to startup. I tried to grab the standard output the tools service produces in that scenario, but it looks like it already gets pulled off the stream as part of the RPC client reading off incoming messages. Enabling tracing for the RPC client also didn't reveal what that incoming message was, so this is the best I can do without getting into some weird middleman stream to capture incoming messages from the tools service.