### PR TITLE
Bump minimum version for Kusto and SQL dotnet tools to 1.2.0.

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Kql/KqlKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql/KqlKernelExtension.cs
@@ -14,7 +14,7 @@ public class KqlKernelExtension : IKernelExtension
         if (kernel is CompositeKernel compositeKernel)
         {
             var kqlToolName = "MicrosoftKustoServiceLayer";
-            await Utils.CheckAndInstallGlobalToolAsync(kqlToolName, "1.1.0", "Microsoft.SqlServer.KustoServiceLayer.Tool");
+            await Utils.CheckAndInstallGlobalToolAsync(kqlToolName, "1.2.0", "Microsoft.SqlServer.KustoServiceLayer.Tool");
 
             compositeKernel
                 .AddKernelConnector(new ConnectKqlCommand(kqlToolName));

--- a/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelExtension.cs
@@ -13,7 +13,7 @@ public class MsSqlKernelExtension : IKernelExtension
         if (kernel is CompositeKernel compositeKernel)
         {
             var sqlToolName = "MicrosoftSqlToolsServiceLayer";
-            await Utils.CheckAndInstallGlobalToolAsync(sqlToolName, "1.1.0", "Microsoft.SqlServer.SqlToolsServiceLayer.Tool");
+            await Utils.CheckAndInstallGlobalToolAsync(sqlToolName, "1.2.0", "Microsoft.SqlServer.SqlToolsServiceLayer.Tool");
 
             compositeKernel
                 .AddKernelConnector(new ConnectMsSqlCommand(sqlToolName));


### PR DESCRIPTION
We upgraded our Kusto and SQL services to use net7.0, and I just pushed up new versions of their dotnet tool nuget packages. 