### PR TITLE
fix #2802

### DIFF
--- a/src/polyglot-notebooks-vscode-common/src/notebookCellStatusBarItemProvider.ts
+++ b/src/polyglot-notebooks-vscode-common/src/notebookCellStatusBarItemProvider.ts
@@ -26,14 +26,14 @@ export function registerNotbookCellStatusBarItemProvider(context: vscode.Extensi
         });
     });
     context.subscriptions.push(vscode.notebooks.registerNotebookCellStatusBarItemProvider(constants.NotebookViewType, cellItemProvider));
-    context.subscriptions.push(vscode.notebooks.registerNotebookCellStatusBarItemProvider(constants.JupyterViewType, cellItemProvider)); // TODO: fix this
+    context.subscriptions.push(vscode.notebooks.registerNotebookCellStatusBarItemProvider(constants.JupyterViewType, cellItemProvider));
     context.subscriptions.push(vscode.commands.registerCommand(selectKernelCommandName, async (cell?: vscode.NotebookCell) => {
         if (cell) {
             const client = await clientMapper.tryGetClient(cell.notebook.uri);
             if (client) {
                 const availableOptions = kernelSelectorUtilities.getKernelSelectorOptions(client.kernel, cell.notebook, contracts.SubmitCodeType);
                 const availableDisplayOptions = availableOptions.map(o => o.displayValue);
-                const selectedDisplayOption = await vscode.window.showQuickPick(availableDisplayOptions, { title: 'Select kernel' });
+                const selectedDisplayOption = await vscode.window.showQuickPick(availableDisplayOptions, { title: 'Select cell kernel' });
                 if (selectedDisplayOption) {
                     const selectedValueIndex = availableDisplayOptions.indexOf(selectedDisplayOption);
                     if (selectedValueIndex >= 0) {
@@ -93,12 +93,8 @@ class DotNetNotebookCellStatusBarItemProvider {
         }
 
         const item = new vscode.NotebookCellStatusBarItem(displayText, vscode.NotebookCellStatusBarAlignment.Right);
-        const command: vscode.Command = {
-            title: '<unused>',
-            command: selectKernelCommandName,
-            arguments: [],
-        };
-        item.command = command;
+        item.command = selectKernelCommandName;
+        item.tooltip = "Select cell kernel";
         return [item];
     }
 

--- a/src/polyglot-notebooks-vscode-insiders/package.json
+++ b/src/polyglot-notebooks-vscode-insiders/package.json
@@ -290,10 +290,6 @@
         "title": "Share value with..."
       },
       {
-        "command": "polyglot-notebook.selectCellKernel",
-        "title": "Polyglot Notebook: Select cell kernel"
-      },
-      {
         "command": "polyglot-notebook.notebookEditor.restartKernel",
         "title": "Restart",
         "icon": {

--- a/src/polyglot-notebooks-vscode/package.json
+++ b/src/polyglot-notebooks-vscode/package.json
@@ -290,10 +290,6 @@
         "title": "Share value with..."
       },
       {
-        "command": "polyglot-notebook.selectCellKernel",
-        "title": "Polyglot Notebook: Select cell kernel"
-      },
-      {
         "command": "polyglot-notebook.notebookEditor.restartKernel",
         "title": "Restart",
         "icon": {


### PR DESCRIPTION
This adds a tool tip to, and gives a proper name to, the `Select cell kernel` button.

<img width="214" alt="image" src="https://user-images.githubusercontent.com/547415/224418769-af75ffd6-fc20-42a3-97ab-74f107ec3b58.png">

