### PR TITLE
Set Culture in dotnet interactive command line

### DIFF
--- a/src/dotnet-interactive/CommandLine/CommandLineParser.cs
+++ b/src/dotnet-interactive/CommandLine/CommandLineParser.cs
@@ -8,6 +8,7 @@ using System.CommandLine.Invocation;
 using System.CommandLine.IO;
 using System.CommandLine.NamingConventionBinder;
 using System.CommandLine.Parsing;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Text.Encodings.Web;
@@ -130,6 +131,10 @@ public static class CommandLineParser
             description: LocalizationResources.Cli_dotnet_interactive_jupyter_default_kernel_Description(),
             getDefaultValue: () => "csharp").AddCompletions("fsharp", "csharp", "pwsh");
 
+        var cultureOption = new Option<string>(
+            "--culture",
+            LocalizationResources.Cli_dotnet_interactive_culture_Description());
+
         var rootCommand = DotnetInteractive();
 
         rootCommand.AddCommand(Jupyter());
@@ -172,6 +177,7 @@ public static class CommandLineParser
 
             command.AddGlobalOption(logPathOption);
             command.AddGlobalOption(verboseOption);
+            command.AddGlobalOption(cultureOption);
 
             return command;
         }

--- a/src/dotnet-interactive/LocalizationResources.cs
+++ b/src/dotnet-interactive/LocalizationResources.cs
@@ -139,6 +139,12 @@ internal static class LocalizationResources
         => GetResourceString(Resources.Cli_dotnet_interactive_verbose_Description);
 
     /// <summary>
+    ///   Interpolates values into a localized string Set current culture for dotnet interactive command line commands
+    /// </summary>
+    internal static string Cli_dotnet_interactive_culture_Description()
+        => GetResourceString(Resources.Cli_dotnet_interactive_culture_Description);
+
+    /// <summary>
     /// Interpolates values into a localized string.
     /// </summary>
     /// <param name="resourceString">The string template into which values will be interpolated.</param>

--- a/src/dotnet-interactive/Resources.Designer.cs
+++ b/src/dotnet-interactive/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace Microsoft.DotNet.Interactive.App {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Set current culture for dotnet interactive command line commands.
+        /// </summary>
+        internal static string Cli_dotnet_interactive_culture_Description {
+            get {
+                return ResourceManager.GetString("Cli_dotnet_interactive_culture_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Interactive programming for .NET..
         /// </summary>
         internal static string Cli_dotnet_interactive_Description {

--- a/src/dotnet-interactive/Resources.resx
+++ b/src/dotnet-interactive/Resources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Cli_dotnet_interactive_culture_Description" xml:space="preserve">
+    <value>Set current culture for dotnet interactive command line commands</value>
+  </data>
   <data name="Cli_dotnet_interactive_Description" xml:space="preserve">
     <value>Interactive programming for .NET.</value>
   </data>

--- a/src/dotnet-interactive/xlf/Resources.cs.xlf
+++ b/src/dotnet-interactive/xlf/Resources.cs.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Interaktivní programování pro platformu .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cli_dotnet_interactive_culture_Description">
+        <source>Set current culture for dotnet interactive command line commands</source>
+        <target state="new">Set current culture for dotnet interactive command line commands</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cli_dotnet_interactive_jupyter_Description">
         <source>Starts dotnet-interactive as a Jupyter kernel</source>
         <target state="translated">Spustí dotnet-interactive jako jádro Jupyter.</target>

--- a/src/dotnet-interactive/xlf/Resources.de.xlf
+++ b/src/dotnet-interactive/xlf/Resources.de.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Interaktive Programmierung für .NET.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cli_dotnet_interactive_culture_Description">
+        <source>Set current culture for dotnet interactive command line commands</source>
+        <target state="new">Set current culture for dotnet interactive command line commands</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cli_dotnet_interactive_jupyter_Description">
         <source>Starts dotnet-interactive as a Jupyter kernel</source>
         <target state="translated">Startet dotnet-interactive als Jupyter-Kernel</target>

--- a/src/dotnet-interactive/xlf/Resources.es.xlf
+++ b/src/dotnet-interactive/xlf/Resources.es.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Programación interactiva para .NET.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cli_dotnet_interactive_culture_Description">
+        <source>Set current culture for dotnet interactive command line commands</source>
+        <target state="new">Set current culture for dotnet interactive command line commands</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cli_dotnet_interactive_jupyter_Description">
         <source>Starts dotnet-interactive as a Jupyter kernel</source>
         <target state="translated">Inicia dotnet-interactive como kernel de Jupyter</target>

--- a/src/dotnet-interactive/xlf/Resources.fr.xlf
+++ b/src/dotnet-interactive/xlf/Resources.fr.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Programmation interactive pour .NET.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cli_dotnet_interactive_culture_Description">
+        <source>Set current culture for dotnet interactive command line commands</source>
+        <target state="new">Set current culture for dotnet interactive command line commands</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cli_dotnet_interactive_jupyter_Description">
         <source>Starts dotnet-interactive as a Jupyter kernel</source>
         <target state="translated">Démarre dotnet-interactive en tant que noyau Jupyter</target>

--- a/src/dotnet-interactive/xlf/Resources.it.xlf
+++ b/src/dotnet-interactive/xlf/Resources.it.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Programmazione interattiva per .NET.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cli_dotnet_interactive_culture_Description">
+        <source>Set current culture for dotnet interactive command line commands</source>
+        <target state="new">Set current culture for dotnet interactive command line commands</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cli_dotnet_interactive_jupyter_Description">
         <source>Starts dotnet-interactive as a Jupyter kernel</source>
         <target state="translated">Avvia dotnet-interactive come kernel Jupyter</target>

--- a/src/dotnet-interactive/xlf/Resources.ja.xlf
+++ b/src/dotnet-interactive/xlf/Resources.ja.xlf
@@ -22,6 +22,11 @@
         <target state="translated">.NET の対話型プログラミング。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cli_dotnet_interactive_culture_Description">
+        <source>Set current culture for dotnet interactive command line commands</source>
+        <target state="new">Set current culture for dotnet interactive command line commands</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cli_dotnet_interactive_jupyter_Description">
         <source>Starts dotnet-interactive as a Jupyter kernel</source>
         <target state="translated">Jupyter カーネルとして dotnet-interactive を起動します</target>

--- a/src/dotnet-interactive/xlf/Resources.ko.xlf
+++ b/src/dotnet-interactive/xlf/Resources.ko.xlf
@@ -22,6 +22,11 @@
         <target state="translated">.NET에 대한 대화형 프로그래밍입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cli_dotnet_interactive_culture_Description">
+        <source>Set current culture for dotnet interactive command line commands</source>
+        <target state="new">Set current culture for dotnet interactive command line commands</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cli_dotnet_interactive_jupyter_Description">
         <source>Starts dotnet-interactive as a Jupyter kernel</source>
         <target state="translated">dotnet-interactive을 Jupyter 커널로 시작합니다.</target>

--- a/src/dotnet-interactive/xlf/Resources.pl.xlf
+++ b/src/dotnet-interactive/xlf/Resources.pl.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Programowanie interakcyjne dla platformy .NET.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cli_dotnet_interactive_culture_Description">
+        <source>Set current culture for dotnet interactive command line commands</source>
+        <target state="new">Set current culture for dotnet interactive command line commands</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cli_dotnet_interactive_jupyter_Description">
         <source>Starts dotnet-interactive as a Jupyter kernel</source>
         <target state="translated">Uruchamia narzędzie dotnet-interactive jako jądro Jupyter</target>

--- a/src/dotnet-interactive/xlf/Resources.pt-BR.xlf
+++ b/src/dotnet-interactive/xlf/Resources.pt-BR.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Programação interativa para .NET.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cli_dotnet_interactive_culture_Description">
+        <source>Set current culture for dotnet interactive command line commands</source>
+        <target state="new">Set current culture for dotnet interactive command line commands</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cli_dotnet_interactive_jupyter_Description">
         <source>Starts dotnet-interactive as a Jupyter kernel</source>
         <target state="translated">Inicia dotnet-interactive como um kernel do Jupyter</target>

--- a/src/dotnet-interactive/xlf/Resources.ru.xlf
+++ b/src/dotnet-interactive/xlf/Resources.ru.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Интерактивное программирование для .NET.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cli_dotnet_interactive_culture_Description">
+        <source>Set current culture for dotnet interactive command line commands</source>
+        <target state="new">Set current culture for dotnet interactive command line commands</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cli_dotnet_interactive_jupyter_Description">
         <source>Starts dotnet-interactive as a Jupyter kernel</source>
         <target state="translated">Запускает dotnet-interactive в качестве ядра Jupyter</target>

--- a/src/dotnet-interactive/xlf/Resources.tr.xlf
+++ b/src/dotnet-interactive/xlf/Resources.tr.xlf
@@ -22,6 +22,11 @@
         <target state="translated">.NET için etkileşimli programlama.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cli_dotnet_interactive_culture_Description">
+        <source>Set current culture for dotnet interactive command line commands</source>
+        <target state="new">Set current culture for dotnet interactive command line commands</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cli_dotnet_interactive_jupyter_Description">
         <source>Starts dotnet-interactive as a Jupyter kernel</source>
         <target state="translated">Dotnet-interactive'i Jupyter çekirdeği olarak başlatır</target>

--- a/src/dotnet-interactive/xlf/Resources.zh-Hans.xlf
+++ b/src/dotnet-interactive/xlf/Resources.zh-Hans.xlf
@@ -22,6 +22,11 @@
         <target state="translated">.NET 的交互式编程。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cli_dotnet_interactive_culture_Description">
+        <source>Set current culture for dotnet interactive command line commands</source>
+        <target state="new">Set current culture for dotnet interactive command line commands</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cli_dotnet_interactive_jupyter_Description">
         <source>Starts dotnet-interactive as a Jupyter kernel</source>
         <target state="translated">启动 dotnet-interactive 作为 Jupyter 内核</target>

--- a/src/dotnet-interactive/xlf/Resources.zh-Hant.xlf
+++ b/src/dotnet-interactive/xlf/Resources.zh-Hant.xlf
@@ -22,6 +22,11 @@
         <target state="translated">.NET 的互動式程式設計。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cli_dotnet_interactive_culture_Description">
+        <source>Set current culture for dotnet interactive command line commands</source>
+        <target state="new">Set current culture for dotnet interactive command line commands</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cli_dotnet_interactive_jupyter_Description">
         <source>Starts dotnet-interactive as a Jupyter kernel</source>
         <target state="translated">以 Jupyter 核心啟動 dotnet-interactive</target>


### PR DESCRIPTION
Three parts of this implementation:

- [ ] Add a new option to pass an specific Culture to the dotnet interactive command line
- [ ] In VS, should launch the process dotnet interactive passing a Culture.
- [ ] In VS Code, should launch the process dotnet interactive passing a Culture.

-----
It seems that we need to get a new architecture around this to correctly propagate Culture to all kernels