### PR TITLE
Add Preview info on `#!connect jupyter` command

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterKernelTestBase.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterKernelTestBase.cs
@@ -32,7 +32,7 @@ public abstract class JupyterKernelTestBase : IDisposable
         _disposables.Dispose();
     }
 
-    protected CompositeKernel CreateCompositeKernelAsync(IJupyterKernelConnectionOptions options = null)
+    protected CompositeKernel CreateCompositeKernelAsync(params IJupyterKernelConnectionOptions[] optionsList)
     {
         Formatter.SetPreferredMimeTypesFor(typeof(TabularDataResource), HtmlFormatter.MimeType, CsvFormatter.MimeType);
 
@@ -43,11 +43,14 @@ public abstract class JupyterKernelTestBase : IDisposable
         var kernel = new CompositeKernel { csharpKernel };
         kernel.DefaultKernelName = csharpKernel.Name;
 
-        if (options != null)
+        var jupyterKernelCommand = new ConnectJupyterKernelCommand();
+
+        foreach (var options in optionsList) 
         {
-            var jupyterKernelCommand = new ConnectJupyterKernelCommand();
-            kernel.AddKernelConnector(jupyterKernelCommand.AddConnectionOptions(options));
+            jupyterKernelCommand.AddConnectionOptions(options);
         }
+
+        kernel.AddKernelConnector(jupyterKernelCommand);
         _disposables.Add(kernel);
         return kernel;
     }

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterKernelTestBase.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterKernelTestBase.cs
@@ -32,7 +32,7 @@ public abstract class JupyterKernelTestBase : IDisposable
         _disposables.Dispose();
     }
 
-    protected CompositeKernel CreateCompositeKernelAsync(IJupyterKernelConnectionOptions options)
+    protected CompositeKernel CreateCompositeKernelAsync(IJupyterKernelConnectionOptions options = null)
     {
         Formatter.SetPreferredMimeTypesFor(typeof(TabularDataResource), HtmlFormatter.MimeType, CsvFormatter.MimeType);
 
@@ -43,9 +43,11 @@ public abstract class JupyterKernelTestBase : IDisposable
         var kernel = new CompositeKernel { csharpKernel };
         kernel.DefaultKernelName = csharpKernel.Name;
 
-        var jupyterKernelCommand = new ConnectJupyterKernelCommand();
-        kernel.AddKernelConnector(jupyterKernelCommand.AddConnectionOptions(options));
-
+        if (options != null)
+        {
+            var jupyterKernelCommand = new ConnectJupyterKernelCommand();
+            kernel.AddKernelConnector(jupyterKernelCommand.AddConnectionOptions(options));
+        }
         _disposables.Add(kernel);
         return kernel;
     }

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterKernelTests.cs
@@ -22,6 +22,33 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests;
 public class JupyterKernelTests : JupyterKernelTestBase
 {
     [Fact]
+    public async Task can_get_help_for_connect_jupyter()
+    {
+        var kernel = CreateCompositeKernelAsync();
+        var jupyterKernelCommand = new ConnectJupyterKernelCommand();
+        jupyterKernelCommand
+            .AddConnectionOptions(new JupyterHttpKernelConnectionOptions())
+            .AddConnectionOptions(new JupyterLocalKernelConnectionOptions());
+        
+        kernel.AddKernelConnector(jupyterKernelCommand);
+
+        var command = new SubmitCode("#!connect jupyter --help");
+
+        var result = await kernel.SendAsync(command);
+
+        var outputs = result.Events.OfType<StandardOutputValueProduced>();
+
+        outputs.Should().HaveCount(1);
+
+        string.Join("",
+                outputs
+                    .SelectMany(e => e.FormattedValues.Select(v => v.Value))
+            ).ToLowerInvariant()
+            .Should()
+            .ContainAll("--kernel-spec", "--init-script", "--url", "--token", "in preview");
+    }
+
+    [Fact]
     public async Task variable_sharing_not_enabled_for_unsupported_languages()
     {
         var options = new TestJupyterConnectionOptions(GenerateReplies(null, "unsupportedLanguage"));

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterKernelTests.cs
@@ -24,14 +24,8 @@ public class JupyterKernelTests : JupyterKernelTestBase
     [Fact]
     public async Task can_get_help_for_connect_jupyter()
     {
-        var kernel = CreateCompositeKernelAsync();
-        var jupyterKernelCommand = new ConnectJupyterKernelCommand();
-        jupyterKernelCommand
-            .AddConnectionOptions(new JupyterHttpKernelConnectionOptions())
-            .AddConnectionOptions(new JupyterLocalKernelConnectionOptions());
+        var kernel = CreateCompositeKernelAsync(new JupyterHttpKernelConnectionOptions(), new JupyterLocalKernelConnectionOptions());
         
-        kernel.AddKernelConnector(jupyterKernelCommand);
-
         var command = new SubmitCode("#!connect jupyter --help");
 
         var result = await kernel.SendAsync(command);

--- a/src/Microsoft.DotNet.Interactive.Jupyter/ConnectJupyterKernelCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/ConnectJupyterKernelCommand.cs
@@ -19,10 +19,10 @@ public class ConnectJupyterKernelCommand : ConnectKernelCommand
     private KeyValuePair<int, IEnumerable<CompletionItem>> _mruKernelSpecSuggestions;
 
     public ConnectJupyterKernelCommand() : base("jupyter",
-                                        "Connects to a jupyter kernel")
+                                        "Connects to a jupyter kernel. This feature is in preview.")
     {
-        AddOption(InitScript);
         AddOption(KernelSpecName.AddCompletions(ctx => GetKernelSpecsCompletions(ctx)));
+        AddOption(InitScript);
     }
 
     public Option<string> KernelSpecName { get; } =
@@ -52,6 +52,10 @@ public class ConnectJupyterKernelCommand : ConnectKernelCommand
         KernelInvocationContext context,
         InvocationContext commandLineContext)
     {
+        context.DisplayAs(
+            "The `#!connect jupyter` feature is in preview. Please report any feedback or issues at https://github.com/dotnet/interactive/issues/new/choose.", 
+            "text/markdown");
+
         var kernelSpecName = commandLineContext.ParseResult.GetValueForOption(KernelSpecName);
         var initScript = commandLineContext.ParseResult.GetValueForOption(InitScript);
 
@@ -60,7 +64,7 @@ public class ConnectJupyterKernelCommand : ConnectKernelCommand
         {
             throw new InvalidOperationException("No supported connection options were specified");
         }
-        
+
         JupyterKernelConnector connector = new JupyterKernelConnector(connection, kernelSpecName, initScript);
 
         var localName = commandLineContext.ParseResult.GetValueForOption(KernelNameOption);

--- a/src/Microsoft.DotNet.Interactive.Jupyter/JupyterHttpKernelConnectionOptions.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/JupyterHttpKernelConnectionOptions.cs
@@ -15,17 +15,17 @@ public sealed class JupyterHttpKernelConnectionOptions : IJupyterKernelConnectio
     private readonly IReadOnlyCollection<Option> _options;
 
     public Option<string> TargetUrl { get; } =
-    new("--url", "URl to connect to the jupyter server")
+    new("--url", "URL to connect to a remote jupyter server")
     {
     };
 
     public Option<string> Token { get; } =
-    new("--token", "token to connect to the jupyter server")
+    new("--token", "token to connect to a remote jupyter server")
     {
     };
 
     private Option<bool> UseBearerAuth { get; } =
-    new("--bearer", "auth type is bearer token")
+    new("--bearer", "auth type is bearer token for remote jupyter server")
     {
     };
 

--- a/src/Microsoft.DotNet.Interactive.Jupyter/JupyterKernelSpecModule.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/JupyterKernelSpecModule.cs
@@ -60,7 +60,7 @@ public class JupyterKernelSpecModule : IJupyterKernelSpecModule
         }
         catch (Exception exception)
         {
-            Log.Error("Failed to retrieve kernel specs", exception);
+            Log.Warning("Failed to retrieve kernel specs", exception);
             // fall back to custom lookup logic 
             return LookupInstalledKernels();
         }

--- a/src/Microsoft.DotNet.Interactive.Jupyter/JupyterKernelSpecModule.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/JupyterKernelSpecModule.cs
@@ -9,6 +9,8 @@ using System.Threading.Tasks;
 using System.Linq;
 using Microsoft.DotNet.Interactive.Formatting;
 using System;
+using Pocket;
+using static Pocket.Logger;
 
 namespace Microsoft.DotNet.Interactive.Jupyter;
 
@@ -56,8 +58,9 @@ public class JupyterKernelSpecModule : IJupyterKernelSpecModule
                 return LookupInstalledKernels();
             }
         }
-        catch (Exception)
+        catch (Exception exception)
         {
+            Log.Error("Failed to retrieve kernel specs", exception);
             // fall back to custom lookup logic 
             return LookupInstalledKernels();
         }


### PR DESCRIPTION
Clarify that Jupyter subkernels are in preview support by adding a message on connect and improving the connect help doc.

<img width="950" alt="image" src="https://user-images.githubusercontent.com/26466942/230519918-07dc09de-fcda-4272-8512-f212ad5e8a34.png">


