### PR TITLE
Update developer guide with new notebook creation command

### DIFF
--- a/DEVELOPER-GUIDE.md
+++ b/DEVELOPER-GUIDE.md
@@ -114,7 +114,7 @@ To get started, you'll need:
 
 5. Press F5 to launch the Visual Studio Code Extension Development Host.
 
-6. Run `.NET Interactive: Create new blank notebook` or open a file with the `.ipynb` extension.
+6. Run `Polyglot Notebook: Create new blank notebook` or open a file with the `.ipynb` extension.
 
 ### Use a local build of the `dotnet-interactive` tool
 


### PR DESCRIPTION
The documentation at [developer guide](https://github.com/dotnet/interactive/blob/main/DEVELOPER-GUIDE.md) says `.NET Interactive: Create new blank notebook`, but the command palette is showing `Polyglot Notebook: Create new blank notebook`

![image](https://user-images.githubusercontent.com/510598/222085978-9b9277f6-9929-4b75-b456-65d97180e769.png)

This PR just updates the documentation to match the current behavior.