### PR TITLE
change ipython.magic to ipython.run_line_magic

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Jupyter/CommandEvents/LanguageHandlers/python/coe_comm_handler.py
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/CommandEvents/LanguageHandlers/python/coe_comm_handler.py
@@ -66,7 +66,7 @@ def __get_dotnet_coe_comm_handler():
             return envelop.payload()
 
         def __handle_request_value_infos(self, command):
-            results_who_ls = get_ipython().magic('who_ls')
+            results_who_ls = get_ipython().run_line_magic('who_ls', '')
             variables = globals()
             results = [KernelValueInfo(x, FormattedValue.fromValue(variables[x]), str(type(variables[x]))) 
                                     for x in results_who_ls 


### PR DESCRIPTION
Use run_line_magic as recommended by deprecation warning. 
> DeprecationWarning: `magic(...)` is deprecated since IPython 0.13 (warning added in 8.1), use run_line_magic(magic_name, parameter_s).