### PR TITLE
Fix updateCellMetadata: keep existing metadata on update.

### DIFF
--- a/src/polyglot-notebooks-vscode-common/src/vscodeUtilities.ts
+++ b/src/polyglot-notebooks-vscode-common/src/vscodeUtilities.ts
@@ -90,7 +90,8 @@ export async function setCellKernelName(cell: vscode.NotebookCell, kernelName: s
         kernelName
     };
     const rawCellMetadata = metadataUtilities.getRawNotebookCellMetadataFromNotebookCellMetadata(cellMetadata);
-    await vscodeNotebookManagement.replaceNotebookCellMetadata(cell.notebook.uri, cell.index, rawCellMetadata);
+    const mergedMetadata = metadataUtilities.mergeRawMetadata(cell.metadata, rawCellMetadata);
+    await vscodeNotebookManagement.replaceNotebookCellMetadata(cell.notebook.uri, cell.index, mergedMetadata);
 }
 
 export async function ensureCellKernelKind(cell: vscode.NotebookCell, kind: vscode.NotebookCellKind): Promise<vscode.NotebookCell> {


### PR DESCRIPTION
`updateCellMetadata` replaces the cell metadata so we don't merge the new metadata with the existing one, we would lose data.