### PR TITLE
strip cell metadata for markdown cells

### DIFF
--- a/src/polyglot-notebooks-vscode-common/src/commands.ts
+++ b/src/polyglot-notebooks-vscode-common/src/commands.ts
@@ -175,8 +175,8 @@ export function registerFileCommands(context: vscode.ExtensionContext, parserSer
     const eol = getEol();
 
     const notebookFileFilters = {
-        'Polyglot Notebooks': ['dib'],
-        'Jupyter Notebooks': ['ipynb'],
+        'Polyglot Notebook Script': ['dib'],
+        'Jupyter Notebook': ['ipynb'],
     };
 
     async function newNotebookCommandHandler(preferDefaults: boolean): Promise<void> {


### PR DESCRIPTION
This fixes #2853 by stripping cell metadata for Markdown cells.

<img width="598" alt="image" src="https://user-images.githubusercontent.com/547415/226759323-dc01039a-5f6c-447a-9bf0-8598bf3cd55c.png">
