### PR TITLE
allow persisting default values for new notebooks

### DIFF
--- a/src/polyglot-notebooks-vscode-insiders/package.json
+++ b/src/polyglot-notebooks-vscode-insiders/package.json
@@ -48,6 +48,7 @@
     "onNotebook:polyglot-notebook-window",
     "onNotebook:jupyter-notebook",
     "onCommand:dotnet-interactive.acquire",
+    "onCommand:polyglot-notebook.fileNew",
     "onCommand:polyglot-notebook.newNotebook",
     "onCommand:polyglot-notebook.openNotebook",
     "onCommand:polyglot-notebook.saveAsNotebook",
@@ -98,6 +99,56 @@
     "configuration": {
       "title": "Polyglot Notebook",
       "properties": {
+        "polyglot-notebook.suppressPromptToSaveDefaults": {
+          "type": "boolean",
+          "default": false,
+          "description": "Suppresses the prompt to save the default notebook extension and language."
+        },
+        "polyglot-notebook.defaultNotebookExtension": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "enum": [
+            ".dib",
+            ".ipynb"
+          ],
+          "enumDescriptions": [
+            "Use .dib files for notebooks.",
+            "Use .ipynb files for notebooks."
+          ]
+        },
+        "polyglot-notebook.defaultNotebookLanguage": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "description": "The default starting language for new notebooks.",
+          "enum": [
+            "csharp",
+            "fsharp",
+            "html",
+            "javascript",
+            "kql",
+            "markdown",
+            "mermaid",
+            "pwsh",
+            "sql"
+          ],
+          "enumDescriptions": [
+            "C#",
+            "F#",
+            "HTML",
+            "JavaScript",
+            "KQL",
+            "Markdown",
+            "Mermaid",
+            "PowerShell",
+            "SQL"
+          ]
+        },
         "polyglot-notebook.kernelEnvironmentVariables": {
           "type": "object",
           "default": {},
@@ -205,8 +256,22 @@
         "title": "Polyglot Notebook: Save notebook as..."
       },
       {
+        "command": "polyglot-notebook.fileNew",
+        "enablement": "false",
+        "title": "New Polyglot Notebook",
+        "shortTitle": "Polyglot Notebook"
+      },
+      {
         "command": "polyglot-notebook.newNotebook",
+        "title": "Polyglot Notebook: Create default notebook"
+      },
+      {
+        "command": "polyglot-notebook.newNotebookNoDefaults",
         "title": "Polyglot Notebook: Create new blank notebook"
+      },
+      {
+        "command": "polyglot-notebook.setNewNotebookDefaults",
+        "title": "Polyglot Notebook: Set new notebook default values"
       },
       {
         "command": "polyglot-notebook.restartCurrentNotebookKernel",
@@ -258,6 +323,12 @@
       }
     ],
     "menus": {
+      "file/newFile": [
+        {
+          "command": "polyglot-notebook.fileNew",
+          "group": "notebook"
+        }
+      ],
       "notebook/toolbar": [
         {
           "command": "polyglot-notebook.notebookEditor.restartKernel",

--- a/src/polyglot-notebooks-vscode/package.json
+++ b/src/polyglot-notebooks-vscode/package.json
@@ -48,6 +48,7 @@
     "onNotebook:polyglot-notebook-window",
     "onNotebook:jupyter-notebook",
     "onCommand:dotnet-interactive.acquire",
+    "onCommand:polyglot-notebook.fileNew",
     "onCommand:polyglot-notebook.newNotebook",
     "onCommand:polyglot-notebook.openNotebook",
     "onCommand:polyglot-notebook.saveAsNotebook",
@@ -98,6 +99,56 @@
     "configuration": {
       "title": "Polyglot Notebook",
       "properties": {
+        "polyglot-notebook.suppressPromptToSaveDefaults": {
+          "type": "boolean",
+          "default": false,
+          "description": "Suppresses the prompt to save the default notebook extension and language."
+        },
+        "polyglot-notebook.defaultNotebookExtension": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "enum": [
+            ".dib",
+            ".ipynb"
+          ],
+          "enumDescriptions": [
+            "Use .dib files for notebooks.",
+            "Use .ipynb files for notebooks."
+          ]
+        },
+        "polyglot-notebook.defaultNotebookLanguage": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "description": "The default starting language for new notebooks.",
+          "enum": [
+            "csharp",
+            "fsharp",
+            "html",
+            "javascript",
+            "kql",
+            "markdown",
+            "mermaid",
+            "pwsh",
+            "sql"
+          ],
+          "enumDescriptions": [
+            "C#",
+            "F#",
+            "HTML",
+            "JavaScript",
+            "KQL",
+            "Markdown",
+            "Mermaid",
+            "PowerShell",
+            "SQL"
+          ]
+        },
         "polyglot-notebook.kernelEnvironmentVariables": {
           "type": "object",
           "default": {},
@@ -205,8 +256,22 @@
         "title": "Polyglot Notebook: Save notebook as..."
       },
       {
+        "command": "polyglot-notebook.fileNew",
+        "enablement": "false",
+        "title": "New Polyglot Notebook",
+        "shortTitle": "Polyglot Notebook"
+      },
+      {
         "command": "polyglot-notebook.newNotebook",
+        "title": "Polyglot Notebook: Create default notebook"
+      },
+      {
+        "command": "polyglot-notebook.newNotebookNoDefaults",
         "title": "Polyglot Notebook: Create new blank notebook"
+      },
+      {
+        "command": "polyglot-notebook.setNewNotebookDefaults",
+        "title": "Polyglot Notebook: Set new notebook default values"
       },
       {
         "command": "polyglot-notebook.restartCurrentNotebookKernel",
@@ -258,6 +323,12 @@
       }
     ],
     "menus": {
+      "file/newFile": [
+        {
+          "command": "polyglot-notebook.fileNew",
+          "group": "notebook"
+        }
+      ],
       "notebook/toolbar": [
         {
           "command": "polyglot-notebook.notebookEditor.restartKernel",


### PR DESCRIPTION
The command `Polyglot Notebook: Create new blank notebook` was renamed to `Polyglot Notebook: Create default notebook` and it's been modified to use user-saved defaults for the notebook type ('.dib', '.ipynb') and the default language/kernel ('csharp', 'fsharp', etc.).

If those defaults have already been set, the user experience is that they invoke the command and they're immediately given a new untitled notebook with the specified type and language.

If those defautls have _not_ been set, the user is asked (like the old experience), but then a toast is shown in the bottom corner that allows them to persist it.  If they choose to do so, the selected values are set as the default, but the user is then immediately shown the settings UI to change the values if desired.

<img width="346" alt="image" src="https://user-images.githubusercontent.com/926281/218815116-fef60b0d-6c2f-4e3e-a7a1-ec95b3dd49fd.png">

Values saved in UI view:

<img width="275" alt="image" src="https://user-images.githubusercontent.com/926281/218815223-09b6a2f8-dc21-4bc7-85e5-885e90996b24.png">

N.b., the two values (type and language) are stored separately and it's possible for the user to, e.g., _not_ specify the notebook type, but to set C#.  In this example, they'll be asked each time if they want .dib or .ipynb, but once that selection is made C# will be auto-selected.

I also added a new command, `Polyglot Notebook: Create new blank notebook` which will always prompt the user for both values, even if they've already set one.  In this case, their saved values are not overwritten.

I've also added the "new" command (the one that honors defaults) to the File -> New menu:

<img width="460" alt="image" src="https://user-images.githubusercontent.com/926281/217937984-0c6f20fe-f801-4127-8f0f-2829922e6c2f.png">

Fixes #1883.
Fixes #2024.