### PR TITLE
special-case markdown in the dynamic grammar

### DIFF
--- a/src/dotnet-interactive-vscode-common/src/dynamicGrammarSemanticTokenProvider.ts
+++ b/src/dotnet-interactive-vscode-common/src/dynamicGrammarSemanticTokenProvider.ts
@@ -192,8 +192,25 @@ export class DynamicGrammarSemanticTokenProvider {
         }
 
         // update that collection with new/changed values
+        let hasMarkdownKernel = false;
         for (const kernelInfo of kernelInfos) {
             documentKernelInfos.set(kernelInfo.localName, kernelInfo);
+            if (kernelInfo.localName.toLocaleLowerCase() === 'markdown') {
+                hasMarkdownKernel = true;
+            }
+        }
+
+        if (!hasMarkdownKernel) {
+            // the markdown kernel isn't real, but still needs to be accounted for in the grammar
+            documentKernelInfos.set('markdown', {
+                localName: 'markdown', // always assume it's called #!markdown
+                displayName: 'unused',
+                languageName: 'markdown',
+                aliases: ['md'],
+                supportedKernelCommands: [],
+                supportedDirectives: [],
+                uri: 'unused',
+            });
         }
 
         // keep that collection for next time
@@ -284,7 +301,7 @@ export class DynamicGrammarSemanticTokenProvider {
                     // set language info
                     const languageInfo = this._languageNameInfoMap.get(languageId);
                     if (languageInfo) {
-                        const aliases = Array.isArray(language.aliases) ? language.aliases : [];
+                        const aliases: string[] = (Array.isArray(language.aliases) ? <any[]>language.aliases : []).filter(a => typeof a === 'string');
                         for (const alias of aliases.map(normalizeLanguageName)) {
                             this._languageNameInfoMap.set(alias, languageInfo);
                             if (languageConfigurationObject) {

--- a/src/dotnet-interactive-vscode-common/tests/dynamicGrammarSemanticTokenProvider.test.ts
+++ b/src/dotnet-interactive-vscode-common/tests/dynamicGrammarSemanticTokenProvider.test.ts
@@ -435,6 +435,20 @@ User-Agent: abc/{{userAgent}}/def`;
         ]);
     });
 
+    it('markdown grammar can classify code', async () => {
+        const code = `
+#!markdown
+This is \`markdown\`.
+`;
+        const tokens = await getTokens('test-csharp', code);
+        expect(tokens).to.deep.equal([
+            {
+                tokenText: '`markdown`',
+                tokenType: 'polyglot-notebook-string'
+            }
+        ]);
+    });
+
     it('language configuration can be pulled from kernel name', () => {
         const notebookDocument: vscodeLike.NotebookDocument = {
             uri: testUri,
@@ -628,6 +642,30 @@ User-Agent: abc/{{userAgent}}/def`;
                         ]
                     }
                 }
+            },
+            // markdown isn't in the kernel list, but it's special-cased inside
+            {
+                id: 'test-extension.markdown',
+                extensionPath: '',
+                packageJSON: {
+                    contributes: {
+                        grammars: [
+                            {
+                                language: 'markdown',
+                                scopeName: 'source.markdown',
+                                path: 'markdown.tmGrammar.json'
+                            }
+                        ],
+                        languages: [
+                            {
+                                id: 'markdown',
+                                aliases: [
+                                    'md'
+                                ]
+                            }
+                        ]
+                    }
+                }
             }
         ];
 
@@ -645,13 +683,21 @@ User-Agent: abc/{{userAgent}}/def`;
                 }
             ]
         }));
-
         grammarContentsByPath.set('erlang.tmGrammar.json', JSON.stringify({
             scopeName: 'source.erlang',
             patterns: [
                 {
                     name: 'comment.line.erlang',
                     match: '%.*'
+                }
+            ]
+        }));
+        grammarContentsByPath.set('markdown.tmGrammar.json', JSON.stringify({
+            scopeName: 'source.markdown',
+            patterns: [
+                {
+                    name: 'string.raw',
+                    match: '`[^`]*`'
                 }
             ]
         }));


### PR DESCRIPTION
Before:

<img width="142" alt="image" src="https://user-images.githubusercontent.com/926281/214923841-d50dc990-4605-41d5-99b3-98f7b1ffbfa9.png">

After:

<img width="312" alt="image" src="https://user-images.githubusercontent.com/926281/215912596-c5cc2f24-b5ca-4964-a0d1-437321820020.png">

Fixes #2651.