### PR TITLE
Create a new HostUtils package (targeting netstandard2.0)

### DIFF
--- a/dotnet-interactive.sln
+++ b/dotnet-interactive.sln
@@ -110,7 +110,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Interactiv
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Interactive.HttpRequest.Tests", "src\Microsoft.DotNet.Interactive.HttpRequest.Tests\Microsoft.DotNet.Interactive.HttpRequest.Tests.csproj", "{0BFB2568-B6FB-4C1E-A002-B2DB86551A4F}"
 EndProject
-Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Microsoft.Dotnet.Interactive.Shared", "src\Microsoft.Dotnet.Interactive.Shared\Microsoft.Dotnet.Interactive.Shared.shproj", "{6273EEFB-E920-48F4-B0AF-8620B6D9FB28}"
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Microsoft.DotNet.Interactive.Shared", "src\Microsoft.DotNet.Interactive.Shared\Microsoft.DotNet.Interactive.Shared.shproj", "{6273EEFB-E920-48F4-B0AF-8620B6D9FB28}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Microsoft.DotNet.Interactive.HostUtils.Shared", "src\Microsoft.DotNet.Interactive.HostUtils.Shared\Microsoft.DotNet.Interactive.HostUtils.Shared.shproj", "{9EA5B22E-6DEE-41CA-8112-2B370E14D523}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Interactive.HostUtils", "src\Microsoft.DotNet.Interactive.HostUtils\Microsoft.DotNet.Interactive.HostUtils.csproj", "{5CA49173-5F69-46C2-9246-E1FC9B9000D8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -638,6 +642,18 @@ Global
 		{0BFB2568-B6FB-4C1E-A002-B2DB86551A4F}.Release|x64.Build.0 = Release|Any CPU
 		{0BFB2568-B6FB-4C1E-A002-B2DB86551A4F}.Release|x86.ActiveCfg = Release|Any CPU
 		{0BFB2568-B6FB-4C1E-A002-B2DB86551A4F}.Release|x86.Build.0 = Release|Any CPU
+		{5CA49173-5F69-46C2-9246-E1FC9B9000D8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5CA49173-5F69-46C2-9246-E1FC9B9000D8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5CA49173-5F69-46C2-9246-E1FC9B9000D8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5CA49173-5F69-46C2-9246-E1FC9B9000D8}.Debug|x64.Build.0 = Debug|Any CPU
+		{5CA49173-5F69-46C2-9246-E1FC9B9000D8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5CA49173-5F69-46C2-9246-E1FC9B9000D8}.Debug|x86.Build.0 = Debug|Any CPU
+		{5CA49173-5F69-46C2-9246-E1FC9B9000D8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5CA49173-5F69-46C2-9246-E1FC9B9000D8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5CA49173-5F69-46C2-9246-E1FC9B9000D8}.Release|x64.ActiveCfg = Release|Any CPU
+		{5CA49173-5F69-46C2-9246-E1FC9B9000D8}.Release|x64.Build.0 = Release|Any CPU
+		{5CA49173-5F69-46C2-9246-E1FC9B9000D8}.Release|x86.ActiveCfg = Release|Any CPU
+		{5CA49173-5F69-46C2-9246-E1FC9B9000D8}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -687,13 +703,19 @@ Global
 		{B830CFD8-6EE0-45FA-9C29-E3F0244912C6} = {B95A8485-8C53-4F56-B0CE-19C0726B5805}
 		{0BFB2568-B6FB-4C1E-A002-B2DB86551A4F} = {11BA3480-4584-435C-BA9A-8C554DB60E9F}
 		{6273EEFB-E920-48F4-B0AF-8620B6D9FB28} = {B95A8485-8C53-4F56-B0CE-19C0726B5805}
+		{9EA5B22E-6DEE-41CA-8112-2B370E14D523} = {B95A8485-8C53-4F56-B0CE-19C0726B5805}
+		{5CA49173-5F69-46C2-9246-E1FC9B9000D8} = {B95A8485-8C53-4F56-B0CE-19C0726B5805}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6D05A9AF-CFFB-4187-8599-574387B76727}
 	EndGlobalSection
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		src\Microsoft.DotNet.Interactive.HostUtils.Shared\Microsoft.DotNet.Interactive.HostUtils.Shared.projitems*{1a4a744f-fef3-4361-a2e5-c5d496f7bfdc}*SharedItemsImports = 5
 		src\Microsoft.Dotnet.Interactive.Shared\Microsoft.Dotnet.Interactive.Shared.projitems*{42cc26ba-8057-4654-b23c-e6a48475b381}*SharedItemsImports = 5
+		src\Microsoft.DotNet.Interactive.HostUtils.Shared\Microsoft.DotNet.Interactive.HostUtils.Shared.projitems*{5ca49173-5f69-46c2-9246-e1fc9b9000d8}*SharedItemsImports = 5
 		src\Microsoft.Dotnet.Interactive.Shared\Microsoft.Dotnet.Interactive.Shared.projitems*{6273eefb-e920-48f4-b0af-8620b6d9fb28}*SharedItemsImports = 13
+		src\Microsoft.DotNet.Interactive.HostUtils.Shared\Microsoft.DotNet.Interactive.HostUtils.Shared.projitems*{9ea5b22e-6dee-41ca-8112-2b370e14d523}*SharedItemsImports = 13
+		src\Microsoft.DotNet.Interactive.HostUtils.Shared\Microsoft.DotNet.Interactive.HostUtils.Shared.projitems*{c858afc0-5dec-4925-812d-4904dd7b5bc4}*SharedItemsImports = 5
 		src\Microsoft.Dotnet.Interactive.Shared\Microsoft.Dotnet.Interactive.Shared.projitems*{e06f109d-e9b5-4c68-9904-6955ca30252d}*SharedItemsImports = 5
 		src\Microsoft.Dotnet.Interactive.Shared\Microsoft.Dotnet.Interactive.Shared.projitems*{e3297a6a-95aa-4dad-8dd1-971a45856bc2}*SharedItemsImports = 5
 	EndGlobalSection

--- a/src/Microsoft.DotNet.Interactive.Browser/Microsoft.DotNet.Interactive.Browser.csproj
+++ b/src/Microsoft.DotNet.Interactive.Browser/Microsoft.DotNet.Interactive.Browser.csproj
@@ -35,13 +35,11 @@
   <ItemGroup>
     <Folder Include="%28Recipes%29\" />
   </ItemGroup>
-  
-  <ItemGroup>
-    <EmbeddedResource Include="..\polyglot-notebooks\lib\polyglot-notebooks.js" />
-  </ItemGroup>
 
   <ItemGroup>
     <None Include="extension.dib" Pack="true" PackagePath="interactive-extensions/dotnet" />
   </ItemGroup>
+
+  <Import Project="..\Microsoft.DotNet.Interactive.HostUtils.Shared\Microsoft.DotNet.Interactive.HostUtils.Shared.projitems" Label="Shared" />
 
 </Project>

--- a/src/Microsoft.DotNet.Interactive.HostUtils.Shared/Connection/ConnectStdIO.cs
+++ b/src/Microsoft.DotNet.Interactive.HostUtils.Shared/Connection/ConnectStdIO.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;

--- a/src/Microsoft.DotNet.Interactive.HostUtils.Shared/Connection/StdIoKernelConnector.cs
+++ b/src/Microsoft.DotNet.Interactive.HostUtils.Shared/Connection/StdIoKernelConnector.cs
@@ -87,7 +87,7 @@ public class StdIoKernelConnector : IKernelConnector, IDisposable
                     stdOutObservable.OnNext(args.Data);
                 }
             };
-            
+
             var stdErr = new StringBuilder();
             _process.ErrorDataReceived += (_, args) =>
             {
@@ -176,8 +176,13 @@ public class StdIoKernelConnector : IKernelConnector, IDisposable
     {
         if (_process is { HasExited: false })
         {
-            // todo: ensure killing process tree
-            _process?.Kill(true);
+#if NETSTANDARD2_0
+            // TODO: Kill entrie process tree.
+            _process?.Kill();
+#else
+            _process?.Kill(entireProcessTree: true);
+#endif
+
             _process?.Dispose();
             _process = null;
         }

--- a/src/Microsoft.DotNet.Interactive.HostUtils.Shared/Connection/StdIoKernelConnector.cs
+++ b/src/Microsoft.DotNet.Interactive.HostUtils.Shared/Connection/StdIoKernelConnector.cs
@@ -74,7 +74,9 @@ public class StdIoKernelConnector : IKernelConnector, IDisposable
                     RedirectStandardInput = true,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
-                    StandardOutputEncoding = Encoding.UTF8
+                    StandardOutputEncoding = Encoding.UTF8,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
                 },
                 EnableRaisingEvents = true
             };

--- a/src/Microsoft.DotNet.Interactive.HostUtils.Shared/Microsoft.DotNet.Interactive.HostUtils.Shared.projitems
+++ b/src/Microsoft.DotNet.Interactive.HostUtils.Shared/Microsoft.DotNet.Interactive.HostUtils.Shared.projitems
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects Condition="'$(MSBuildVersion)' == '' Or '$(MSBuildVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>9ea5b22e-6dee-41ca-8112-2b370e14d523</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>Microsoft.DotNet.Interactive.HostUtils.Shared</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Connection\ConnectStdIO.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Connection\StdIoKernelConnector.cs" />
+  </ItemGroup>
+  <ItemGroup>
+	<EmbeddedResource Include="..\polyglot-notebooks\lib\polyglot-notebooks.js" LogicalName="$(AssemblyName).resources.%(FileName)%(Extension)" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="$(MSBuildThisFileDirectory)Connection\" />
+  </ItemGroup>
+</Project>

--- a/src/Microsoft.DotNet.Interactive.HostUtils.Shared/Microsoft.DotNet.Interactive.HostUtils.Shared.projitems
+++ b/src/Microsoft.DotNet.Interactive.HostUtils.Shared/Microsoft.DotNet.Interactive.HostUtils.Shared.projitems
@@ -13,7 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Connection\StdIoKernelConnector.cs" />
   </ItemGroup>
   <ItemGroup>
-	<EmbeddedResource Include="..\polyglot-notebooks\lib\polyglot-notebooks.js" LogicalName="$(AssemblyName).resources.%(FileName)%(Extension)" />
+	<EmbeddedResource Include="..\polyglot-notebooks\lib\polyglot-notebooks.js" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="$(MSBuildThisFileDirectory)Connection\" />

--- a/src/Microsoft.DotNet.Interactive.HostUtils.Shared/Microsoft.DotNet.Interactive.HostUtils.Shared.shproj
+++ b/src/Microsoft.DotNet.Interactive.HostUtils.Shared/Microsoft.DotNet.Interactive.HostUtils.Shared.shproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>9ea5b22e-6dee-41ca-8112-2b370e14d523</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="Microsoft.DotNet.Interactive.HostUtils.Shared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/src/Microsoft.DotNet.Interactive.HostUtils/Directory.Build.props
+++ b/src/Microsoft.DotNet.Interactive.HostUtils/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/Microsoft.DotNet.Interactive.HostUtils/Microsoft.DotNet.Interactive.HostUtils.csproj
+++ b/src/Microsoft.DotNet.Interactive.HostUtils/Microsoft.DotNet.Interactive.HostUtils.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <PackageId>Microsoft.DotNet.Interactive.HostUtils</PackageId>
+    <PackageDescription>Utilities for hosting applications providing interactive programming for .NET.</PackageDescription>
+    <PackageTags>interactive host utilities</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Pocket.Disposable" Version="1.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.DotNet.Interactive.NetStandard20\Microsoft.DotNet.Interactive.Netstandard20.csproj" />
+  </ItemGroup>
+
+  <Import Project="..\Microsoft.DotNet.Interactive.HostUtils.Shared\Microsoft.DotNet.Interactive.HostUtils.Shared.projitems" Label="Shared" />
+
+</Project>

--- a/src/Microsoft.DotNet.Interactive.HostUtils/Microsoft.DotNet.Interactive.HostUtils.v3.ncrunchproject
+++ b/src/Microsoft.DotNet.Interactive.HostUtils/Microsoft.DotNet.Interactive.HostUtils.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>

--- a/src/Microsoft.DotNet.Interactive.NetStandard20/Microsoft.DotNet.Interactive.Netstandard20.csproj
+++ b/src/Microsoft.DotNet.Interactive.NetStandard20/Microsoft.DotNet.Interactive.Netstandard20.csproj
@@ -2,8 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
     <PackageId>Microsoft.DotNet.Interactive.Netstandard20</PackageId>
-    <PackageDescription>Core types for building applications providing interactive programming for .NET. for the desktop</PackageDescription>
+    <PackageDescription>Core types for building applications providing interactive programming for .NET for the desktop.</PackageDescription>
     <PackageTags>interactive desktop</PackageTags>
   </PropertyGroup>
 

--- a/src/dotnet-interactive/dotnet-interactive.csproj
+++ b/src/dotnet-interactive/dotnet-interactive.csproj
@@ -177,6 +177,8 @@
   <Target Name="ExportVersionNumberForAzureDevOps" AfterTargets="Build">
     <Message Text="##vso[task.setvariable variable=StableToolVersionNumber]$(Version)" Importance="high" />
   </Target>
+  
+  <Import Project="..\Microsoft.DotNet.Interactive.HostUtils.Shared\Microsoft.DotNet.Interactive.HostUtils.Shared.projitems" Label="Shared" />
 
 </Project>
 


### PR DESCRIPTION
This package allows us to share helper code such as StdIoKernelConnector, as well as the JavaScript sub-kernel code, with other hosting environments that require netstandard2.0. More such types can be added here in the future.