### PR TITLE
Port a subset of tests to run against Microsoft.DotNet.Interactive.VisualStudio

### DIFF
--- a/dotnet-interactive.sln
+++ b/dotnet-interactive.sln
@@ -116,6 +116,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Interactiv
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Interactive.SQLite.Tests", "src\Microsoft.DotNet.Interactive.SQLite.Tests\Microsoft.DotNet.Interactive.SQLite.Tests.csproj", "{83B62E34-7AE3-4A7A-A105-1707FF389D39}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Interactive.VisualStudio.Tests", "src\Microsoft.DotNet.Interactive.VisualStudio.Tests\Microsoft.DotNet.Interactive.VisualStudio.Tests.csproj", "{DE705C7B-7CBD-42C2-81DE-B43ECD179EBC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -666,6 +668,18 @@ Global
 		{83B62E34-7AE3-4A7A-A105-1707FF389D39}.Release|x64.Build.0 = Release|Any CPU
 		{83B62E34-7AE3-4A7A-A105-1707FF389D39}.Release|x86.ActiveCfg = Release|Any CPU
 		{83B62E34-7AE3-4A7A-A105-1707FF389D39}.Release|x86.Build.0 = Release|Any CPU
+		{DE705C7B-7CBD-42C2-81DE-B43ECD179EBC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE705C7B-7CBD-42C2-81DE-B43ECD179EBC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE705C7B-7CBD-42C2-81DE-B43ECD179EBC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DE705C7B-7CBD-42C2-81DE-B43ECD179EBC}.Debug|x64.Build.0 = Debug|Any CPU
+		{DE705C7B-7CBD-42C2-81DE-B43ECD179EBC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DE705C7B-7CBD-42C2-81DE-B43ECD179EBC}.Debug|x86.Build.0 = Debug|Any CPU
+		{DE705C7B-7CBD-42C2-81DE-B43ECD179EBC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DE705C7B-7CBD-42C2-81DE-B43ECD179EBC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DE705C7B-7CBD-42C2-81DE-B43ECD179EBC}.Release|x64.ActiveCfg = Release|Any CPU
+		{DE705C7B-7CBD-42C2-81DE-B43ECD179EBC}.Release|x64.Build.0 = Release|Any CPU
+		{DE705C7B-7CBD-42C2-81DE-B43ECD179EBC}.Release|x86.ActiveCfg = Release|Any CPU
+		{DE705C7B-7CBD-42C2-81DE-B43ECD179EBC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -717,6 +731,7 @@ Global
 		{6273EEFB-E920-48F4-B0AF-8620B6D9FB28} = {B95A8485-8C53-4F56-B0CE-19C0726B5805}
 		{CAB71ACA-9CDA-492D-A3DD-E5BA2C84FD64} = {B95A8485-8C53-4F56-B0CE-19C0726B5805}
 		{83B62E34-7AE3-4A7A-A105-1707FF389D39} = {11BA3480-4584-435C-BA9A-8C554DB60E9F}
+		{DE705C7B-7CBD-42C2-81DE-B43ECD179EBC} = {11BA3480-4584-435C-BA9A-8C554DB60E9F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6D05A9AF-CFFB-4187-8599-574387B76727}

--- a/dotnet-interactive.sln
+++ b/dotnet-interactive.sln
@@ -117,6 +117,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Interactive.SQLite.Tests", "src\Microsoft.DotNet.Interactive.SQLite.Tests\Microsoft.DotNet.Interactive.SQLite.Tests.csproj", "{83B62E34-7AE3-4A7A-A105-1707FF389D39}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Interactive.VisualStudio.Tests", "src\Microsoft.DotNet.Interactive.VisualStudio.Tests\Microsoft.DotNet.Interactive.VisualStudio.Tests.csproj", "{DE705C7B-7CBD-42C2-81DE-B43ECD179EBC}"
+	ProjectSection(ProjectDependencies) = postProject
+		{1A4A744F-FEF3-4361-A2E5-C5D496F7BFDC} = {1A4A744F-FEF3-4361-A2E5-C5D496F7BFDC}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Microsoft.DotNet.Interactive.Tests/KernelSchedulerTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/KernelSchedulerTests.cs
@@ -149,7 +149,7 @@ public class KernelSchedulerTests : IDisposable
         var deferredOperations = new[] { 1, 2, 3 };
         var completedDeferredOperations = new List<int>();
 
-        var deferredOperationsTaskCompletionSource = new TaskCompletionSource();
+        var deferredOperationsTaskCompletionSource = new TaskCompletionSource<bool>();
         scheduler.RegisterDeferredOperationSource(
             (_, _) => deferredOperations,
             async i =>
@@ -164,7 +164,7 @@ public class KernelSchedulerTests : IDisposable
                 completedDeferredOperations.Add(i);
                 if (completedDeferredOperations.Count == deferredOperations.Length)
                 {
-                    deferredOperationsTaskCompletionSource.SetResult();
+                    deferredOperationsTaskCompletionSource.SetResult(true);
                 }
 
                 return i;
@@ -211,7 +211,11 @@ public class KernelSchedulerTests : IDisposable
         laterWorkWasExecuted.Should().BeFalse();
     }
 
+#if NETFRAMEWORK
+    [FactSkipNetFramework]
+#else
     [FactSkipLinux]
+#endif
     public void cancelling_work_in_progress_prevents_subsequent_work_scheduled_before_cancellation_from_executing()
     {
         using var scheduler = new KernelScheduler<int, int>();

--- a/src/Microsoft.DotNet.Interactive.Tests/KernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/KernelTests.cs
@@ -5,17 +5,19 @@ using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.NamingConventionBinder;
-using FluentAssertions;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
+using FluentAssertions;
 using FluentAssertions.Extensions;
 using Microsoft.DotNet.Interactive.Commands;
-using Microsoft.DotNet.Interactive.CSharp;
 using Microsoft.DotNet.Interactive.Events;
-using Microsoft.DotNet.Interactive.PowerShell;
 using Microsoft.DotNet.Interactive.Tests.Utility;
 using Xunit;
+
+#if !NETFRAMEWORK
+using Microsoft.DotNet.Interactive.CSharp;
+#endif
 
 namespace Microsoft.DotNet.Interactive.Tests;
 
@@ -165,6 +167,7 @@ public partial class KernelTests
         lastEvent.Should().BeNull();
     }
 
+#if !NETFRAMEWORK
     [Fact]
     public async Task Awaiting_a_disposed_task_does_not_deadlock()
     {
@@ -224,4 +227,5 @@ public partial class KernelTests
         result.Events.Should().ContainSingle<ReturnValueProduced>()
               .Which.Value.As<int>().Should().BeGreaterThan(0);
     }
+#endif
 }

--- a/src/Microsoft.DotNet.Interactive.Tests/Utility/FactSkipNetFramework.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Utility/FactSkipNetFramework.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Microsoft.DotNet.Interactive.Tests.Utility;
+
+public sealed class FactSkipNetFramework : FactAttribute
+{
+    public FactSkipNetFramework(string reason = null)
+    {
+        if (RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase))
+        {
+            Skip = string.IsNullOrWhiteSpace(reason) ? "Ignored on .NET Framework" : reason;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Interactive.VisualStudio.Tests/(Pocket)/Logger/LogEvents.cs
+++ b/src/Microsoft.DotNet.Interactive.VisualStudio.Tests/(Pocket)/Logger/LogEvents.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.DotNet.Interactive.Events;
+using Xunit.Abstractions;
+
+namespace Pocket;
+
+internal partial class LogEvents
+{
+    public static IDisposable SubscribeToPocketLogger(this ITestOutputHelper output) =>
+        Subscribe(
+            e => output.WriteLine(e.ToLogString()),
+            new[]
+            {
+                typeof(LogEvents).Assembly,
+                typeof(KernelEvent).Assembly
+            });
+}

--- a/src/Microsoft.DotNet.Interactive.VisualStudio.Tests/Directory.Build.props
+++ b/src/Microsoft.DotNet.Interactive.VisualStudio.Tests/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/Microsoft.DotNet.Interactive.VisualStudio.Tests/Microsoft.DotNet.Interactive.VisualStudio.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.VisualStudio.Tests/Microsoft.DotNet.Interactive.VisualStudio.Tests.csproj
@@ -1,0 +1,50 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="TestResults\**" />
+    <EmbeddedResource Remove="TestResults\**" />
+    <None Remove="TestResults\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Microsoft.DotNet.Interactive.Tests\Utility\FactSkipLinux.cs" Link="Utility\FactSkipLinux.cs" />
+    <Compile Include="..\Microsoft.DotNet.Interactive.Tests\Utility\FactSkipNetFramework.cs" Link="Utility\FactSkipNetFramework.cs" />
+    <Compile Include="..\Microsoft.DotNet.Interactive.Tests\Utility\TestUtility.cs" Link="Utility\TestUtility.cs" />
+    <Compile Include="..\Microsoft.DotNet.Interactive.Tests\KernelSchedulerTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.8.0" />
+    <PackageReference Include="Pocket.Disposable" Version="1.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="PocketLogger" Version="0.4.1">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="PocketLogger.For.Xunit" Version="0.6.1">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="PocketLogger.Subscribe" Version="0.7.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.DotNet.Interactive.VisualStudio\Microsoft.DotNet.Interactive.VisualStudio.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="$(xunitrunnervisualstudioVersion)">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.DotNet.Interactive.VisualStudio.Tests/Microsoft.DotNet.Interactive.VisualStudio.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.VisualStudio.Tests/Microsoft.DotNet.Interactive.VisualStudio.Tests.csproj
@@ -12,9 +12,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Microsoft.DotNet.Interactive.Tests\Utility\ConnectHost.cs" Link="Utility\ConnectHost.cs" />
     <Compile Include="..\Microsoft.DotNet.Interactive.Tests\Utility\FactSkipLinux.cs" Link="Utility\FactSkipLinux.cs" />
     <Compile Include="..\Microsoft.DotNet.Interactive.Tests\Utility\FactSkipNetFramework.cs" Link="Utility\FactSkipNetFramework.cs" />
+    <Compile Include="..\Microsoft.DotNet.Interactive.Tests\Utility\FakeKernel.cs" Link="Utility\FakeKernel.cs" />
     <Compile Include="..\Microsoft.DotNet.Interactive.Tests\Utility\TestUtility.cs" Link="Utility\TestUtility.cs" />
+    <Compile Include="..\Microsoft.DotNet.Interactive.Tests\KernelRoutingTests.cs" />
     <Compile Include="..\Microsoft.DotNet.Interactive.Tests\KernelSchedulerTests.cs" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.Interactive.VisualStudio.Tests/Microsoft.DotNet.Interactive.VisualStudio.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.VisualStudio.Tests/Microsoft.DotNet.Interactive.VisualStudio.Tests.csproj
@@ -20,6 +20,7 @@
     <Compile Include="..\Microsoft.DotNet.Interactive.Tests\KernelTests.cs" />
     <Compile Include="..\Microsoft.DotNet.Interactive.Tests\KernelRoutingTests.cs" />
     <Compile Include="..\Microsoft.DotNet.Interactive.Tests\KernelSchedulerTests.cs" />
+    <Compile Include="..\dotnet-interactive.Tests\StdIoKernelConnectorTests.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Interactive.VisualStudio.Tests/Microsoft.DotNet.Interactive.VisualStudio.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.VisualStudio.Tests/Microsoft.DotNet.Interactive.VisualStudio.Tests.csproj
@@ -17,6 +17,7 @@
     <Compile Include="..\Microsoft.DotNet.Interactive.Tests\Utility\FactSkipNetFramework.cs" Link="Utility\FactSkipNetFramework.cs" />
     <Compile Include="..\Microsoft.DotNet.Interactive.Tests\Utility\FakeKernel.cs" Link="Utility\FakeKernel.cs" />
     <Compile Include="..\Microsoft.DotNet.Interactive.Tests\Utility\TestUtility.cs" Link="Utility\TestUtility.cs" />
+    <Compile Include="..\Microsoft.DotNet.Interactive.Tests\KernelTests.cs" />
     <Compile Include="..\Microsoft.DotNet.Interactive.Tests\KernelRoutingTests.cs" />
     <Compile Include="..\Microsoft.DotNet.Interactive.Tests\KernelSchedulerTests.cs" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Interactive.VisualStudio.Tests/Microsoft.DotNet.Interactive.VisualStudio.Tests.v3.ncrunchproject
+++ b/src/Microsoft.DotNet.Interactive.VisualStudio.Tests/Microsoft.DotNet.Interactive.VisualStudio.Tests.v3.ncrunchproject
@@ -1,0 +1,9 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <CopyReferencedAssembliesToWorkspace>True</CopyReferencedAssembliesToWorkspace>
+    <DefaultTestTimeout>10000</DefaultTestTimeout>
+    <HiddenComponentWarnings>
+      <Value>CopyReferencedAssembliesToWorkspaceIsOn</Value>
+    </HiddenComponentWarnings>
+  </Settings>
+</ProjectConfiguration>

--- a/src/dotnet-interactive.Tests/StdIoKernelConnectorTests.cs
+++ b/src/dotnet-interactive.Tests/StdIoKernelConnectorTests.cs
@@ -25,10 +25,30 @@ namespace Microsoft.DotNet.Interactive.App.Tests
                 loggingArgs = $"--verbose --log-path {logDir}";
             }
 
-            var dotnetInteractive = typeof(Program).Assembly.Location;
+            var binPath =
+                Path.GetDirectoryName(
+                    Path.GetDirectoryName(
+                        Path.GetDirectoryName(
+                            Path.GetDirectoryName(
+                                typeof(StdIoKernelConnector).Assembly.Location))));
+
+            Func<string, bool> predicate =
+                filePath =>
+                    !string.Equals(
+                        Path.GetFileName(Path.GetDirectoryName(filePath)),
+                        "publish",
+                        StringComparison.OrdinalIgnoreCase);
+
+            var toolAppDllPath =
+                Directory.GetFiles(
+                    Path.Combine(binPath, "dotnet-interactive"),
+                    "Microsoft.DotNet.Interactive.App.dll",
+                    SearchOption.AllDirectories)
+                        .Single(predicate);
+
             var hostUri = KernelHost.CreateHostUri("host");
             var connector = new StdIoKernelConnector(
-                new[] { "dotnet", $""" "{dotnetInteractive}" stdio {loggingArgs}""" },
+                new[] { "dotnet", $""" "{toolAppDllPath}" stdio {loggingArgs}""" },
                 rootProxyKernelLocalName: "rootProxy",
                 hostUri);
 

--- a/test-retry-runner.ps1
+++ b/test-retry-runner.ps1
@@ -7,9 +7,18 @@ param (
 Set-StrictMode -version 2.0
 $ErrorActionPreference = "Stop"
 
-$projectsToSkip = @(
-    "Microsoft.DotNet.Interactive.CSharpProject.Tests"
-    )
+if ($IsWindows) {
+    $projectsToSkip = @(
+        "Microsoft.DotNet.Interactive.CSharpProject.Tests"
+        )
+}
+else
+{
+    $projectsToSkip = @(
+        "Microsoft.DotNet.Interactive.VisualStudio.Tests",
+        "Microsoft.DotNet.Interactive.CSharpProject.Tests"
+        )
+}
 
 function ExecuteTestDirectory([string]$testDirectory, [string]$extraArgs = "") {
     $testCommand = "dotnet test $testDirectory/ $extraArgs -l trx --no-restore --no-build --blame-hang-timeout 15m --blame-hang-dump-type full --blame-crash -c $buildConfig --results-directory $repoRoot/artifacts/TestResults/$buildConfig"


### PR DESCRIPTION
Addresses #2965 by creating a new test project that targets .NET Framework and linking a small number of existing unit tests into this project.