### PR TITLE
Removed unnecessary Imports or usings from all projects

### DIFF
--- a/src/Microsoft.DotNet.Interactive.AspNetCore/AspNetCoreCSharpKernelExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.AspNetCore/AspNetCoreCSharpKernelExtensions.cs
@@ -16,7 +16,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.CSharp;
-using Microsoft.DotNet.Interactive.Formatting;
 using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.DotNet.Interactive.AspNetCore;

--- a/src/Microsoft.DotNet.Interactive.Browser.Tests/HtmlKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Browser.Tests/HtmlKernelTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 

--- a/src/Microsoft.DotNet.Interactive.Browser.Tests/JavaScriptKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Browser.Tests/JavaScriptKernelTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using FluentAssertions;

--- a/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/BufferExtractorTests.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/BufferExtractorTests.cs
@@ -3,7 +3,6 @@
 
 using System.Linq;
 using FluentAssertions;
-using Microsoft.DotNet.Interactive.CSharpProject.MLS.Project;
 using Xunit;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject.Tests;

--- a/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/BufferInliningTransformerTests.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/BufferInliningTransformerTests.cs
@@ -8,9 +8,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.DotNet.Interactive.Utility;
 using Xunit;
-using Buffer = Microsoft.DotNet.Interactive.CSharpProject.Buffer;
 using File = System.IO.File;
-using Microsoft.DotNet.Interactive.CSharpProject.MLS.Project;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject.Tests;
 

--- a/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/InMemoryDirectoryAccessor.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/InMemoryDirectoryAccessor.cs
@@ -6,7 +6,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Microsoft.DotNet.Interactive.CSharpProject.Tools;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject.Tests;
 

--- a/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/Instrumentation/InstrumentationExtractorTests.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/Instrumentation/InstrumentationExtractorTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;

--- a/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/Instrumentation/RewriterVariableLocationTests.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/Instrumentation/RewriterVariableLocationTests.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.DotNet.Interactive.CSharpProject.MLS.Project;
 using Microsoft.DotNet.Interactive.CSharpProject.Servers.Roslyn.Instrumentation;
 using Microsoft.DotNet.Interactive.CSharpProject.Utility;
 using Xunit;

--- a/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/Instrumentation/TestUtils.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/Instrumentation/TestUtils.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject.Tests.Instrumentation;

--- a/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/Instrumentation/VisitorVariableLocationTests.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/Instrumentation/VisitorVariableLocationTests.cs
@@ -6,7 +6,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.DotNet.Interactive.CSharpProject.MLS.Project;
 using Microsoft.DotNet.Interactive.CSharpProject.Servers.Roslyn.Instrumentation;
 using Microsoft.DotNet.Interactive.CSharpProject.Utility;
 using Xunit;

--- a/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/PackageTests2.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/PackageTests2.cs
@@ -8,7 +8,6 @@ using FluentAssertions;
 using Microsoft.DotNet.Interactive.Utility;
 using Microsoft.DotNet.Interactive.CSharpProject.Packaging;
 using Xunit;
-using Microsoft.DotNet.Interactive.CSharpProject.Tools;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject.Tests;
 

--- a/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/RelativeDirectoryPathTests.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/RelativeDirectoryPathTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using FluentAssertions;
-using Microsoft.DotNet.Interactive.CSharpProject.Tools;
 using Xunit;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject.Tests;

--- a/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/RoslynWorkspaceServerTestsCore.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/RoslynWorkspaceServerTestsCore.cs
@@ -1,10 +1,8 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.DotNet.Interactive.CSharpProject.Packaging;
 using Microsoft.DotNet.Interactive.CSharpProject.Servers.Roslyn;
 using Xunit.Abstractions;
-using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject.Tests;
 

--- a/src/Microsoft.DotNet.Interactive.CSharpProject/BufferFromRegionExtractor.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/BufferFromRegionExtractor.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.DotNet.Interactive.CSharpProject.MLS.Project;
-using Workspace = Microsoft.DotNet.Interactive.CSharpProject.Workspace;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject;
 

--- a/src/Microsoft.DotNet.Interactive.CSharpProject/CodeMergeTransformer.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/CodeMergeTransformer.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.DotNet.Interactive.CSharpProject.MLS.Project;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject;
 

--- a/src/Microsoft.DotNet.Interactive.CSharpProject/Commands/OpenDocument.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/Commands/OpenDocument.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Text.Json.Serialization;
 using Microsoft.DotNet.Interactive.Commands;
-using Microsoft.DotNet.Interactive.CSharpProject.Tools;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject.Commands;
 

--- a/src/Microsoft.DotNet.Interactive.CSharpProject/DiagnosticsExtractor.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/DiagnosticsExtractor.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.Interactive.CSharpProject.Transformations;
-using Workspace = Microsoft.DotNet.Interactive.CSharpProject.Workspace;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject;
 

--- a/src/Microsoft.DotNet.Interactive.CSharpProject/DirectoryAccessExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/DirectoryAccessExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.DotNet.Interactive.CSharpProject.Tools;
 using System;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.CSharpProject.Packaging;

--- a/src/Microsoft.DotNet.Interactive.CSharpProject/Events/DocumentOpened.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/Events/DocumentOpened.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Text.Json.Serialization;
 using Microsoft.DotNet.Interactive.CSharpProject.Commands;
-using Microsoft.DotNet.Interactive.CSharpProject.Tools;
 using Microsoft.DotNet.Interactive.Events;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject.Events;

--- a/src/Microsoft.DotNet.Interactive.CSharpProject/FileSystemDirectoryAccessor.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/FileSystemDirectoryAccessor.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Microsoft.DotNet.Interactive.CSharpProject.Tools;
 using Microsoft.DotNet.Interactive.Utility;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject;

--- a/src/Microsoft.DotNet.Interactive.CSharpProject/FindPackageInDefaultLocation.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/FindPackageInDefaultLocation.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.DotNet.Interactive.CSharpProject.Tools;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.CSharpProject.Packaging;
 

--- a/src/Microsoft.DotNet.Interactive.CSharpProject/IDirectoryAccessor.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/IDirectoryAccessor.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.IO;
-using Microsoft.DotNet.Interactive.CSharpProject.Tools;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject;
 

--- a/src/Microsoft.DotNet.Interactive.CSharpProject/Markdown/CodeBlockAnnotations.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/Markdown/CodeBlockAnnotations.cs
@@ -3,7 +3,6 @@
 
 using System.CommandLine.Parsing;
 using System.Threading.Tasks;
-using Microsoft.DotNet.Interactive.CSharpProject.Tools;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject.Markdown;
 

--- a/src/Microsoft.DotNet.Interactive.CSharpProject/Markdown/CodeFenceAnnotationsParser.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/Markdown/CodeFenceAnnotationsParser.cs
@@ -9,7 +9,6 @@ using System.CommandLine.NamingConventionBinder;
 using System.CommandLine.Parsing;
 using System.Linq;
 using Markdig;
-using Microsoft.DotNet.Interactive.CSharpProject.Tools;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject.Markdown;
 

--- a/src/Microsoft.DotNet.Interactive.CSharpProject/Models/Execution/WorkspaceFactory.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/Models/Execution/WorkspaceFactory.cs
@@ -3,7 +3,6 @@
 
 using System.IO;
 using System.Linq;
-using Microsoft.DotNet.Interactive.CSharpProject.Tools;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject.Models.Execution;
 

--- a/src/Microsoft.DotNet.Interactive.CSharpProject/Packaging/DepsFileParser.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/Packaging/DepsFileParser.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using Microsoft.DotNet.Interactive.CSharpProject.Tools;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject.Packaging;

--- a/src/Microsoft.DotNet.Interactive.CSharpProject/Packaging/FileLock.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/Packaging/FileLock.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.DotNet.Interactive.CSharpProject.Tools;
 using System;
 using System.IO;
 using System.Threading.Tasks;

--- a/src/Microsoft.DotNet.Interactive.CSharpProject/Packaging/Package2.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/Packaging/Package2.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.DotNet.Interactive.CSharpProject.Tools;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Microsoft.DotNet.Interactive.CSharpProject/Packaging/PackageAsset.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/Packaging/PackageAsset.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.DotNet.Interactive.CSharpProject.Tools;
 using System;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject.Packaging;

--- a/src/Microsoft.DotNet.Interactive.CSharpProject/Packaging/PackageBase.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/Packaging/PackageBase.cs
@@ -6,9 +6,7 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.Utility;
-using Microsoft.DotNet.Interactive.CSharpProject.Tools;
 using Microsoft.DotNet.Interactive.CSharpProject.Servers.Roslyn;
-using Microsoft.DotNet.Interactive.CSharpProject.Utility;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject.Packaging;
 

--- a/src/Microsoft.DotNet.Interactive.CSharpProject/Packaging/ProjectAsset.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/Packaging/ProjectAsset.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Buildalyzer;
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.Interactive.Utility;
-using Microsoft.DotNet.Interactive.CSharpProject.Tools;
 using Microsoft.DotNet.Interactive.CSharpProject.Servers.Roslyn;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject.Packaging;

--- a/src/Microsoft.DotNet.Interactive.CSharpProject/ProjectFile.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/ProjectFile.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Text.Json.Serialization;
-using Microsoft.DotNet.Interactive.CSharpProject.Tools;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject;
 

--- a/src/Microsoft.DotNet.Interactive.CSharpProject/RelativeDirectoryPath.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/RelativeDirectoryPath.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using Microsoft.DotNet.Interactive.CSharpProject.Tools;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject;
 

--- a/src/Microsoft.DotNet.Interactive.CSharpProject/RelativeFilePath.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/RelativeFilePath.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using Microsoft.DotNet.Interactive.CSharpProject.Tools;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject;
 

--- a/src/Microsoft.DotNet.Interactive.CSharpProject/Servers/Roslyn/PackageExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/Servers/Roslyn/PackageExtensions.cs
@@ -12,7 +12,6 @@ using Microsoft.DotNet.Interactive.CSharpProject.Packaging;
 using Microsoft.DotNet.Interactive.CSharpProject.Servers.Roslyn.Instrumentation;
 using static System.Environment;
 using Package = Microsoft.DotNet.Interactive.CSharpProject.Packaging.Package;
-using Workspace = Microsoft.DotNet.Interactive.CSharpProject.Workspace;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject.Servers.Roslyn;
 

--- a/src/Microsoft.DotNet.Interactive.Documents.Tests/ImportNotebookTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Documents.Tests/ImportNotebookTests.cs
@@ -1,13 +1,12 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.DotNet.Interactive.Documents.Jupyter;
-using Xunit; 
+using Xunit;
 
 namespace Microsoft.DotNet.Interactive.Documents.Tests;
 

--- a/src/Microsoft.DotNet.Interactive.Documents.Tests/NotebookParserServerTests_ObjectInterface.cs
+++ b/src/Microsoft.DotNet.Interactive.Documents.Tests/NotebookParserServerTests_ObjectInterface.cs
@@ -6,9 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using FluentAssertions;
-using FSharp.Compiler.Text;
-
-using Microsoft.DotNet.Interactive.Connection;
 using Microsoft.DotNet.Interactive.Documents.ParserServer;
 using Newtonsoft.Json;
 

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/SQLiteConnectionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/SQLiteConnectionTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Data.Sqlite;

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/SQLiteKernelExtensionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/SQLiteKernelExtensionTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -11,7 +10,6 @@ using Assent;
 using Microsoft.DotNet.Interactive.CSharp;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Formatting;
-using Microsoft.DotNet.Interactive.Tests.Utility;
 
 using Xunit;
 

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/DataFrameKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/DataFrameKernelExtension.cs
@@ -156,7 +156,7 @@ var {variableName} = new {frameTypeName}();
 
 namespace Microsoft.ML
 {
-   
+
     public static class DataViewExtensions
     {
         private static T GetValue<T>(ValueGetter<T> valueGetter)

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Inspector/CSharpCompiler/CSharpCompilationFailedException.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Inspector/CSharpCompiler/CSharpCompilationFailedException.cs
@@ -4,7 +4,6 @@
 using System.Linq;
 using System;
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis;
 using System.Runtime.Serialization;
 
 namespace Microsoft.DotNet.Interactive.ExtensionLab.Inspector.CSharpCompiler;

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Inspector/CSharpCompiler/CSharpCompilationResult.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Inspector/CSharpCompiler/CSharpCompilationResult.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Immutable;
 using System.IO;
-using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.Interactive.ExtensionLab.Inspector.CSharpCompiler;
 

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/PocketViewTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/PocketViewTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using System.Linq;

--- a/src/Microsoft.DotNet.Interactive.Formatting/MemberAccessor.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/MemberAccessor.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Reflection;
 
 namespace Microsoft.DotNet.Interactive.Formatting;

--- a/src/Microsoft.DotNet.Interactive.Journey.Tests/TeacherValidationTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Journey.Tests/TeacherValidationTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using Microsoft.DotNet.Interactive.Journey.Tests.Utilities;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterRequestHandlerTestBase{T}.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterRequestHandlerTestBase{T}.cs
@@ -8,7 +8,6 @@ using Microsoft.DotNet.Interactive.CSharp;
 using Microsoft.DotNet.Interactive.FSharp;
 using Microsoft.DotNet.Interactive.PowerShell;
 using Microsoft.DotNet.Interactive.Tests;
-using Microsoft.DotNet.Interactive.Tests.Utility;
 using Pocket;
 using Xunit.Abstractions;
 

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/LaTeXFormatterTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/LaTeXFormatterTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved. 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.IO;
 using FluentAssertions;
 using Microsoft.DotNet.Interactive.Formatting;
 using Microsoft.DotNet.Interactive.Jupyter.Formatting;

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/ZMQProtocolTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/ZMQProtocolTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.DotNet.Interactive.Jupyter.Messaging;
 using Microsoft.DotNet.Interactive.Jupyter.Protocol;
-using Microsoft.DotNet.Interactive.Jupyter.ZMQ;
 using Xunit;
 
 namespace Microsoft.DotNet.Interactive.Jupyter.Tests;

--- a/src/Microsoft.DotNet.Interactive.Jupyter/JupyterRequestContext.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/JupyterRequestContext.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Reactive;
 using System.Threading.Tasks;
-using Microsoft.DotNet.Interactive.Jupyter.Messaging;
 using Microsoft.DotNet.Interactive.Jupyter.Protocol;
 using Microsoft.DotNet.Interactive.Jupyter.ZMQ;
 using ZeroMQMessage = Microsoft.DotNet.Interactive.Jupyter.Messaging.Message;

--- a/src/Microsoft.DotNet.Interactive.Jupyter/Protocol/HistoryReplyConverter.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/Protocol/HistoryReplyConverter.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace Microsoft.DotNet.Interactive.Jupyter.Protocol;
 

--- a/src/Microsoft.DotNet.Interactive.Mermaid.Tests/MermaidKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Mermaid.Tests/MermaidKernelTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -11,7 +10,6 @@ using FluentAssertions.Execution;
 using HtmlAgilityPack;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Formatting;
-using Microsoft.DotNet.Interactive.Tests.Utility;
 using Xunit;
 
 namespace Microsoft.DotNet.Interactive.Mermaid.Tests;

--- a/src/Microsoft.DotNet.Interactive.PackageManagement/AddNugetRestoreSourcesResult.cs
+++ b/src/Microsoft.DotNet.Interactive.PackageManagement/AddNugetRestoreSourcesResult.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using Microsoft.DotNet.Interactive.Utility;
 
 namespace Microsoft.DotNet.Interactive;
 

--- a/src/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Management.Automation;
 using System.Threading.Tasks;

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Commands/OutDisplayCommand.cs
@@ -1,6 +1,5 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.DotNet.Interactive.Events;
 using System.Management.Automation;
 using static Microsoft.DotNet.Interactive.Kernel;
 

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Host/Progress/ProgressPane.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Host/Progress/ProgressPane.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.DotNet.Interactive.Events;
 
 namespace Microsoft.DotNet.Interactive.PowerShell.Host.Progress;
 

--- a/src/Microsoft.DotNet.Interactive.SqlServer/ConnectMsSqlCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/ConnectMsSqlCommand.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Linq;

--- a/src/Microsoft.DotNet.Interactive.SqlServer/ToolsServiceClientExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/ToolsServiceClientExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.DotNet.Interactive.SqlServer;
 
 namespace Microsoft.DotNet.Interactive.SqlServer;
 

--- a/src/Microsoft.DotNet.Interactive.Tests/ConnectDirectiveTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/ConnectDirectiveTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Threading.Tasks;

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/KernelCommandAndEventTextStreamSenderTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/KernelCommandAndEventTextStreamSenderTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.IO;
 using System.Text;
 using System.Threading;

--- a/src/Microsoft.DotNet.Interactive.Tests/KernelCommandNestingTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/KernelCommandNestingTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
 using FluentAssertions.Execution;

--- a/src/Microsoft.DotNet.Interactive.Tests/KernelInfoTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/KernelInfoTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;

--- a/src/Microsoft.DotNet.Interactive.Tests/KernelInvocationContextTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/KernelInvocationContextTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using FluentAssertions;
 using System.Linq;
 using System.Threading;

--- a/src/Microsoft.DotNet.Interactive.Tests/KernelRoutingTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/KernelRoutingTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.DotNet.Interactive.Commands;

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelFormattingTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelFormattingTests.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
-using FluentAssertions.Extensions;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.CSharp;
 using Microsoft.DotNet.Interactive.Events;

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.NamingConventionBinder;
 using System.Linq;
@@ -14,7 +13,6 @@ using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
 
 using Microsoft.DotNet.Interactive.Commands;
-using Microsoft.DotNet.Interactive.CSharp;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Formatting;
 using Microsoft.DotNet.Interactive.Tests.Utility;

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/CompletionTests.MagicCommands.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/CompletionTests.MagicCommands.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.NamingConventionBinder;
 using System.Linq;

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/HoverTextTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/HoverTextTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;

--- a/src/Microsoft.DotNet.Interactive.Tests/Parsing/SubmissionParserTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Parsing/SubmissionParserTests.cs
@@ -2,13 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.CommandLine.Parsing;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using FluentAssertions.Execution;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.CSharp;
 using Microsoft.DotNet.Interactive.FSharp;

--- a/src/Microsoft.DotNet.Interactive.Tests/Utility/TestUtility.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Utility/TestUtility.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Reactive.Subjects;
 using System.Threading.Tasks;
 
 using FluentAssertions;

--- a/src/Microsoft.DotNet.Interactive.Tests/VariableSharingTests.SetMagicCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/VariableSharingTests.SetMagicCommand.cs
@@ -4,13 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Dynamic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
-using FluentAssertions.Execution;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.CSharp;
 using Microsoft.DotNet.Interactive.Events;

--- a/src/Microsoft.DotNet.Interactive/DataExplorerFormatterSource.cs
+++ b/src/Microsoft.DotNet.Interactive/DataExplorerFormatterSource.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json;
 
 using Microsoft.DotNet.Interactive.Formatting;

--- a/src/Microsoft.DotNet.Interactive/KernelInvocationContext.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelInvocationContext.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.CommandLine;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Threading;

--- a/src/Microsoft.DotNet.Interactive/Utility/TaskExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/Utility/TaskExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Interactive.Utility;

--- a/src/dotnet-interactive.Tests/JupyterKernelSpecTests.cs
+++ b/src/dotnet-interactive.Tests/JupyterKernelSpecTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.CommandLine.IO;
 using System.ComponentModel;

--- a/src/dotnet-interactive/JupyterInstallCommand.cs
+++ b/src/dotnet-interactive/JupyterInstallCommand.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CommandLine;
 using System.IO;
 using System.IO.Compression;

--- a/src/dotnet-interactive/KernelExtensions.cs
+++ b/src/dotnet-interactive/KernelExtensions.cs
@@ -7,7 +7,6 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.CommandLine.NamingConventionBinder;
 using System.Reflection;
-using System.Runtime.InteropServices.ComTypes;
 using System.Threading.Tasks;
 
 using Microsoft.DotNet.Interactive.Commands;
@@ -15,9 +14,6 @@ using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Formatting;
 using Microsoft.DotNet.Interactive.Telemetry;
 using Microsoft.DotNet.Interactive.Utility;
-using Microsoft.FSharp.Control;
-
-using static FSharp.Compiler.EditorServices.FindDeclExternalSymbol;
 using static Microsoft.DotNet.Interactive.Formatting.PocketViewTags;
 
 namespace Microsoft.DotNet.Interactive.App;

--- a/src/dotnet-interactive/PackageDirectoryExtensionLoader.cs
+++ b/src/dotnet-interactive/PackageDirectoryExtensionLoader.cs
@@ -7,10 +7,8 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.Events;
-using Microsoft.DotNet.Interactive.Utility;
 using Pocket;
 using static Pocket.Logger<Microsoft.DotNet.Interactive.App.PackageDirectoryExtensionLoader>;
 


### PR DESCRIPTION
For this change, I used the Visual Studio Cleanup tools to remove all unnecessary usings from the codebase.

This helps to improve the readability and maintainability of the code.

No functional changes were made.