### PR TITLE
Make `CommOpen` to use a readonly dictionary of objects 

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.jupyter_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.jupyter_api_is_not_changed.approved.txt
@@ -206,9 +206,9 @@ Microsoft.DotNet.Interactive.Jupyter.Protocol
     public System.String CommId { get;}
     public System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object> Data { get;}
   public class CommOpen : Message
-    .ctor(System.String commId, System.String targetName, System.Object data)
+    .ctor(System.String commId, System.String targetName, System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object> data)
     public System.String CommId { get;}
-    public System.Object Data { get;}
+    public System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object> Data { get;}
     public System.String TargetName { get;}
   public class CommTarget
     .ctor(System.String targetName)

--- a/src/Microsoft.DotNet.Interactive.Jupyter/Messaging/Comms/ICommTarget.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/Messaging/Comms/ICommTarget.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+
 namespace Microsoft.DotNet.Interactive.Jupyter.Messaging.Comms;
 
 internal interface ICommTarget
 {
     public string Name { get; }
 
-    public void OnCommOpen(CommAgent commAgent, object data);
+    public void OnCommOpen(CommAgent commAgent, IReadOnlyDictionary<string, object> data);
 }

--- a/src/Microsoft.DotNet.Interactive.Jupyter/Protocol/CommOpen.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/Protocol/CommOpen.cs
@@ -17,9 +17,9 @@ public class CommOpen : Message
     public string TargetName { get; }
 
     [JsonPropertyName("data")]
-    public object Data { get; }
+    public IReadOnlyDictionary<string, object> Data { get; }
 
-    public CommOpen(string commId, string targetName, object data)
+    public CommOpen(string commId, string targetName, IReadOnlyDictionary<string, object> data)
     {
         if (string.IsNullOrWhiteSpace(commId))
         {


### PR DESCRIPTION
change to use a dictionary instead of an object as per jupyter message protocol https://jupyter-client.readthedocs.io/en/stable/messaging.html#opening-a-comm