### PR TITLE
remove deprecated commands

### DIFF
--- a/src/dotnet-interactive-vscode-common/src/commands.ts
+++ b/src/dotnet-interactive-vscode-common/src/commands.ts
@@ -117,27 +117,7 @@ function getCurrentNotebookDocument(): vscode.NotebookDocument | undefined {
     return versionSpecificFunctions.getNotebookDocumentFromEditor(vscode.window.activeNotebookEditor);
 }
 
-export function registerLegacyKernelCommands(context: vscode.ExtensionContext, clientMapper: ClientMapper) {
-
-    context.subscriptions.push(vscode.commands.registerCommand('dotnet-interactive.restartCurrentNotebookKernel', async (notebook?: vscode.NotebookDocument | undefined) => {
-        vscode.window.showWarningMessage(`The command '.NET Interactive: Restart the current notebook's kernel' is deprecated.  Please use the 'Polyglot Notebook: Restart the current notebook's kernel' command instead.`);
-        await await vscode.commands.executeCommand('polyglot-notebook.restartCurrentNotebookKernel', notebook);
-    }));
-
-    context.subscriptions.push(vscode.commands.registerCommand('dotnet-interactive.stopCurrentNotebookKernel', async (notebook?: vscode.NotebookDocument | undefined) => {
-        vscode.window.showWarningMessage(`The command '.NET Interactive: Stop the current notebook's kernel' is deprecated.  Please use the 'Polyglot Notebook: Stop the current notebook's kernel' command instead.`);
-        await await vscode.commands.executeCommand('polyglot-notebook.stopCurrentNotebookKernel', notebook);
-    }));
-
-    context.subscriptions.push(vscode.commands.registerCommand('dotnet-interactive.stopAllNotebookKernels', async () => {
-        vscode.window.showWarningMessage(`The command '.NET Interactive: Stop the current notebook's kernel' is deprecated.  Please use the 'Polyglot Notebook: Stop the current notebook's kernel' command instead.`);
-        await await vscode.commands.executeCommand('polyglot-notebook.stopAllNotebookKernels');
-    }));
-}
-
 export function registerKernelCommands(context: vscode.ExtensionContext, clientMapper: ClientMapper) {
-    // TODO: remove this
-    registerLegacyKernelCommands(context, clientMapper);
 
     context.subscriptions.push(vscode.commands.registerCommand('polyglot-notebook.notebookEditor.restartKernel', async (_notebookEditor) => {
         await vscode.commands.executeCommand('polyglot-notebook.restartCurrentNotebookKernel');
@@ -190,35 +170,7 @@ export function registerKernelCommands(context: vscode.ExtensionContext, clientM
     }));
 }
 
-function registerLegacyFileCommands(context: vscode.ExtensionContext, parserServer: NotebookParserServer, clientMapper: ClientMapper) {
-
-    const eol = getEol();
-
-    const notebookFileFilters = {
-        'Polyglot Notebooks': ['dib', 'dotnet-interactive'],
-        'Jupyter Notebooks': ['ipynb'],
-    };
-
-    context.subscriptions.push(vscode.commands.registerCommand('dotnet-interactive.newNotebook', async () => {
-        vscode.window.showWarningMessage(`The command '.NET Interactive: Create new blank notebook' is deprecated.  Please use the 'Polyglot Notebook: Create new blank notebook' command instead.`);
-        await vscode.commands.executeCommand('polyglot-notebook.newNotebook');
-    }));
-
-    context.subscriptions.push(vscode.commands.registerCommand('dotnet-interactive.openNotebook', async (notebookUri: vscode.Uri | undefined) => {
-        vscode.window.showWarningMessage(`The command '.NET Interactive: Open notebook' is deprecated.  Please use the 'Polyglot Notebook: Open notebook' command instead.`);
-        await vscode.commands.executeCommand('polyglot-notebook.openNotebook', notebookUri);
-    }));
-
-    context.subscriptions.push(vscode.commands.registerCommand('dotnet-interactive.saveAsNotebook', async () => {
-        vscode.window.showWarningMessage(`The command '.NET Interactive: Save notebook as...' is deprecated.  Please use the 'Polyglot Notebook: Save notebook as...' command instead.`);
-        await vscode.commands.executeCommand('polyglot-notebook.saveAsNotebook');
-    }));
-}
-
 export function registerFileCommands(context: vscode.ExtensionContext, parserServer: NotebookParserServer, clientMapper: ClientMapper) {
-
-    // todo: delete this later
-    registerLegacyFileCommands(context, parserServer, clientMapper);
 
     const eol = getEol();
 

--- a/src/dotnet-interactive-vscode-insiders/package.json
+++ b/src/dotnet-interactive-vscode-insiders/package.json
@@ -44,9 +44,6 @@
     "onNotebook:dotnet-interactive",
     "onNotebook:dotnet-interactive-window",
     "onNotebook:jupyter-notebook",
-    "onCommand:dotnet-interactive.newNotebook",
-    "onCommand:dotnet-interactive.openNotebook",
-    "onCommand:dotnet-interactive.saveAsNotebook",
     "onNotebook:polyglot-notebook",
     "onNotebook:polyglot-notebook-window",
     "onNotebook:jupyter-notebook",
@@ -232,36 +229,12 @@
         "title": "Polyglot Notebook: Select cell kernel"
       },
       {
-        "command": "dotnet-interactive.openNotebook",
-        "title": ".NET Interactive: Open notebook"
-      },
-      {
-        "command": "dotnet-interactive.saveAsNotebook",
-        "title": ".NET Interactive: Save notebook as..."
-      },
-      {
-        "command": "dotnet-interactive.newNotebook",
-        "title": ".NET Interactive: Create new blank notebook"
-      },
-      {
-        "command": "dotnet-interactive.restartCurrentNotebookKernel",
-        "title": ".NET Interactive: Restart the current notebook's kernel"
-      },
-      {
         "command": "polyglot-notebook.notebookEditor.restartKernel",
         "title": "Restart",
         "icon": {
           "light": "resources/light/restart-kernel.svg",
           "dark": "resources/dark/restart-kernel.svg"
         }
-      },
-      {
-        "command": "dotnet-interactive.stopCurrentNotebookKernel",
-        "title": ".NET Interactive: Stop the current notebook's kernel"
-      },
-      {
-        "command": "dotnet-interactive.stopAllNotebookKernels",
-        "title": ".NET Interactive: Stop all notebook kernels"
       },
       {
         "command": "polyglot-notebook.notebookEditor.openValueViewer",

--- a/src/dotnet-interactive-vscode/package.json
+++ b/src/dotnet-interactive-vscode/package.json
@@ -44,9 +44,6 @@
     "onNotebook:dotnet-interactive",
     "onNotebook:dotnet-interactive-window",
     "onNotebook:jupyter-notebook",
-    "onCommand:dotnet-interactive.newNotebook",
-    "onCommand:dotnet-interactive.openNotebook",
-    "onCommand:dotnet-interactive.saveAsNotebook",
     "onNotebook:polyglot-notebook",
     "onNotebook:polyglot-notebook-window",
     "onNotebook:jupyter-notebook",
@@ -232,36 +229,12 @@
         "title": "Polyglot Notebook: Select cell kernel"
       },
       {
-        "command": "dotnet-interactive.openNotebook",
-        "title": ".NET Interactive: Open notebook"
-      },
-      {
-        "command": "dotnet-interactive.saveAsNotebook",
-        "title": ".NET Interactive: Save notebook as..."
-      },
-      {
-        "command": "dotnet-interactive.newNotebook",
-        "title": ".NET Interactive: Create new blank notebook"
-      },
-      {
-        "command": "dotnet-interactive.restartCurrentNotebookKernel",
-        "title": ".NET Interactive: Restart the current notebook's kernel"
-      },
-      {
         "command": "polyglot-notebook.notebookEditor.restartKernel",
         "title": "Restart",
         "icon": {
           "light": "resources/light/restart-kernel.svg",
           "dark": "resources/dark/restart-kernel.svg"
         }
-      },
-      {
-        "command": "dotnet-interactive.stopCurrentNotebookKernel",
-        "title": ".NET Interactive: Stop the current notebook's kernel"
-      },
-      {
-        "command": "dotnet-interactive.stopAllNotebookKernels",
-        "title": ".NET Interactive: Stop all notebook kernels"
       },
       {
         "command": "polyglot-notebook.notebookEditor.openValueViewer",


### PR DESCRIPTION
Remove 6 commands that have been marked as old for several months:

- `dotnet-interactive.newNotebook`
- `dotnet-interactive.openNotebook`
- `dotnet-interactive.saveAsNotebook`
- `dotnet-interactive.restartCurrentNotebookKernel`
- `dotnet-interactive.stopCurrentNotebookKernel`
- `dotnet-interactive.stopAllNotebookKernels`

All of these commands exist with the `polyglot-notebook` prefix.