### PR TITLE
if .ipynb document metadata isn't present, fall back to interpreting the kernelspec

### DIFF
--- a/src/dotnet-interactive-vscode-common/src/notebookCellStatusBarItemProvider.ts
+++ b/src/dotnet-interactive-vscode-common/src/notebookCellStatusBarItemProvider.ts
@@ -78,8 +78,9 @@ class DotNetNotebookCellStatusBarItemProvider {
             return [];
         }
 
+        const notebookMetadata = metadataUtilities.getNotebookDocumentMetadataFromNotebookDocument(cell.notebook);
         const cellMetadata = metadataUtilities.getNotebookCellMetadataFromNotebookCellElement(cell);
-        const cellKernelName = cellMetadata.kernelName ?? 'csharp';
+        const cellKernelName = cellMetadata.kernelName ?? notebookMetadata.kernelInfo.defaultKernelName;
         const notebookDocument = getNotebookDcoumentFromCellDocument(cell.document);
         const client = await this.clientMapper.tryGetClient(notebookDocument!.uri); // don't force client creation
         let displayText: string;

--- a/src/dotnet-interactive-vscode-common/tests/metadataUtilities.test.ts
+++ b/src/dotnet-interactive-vscode-common/tests/metadataUtilities.test.ts
@@ -222,6 +222,38 @@ describe('metadata utility tests', async () => {
         });
     });
 
+    it('notebook document metadata can be synthesized from .ipynb kernelspec', () => {
+        const notebookDocument: vscodeLike.NotebookDocument = {
+            uri: {
+                fsPath: 'test-notebook.ipynb',
+                scheme: 'unused',
+            },
+            metadata: {
+                custom: {
+                    metadata: {
+                        kernelspec: {
+                            display_name: '.NET (F#)',
+                            language: 'F#',
+                            name: '.net-fsharp',
+                        }
+                    }
+                }
+            }
+        };
+        const notebookDocumentMetadata = metadataUtilities.getNotebookDocumentMetadataFromNotebookDocument(notebookDocument);
+        expect(notebookDocumentMetadata).to.deep.equal({
+            kernelInfo: {
+                defaultKernelName: 'fsharp',
+                items: [
+                    {
+                        name: 'fsharp',
+                        aliases: [],
+                    }
+                ]
+            }
+        });
+    });
+
     it('kernel infos can be created from .dib notebook document', () => {
         const notebookDocument: vscodeLike.NotebookDocument = {
             uri: {

--- a/src/dotnet-interactive-vscode-insiders/src/notebookControllers.ts
+++ b/src/dotnet-interactive-vscode-insiders/src/notebookControllers.ts
@@ -83,14 +83,12 @@ export class DotNetNotebookKernel {
                     const notebookMetadata = metadataUtilities.getNotebookDocumentMetadataFromNotebookDocument(notebook);
                     const cells = notebook.getCells();
                     const foundCell = cells.find(cell => cell.document === textDocument);
-                    if (foundCell && foundCell.index > 0) {
-                        // if we found the cell and it's not the first, ensure it has kernel metadata
+                    if (foundCell) {
+                        // if we found the cell ensure it has kernel metadata
                         const cellMetadata = metadataUtilities.getNotebookCellMetadataFromNotebookCellElement(foundCell);
                         if (!cellMetadata.kernelName) {
-                            // no kernel metadata; copy from previous cell
-                            const previousCell = cells[foundCell.index - 1];
-                            const previousCellMetadata = metadataUtilities.getNotebookCellMetadataFromNotebookCellElement(previousCell);
-                            await vscodeUtilities.setCellKernelName(foundCell, previousCellMetadata.kernelName ?? notebookMetadata.kernelInfo.defaultKernelName);
+                            // no kernel name; set it from the notebook metadata
+                            await vscodeUtilities.setCellKernelName(foundCell, notebookMetadata.kernelInfo.defaultKernelName);
                         }
                     }
                 }


### PR DESCRIPTION
If a cell doesn't have kernel metadata, fall back to using the document's metadata, and if the document doesn't have the appropriate metadata, re-create it from the kernelspec.

This bug was only in the VS Code extension; the document APIs already has a test for exactly this scenario [here](https://github.com/dotnet/interactive/blob/208167e09a6ae48311e1e20bd21bda1068fb8429/src/Microsoft.DotNet.Interactive.Documents.Tests/JupyterFormatTests.cs#L40).

Fixes #2685.