### PR TITLE
Introduce a command to replace contents of selected html elements

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
@@ -406,6 +406,10 @@ Microsoft.DotNet.Interactive.Commands
   public class Quit : KernelCommand, System.IEquatable<KernelCommand>
     .ctor()
     public System.Threading.Tasks.Task InvokeAsync(Microsoft.DotNet.Interactive.KernelInvocationContext context)
+  public class ReplaceHtml : KernelCommand, System.IEquatable<KernelCommand>
+    .ctor(System.String elementSelector, System.String replacementHtml, System.String targetKernelName = null)
+    public System.String ElementSelector { get;}
+    public System.String ReplacementHtml { get;}
   public class RequestCompletions : LanguageServiceCommand, System.IEquatable<KernelCommand>
     .ctor(System.String code, Microsoft.DotNet.Interactive.LinePosition linePosition, System.String targetKernelName = null)
   public class RequestDiagnostics : KernelCommand, System.IEquatable<KernelCommand>

--- a/src/Microsoft.DotNet.Interactive.Browser/PlaywrightKernelConnector.cs
+++ b/src/Microsoft.DotNet.Interactive.Browser/PlaywrightKernelConnector.cs
@@ -118,7 +118,7 @@ document.head.insertAdjacentHTML('afterbegin', `<style>${notebookCSS}</style>`);
                                    var html = new BrowserDisplayEvent(@event, root.SubmissionCount + 1).ToDisplayString(HtmlFormatter.MimeType);
 
                                    var htmlCommand = new SubmitCode(html);
-                                   htmlKernel.SendAsync(htmlCommand).ConfigureAwait(false);
+                                   var _ = htmlKernel.SendAsync(htmlCommand);
                                });
 
             htmlKernel.RegisterForDisposal(subscription);

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Command_contract_has_not_been_broken.approved.ReplaceHtml.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Command_contract_has_not_been_broken.approved.ReplaceHtml.json
@@ -1,0 +1,16 @@
+{
+  "token": "the-token",
+  "id": "command-id",
+  "commandType": "ReplaceHtml",
+  "command": {
+    "elementSelector": "div[id=\"the-id\"]",
+    "replacementHtml": "<div id=\"the-id\">hi!</div>",
+    "targetKernelName": "html",
+    "originUri": null,
+    "destinationUri": null
+  },
+  "routingSlip": [
+    "kernel://somelocation/kernelName?tag=arrived",
+    "kernel://somelocation/kernelName"
+  ]
+}

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.cs
@@ -175,6 +175,8 @@ public class SerializationTests
                 new FormattedValue("text/html", "<b>hi!</b>")
             );
 
+            yield return new ReplaceHtml("""div[id="the-id"]""", """<div id="the-id">hi!</div>""", "html");
+
             yield return new RequestCompletions("Cons", new LinePosition(0, 4), "csharp");
 
             yield return new RequestDiagnostics("the-code");

--- a/src/Microsoft.DotNet.Interactive/Commands/ReplaceHtml.cs
+++ b/src/Microsoft.DotNet.Interactive/Commands/ReplaceHtml.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.DotNet.Interactive.Commands;
+
+public class ReplaceHtml : KernelCommand
+{
+    public ReplaceHtml(
+        string elementSelector,
+        string replacementHtml,
+        string targetKernelName = null) : base(targetKernelName)
+    {
+        ElementSelector = elementSelector ?? throw new ArgumentNullException(nameof(elementSelector));
+        ReplacementHtml = replacementHtml ?? throw new ArgumentNullException(nameof(replacementHtml));
+    }
+
+    public string ElementSelector { get; }
+
+    public string ReplacementHtml { get; }
+}

--- a/src/Microsoft.DotNet.Interactive/Connection/KernelCommandEnvelope.cs
+++ b/src/Microsoft.DotNet.Interactive/Connection/KernelCommandEnvelope.cs
@@ -62,6 +62,7 @@ public abstract class KernelCommandEnvelope : IKernelCommandEnvelope
             [nameof(ChangeWorkingDirectory)] = typeof(KernelCommandEnvelope<ChangeWorkingDirectory>),
             [nameof(DisplayError)] = typeof(KernelCommandEnvelope<DisplayError>),
             [nameof(DisplayValue)] = typeof(KernelCommandEnvelope<DisplayValue>),
+            [nameof(ReplaceHtml)] = typeof(KernelCommandEnvelope<ReplaceHtml>),
             [nameof(RequestCompletions)] = typeof(KernelCommandEnvelope<RequestCompletions>),
             [nameof(RequestDiagnostics)] = typeof(KernelCommandEnvelope<RequestDiagnostics>),
             [nameof(RequestHoverText)] = typeof(KernelCommandEnvelope<RequestHoverText>),

--- a/src/polyglot-notebooks/src/contracts.ts
+++ b/src/polyglot-notebooks/src/contracts.ts
@@ -13,6 +13,7 @@ export const DisplayValueType = "DisplayValue";
 export const OpenDocumentType = "OpenDocument";
 export const OpenProjectType = "OpenProject";
 export const QuitType = "Quit";
+export const ReplaceHtmlType = "ReplaceHtml";
 export const RequestCompletionsType = "RequestCompletions";
 export const RequestDiagnosticsType = "RequestDiagnostics";
 export const RequestHoverTextType = "RequestHoverText";
@@ -35,6 +36,7 @@ export type KernelCommandType =
     | typeof OpenDocumentType
     | typeof OpenProjectType
     | typeof QuitType
+    | typeof ReplaceHtmlType
     | typeof RequestCompletionsType
     | typeof RequestDiagnosticsType
     | typeof RequestHoverTextType
@@ -83,6 +85,11 @@ export interface OpenProject extends KernelCommand {
 }
 
 export interface Quit extends KernelCommand {
+}
+
+export interface ReplaceHtml extends KernelCommand {
+    elementSelector: string;
+    replacementHtml: string;
 }
 
 export interface RequestCompletions extends LanguageServiceCommand {


### PR DESCRIPTION
This makes it easier for clients to implement support for updating previously displayed values in response to `DisplayedValueUpdated` events.