### PR TITLE
correctly set cell's missing metadata

### DIFF
--- a/src/polyglot-notebooks-vscode-common/src/vscodeUtilities.ts
+++ b/src/polyglot-notebooks-vscode-common/src/vscodeUtilities.ts
@@ -86,9 +86,6 @@ export function getCellKernelName(cell: vscode.NotebookCell): string {
 }
 
 export async function setCellKernelName(cell: vscode.NotebookCell, kernelName: string): Promise<void> {
-    if (cell.index < 0) {
-        const x = cell;
-    }
     const cellMetadata: metadataUtilities.NotebookCellMetadata = {
         kernelName
     };


### PR DESCRIPTION
- When the notebook is first opened, the missing metadata should be set to the notebook's default.
- When a new cell is added, the missing metadata should be copied from the previous cell.

## Details

When a notebook is first opened, VS Code generates a series of `onDidOpenTextDocument` events, one for each cell, followed by one `onDidOpenNotebookDocument` event.

Also, when the user adds a new cell to an existing notebook, an `onDidOpenTextDocument` event fires.

Unfortunately, when we see the `onDidOpenTextDocument` event, we don't know if it's part of the initial notebook open, or if the user just added a new cell and it's possible for this cell's metadata to be missing:

1. If a notebook was last used in Jupyter Lab and the user added a cell, the cell metadata will be missing.
2. If the user adds a new cell in VS Code, the new cell's metadata will be missing.

In scenario (1) above, the cell's metadata should be set from the parent notebook.  In scenario (2), the cell's metadata should be set from the previous cell.

To make this even worse, the APIs that set the cell metadata are `async` and as soon as the code hits an `await`, the order of the events is no longer guaranteed; e.g., if we try to set the metadata on cell 2 and make the `await` call, we might then next get the `onDidOpenNotebookDocument` event, followed by the initial `onDidOpenTextDocument` events corresponding to the remaining cells.

The fix is a little convoluted, but works:

When `onDidOpenNotebookDocument` occurs, we loop through all cells one at a time ensuring the metadata is set, preferring the document's metadata.  We then set a flag indicating that the initial notebook document open is complete.

When `onDidOpenTextDocument` occurs, if the notebook document open flag is _not_ set, we do nothing because the notebook open code will handle the metadata fixing.  If that flag _is_ set, however, then this means the user added a new cell and we then ensure the metadata is set, preferring the previous cell's metadata.

When the notebook document is closed, the flag is removed.

Fixes #2794.