### PR TITLE
allow TypeFormatterSource attributes to set MIME type preferences 

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Formatting_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Formatting_api_is_not_changed.approved.txt
@@ -272,6 +272,7 @@ Microsoft.DotNet.Interactive.Formatting
   public class TypeFormatterSourceAttribute : System.Attribute
     .ctor(System.Type formatterSourceType)
     public System.Type FormatterSourceType { get;}
+    public System.String[] PreferredMimeTypes { get; set;}
 Microsoft.DotNet.Interactive.Formatting.Csv
   public static class CsvFormatter
     public static Microsoft.DotNet.Interactive.Formatting.ITypeFormatter GetPreferredFormatterFor(System.Type type)

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/FormatterTests.FormatterSources.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/FormatterTests.FormatterSources.cs
@@ -52,6 +52,24 @@ public sealed partial class FormatterTests
         }
 
         [Fact]
+        public void Formatter_sources_can_set_preferred_MIME_type()
+        {
+            var obj = new TypeWithCustomFormatterAndMimeType();
+
+            var preferredMimeTypes = Formatter.GetPreferredMimeTypesFor(obj.GetType());
+
+            preferredMimeTypes
+                .Should()
+                .BeEquivalentTo(
+                    new[]
+                    {
+                        "text/one",
+                        "text/two"
+                    },
+                    c => c.WithStrictOrdering());
+        }
+
+        [Fact]
         public void Convention_based_formatter_sources_are_still_registered_after_formatters_are_reset()
         {
             var obj = new TypeWithConventionBasedFormatter();
@@ -64,9 +82,32 @@ public sealed partial class FormatterTests
 
             formattedAfter.Should().Be(formattedBefore);
         }
-        
+
+        [Fact]
+        public void Convention_based_formatter_sources_can_set_preferred_MIME_type()
+        {
+            var obj = new TypeWithConventionBasedFormatterAndMimeType();
+
+            var preferredMimeTypes = Formatter.GetPreferredMimeTypesFor(obj.GetType());
+
+            preferredMimeTypes
+                .Should()
+                .BeEquivalentTo(
+                    new[]
+                    {
+                        "text/one",
+                        "text/two"
+                    },
+                    c => c.WithStrictOrdering());
+        }
+
         [TypeFormatterSource(typeof(CustomFormatterSource))]
         private class TypeWithCustomFormatter
+        {
+        }
+
+        [TypeFormatterSource(typeof(CustomFormatterSource), PreferredMimeTypes = new[] { "text/one", "text/two" })]
+        private class TypeWithCustomFormatterAndMimeType
         {
         }
 
@@ -87,6 +128,11 @@ public sealed partial class FormatterTests
         {
         }
 
+        [ConventionBased.TypeFormatterSourceAttribute(typeof(ConventionBased.FormatterSource), PreferredMimeTypes = new []{ "text/one", "text/two" })]
+        private class TypeWithConventionBasedFormatterAndMimeType
+        {
+        }
+
         private static class ConventionBased
         {
             // This class is here to allow this type not to conflict with the Microsoft.DotNet.Interactive.Formatting.TypeFormatterSourceAttribute
@@ -100,6 +146,8 @@ public sealed partial class FormatterTests
                 }
 
                 public Type FormatterSourceType { get; }
+
+                public string[] PreferredMimeTypes { get; set; }
             }
 
             internal class FormatterSource

--- a/src/Microsoft.DotNet.Interactive.Formatting/TypeFormatterSourceAttribute.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/TypeFormatterSourceAttribute.cs
@@ -14,4 +14,6 @@ public class TypeFormatterSourceAttribute : Attribute
     }
 
     public Type FormatterSourceType { get; }
+
+    public string[] PreferredMimeTypes { get; set; }
 }

--- a/src/Microsoft.DotNet.Interactive/Kernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Kernel.cs
@@ -12,7 +12,6 @@ using System.Reactive.Subjects;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading;
-using System.Threading.Channels;
 using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis.Text;

--- a/src/Microsoft.DotNet.Interactive/Utility/StringExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/Utility/StringExtensions.cs
@@ -31,7 +31,11 @@ internal static class StringExtensions
         {
             firstLine = firstLine[..maxLength] + " ...";
         }
-       
+        else if (lines.Length > 1)
+        {
+            firstLine += " ...";
+        }
+
         return firstLine;
     }
 }

--- a/src/dotnet-interactive/Pocket/Format.CustomizeLogString.cs
+++ b/src/dotnet-interactive/Pocket/Format.CustomizeLogString.cs
@@ -332,7 +332,7 @@ internal static partial class Format
             return string.Empty;
         }
 
-        var lines = value!.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        var lines = value.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
         var firstLine = lines.FirstOrDefault();
 
         if (string.IsNullOrEmpty(firstLine))
@@ -346,7 +346,7 @@ internal static partial class Format
         }
         else if (lines.Length > 1)
         {
-            firstLine = firstLine + " ...";
+            firstLine += " ...";
         }
 
         return firstLine;


### PR DESCRIPTION
This adds the ability for attribute-based formatter registrations to also set preferred formatter MIME types for the attributed type. This applies to both the public `TypeFormatterSourceAttribute` and the convention-based ones that don't require a reference to Microsoft.DotNet.Interactive.Formatting.