### PR TITLE
parse regular expressions in language configurations

### DIFF
--- a/src/dotnet-interactive-vscode-common/src/dynamicGrammarSemanticTokenProvider.ts
+++ b/src/dotnet-interactive-vscode-common/src/dynamicGrammarSemanticTokenProvider.ts
@@ -226,7 +226,7 @@ export class DynamicGrammarSemanticTokenProvider {
             if (this.fileExists(languageConfigurationFilePath)) {
                 try {
                     const languageConfigurationContents = this.fileReader(languageConfigurationFilePath);
-                    const languageConfiguration = JSON.parse(languageConfigurationContents);
+                    const languageConfiguration = parseLanguageConfiguration(languageConfigurationContents);
                     for (const languageNameOrAlias of allNames) {
                         this._languageNameConfigurationMap.set(languageNameOrAlias, languageConfiguration);
                     }
@@ -273,7 +273,7 @@ export class DynamicGrammarSemanticTokenProvider {
                         if (this.fileExists(languageConfigurationPath)) {
                             const languageConfigurationContents = this.fileReader(languageConfigurationPath);
                             try {
-                                languageConfigurationObject = JSON.parse(languageConfigurationContents);
+                                languageConfigurationObject = parseLanguageConfiguration(languageConfigurationContents);
                                 this._languageNameConfigurationMap.set(languageId, languageConfigurationObject);
                             } catch {
                                 // we don't care if we couldn't parse it
@@ -512,4 +512,35 @@ function normalizeLanguageName(languageName: string): string {
 function languageNameFromKernelInfo(kernelInfo: contracts.KernelInfo): string {
     // ensure we have some kind of language name, even if it doesn't map to anything
     return normalizeLanguageName(kernelInfo.languageName ?? `unknown-language-from-kernel-${kernelInfo.localName}`);
+}
+
+export function parseLanguageConfiguration(content: string): any {
+    const languageConfigurationObject = JSON.parse(content);
+
+    fixRegExpProperty(languageConfigurationObject, 'wordPattern');
+
+    if (typeof languageConfigurationObject.indentationRules === 'object') {
+        fixRegExpProperty(languageConfigurationObject.indentationRules, 'decreaseIndentPattern');
+        fixRegExpProperty(languageConfigurationObject.indentationRules, 'increaseIndentPattern');
+        fixRegExpProperty(languageConfigurationObject.indentationRules, 'indentNextLinePattern');
+        fixRegExpProperty(languageConfigurationObject.indentationRules, 'unIndentedLinePattern');
+    }
+
+    if (Array.isArray(languageConfigurationObject.onEnterRules)) {
+        languageConfigurationObject.onEnterRules.forEach((rule: any) => {
+            fixRegExpProperty(rule, 'beforeText');
+            fixRegExpProperty(rule, 'afterText');
+            fixRegExpProperty(rule, 'previousLineText');
+        });
+    }
+
+    return languageConfigurationObject;
+}
+
+function fixRegExpProperty(value: any, propertyName: string) {
+    if (typeof value[propertyName] === 'string') {
+        value[propertyName] = new RegExp(value[propertyName]);
+    } else if (typeof value[propertyName] === 'object' && typeof value[propertyName].pattern === 'string') {
+        value[propertyName] = new RegExp(value[propertyName].pattern);
+    }
 }

--- a/src/dotnet-interactive-vscode-common/tests/dynamicGrammarSemanticTokenProvider.test.ts
+++ b/src/dotnet-interactive-vscode-common/tests/dynamicGrammarSemanticTokenProvider.test.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscodeLike from '../../src/vscode-common/interfaces/vscode-like';
 import { expect } from 'chai';
-import { DynamicGrammarSemanticTokenProvider, VSCodeExtensionLike } from '../../src/vscode-common/dynamicGrammarSemanticTokenProvider';
+import { DynamicGrammarSemanticTokenProvider, VSCodeExtensionLike, parseLanguageConfiguration } from '../../src/vscode-common/dynamicGrammarSemanticTokenProvider';
 import { Logger } from '../../src/vscode-common/dotnet-interactive';
 
 describe('dynamic grammar tests', async () => {
@@ -711,4 +711,187 @@ User-Agent: abc/{{userAgent}}/def`;
             expect(logMessages).to.deep.equal([]);
         }
     });
+});
+
+describe('deserializing language configuration tests', () => {
+
+    // it'll be easier to test if we can pass in a raw object
+    function getConfigurationFromObject(obj: any): any {
+        const asString = JSON.stringify(obj);
+        const config = parseLanguageConfiguration(asString);
+        return config;
+    }
+
+    function verifyIsRegExp(obj: any) {
+        expect(obj.constructor.name).to.equal('RegExp');
+    }
+
+    it('`wordPattern` can be deserialized from string', () => {
+        const config = getConfigurationFromObject({
+            wordPattern: 'abc',
+        });
+        verifyIsRegExp(config.wordPattern);
+    });
+
+    it('`wordPattern` can be deserialized from object', () => {
+        const config = getConfigurationFromObject({
+            wordPattern: {
+                pattern: 'abc',
+            },
+        });
+        verifyIsRegExp(config.wordPattern);
+    });
+
+    it('`indentationRules.decreaseIndentPattern` can be deserialized from string', () => {
+        const config = getConfigurationFromObject({
+            indentationRules: {
+                decreaseIndentPattern: 'abc',
+            },
+        });
+        verifyIsRegExp(config.indentationRules.decreaseIndentPattern);
+    });
+
+    it('`indentationRules.decreaseIndentPattern` can be deserialized from object', () => {
+        const config = getConfigurationFromObject({
+            indentationRules: {
+                decreaseIndentPattern: {
+                    pattern: 'abc',
+                },
+            },
+        });
+        verifyIsRegExp(config.indentationRules.decreaseIndentPattern);
+    });
+
+    it('`indentationRules.increaseIndentPattern` can be deserialized from string', () => {
+        const config = getConfigurationFromObject({
+            indentationRules: {
+                increaseIndentPattern: 'abc',
+            },
+        });
+        verifyIsRegExp(config.indentationRules.increaseIndentPattern);
+    });
+
+    it('`indentationRules.increaseIndentPattern` can be deserialized from object', () => {
+        const config = getConfigurationFromObject({
+            indentationRules: {
+                increaseIndentPattern: {
+                    pattern: 'abc',
+                },
+            },
+        });
+        verifyIsRegExp(config.indentationRules.increaseIndentPattern);
+    });
+
+    it('`indentationRules.indentNextLinePattern` can be deserialized from string', () => {
+        const config = getConfigurationFromObject({
+            indentationRules: {
+                indentNextLinePattern: 'abc',
+            },
+        });
+        verifyIsRegExp(config.indentationRules.indentNextLinePattern);
+    });
+
+    it('`indentationRules.indentNextLinePattern` can be deserialized from object', () => {
+        const config = getConfigurationFromObject({
+            indentationRules: {
+                indentNextLinePattern: {
+                    pattern: 'abc',
+                },
+            },
+        });
+        verifyIsRegExp(config.indentationRules.indentNextLinePattern);
+    });
+
+    it('`indentationRules.unIndentedLinePattern` can be deserialized from string', () => {
+        const config = getConfigurationFromObject({
+            indentationRules: {
+                unIndentedLinePattern: 'abc',
+            },
+        });
+        verifyIsRegExp(config.indentationRules.unIndentedLinePattern);
+    });
+
+    it('`indentationRules.unIndentedLinePattern` can be deserialized from object', () => {
+        const config = getConfigurationFromObject({
+            indentationRules: {
+                unIndentedLinePattern: {
+                    pattern: 'abc',
+                },
+            },
+        });
+        verifyIsRegExp(config.indentationRules.unIndentedLinePattern);
+    });
+
+    it('`onEnterRules.beforeText` can be deserialized from string', () => {
+        const config = getConfigurationFromObject({
+            onEnterRules: [
+                {
+                    beforeText: 'abc',
+                }
+            ]
+        });
+        verifyIsRegExp(config.onEnterRules[0].beforeText);
+    });
+
+    it('`onEnterRules.beforeText` can be deserialized from object', () => {
+        const config = getConfigurationFromObject({
+            onEnterRules: [
+                {
+                    beforeText: {
+                        pattern: 'abc',
+                    },
+                }
+            ]
+        });
+        verifyIsRegExp(config.onEnterRules[0].beforeText);
+    });
+
+    it('`onEnterRules.afterText` can be deserialized from string', () => {
+        const config = getConfigurationFromObject({
+            onEnterRules: [
+                {
+                    afterText: 'abc',
+                }
+            ]
+        });
+        verifyIsRegExp(config.onEnterRules[0].afterText);
+    });
+
+    it('`onEnterRules.afterText` can be deserialized from object', () => {
+        const config = getConfigurationFromObject({
+            onEnterRules: [
+                {
+                    afterText: {
+                        pattern: 'abc',
+                    },
+                }
+            ]
+        });
+        verifyIsRegExp(config.onEnterRules[0].afterText);
+    });
+
+    it('`onEnterRules.previousLineText` can be deserialized from string', () => {
+        const config = getConfigurationFromObject({
+            onEnterRules: [
+                {
+                    previousLineText: 'abc',
+                }
+            ]
+        });
+        verifyIsRegExp(config.onEnterRules[0].previousLineText);
+    });
+
+    it('`onEnterRules.previousLineText` can be deserialized from object', () => {
+        const config = getConfigurationFromObject({
+            onEnterRules: [
+                {
+                    previousLineText: {
+                        pattern: 'abc',
+                    },
+                }
+            ]
+        });
+        verifyIsRegExp(config.onEnterRules[0].previousLineText);
+    });
+
 });


### PR DESCRIPTION
Certain properties in the language configuration object are meant to be `RegExp` so we have to special-case those when parsing.

Fixes an issue where switching a cell to JavaScript would throw the error `$.exec is not a function`.