### PR TITLE
Include PocketLogger custom formatting code as a content file as part of the Microsoft.DotNet.Interactive.VisualStudio NuGet package

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Browser/Microsoft.DotNet.Interactive.Browser.csproj
+++ b/src/Microsoft.DotNet.Interactive.Browser/Microsoft.DotNet.Interactive.Browser.csproj
@@ -31,10 +31,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.Interactive\Microsoft.DotNet.Interactive.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="%28Recipes%29\" />
-  </ItemGroup>
   
   <ItemGroup>
     <EmbeddedResource Include="..\polyglot-notebooks\lib\polyglot-notebooks.js" />

--- a/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/Microsoft.DotNet.Interactive.CSharpProject.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/Microsoft.DotNet.Interactive.CSharpProject.Tests.csproj
@@ -99,10 +99,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Pocket\" />
-  </ItemGroup>
   
 </Project>
 

--- a/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/Microsoft.DotNet.Interactive.CSharpProject.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/Microsoft.DotNet.Interactive.CSharpProject.Tests.csproj
@@ -20,7 +20,6 @@
 
   <ItemGroup>
     <Compile Include="..\dotnet-interactive\Pocket\Format.CustomizeLogString.cs" Link="Pocket\Format.CustomizeLogString.cs" />
-    <Compile Include="..\Microsoft.DotNet.Interactive\Utility\StringExtensions.cs" Link="Utility\StringExtensions.cs" />
     <Compile Include="..\Microsoft.DotNet.Interactive.CSharpProject\%28Recipes%29\AsyncLazy{T}.cs" Link="Utility\AsyncLazy{T}.cs" />
     <Compile Include="..\Microsoft.DotNet.Interactive.CSharpProject\(Recipes)\JsonSerializationExtensions.cs" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Interactive.CSharpProject/Microsoft.DotNet.Interactive.CSharpProject.csproj
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/Microsoft.DotNet.Interactive.CSharpProject.csproj
@@ -69,8 +69,4 @@
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.Interactive.Documents.Tests/Microsoft.DotNet.Interactive.Documents.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.Documents.Tests/Microsoft.DotNet.Interactive.Documents.Tests.csproj
@@ -18,7 +18,6 @@
     <Compile Include="..\Microsoft.DotNet.Interactive.Documents\Utility\StringExtension.cs" Link="Utility\StringExtension.cs" />
   </ItemGroup>
 
-
   <ItemGroup>
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Assent" Version="1.7.0" />
@@ -61,10 +60,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Utility\" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/Microsoft.DotNet.Interactive.Jupyter.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/Microsoft.DotNet.Interactive.Jupyter.Tests.csproj
@@ -20,7 +20,6 @@
     <Compile Include="..\dotnet-interactive\(Recipes)\TaskExtensions.cs" />
     <Compile Include="..\dotnet-interactive\Pocket\Format.CustomizeLogString.cs" Link="Pocket\Format.CustomizeLogString.cs" />
     <Compile Include="..\dotnet-interactive\Utility\KernelDiagnostics.cs" Link="KernelDiagnostics.cs" />
-    <Compile Include="..\Microsoft.DotNet.Interactive\Utility\StringExtensions.cs" Link="Utility\StringExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/Microsoft.DotNet.Interactive.Jupyter.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/Microsoft.DotNet.Interactive.Jupyter.Tests.csproj
@@ -53,8 +53,4 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Utility\" />
-    <Folder Include="Pocket\" />
-  </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Interactive.Jupyter/Microsoft.DotNet.Interactive.Jupyter.csproj
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/Microsoft.DotNet.Interactive.Jupyter.csproj
@@ -38,9 +38,6 @@
     <ProjectReference Include="..\Microsoft.DotNet.Interactive\Microsoft.DotNet.Interactive.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Utility\" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Update="Resources.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/src/Microsoft.DotNet.Interactive.SQLite/Microsoft.DotNet.Interactive.SQLite.csproj
+++ b/src/Microsoft.DotNet.Interactive.SQLite/Microsoft.DotNet.Interactive.SQLite.csproj
@@ -9,7 +9,6 @@
     <NoWarn>$(NoWarn);NU5100;VSTHRD002</NoWarn>
     <!-- dll outside of lib/ folder -->
   </PropertyGroup>
-
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.0" />
@@ -25,12 +24,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.Interactive\Microsoft.DotNet.Interactive.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="%28Recipes%29\" />
-  </ItemGroup>
-  
-
 
   <ItemGroup>
     <None Include="extension.dib" Pack="true" PackagePath="interactive-extensions/dotnet" />

--- a/src/Microsoft.DotNet.Interactive.VisualStudio/Microsoft.DotNet.Interactive.VisualStudio.csproj
+++ b/src/Microsoft.DotNet.Interactive.VisualStudio/Microsoft.DotNet.Interactive.VisualStudio.csproj
@@ -25,6 +25,14 @@
     <EmbeddedResource Include="..\polyglot-notebooks\lib\polyglot-notebooks.js" />
   </ItemGroup>
 
+  <ItemGroup Label="Logging Customization">
+    <!-- Implementation for partial method in Pocket that customizes logging for commands and events -->
+    <None Include="..\dotnet-interactive\Pocket\Format.CustomizeLogString.cs">
+      <Pack>true</Pack>
+      <PackagePath>contentFiles\cs\any\(Pocket)\LoggerExtensions\Format.CustomizeLogString.cs</PackagePath>
+    </None>
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />

--- a/src/Microsoft.DotNet.Interactive/Events/DiagnosticsProduced.cs
+++ b/src/Microsoft.DotNet.Interactive/Events/DiagnosticsProduced.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.DotNet.Interactive.Commands;
 
 namespace Microsoft.DotNet.Interactive.Events;
@@ -16,7 +17,16 @@ public class DiagnosticsProduced : KernelEvent
         KernelCommand command,
         IReadOnlyCollection<FormattedValue> formattedDiagnostics = null) : base(command)
     {
-        _diagnostics = (diagnostics ?? Array.Empty<Diagnostic>()).ToImmutableList();
+        if (diagnostics is null)
+        {
+            throw new ArgumentNullException(nameof(diagnostics));
+        }
+        else if (!diagnostics.Any())
+        {
+            throw new ArgumentException("At least one diagnostic required.", nameof(diagnostics));
+        }
+
+        _diagnostics = diagnostics.ToImmutableList();
         FormattedDiagnostics = formattedDiagnostics ?? Array.Empty<FormattedValue>();
     }
 

--- a/src/dotnet-interactive/Pocket/Format.CustomizeLogString.cs
+++ b/src/dotnet-interactive/Pocket/Format.CustomizeLogString.cs
@@ -7,6 +7,8 @@ using Microsoft.DotNet.Interactive;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
 
+#nullable enable
+
 namespace Pocket;
 
 internal static partial class Format
@@ -285,7 +287,7 @@ internal static partial class Format
             ("CommandToken", @event.Command.GetOrCreateToken()));
     }
 
-    private static void AppendProperties(this TextWriter writer, params (string Name, string Value)[] properties)
+    private static void AppendProperties(this TextWriter writer, params (string Name, string? Value)[] properties)
     {
         if (properties.Length > 0)
         {
@@ -306,10 +308,10 @@ internal static partial class Format
         }
     }
 
-    private static void AppendProperty(this TextWriter writer, (string Name, string Value) property)
+    private static void AppendProperty(this TextWriter writer, (string Name, string? Value) property)
         => writer.AppendProperty(property.Name, property.Value);
 
-    private static void AppendProperty(this TextWriter writer, string name, string value)
+    private static void AppendProperty(this TextWriter writer, string name, string? value)
     {
         writer.Write(name);
         writer.Write(": ");

--- a/src/dotnet-interactive/Pocket/Format.CustomizeLogString.cs
+++ b/src/dotnet-interactive/Pocket/Format.CustomizeLogString.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.IO;
 using System.Linq;
-using Microsoft.DotNet.Interactive;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
 
@@ -45,16 +45,16 @@ internal static partial class Format
         switch (command)
         {
             case ChangeWorkingDirectory changeWorkingDirectory:
-                writer.Write(changeWorkingDirectory.WorkingDirectory.TruncateForDisplay());
+                writer.Write(changeWorkingDirectory.WorkingDirectory.TruncateIfNeeded());
                 break;
 
             case DisplayError displayError:
-                writer.Write(displayError.Message.TruncateForDisplay());
+                writer.Write(displayError.Message.TruncateIfNeeded());
                 break;
 
             case DisplayValue displayValue:
                 writer.Write('\'');
-                writer.Write(displayValue.FormattedValue.Value.TruncateForDisplay());
+                writer.Write(displayValue.FormattedValue.Value.TruncateIfNeeded());
                 writer.Write("' (");
                 writer.Write(displayValue.FormattedValue.MimeType);
                 writer.Write(')');
@@ -63,7 +63,7 @@ internal static partial class Format
                 break;
 
             case RequestDiagnostics requestDiagnostics:
-                writer.Write(requestDiagnostics.Code.TruncateForDisplay());
+                writer.Write(requestDiagnostics.Code.TruncateIfNeeded());
                 break;
 
             case RequestInput requestInput:
@@ -86,7 +86,7 @@ internal static partial class Format
                 break;
 
             case SendEditableCode sendEditableCode:
-                writer.Write(sendEditableCode.Code.TruncateForDisplay());
+                writer.Write(sendEditableCode.Code.TruncateIfNeeded());
                 writer.AppendProperties(
                     (nameof(sendEditableCode.KernelName), sendEditableCode.KernelName));
                 break;
@@ -94,19 +94,19 @@ internal static partial class Format
             case SendValue sendValue:
                 writer.Write(sendValue.Name);
                 writer.Write(" '");
-                writer.Write(sendValue.FormattedValue.Value.TruncateForDisplay());
+                writer.Write(sendValue.FormattedValue.Value.TruncateIfNeeded());
                 writer.Write("' (");
                 writer.Write(sendValue.FormattedValue.MimeType);
                 writer.Write(')');
                 break;
 
             case SubmitCode submitCode:
-                writer.Write(submitCode.Code.TruncateForDisplay());
+                writer.Write(submitCode.Code.TruncateIfNeeded());
                 break;
 
             case UpdateDisplayedValue updateDisplayedValue:
                 writer.Write('\'');
-                writer.Write(updateDisplayedValue.FormattedValue.Value.TruncateForDisplay());
+                writer.Write(updateDisplayedValue.FormattedValue.Value.TruncateIfNeeded());
                 writer.Write("' (");
                 writer.Write(updateDisplayedValue.FormattedValue.MimeType);
                 writer.Write(')');
@@ -116,7 +116,7 @@ internal static partial class Format
 
             // Base command types.
             case LanguageServiceCommand languageServiceCommand:
-                writer.Write(languageServiceCommand.Code.TruncateForDisplay());
+                writer.Write(languageServiceCommand.Code.TruncateIfNeeded());
                 writer.Write(' ');
                 writer.Write(languageServiceCommand.LinePosition.ToString());
                 break;
@@ -140,15 +140,15 @@ internal static partial class Format
         switch (@event)
         {
             case CodeSubmissionReceived codeSubmissionReceived:
-                writer.Write(codeSubmissionReceived.Code.TruncateForDisplay());
+                writer.Write(codeSubmissionReceived.Code.TruncateIfNeeded());
                 break;
 
             case CommandFailed commandFailed:
-                writer.Write(commandFailed.Message.TruncateForDisplay());
+                writer.Write(commandFailed.Message.TruncateIfNeeded());
                 break;
 
             case CompleteCodeSubmissionReceived completeCodeSubmissionReceived:
-                writer.Write(completeCodeSubmissionReceived.Code.TruncateForDisplay());
+                writer.Write(completeCodeSubmissionReceived.Code.TruncateIfNeeded());
                 break;
 
             case CompletionsProduced completionsProduced:
@@ -159,7 +159,7 @@ internal static partial class Format
                 var diagnostics = diagnosticsProduced.Diagnostics;
                 if (diagnostics.Any()) // TODO: How come we produce empty DiagnosticsProduced events?
                 {
-                    var firstMessage = diagnostics.First().Message.TruncateForDisplay();
+                    var firstMessage = diagnostics.First().Message.TruncateIfNeeded();
                     writer.Write(firstMessage);
 
                     var diagnosticsCount = diagnostics.Count;
@@ -173,14 +173,14 @@ internal static partial class Format
                 break;
 
             case ErrorProduced errorProduced:
-                writer.Write(errorProduced.Message.TruncateForDisplay());
+                writer.Write(errorProduced.Message.TruncateIfNeeded());
                 break;
 
             case HoverTextProduced hoverTextProduced:
                 var content = hoverTextProduced.Content;
                 var firstContent = content.First();
                 writer.Write('\'');
-                writer.Write(firstContent.Value.TruncateForDisplay());
+                writer.Write(firstContent.Value.TruncateIfNeeded());
                 writer.Write("' (");
                 writer.Write(firstContent.MimeType);
                 writer.Write(')');
@@ -194,7 +194,7 @@ internal static partial class Format
                 break;
 
             case InputProduced inputProduced:
-                writer.Write(inputProduced.Value.TruncateForDisplay());
+                writer.Write(inputProduced.Value.TruncateIfNeeded());
                 break;
 
             case KernelInfoProduced kernelInfoProduced:
@@ -234,20 +234,20 @@ internal static partial class Format
             case ValueProduced valueProduced:
                 writer.Write(valueProduced.Name);
                 writer.Write(" '");
-                writer.Write(valueProduced.FormattedValue.Value.TruncateForDisplay());
+                writer.Write(valueProduced.FormattedValue.Value.TruncateIfNeeded());
                 writer.Write("' (");
                 writer.Write(valueProduced.FormattedValue.MimeType);
                 writer.Write(')');
                 break;
 
             case WorkingDirectoryChanged workingDirectoryChanged:
-                writer.Write(workingDirectoryChanged.WorkingDirectory.TruncateForDisplay());
+                writer.Write(workingDirectoryChanged.WorkingDirectory.TruncateIfNeeded());
                 break;
 
             // Base event types.
             case DisplayEvent displayEvent:
                 writer.Write('\'');
-                writer.Write(displayEvent.Value?.ToString().TruncateForDisplay());
+                writer.Write(displayEvent.Value?.ToString().TruncateIfNeeded());
                 writer.Write('\'');
 
                 var formattedValues = displayEvent.FormattedValues;
@@ -258,7 +258,7 @@ internal static partial class Format
                     writer.Write(": ");
                     var firstFormattedValue = formattedValues.First();
                     writer.Write('\'');
-                    writer.Write(firstFormattedValue.Value.TruncateForDisplay());
+                    writer.Write(firstFormattedValue.Value.TruncateIfNeeded());
                     writer.Write("' (");
                     writer.Write(firstFormattedValue.MimeType);
                     writer.Write(')');
@@ -316,5 +316,32 @@ internal static partial class Format
         writer.Write(name);
         writer.Write(": ");
         writer.Write(value);
+    }
+
+    internal static string TruncateIfNeeded(this string? value, int maxLength = 50)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        var lines = value!.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        var firstLine = lines.FirstOrDefault();
+
+        if (string.IsNullOrEmpty(firstLine))
+        {
+            return string.Empty;
+        }
+
+        if (firstLine.Length > maxLength)
+        {
+            firstLine = firstLine.Substring(0, maxLength) + " ...";
+        }
+        else if (lines.Length > 1)
+        {
+            firstLine = firstLine + " ...";
+        }
+
+        return firstLine;
     }
 }

--- a/src/dotnet-interactive/Pocket/Format.CustomizeLogString.cs
+++ b/src/dotnet-interactive/Pocket/Format.CustomizeLogString.cs
@@ -11,6 +11,14 @@ using Microsoft.DotNet.Interactive.Events;
 
 namespace Pocket;
 
+// ----------------------------------------------------------------------------
+// NOTE: The code in this file is shipped as content in a NuGet package and
+// utilized by some components that live outside the current repo. It should
+// therefore be kept self-sufficient. Avoid referencing any internal types,
+// extension methods or helper code defined within other files as much as
+// possible.
+// ----------------------------------------------------------------------------
+
 internal static partial class Format
 {
     static partial void CustomizeLogString(object value, ref string output)

--- a/src/dotnet-interactive/Pocket/Format.CustomizeLogString.cs
+++ b/src/dotnet-interactive/Pocket/Format.CustomizeLogString.cs
@@ -157,18 +157,15 @@ internal static partial class Format
 
             case DiagnosticsProduced diagnosticsProduced:
                 var diagnostics = diagnosticsProduced.Diagnostics;
-                if (diagnostics.Any()) // TODO: How come we produce empty DiagnosticsProduced events?
-                {
-                    var firstMessage = diagnostics.First().Message.TruncateIfNeeded();
-                    writer.Write(firstMessage);
+                var firstMessage = diagnostics.First().Message.TruncateIfNeeded();
+                writer.Write(firstMessage);
 
-                    var diagnosticsCount = diagnostics.Count;
-                    if (diagnosticsCount > 1)
-                    {
-                        writer.Write(" (and ");
-                        writer.Write(diagnosticsCount - 1);
-                        writer.Write(" more)");
-                    }
+                var diagnosticsCount = diagnostics.Count;
+                if (diagnosticsCount > 1)
+                {
+                    writer.Write(" (and ");
+                    writer.Write(diagnosticsCount - 1);
+                    writer.Write(" more)");
                 }
                 break;
 
@@ -184,6 +181,7 @@ internal static partial class Format
                 writer.Write("' (");
                 writer.Write(firstContent.MimeType);
                 writer.Write(')');
+
                 var contentCount = content.Count;
                 if (contentCount > 1)
                 {
@@ -256,6 +254,7 @@ internal static partial class Format
                     writer.Write(" (");
                     writer.Write(nameof(displayEvent.FormattedValues));
                     writer.Write(": ");
+
                     var firstFormattedValue = formattedValues.First();
                     writer.Write('\'');
                     writer.Write(firstFormattedValue.Value.TruncateIfNeeded());

--- a/src/dotnet-interactive/dotnet-interactive.csproj
+++ b/src/dotnet-interactive/dotnet-interactive.csproj
@@ -119,7 +119,6 @@
     <None Remove="resources\logo-456x456.png" />
     <None Remove="resources\logo-64x64.png" />
     <Compile Include="..\Microsoft.DotNet.Interactive\Utility\InvocationContextExtensions.cs" Link="Utility\InvocationContextExtensions.cs" />
-    <Compile Include="..\Microsoft.DotNet.Interactive\Utility\StringExtensions.cs" Link="Utility\StringExtensions.cs" />
 
     <TypescriptOutputFiles Include="$(JsApiRoot)dist/dotnet-interactive.js" />
 


### PR DESCRIPTION
This makes it possible for consumers of this package to utilize the same custom formatting for commands and events as the dotnet-interactive tool when logging these objects via PocketLogger.

Also includes changes to:
1. Make the code in Format.CustomizeLogString.cs self-sufficient.
2. Make it an error to construct DiagnosticsProduced with 0 diagnostics. This a follow up to the change in #3003 that allows us to clean up a TODO in Format.CustomizeLogString.cs.