### PR TITLE
don't error on unrecognized MIME types

### DIFF
--- a/src/polyglot-notebooks/src/javascriptKernel.ts
+++ b/src/polyglot-notebooks/src/javascriptKernel.ts
@@ -30,7 +30,8 @@ export class JavascriptKernel extends Kernel {
                     (<any>globalThis)[sendValue.name] = JSON.parse(sendValue.formattedValue.value);
                     break;
                 default:
-                    throw new Error(`mimetype ${sendValue.formattedValue.mimeType} not supported`);
+                    (<any>globalThis)[sendValue.name] = sendValue.formattedValue.value;
+                    break;
             }
             return Promise.resolve();
         }


### PR DESCRIPTION
Instead of erroring on an unrecognized MIME type in JavaScript, just assign it to a string variable.