### PR TITLE
Enforce a minimum version for Kusto and SQL Service dotnet tools.

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.kql_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.kql_api_is_not_changed.approved.txt
@@ -276,9 +276,6 @@ Microsoft.DotNet.Interactive.SqlServer
     public System.Threading.Tasks.Task HandleAsync(Microsoft.DotNet.Interactive.Commands.SendValue command, Microsoft.DotNet.Interactive.KernelInvocationContext context)
     protected System.Void StoreQueryResults(System.Collections.Generic.IReadOnlyCollection<Microsoft.DotNet.Interactive.Formatting.TabularData.TabularDataResource> results, System.CommandLine.Parsing.ParseResult commandKernelChooserParseResult)
     public System.Boolean TryGetValue<T>(System.String name, ref T& value)
-  public static class Utils
-    public static System.String AsDoubleQuotedString()
-    public static System.String AsSingleQuotedString()
   public class VersionedTextDocumentIdentifier : TextDocumentIdentifier
     .ctor()
     public System.Int32 Version { get; set;}

--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.mssql_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.mssql_api_is_not_changed.approved.txt
@@ -268,9 +268,6 @@ Microsoft.DotNet.Interactive.SqlServer
     public System.Threading.Tasks.Task HandleAsync(Microsoft.DotNet.Interactive.Commands.SendValue command, Microsoft.DotNet.Interactive.KernelInvocationContext context)
     protected System.Void StoreQueryResults(System.Collections.Generic.IReadOnlyCollection<Microsoft.DotNet.Interactive.Formatting.TabularData.TabularDataResource> results, System.CommandLine.Parsing.ParseResult commandKernelChooserParseResult)
     public System.Boolean TryGetValue<T>(System.String name, ref T& value)
-  public static class Utils
-    public static System.String AsDoubleQuotedString()
-    public static System.String AsSingleQuotedString()
   public class VersionedTextDocumentIdentifier : TextDocumentIdentifier
     .ctor()
     public System.Int32 Version { get; set;}

--- a/src/Microsoft.DotNet.Interactive.Kql/KqlKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql/KqlKernelExtension.cs
@@ -14,7 +14,7 @@ public class KqlKernelExtension : IKernelExtension
         if (kernel is CompositeKernel compositeKernel)
         {
             var kqlToolName = "MicrosoftKustoServiceLayer";
-            await Utils.CheckAndInstallGlobalToolAsync(kqlToolName, "1.1.0");
+            await Utils.CheckAndInstallGlobalToolAsync(kqlToolName, "1.1.0", "Microsoft.SqlServer.KustoServiceLayer.Tool");
 
             compositeKernel
                 .AddKernelConnector(new ConnectKqlCommand(kqlToolName));

--- a/src/Microsoft.DotNet.Interactive.Kql/KqlKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql/KqlKernelExtension.cs
@@ -14,7 +14,7 @@ public class KqlKernelExtension : IKernelExtension
         if (kernel is CompositeKernel compositeKernel)
         {
             var kqlToolName = "MicrosoftKustoServiceLayer";
-            await Utils.CheckAndInstallGlobalTool(kqlToolName, "1.1.0");
+            await Utils.CheckAndInstallGlobalToolAsync(kqlToolName, "1.1.0");
 
             compositeKernel
                 .AddKernelConnector(new ConnectKqlCommand(kqlToolName));

--- a/src/Microsoft.DotNet.Interactive.Kql/KqlKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql/KqlKernelExtension.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
-using Microsoft.DotNet.Interactive.Utility;
+using Microsoft.DotNet.Interactive.SqlServer;
 
 namespace Microsoft.DotNet.Interactive.Kql;
 
@@ -15,16 +13,8 @@ public class KqlKernelExtension : IKernelExtension
     {
         if (kernel is CompositeKernel compositeKernel)
         {
-            // Check if the required Sql Tools Service tool is installed, and then install it if necessary
-            var dotnet = new Dotnet();
-            var installedGlobalTools = await dotnet.ToolList();
-            const string kqlToolName = "MicrosoftKustoServiceLayer";
-            bool kqlToolInstalled = installedGlobalTools.Any(tool => string.Equals(tool, kqlToolName, StringComparison.InvariantCultureIgnoreCase));
-            if (!kqlToolInstalled)
-            {
-                var commandLineResult = await dotnet.ToolInstall("Microsoft.SqlServer.KustoServiceLayer.Tool", null, null, "1.1.0");
-                commandLineResult.ThrowOnFailure();
-            }
+            var kqlToolName = "MicrosoftKustoServiceLayer";
+            await Utils.CheckAndInstallGlobalTool(kqlToolName, "1.1.0");
 
             compositeKernel
                 .AddKernelConnector(new ConnectKqlCommand(kqlToolName));

--- a/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelExtension.cs
@@ -13,7 +13,7 @@ public class MsSqlKernelExtension : IKernelExtension
         if (kernel is CompositeKernel compositeKernel)
         {
             var sqlToolName = "MicrosoftSqlToolsServiceLayer";
-            await Utils.CheckAndInstallGlobalTool(sqlToolName, "1.1.0"); 
+            await Utils.CheckAndInstallGlobalToolAsync(sqlToolName, "1.1.0");
 
             compositeKernel
                 .AddKernelConnector(new ConnectMsSqlCommand(sqlToolName));

--- a/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelExtension.cs
@@ -13,7 +13,7 @@ public class MsSqlKernelExtension : IKernelExtension
         if (kernel is CompositeKernel compositeKernel)
         {
             var sqlToolName = "MicrosoftSqlToolsServiceLayer";
-            await Utils.CheckAndInstallGlobalToolAsync(sqlToolName, "1.1.0");
+            await Utils.CheckAndInstallGlobalToolAsync(sqlToolName, "1.1.0", "Microsoft.SqlServer.SqlToolsServiceLayer.Tool");
 
             compositeKernel
                 .AddKernelConnector(new ConnectMsSqlCommand(sqlToolName));

--- a/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelExtension.cs
@@ -1,11 +1,8 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
-using Microsoft.DotNet.Interactive.Utility;
 
 namespace Microsoft.DotNet.Interactive.SqlServer;
 
@@ -15,16 +12,8 @@ public class MsSqlKernelExtension : IKernelExtension
     {
         if (kernel is CompositeKernel compositeKernel)
         {
-            // Check if the required Sql Tools Service tool is installed, and then install it if necessary
-            var dotnet = new Dotnet();
-            var installedGlobalTools = await dotnet.ToolList();
-            const string sqlToolName = "MicrosoftSqlToolsServiceLayer";
-            bool sqlToolInstalled = installedGlobalTools.Any(tool => string.Equals(tool, sqlToolName, StringComparison.InvariantCultureIgnoreCase));
-            if (!sqlToolInstalled)
-            {
-                var commandLineResult = await dotnet.ToolInstall("Microsoft.SqlServer.SqlToolsServiceLayer.Tool", null, null, "1.1.0");
-                commandLineResult.ThrowOnFailure();
-            }
+            var sqlToolName = "MicrosoftSqlToolsServiceLayer";
+            await Utils.CheckAndInstallGlobalTool(sqlToolName, "1.1.0"); 
 
             compositeKernel
                 .AddKernelConnector(new ConnectMsSqlCommand(sqlToolName));

--- a/src/Microsoft.DotNet.Interactive.SqlServer/Utils.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/Utils.cs
@@ -69,7 +69,7 @@ public static class Utils
             });
     }
 
-    public static async Task CheckAndInstallGlobalToolAsync(string toolName, string minimumVersion)
+    public static async Task CheckAndInstallGlobalToolAsync(string toolName, string minimumVersion, string nugetPackage)
     {
         var dotnet = new Dotnet();
         var installedGlobalTools = await Utils.GetGlobalToolListAsync();
@@ -88,7 +88,7 @@ public static class Utils
         });
         if (!toolInstalled)
         {
-            var commandLineResult = await dotnet.ToolInstall("Microsoft.SqlServer.KustoServiceLayer.Tool", null, null, minimumVersion);
+            var commandLineResult = await dotnet.ToolInstall(nugetPackage, null, null, minimumVersion);
             commandLineResult.ThrowOnFailure();
         }
     }

--- a/src/Microsoft.DotNet.Interactive.SqlServer/Utils.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/Utils.cs
@@ -9,14 +9,14 @@ using Microsoft.DotNet.Interactive.Utility;
 
 namespace Microsoft.DotNet.Interactive.SqlServer;
 
-public class DotnetToolInfo {
+internal class DotnetToolInfo {
     public string PackageId { get; set; }
     public string PackageVersion { get; set; }
     public string CommandName { get; set; }
 
 }
 
-public static class Utils
+internal static class Utils
 {
     /// <summary>
     /// Returns a version of the string quoted with single quotes. Any single quotes in the string are escaped as ''

--- a/src/Microsoft.DotNet.Interactive.SqlServer/Utils.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/Utils.cs
@@ -1,7 +1,20 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Interactive.Utility;
+
 namespace Microsoft.DotNet.Interactive.SqlServer;
+
+public class DotnetToolInfo {
+    public string PackageId { get; set; }
+    public string PackageVersion { get; set; }
+    public string CommandName { get; set; }
+
+}
 
 public static class Utils
 {
@@ -23,5 +36,60 @@ public static class Utils
     public static string AsDoubleQuotedString(this string str)
     {
         return $"\"{str.Replace("\"", "\\\"")}\"";
+    }
+
+    public static async Task<IEnumerable<DotnetToolInfo>> GetGlobalToolListAsync()
+    {
+        var dotnet = new Dotnet();
+        var args = "tool list --global";
+        var result = await dotnet.Execute(args);
+        if (result.ExitCode != 0)
+        {
+            return new DotnetToolInfo[0];
+        }
+
+        // Output of dotnet tool list is:
+        // Package Id        Version      Commands
+        // -------------------------------------------
+        // dotnettry.p1      1.0.0        dotnettry.p1
+
+        string[] separator = new[] { " " };
+        return result.Output
+            .Skip(2)
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Select(s =>
+            {
+                var parts = s.Split(separator, StringSplitOptions.RemoveEmptyEntries);
+                return new DotnetToolInfo()
+                {
+                    PackageId = parts[0],
+                    PackageVersion = parts[1],
+                    CommandName = parts[2]
+                };
+            });
+    }
+
+    public static async Task CheckAndInstallGlobalToolAsync(string toolName, string minimumVersion)
+    {
+        var dotnet = new Dotnet();
+        var installedGlobalTools = await Utils.GetGlobalToolListAsync();
+        var expectedVersion = Version.Parse(minimumVersion);
+        bool toolInstalled = installedGlobalTools.Any(tool =>
+        {
+            if (string.Equals(tool.CommandName, toolName, StringComparison.InvariantCultureIgnoreCase))
+            {
+                var installedVersion = Version.Parse(tool.PackageVersion);
+                return installedVersion >= expectedVersion;
+            }
+            else
+            {
+                return false;
+            }
+        });
+        if (!toolInstalled)
+        {
+            var commandLineResult = await dotnet.ToolInstall("Microsoft.SqlServer.KustoServiceLayer.Tool", null, null, minimumVersion);
+            commandLineResult.ThrowOnFailure();
+        }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.SqlServer/Utils.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/Utils.cs
@@ -91,12 +91,12 @@ public static class Utils
         var dotnet = new Dotnet();
         if (updateNeeded)
         {
-            var commandLineResult = await dotnet.Execute($"tool update --global {nugetPackage} --version {minimumVersion}");
+            var commandLineResult = await dotnet.Execute($"tool update --global \"{nugetPackage}\" --version \"{minimumVersion}\"");
             commandLineResult.ThrowOnFailure();
         }
         else if (installNeeded)
         {
-            var commandLineResult = await dotnet.Execute($"tool install --global {nugetPackage} --version {minimumVersion}");
+            var commandLineResult = await dotnet.Execute($"tool install --global \"{nugetPackage}\" --version \"{minimumVersion}\"");
             commandLineResult.ThrowOnFailure();
         }
     }


### PR DESCRIPTION
A while back, I checked in a version bump for the dotnet tools we install as part of starting up the Kusto and SQL kernels. However, I forgot to add a mechanism for enforcing a minimum version of those tools, which is a problem because we changed how we launch the tool in the Kusto kernel by adding an extra argument, which is not supported in the previous version of the tool. This change checks if the package is installed, and then whether it needs to be updated if it's already present. 

I verified the following scenarios:
1. Old 1.0.0 tool installed for Kusto and SQL
2. Current 1.1.0 tool installed for both
3. No version of either tool installed

I also made sure to keep the changes contained to the KQL and SqlServer projects, so we only need to update those nuget packages.

Fixes #2681 