### PR TITLE
Upgrade to mermaid 10 api

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Mermaid.Tests/MermaidKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Mermaid.Tests/MermaidKernelTests.cs
@@ -46,7 +46,7 @@ public class MermaidKernelTests
         scriptNode.InnerText.Should()
             .Contain(markdown);
         scriptNode.InnerText.Should()
-            .Contain("(['mermaidUri'], (mermaid) => {");
+            .Contain("import mermaid from ");
 
         renderTarget.Should().NotBeNull();
     }

--- a/src/Microsoft.DotNet.Interactive.Mermaid.Tests/StringExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.Mermaid.Tests/StringExtensions.cs
@@ -12,7 +12,7 @@ internal static class StringExtensions
         var reg = new Regex(@".*\s+id=""(?<id>\S+)""\s*.*", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Compiled);
         var id1 = reg.Match(source).Groups["id"].Value;
         var id = id1;
-        return source.Replace(id, "00000000000000000000000000000000");
+        return string.IsNullOrWhiteSpace(id) ? source : source.Replace(id, "00000000000000000000000000000000");
     }
 
     public static string FixedCacheBuster(this string source)
@@ -20,6 +20,6 @@ internal static class StringExtensions
         var reg = new Regex(@".*\s+'cacheBuster=(?<cacheBuster>\S+)'\s*.*", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Compiled);
         var id1 = reg.Match(source).Groups["cacheBuster"].Value;
         var id = id1;
-        return source.Replace(id, "00000000000000000000000000000000");
+        return string.IsNullOrWhiteSpace(id) ? source : source.Replace(id, "00000000000000000000000000000000");
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Mermaid/MermaidMarkdownFormatter.cs
+++ b/src/Microsoft.DotNet.Interactive.Mermaid/MermaidMarkdownFormatter.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Interactive.Mermaid;
 internal class MermaidMarkdownFormatter : ITypeFormatterSource
 {
     private const string DefaultLibraryVersion = "10.1.0";
-    private static readonly Uri DefaultLibraryUri = new($@"https://cdn.jsdelivr.net/npm/mermaid@{DefaultLibraryVersion}/dist/mermaid.min.js", UriKind.Absolute);
+    private static readonly Uri DefaultLibraryUri = new($@"https://cdn.jsdelivr.net/npm/mermaid@{DefaultLibraryVersion}/dist/mermaid.esm.min.mjs", UriKind.Absolute);
     private static readonly Uri RequireUri = new("https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js");
     
     
@@ -58,10 +58,7 @@ internal class MermaidMarkdownFormatter : ITypeFormatterSource
         code.AppendLine($"<div class=\"mermaidMarkdownContainer\" style=\"background-color:{markdown.Background}\">");
         code.AppendLine(@"<link rel=""stylesheet"" href=""https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css"">");
             
-                                             code.AppendLine(@"<script type=""text/javascript"">");
-        AppendJsCode(code, divId, functionName, libraryUri, libraryVersion, markdown.ToString());
-        code.AppendLine(JavascriptUtilities.GetCodeForEnsureRequireJs(RequireUri, functionName));
-        code.AppendLine("</script>");
+       
         var style = string.Empty;
         if (!string.IsNullOrWhiteSpace(markdown.Width) || !string.IsNullOrWhiteSpace(markdown.Width))
         {
@@ -80,36 +77,33 @@ internal class MermaidMarkdownFormatter : ITypeFormatterSource
             style += "\" ";
         }
         code.AppendLine($"<div id=\"{divId}\"{style}></div>");
+
+        code.AppendLine(@"<script type=""module"">");
+        AppendJsCode(code, divId, libraryUri, libraryVersion, markdown.ToString());
+        code.AppendLine("</script>");
+
         code.AppendLine("</div>");
 
         var html = new HtmlString(code.ToString());
         return html;
     }
 
-    private static void AppendJsCode(StringBuilder stringBuilder, string divId, string functionName, Uri libraryUri, string libraryVersion, string markdown)
+    private static void AppendJsCode(StringBuilder stringBuilder, string divId,  Uri libraryUri, string libraryVersion, string markdown)
     {
         var escapedMarkdown = Regex.Replace(markdown, @"(?<pre>[^\\])(?<newLine>\\n)", @"${pre}\\n");
-        stringBuilder.AppendLine($@"
-{functionName} = () => {{");
-
-        var libraryAbsoluteUri = Regex.Replace(libraryUri.AbsoluteUri, @"(\.js)$", string.Empty);
-
-        stringBuilder.AppendLine($@" 
-        (require.config({{ 'paths': {{ 'context': '{libraryVersion}', 'mermaidUri' : '{libraryAbsoluteUri}', 'urlArgs': 'cacheBuster={CacheBuster}' }}}}) || require)(['mermaidUri'], (mermaid) => {{");
-
 
         stringBuilder.AppendLine($@"
+            import mermaid from '{libraryUri.AbsoluteUri}';
             let renderTarget = document.getElementById('{divId}');
-            mermaid.mermaidAPI.render( 
-                'mermaid_{divId}', 
-                `{escapedMarkdown}`, 
-                g => {{
-                    renderTarget.innerHTML = g 
-                }});
-        }},
-        (error) => {{
-            console.log(error);
-        }});
-}}");
+            try {{
+                const {{svg, bindFunctions}} = await mermaid.mermaidAPI.render( 
+                    'mermaid_{divId}', 
+                    `{escapedMarkdown}`);
+                renderTarget.innerHTML = svg;
+                bindFunctions?.(renderTarget);
+            }}
+            catch (error) {{
+                console.log(error);
+            }}");
     }
 }


### PR DESCRIPTION
Form version 10 mermaid is only esm and published with .mjs extension. Api changed to async with no callbacks.
```html
<script type="module">
  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
  mermaid.initialize({ startOnLoad: true });
</script>
```

See [changelog](https://github.com/mermaid-js/mermaid/blob/develop/CHANGELOG.md) for more details