### PR TITLE
remove type hint change that is not supported in older python versions

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Jupyter/CommandEvents/LanguageHandlers/python/coe_comm_handler.py
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/CommandEvents/LanguageHandlers/python/coe_comm_handler.py
@@ -201,7 +201,7 @@ def __get_dotnet_coe_comm_handler():
             self.formattedValue = formattedValue
     
     class ValueInfosProduced(KernelEvent):
-        def __init__(self, valueInfos: list[KernelValueInfo]):
+        def __init__(self, valueInfos):
             self.valueInfos = valueInfos
             
     class Envelope:

--- a/src/polyglot-notebooks-vscode-insiders/README.md
+++ b/src/polyglot-notebooks-vscode-insiders/README.md
@@ -36,7 +36,7 @@ The following languages are supported by Polyglot Notebooks:
 - Notebook-friendly diffing tool that makes it easy to visually compare inputs, outputs, and metadata
 - Navigate via Outline View
 - Customizable notebook layout
-- Connect to Python and R Jupyter kernels installed locally or remotely and share variables between them.
+- Connect to Python (3.7+) and R Jupyter kernels installed locally or remotely and share variables between them.
 
 ## Getting Started
 

--- a/src/polyglot-notebooks-vscode/README.md
+++ b/src/polyglot-notebooks-vscode/README.md
@@ -36,7 +36,7 @@ The following languages are supported by Polyglot Notebooks:
 - Notebook-friendly diffing tool that makes it easy to visually compare inputs, outputs, and metadata
 - Navigate via Outline View
 - Customizable notebook layout
-- Connect to Python and R Jupyter kernels installed locally or remotely and share variables between them.
+- Connect to Python (3.7+) and R Jupyter kernels installed locally or remotely and share variables between them.
 
 ## Getting Started
 


### PR DESCRIPTION
Remove `list[]` type hint support that seems to be causing problems in <=3.8 versions of python causing value sharing to be disabled. Validated that this works with python 3.6, 3.8, 3.9