### PR TITLE
Use full path to global dotnet tools when starting SQL and Kusto services.

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Kql/KqlKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql/KqlKernelExtension.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
 using Microsoft.DotNet.Interactive.SqlServer;
@@ -13,11 +14,13 @@ public class KqlKernelExtension : IKernelExtension
     {
         if (kernel is CompositeKernel compositeKernel)
         {
-            var kqlToolName = "MicrosoftKustoServiceLayer";
+            var kqlToolName =  "MicrosoftKustoServiceLayer";
             await Utils.CheckAndInstallGlobalToolAsync(kqlToolName, "1.2.0", "Microsoft.SqlServer.KustoServiceLayer.Tool");
 
+            var userFolder = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
+            var kqlToolPath = Path.Join(userFolder, ".dotnet", "tools", kqlToolName);
             compositeKernel
-                .AddKernelConnector(new ConnectKqlCommand(kqlToolName));
+                .AddKernelConnector(new ConnectKqlCommand(kqlToolPath));
 
             KernelInvocationContext.Current?.Display(
                 new HtmlString(@"<details><summary>Query Microsoft Kusto Server databases.</summary>

--- a/src/Microsoft.DotNet.Interactive.Kql/KqlKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql/KqlKernelExtension.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
 using Microsoft.DotNet.Interactive.SqlServer;
+using Microsoft.DotNet.Interactive.Utility;
 
 namespace Microsoft.DotNet.Interactive.Kql;
 
@@ -14,11 +15,10 @@ public class KqlKernelExtension : IKernelExtension
     {
         if (kernel is CompositeKernel compositeKernel)
         {
-            var kqlToolName =  "MicrosoftKustoServiceLayer";
+            var kqlToolName = "MicrosoftKustoServiceLayer";
             await Utils.CheckAndInstallGlobalToolAsync(kqlToolName, "1.2.0", "Microsoft.SqlServer.KustoServiceLayer.Tool");
 
-            var userFolder = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
-            var kqlToolPath = Path.Join(userFolder, ".dotnet", "tools", kqlToolName);
+            var kqlToolPath = Path.Combine(Paths.DotnetToolsPath, kqlToolName);
             compositeKernel
                 .AddKernelConnector(new ConnectKqlCommand(kqlToolPath));
 

--- a/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelExtension.cs
@@ -4,6 +4,7 @@
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
+using Microsoft.DotNet.Interactive.Utility;
 
 namespace Microsoft.DotNet.Interactive.SqlServer;
 
@@ -16,8 +17,7 @@ public class MsSqlKernelExtension : IKernelExtension
             var sqlToolName = "MicrosoftSqlToolsServiceLayer";
             await Utils.CheckAndInstallGlobalToolAsync(sqlToolName, "1.2.0", "Microsoft.SqlServer.SqlToolsServiceLayer.Tool");
 
-            var userFolder = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
-            var sqlToolPath = Path.Join(userFolder, ".dotnet", "tools", sqlToolName);
+            var sqlToolPath = Path.Combine(Paths.DotnetToolsPath, sqlToolName);
             compositeKernel
                 .AddKernelConnector(new ConnectMsSqlCommand(sqlToolPath));
 

--- a/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelExtension.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
 
@@ -15,8 +16,10 @@ public class MsSqlKernelExtension : IKernelExtension
             var sqlToolName = "MicrosoftSqlToolsServiceLayer";
             await Utils.CheckAndInstallGlobalToolAsync(sqlToolName, "1.2.0", "Microsoft.SqlServer.SqlToolsServiceLayer.Tool");
 
+            var userFolder = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
+            var sqlToolPath = Path.Join(userFolder, ".dotnet", "tools", sqlToolName);
             compositeKernel
-                .AddKernelConnector(new ConnectMsSqlCommand(sqlToolName));
+                .AddKernelConnector(new ConnectMsSqlCommand(sqlToolPath));
 
             compositeKernel
                 .SubmissionParser


### PR DESCRIPTION
Currently we rely on the global tools folder being on the PATH, but that might not always be true, like with containers. This change  calls the tools using their full path in the user's .dotnet/tools folder instead.