### PR TITLE
don't require IJupyterConnection to be IDiposable

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.jupyter_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.jupyter_api_is_not_changed.approved.txt
@@ -118,7 +118,7 @@ Microsoft.DotNet.Interactive.Jupyter
     public static System.String input(System.String prompt = )
     public static Microsoft.DotNet.Interactive.PasswordString password(System.String prompt = )
 Microsoft.DotNet.Interactive.Jupyter.Connection
-  public abstract class IJupyterConnection, System.IDisposable
+  public abstract class IJupyterConnection
     public System.Threading.Tasks.Task<IJupyterKernelConnection> CreateKernelConnectionAsync(System.String kernelSpecName)
     public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.DotNet.Interactive.Jupyter.KernelSpec>> GetKernelSpecsAsync()
   public abstract class IJupyterKernelConnection, System.IDisposable

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/TestJupyterConnectionOptions.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/TestJupyterConnectionOptions.cs
@@ -219,7 +219,7 @@ public class TestJupyterKernelConnection : IJupyterKernelConnection
     public bool IsDisposed => _disposed;
 }
 
-public class TestJupyterConnection : IJupyterConnection
+public class TestJupyterConnection : IJupyterConnection, IDisposable
 {
     private IJupyterConnection _testJupyterConnection;
     private TestJupyterKernelConnection _testKernelConnection;
@@ -254,7 +254,7 @@ public class TestJupyterConnection : IJupyterConnection
 
     public void Dispose()
     {
-        _testJupyterConnection?.Dispose();
+        (_testJupyterConnection as IDisposable)?.Dispose();
         _disposed = true;
     }
 

--- a/src/Microsoft.DotNet.Interactive.Jupyter/ConnectJupyterKernelCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/ConnectJupyterKernelCommand.cs
@@ -69,7 +69,10 @@ public class ConnectJupyterKernelCommand : ConnectKernelCommand
         var localName = commandLineContext.ParseResult.GetValueForOption(KernelNameOption);
 
         var kernel = await connector?.CreateKernelAsync(localName);
-        kernel?.RegisterForDisposal(connection);
+        if (connection is IDisposable disposableConnection)
+        {
+            kernel?.RegisterForDisposal(disposableConnection);
+        }
         return kernel;
     }
 
@@ -95,8 +98,8 @@ public class ConnectJupyterKernelCommand : ConnectKernelCommand
         }
 
         IEnumerable<CompletionItem> completions;
-        using (var connection = GetJupyterConnection(ctx.ParseResult))
-        {
+        var connection = GetJupyterConnection(ctx.ParseResult);
+        using (connection as IDisposable) {
             completions = GetKernelSpecsCompletions(connection);
         }
 

--- a/src/Microsoft.DotNet.Interactive.Jupyter/Connection/IJupyterConnection.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/Connection/IJupyterConnection.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Interactive.Jupyter.Connection;
 
-public interface IJupyterConnection : IDisposable
+public interface IJupyterConnection
 {
     Task<IEnumerable<KernelSpec>> GetKernelSpecsAsync();
 

--- a/src/Microsoft.DotNet.Interactive.Jupyter/Http/JupyterHttpConnection.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/Http/JupyterHttpConnection.cs
@@ -13,7 +13,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Interactive.Jupyter.Http;
 
-internal class JupyterHttpConnection : IJupyterConnection
+internal class JupyterHttpConnection : IJupyterConnection, IDisposable
 {
     #region JsonTypes
     private class KernelSessionInfo

--- a/src/Microsoft.DotNet.Interactive.Jupyter/ZMQ/JupyterConnection.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/ZMQ/JupyterConnection.cs
@@ -132,10 +132,6 @@ internal class JupyterConnection : IJupyterConnection
         return kernelProcess;
     }
 
-    public void Dispose()
-    {
-    }
-
     private async Task<KernelSpec> GetKernelSpecAsync(string kernelSpecName)
     {
         var installedSpecs = await _getKernelSpecs;


### PR DESCRIPTION
Addresses improvement feedback on not requiring IJupyterConnection to be IDisposable. Instead disposes them if they are IDisposable. 

https://github.com/dotnet/interactive/pull/2791