### PR TITLE
HTTP kernel cleanups and some unimplemented tests

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.httpRequest_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.httpRequest_api_is_not_changed.approved.txt
@@ -14,7 +14,6 @@ Microsoft.DotNet.Interactive.HttpRequest
     public System.String Version { get;}
   public class HttpRequestKernel : Microsoft.DotNet.Interactive.Kernel, Microsoft.DotNet.Interactive.IKernelCommandHandler<Microsoft.DotNet.Interactive.Commands.RequestDiagnostics>, Microsoft.DotNet.Interactive.IKernelCommandHandler<Microsoft.DotNet.Interactive.Commands.RequestKernelInfo>, Microsoft.DotNet.Interactive.IKernelCommandHandler<Microsoft.DotNet.Interactive.Commands.RequestValue>, Microsoft.DotNet.Interactive.IKernelCommandHandler<Microsoft.DotNet.Interactive.Commands.SendValue>, Microsoft.DotNet.Interactive.IKernelCommandHandler<Microsoft.DotNet.Interactive.Commands.SubmitCode>, System.IDisposable
     .ctor(System.String name = null, System.Net.Http.HttpClient client = null)
-    public System.Uri BaseAddress { get; set;}
     public System.Void SetValue(System.String valueName, System.String value)
   public class HttpRequestKernelExtension
     public static System.Void Load(Microsoft.DotNet.Interactive.Kernel kernel, System.Net.Http.HttpClient httpClient = null)

--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/AssertionExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/AssertionExtensions.cs
@@ -45,7 +45,7 @@ public static class AssertionExtensions
             assertions.Subject.Should(),
             assertions.Subject);
 
-        string Normalize(string value) => 
+        static string Normalize(string value) =>
             value
                 .Trim()
                 .Crunch()


### PR DESCRIPTION
This removes the `BaseAddress` property from `HttpRequestKernel` and adds some tests, some of which won't be able to pass until the HTTP parser is updated.