### PR TITLE
avoid sending proxies from dotnet interactive

### DIFF
--- a/NotebookTestScript.dib
+++ b/NotebookTestScript.dib
@@ -380,9 +380,15 @@ using Microsoft.DotNet.Interactive.Commands;
 
 var _ = Kernel.Root.SendAsync(new SendEditableCode("fsharp","#!share --from csharp x\nx"));
 
+#!markdown
+
+The code below will add 2 markdown cells
+
 #!csharp
 
 using Microsoft.DotNet.Interactive;
 using Microsoft.DotNet.Interactive.Commands;
 
-var _ = Kernel.Root.SendAsync(new SendEditableCode("markdown","# markdown cell"));
+for(var i = 0; i<2;i++){
+    var _ = await Kernel.Root.SendAsync(new SendEditableCode("markdown",$"# markdown cell {i}"));
+}   

--- a/src/Microsoft.DotNet.Interactive/KernelHost.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelHost.cs
@@ -129,7 +129,10 @@ public class KernelHost : IDisposable
 
         _kernel.VisitSubkernelsAndSelf(k =>
         {
-            kernelInfos.Add(k.KernelInfo);
+            if (k.KernelInfo.IsProxy == false)
+            {
+                kernelInfos.Add(k.KernelInfo);
+            }
         }, true);
 
         await _defaultSender.SendAsync(


### PR DESCRIPTION
vscode extension gets confused when it sees the vscode and jsproxy to a kernelhost hat is not existing yes and creates double proxies to js