### PR TITLE
Fix usage of ExecutionContext in netstandard2.0

### DIFF
--- a/src/Microsoft.DotNet.Interactive.AspNetCore/InteractiveLoggerProvider.cs
+++ b/src/Microsoft.DotNet.Interactive.AspNetCore/InteractiveLoggerProvider.cs
@@ -89,7 +89,7 @@ internal class InteractiveLoggerProvider : ILoggerProvider
 
             if (_loggerProvider._pocketLoggerEC is {} currentEc)
             {
-                ExecutionContext.Run(currentEc, PocketLogCallback, logMessage);
+                ExecutionContext.Run(currentEc.CreateCopy(), PocketLogCallback, logMessage);
             }
             else
             {

--- a/src/Microsoft.DotNet.Interactive/Connection/ProxyKernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Connection/ProxyKernel.cs
@@ -206,38 +206,38 @@ public sealed class ProxyKernel : Kernel
                     _suppressCompletionsForCommandId = null;
                     break;
                 case KernelInfoProduced kip when kip.KernelInfo.Uri == KernelInfo.RemoteUri:
-                {
-                    UpdateKernelInfoFromEvent(kip);
-                    var newEvent = new KernelInfoProduced(KernelInfo, kernelEvent.Command);
-
-                    newEvent.RoutingSlip.ContinueWith(kip.RoutingSlip);
-
-                    if (pending.executionContext is { } ec)
                     {
-                        ExecutionContext.Run(ec, _ =>
+                        UpdateKernelInfoFromEvent(kip);
+                        var newEvent = new KernelInfoProduced(KernelInfo, kernelEvent.Command);
+
+                        newEvent.RoutingSlip.ContinueWith(kip.RoutingSlip);
+
+                        if (pending.executionContext is { } ec)
+                        {
+                            ExecutionContext.Run(ec.CreateCopy(), _ =>
+                            {
+                                pending.invocationContext.Publish(newEvent);
+                                pending.invocationContext.Publish(kip);
+                            }, null);
+                        }
+                        else
                         {
                             pending.invocationContext.Publish(newEvent);
                             pending.invocationContext.Publish(kip);
-                        }, null);
+                        }
                     }
-                    else
-                    {
-                        pending.invocationContext.Publish(newEvent);
-                        pending.invocationContext.Publish(kip);
-                    }
-                }
                     break;
                 default:
-                {
-                    if (pending.executionContext is { } ec)
                     {
-                        ExecutionContext.Run(ec, _ => pending.invocationContext.Publish(kernelEvent), null);
+                        if (pending.executionContext is { } ec)
+                        {
+                            ExecutionContext.Run(ec.CreateCopy(), _ => pending.invocationContext.Publish(kernelEvent), null);
+                        }
+                        else
+                        {
+                            pending.invocationContext.Publish(kernelEvent);
+                        }
                     }
-                    else
-                    {
-                        pending.invocationContext.Publish(kernelEvent);
-                    }
-                }
                     break;
             }
         }

--- a/src/Microsoft.DotNet.Interactive/KernelScheduler.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelScheduler.cs
@@ -38,8 +38,9 @@ public class KernelScheduler<T, TResult> : IDisposable, IKernelScheduler<T, TRes
 
         _disposables = new CompositeDisposable
         {
+            _schedulerDisposalSource.Cancel,
+            _schedulerDisposalSource,
             _topLevelScheduledOperations,
-            () => _schedulerDisposalSource.Cancel()
         };
 
         static bool DoNotPreempt(T one, T two)

--- a/src/Microsoft.DotNet.Interactive/KernelScheduler.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelScheduler.cs
@@ -112,7 +112,7 @@ public class KernelScheduler<T, TResult> : IDisposable, IKernelScheduler<T, TRes
             try
             {
                 ExecutionContext.Run(
-                    executionContext!,
+                    executionContext!.CreateCopy(),
                     _ => RunPreemptively(operation),
                     operation);
 


### PR DESCRIPTION
* Always pass a copy of the captured `ExecutionContext` to the `ExecutionContext.Run` API. Without this, executing this code atop `net472` results in the error mentioned in #2775. It seems like the .NET Framework version of this API requires that the same `ExecutionContext` instance should not be passed to `ExecutionContext.Run` more than once. See [this ](https://learn.microsoft.com/en-us/dotnet/api/system.threading.executioncontext?view=netframework-4.7.2#:~:text=An%20ExecutionContext%20that%20is%20associated%20with%20a%20thread%20cannot%20be%20set%20on%20another%20thread.%20Attempting%20to%20do%20so%20will%20result%20in%20an%20exception%20being%20thrown.%20To%20propagate%20the%20ExecutionContext%20from%20one%20thread%20to%20another%2C%20make%20a%20copy%20of%20the%20ExecutionContext.) note in the documentation under the `The following is applicable to .NET Framework only` section.

* Also fixes a `NullReferenceException` that is encountered during the `KernelScheduler`'s disposal if cancellation is triggered after the blocking collection is disposed. This exception is not encountered if we switch the order of execution to trigger cancellation before the blocking collection is disposed.