### PR TITLE
Adjust resource namespace of resources to Microsoft.DotNet.Interactive for Microsoft.DotNet.Interactive.VisualStudio

### DIFF
--- a/src/Microsoft.DotNet.Interactive.VisualStudio/Microsoft.DotNet.Interactive.VisualStudio.csproj
+++ b/src/Microsoft.DotNet.Interactive.VisualStudio/Microsoft.DotNet.Interactive.VisualStudio.csproj
@@ -42,8 +42,8 @@
 
   <ItemGroup>
     <EmbeddedResource Include="..\Microsoft.DotNet.Interactive\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+      <GenerateSource>"true"</GenerateSource>
+      <LogicalName>Microsoft.DotNet.Interactive.Resources.resources</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
During runtime, the Microsoft.DotNet.Interactive.VisualStudio project searches for string resources within the Microsoft.DotNet.Interactive namespace. This change aligns the resource namespace with the imported project that owns the resource, ensuring proper resource loading and usage.

BEFORE
![image](https://user-images.githubusercontent.com/510598/233240876-79cea419-44c7-44da-95ff-7a68608e7163.png)

AFTER
![image](https://user-images.githubusercontent.com/510598/233239284-31019692-19c2-4cc8-9cf2-cd558613dc26.png)
