### PR TITLE
Issue #2899: Upgrade Mermaid Version from 9.1.7 to 10.1.0.

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Mermaid/MermaidMarkdownFormatter.cs
+++ b/src/Microsoft.DotNet.Interactive.Mermaid/MermaidMarkdownFormatter.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Interactive.Mermaid;
 
 internal class MermaidMarkdownFormatter : ITypeFormatterSource
 {
-    private const string DefaultLibraryVersion = "9.1.7";
+    private const string DefaultLibraryVersion = "10.1.0";
     private static readonly Uri DefaultLibraryUri = new($@"https://cdn.jsdelivr.net/npm/mermaid@{DefaultLibraryVersion}/dist/mermaid.min.js", UriKind.Absolute);
     private static readonly Uri RequireUri = new("https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js");
     


### PR DESCRIPTION
This more closely matches the documentation which will reduce developer friction. This also enables the timeline and mindmap charts.

Relates to issue #2899