### PR TITLE
Support for mermaid markdown in markdown cells

### DIFF
--- a/src/polyglot-notebooks-vscode-insiders/package.json
+++ b/src/polyglot-notebooks-vscode-insiders/package.json
@@ -56,7 +56,8 @@
   ],
   "main": "./out/src/vscode-common/extension.js",
   "extensionDependencies": [
-    "ms-toolsai.jupyter"
+    "ms-toolsai.jupyter",
+    "bierner.markdown-mermaid"
   ],
   "capabilities": {
     "untrustedWorkspaces": {


### PR DESCRIPTION
with the extension [bierner.markdown-mermaid](https://marketplace.visualstudio.com/items?itemName=bierner.markdown-mermaid) using mermaid in markdown cells is rendered as graph inline the difference is that from this input

![image](https://user-images.githubusercontent.com/375556/225988246-97f3e949-66d4-48f2-b5e8-685eaa51296d.png)
the one on the notebook on the left is taking advantage of the extension while the other will treat it as code block

![image](https://user-images.githubusercontent.com/375556/225988381-74240f81-41b4-435d-8565-08e0bd13d750.png)

