### PR TITLE
Fix null reference if content-type specified but no body

### DIFF
--- a/src/Microsoft.DotNet.Interactive.HttpRequest.Tests/HttpRequestKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.HttpRequest.Tests/HttpRequestKernelTests.cs
@@ -193,6 +193,29 @@ Content-Type: application/json
     }
 
     [Fact]
+    public async Task can_set_contenttype_without_a_body()
+    {
+        HttpRequestMessage request = null;
+        var handler = new InterceptingHttpMessageHandler((message, _) =>
+        {
+            request = message;
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            return Task.FromResult(response);
+        });
+        var client = new HttpClient(handler);
+        using var kernel = new HttpRequestKernel(client: client);
+
+        var result = await kernel.SendAsync(new SubmitCode(@"
+Get  https://location1.com:1200/endpoint
+Authorization: Basic username password
+Content-Type: application/json
+"));
+
+        result.Events.Should().NotContainErrors();
+        request.Content.Headers.ContentType.ToString().Should().Be("application/json");
+    }
+
+    [Fact]
     public async Task can_use_symbols_in_body()
     {
         HttpRequestMessage request = null;

--- a/src/Microsoft.DotNet.Interactive.HttpRequest/HttpRequestKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.HttpRequest/HttpRequestKernel.cs
@@ -130,6 +130,10 @@ public class HttpRequestKernel :
                 switch (kvp.Key.ToLowerInvariant())
                 {
                     case "content-type":
+                        if (message.Content is null)
+                        {
+                            message.Content = new StringContent(httpRequest.Body);
+                        }
                         message.Content.Headers.ContentType = MediaTypeHeaderValue.Parse(kvp.Value);
                         break;
                     case "accept":
@@ -275,7 +279,7 @@ public class HttpRequestKernel :
                     verb = parts[0].Trim();
                     address = parts[1].Trim();
                 }
-                else if (!string.IsNullOrWhiteSpace(line) && IsHeader.Matches(line) is { } matches)
+                else if (!string.IsNullOrWhiteSpace(line) && IsHeader.Matches(line) is { } matches && matches.Count != 0)
                 {
                     foreach (Match match in matches)
                     {


### PR DESCRIPTION
If the request has a content-type but no body is specified, it throws a null reference exception as it tries to set the ContentType header on the message.Content object. Simple change to add a Content in this case.
The issue is the RegEx which is trying to match lines containing headers, would sometimes return an empty collection for Body lines and would try to treat these headers. The simple fix is to also check that the collection is not empty.
I added a unit test to validate the first case.