### PR TITLE
Set always authenticate npm

### DIFF
--- a/src/polyglot-notebooks-vscode-insiders/.npmrc
+++ b/src/polyglot-notebooks-vscode-insiders/.npmrc
@@ -1,1 +1,2 @@
 registry=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
+always-auth=true


### PR DESCRIPTION
The step 4 'Project setup' of the updated documentation https://github.com/dotnet/interactive/pull/2805, it suggests enabling authentication. 