### PR TITLE
Improve handling for http responses that are too slow and / or too large

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
@@ -76,6 +76,7 @@ Microsoft.DotNet.Interactive
     public static FormattedValue CreateSingleFromObject(System.Object value, System.String mimeType = null)
     .ctor(System.String mimeType, System.String value)
     public System.String MimeType { get;}
+    public System.Boolean SuppressDisplay { get; set;}
     public System.String Value { get;}
   public abstract class FrontendEnvironment
     public System.Threading.Tasks.Task ExecuteClientScript(System.String code, KernelInvocationContext context)

--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.httpRequest_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.httpRequest_api_is_not_changed.approved.txt
@@ -1,4 +1,6 @@
 Microsoft.DotNet.Interactive.HttpRequest
+  public class EmptyHttpResponse
+    .ctor()
   public class HttpContent
     .ctor(System.String raw, System.Int64 byteLength, System.Collections.Generic.Dictionary<System.String,System.String[]> headers, System.String contentType = null)
     public System.Int64 ByteLength { get;}
@@ -13,19 +15,21 @@ Microsoft.DotNet.Interactive.HttpRequest
     public System.String Uri { get;}
     public System.String Version { get;}
   public class HttpRequestKernel : Microsoft.DotNet.Interactive.Kernel, Microsoft.DotNet.Interactive.IKernelCommandHandler<Microsoft.DotNet.Interactive.Commands.RequestDiagnostics>, Microsoft.DotNet.Interactive.IKernelCommandHandler<Microsoft.DotNet.Interactive.Commands.RequestKernelInfo>, Microsoft.DotNet.Interactive.IKernelCommandHandler<Microsoft.DotNet.Interactive.Commands.RequestValue>, Microsoft.DotNet.Interactive.IKernelCommandHandler<Microsoft.DotNet.Interactive.Commands.SendValue>, Microsoft.DotNet.Interactive.IKernelCommandHandler<Microsoft.DotNet.Interactive.Commands.SubmitCode>, System.IDisposable
-    .ctor(System.String name = null, System.Net.Http.HttpClient client = null)
-    public System.Void SetValue(System.String valueName, System.String value)
+    .ctor(System.String name = null, System.Net.Http.HttpClient client = null, System.Int32 responseDelayThresholdInMilliseconds = 1000, System.Int32 contentByteLengthThreshold = 500000)
   public class HttpRequestKernelExtension
-    public static System.Void Load(Microsoft.DotNet.Interactive.Kernel kernel, System.Net.Http.HttpClient httpClient = null)
+    public static System.Void Load(Microsoft.DotNet.Interactive.Kernel kernel, System.Net.Http.HttpClient httpClient = null, System.Int32 responseDelayThresholdInMilliseconds = 1000, System.Int32 contentByteLengthThreshold = 500000)
     .ctor()
-  public class HttpResponse
+  public class HttpResponse : PartialHttpResponse
     .ctor(System.Int32 statusCode, System.String reasonPhrase, System.String version, System.Collections.Generic.Dictionary<System.String,System.String[]> headers, HttpRequest request = null, HttpContent content = null, System.Nullable<System.Double> elapsedMilliseconds = null)
     public HttpContent Content { get;}
-    public System.Nullable<System.Double> ElapsedMilliseconds { get;}
     public System.Collections.Generic.Dictionary<System.String,System.String[]> Headers { get;}
-    public System.String ReasonPhrase { get;}
     public HttpRequest Request { get;}
-    public System.Int32 StatusCode { get;}
-    public System.String Version { get;}
   public static class HttpResponseMessageFormattingExtensions
     public static System.Void RegisterFormatters()
+  public class PartialHttpResponse : EmptyHttpResponse
+    .ctor(System.Int32 statusCode, System.String reasonPhrase, System.String version, System.Nullable<System.Double> elapsedMilliseconds = null, System.Nullable<System.Int64> contentByteLength = null)
+    public System.Nullable<System.Int64> ContentByteLength { get;}
+    public System.Nullable<System.Double> ElapsedMilliseconds { get;}
+    public System.String ReasonPhrase { get;}
+    public System.Int32 StatusCode { get;}
+    public System.String Version { get;}

--- a/src/Microsoft.DotNet.Interactive.Browser/BrowserDisplayEventFormatterSource.cs
+++ b/src/Microsoft.DotNet.Interactive.Browser/BrowserDisplayEventFormatterSource.cs
@@ -35,7 +35,12 @@ internal class BrowserDisplayEventFormatterSource :
                              @event.FormattedValues.FirstOrDefault(v => v.MimeType == PlainTextFormatter.MimeType) ??
                              @event.FormattedValues.FirstOrDefault();
 
-        IHtmlContent html = formattedValue!.MimeType switch
+        if (formattedValue!.SuppressDisplay)
+        {
+            return false;
+        }
+
+        IHtmlContent html = formattedValue.MimeType switch
         {
             HtmlFormatter.MimeType => new HtmlString(formattedValue.Value),
             _ => code(formattedValue.Value)
@@ -44,7 +49,7 @@ internal class BrowserDisplayEventFormatterSource :
         var codeSummary = browserDisplayEvent.DisplayEvent.Command is SubmitCode submitCode
                               ? submitCode.ToString().Substring("SubmitCode: ".Length)
                               : "";
-        
+
 
         html = div[@class: "dni-treeview"](
             table(

--- a/src/Microsoft.DotNet.Interactive.HttpRequest.Tests/HttpRequestKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.HttpRequest.Tests/HttpRequestKernelTests.cs
@@ -6,8 +6,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Formatting;
@@ -45,6 +47,8 @@ public class HttpRequestKernelTests
 
         var result = await kernel.SendAsync(new SubmitCode($"{verb} http://testuri.ninja"));
 
+        using var _ = new AssertionScope();
+
         result.Events.Should().NotContainErrors();
 
         request.Method.Method.Should().Be(verb);
@@ -63,10 +67,12 @@ public class HttpRequestKernelTests
         var client = new HttpClient(handler);
         using var kernel = new HttpRequestKernel(client: client);
 
-        kernel.SetValue("my_host", "my.host.com");
+        using var _ = new AssertionScope();
 
-        var result = await kernel.SendAsync(new SubmitCode("get  https://{{my_host}}:1200/endpoint"));
+        var result = await kernel.SendAsync(new SendValue("my_host", "my.host.com"));
+        result.Events.Should().NotContainErrors();
 
+        result = await kernel.SendAsync(new SubmitCode("get  https://{{my_host}}:1200/endpoint"));
         result.Events.Should().NotContainErrors();
 
         request.RequestUri.Should().Be("https://my.host.com:1200/endpoint");
@@ -90,6 +96,8 @@ get  https://location1.com:1200/endpoint
 
 put  https://location2.com:1200/endpoint"));
 
+        using var _ = new AssertionScope();
+
         result.Events.Should().NotContainErrors();
 
         requests.Select(r => r.RequestUri.AbsoluteUri).ToArray().Should().BeEquivalentTo(new[] { "https://location1.com:1200/endpoint", "https://location2.com:1200/endpoint" });
@@ -111,6 +119,8 @@ put  https://location2.com:1200/endpoint"));
         var result = await kernel.SendAsync(new SubmitCode(@"
 get  https://location1.com:1200/endpoint
 Authorization: Basic username password"));
+
+        using var _ = new AssertionScope();
 
         result.Events.Should().NotContainErrors();
 
@@ -139,6 +149,8 @@ Authorization: Basic username password"));
             { "key" : "value", "list": [1, 2, 3] }
 
             """));
+
+        using var _ = new AssertionScope();
 
         result.Events.Should().NotContainErrors();
 
@@ -170,6 +182,8 @@ Authorization: Basic username password"));
             }
 
             """));
+
+        using var _ = new AssertionScope();
 
         result.Events.Should().NotContainErrors();
 
@@ -208,6 +222,7 @@ Authorization: Basic username password
 Content-Type: application/json
 "));
 
+        using var _ = new AssertionScope();
         result.Events.Should().NotContainErrors();
         request.Content.Headers.ContentType.ToString().Should().Be("application/json");
     }
@@ -224,15 +239,19 @@ Content-Type: application/json
         });
         var client = new HttpClient(handler);
         using var kernel = new HttpRequestKernel(client: client);
-        kernel.SetValue("one", "1");
-        var result = await kernel.SendAsync(new SubmitCode(@"
+
+        using var _ = new AssertionScope();
+
+        var result = await kernel.SendAsync(new SendValue("one", 1));
+        result.Events.Should().NotContainErrors();
+
+        result = await kernel.SendAsync(new SubmitCode(@"
 post  https://location1.com:1200/endpoint
 Authorization: Basic username password
 Content-Type: application/json
 
 { ""key"" : ""value"", ""list"": [{{one}}, 2, 3] }
 "));
-
         result.Events.Should().NotContainErrors();
 
         var bodyAsString = await request.Content.ReadAsStringAsync();
@@ -251,14 +270,17 @@ Content-Type: application/json
         });
         var client = new HttpClient(handler);
         using var kernel = new HttpRequestKernel(client: client);
-        kernel.SetValue("theHost", "example.com");
+
+        using var _ = new AssertionScope();
+
+        var result = await kernel.SendAsync(new SendValue("theHost", "example.com"));
+        result.Events.Should().NotContainErrors();
 
         var code = @"
 // something to ensure we're not on the first line
 GET https://{{theHost}}";
 
-        var result = await kernel.SendAsync(new SubmitCode(code));
-
+        result = await kernel.SendAsync(new SubmitCode(code));
         result.Events.Should().NotContainErrors();
 
         request.RequestUri.AbsoluteUri.Should().Be("https://example.com/");
@@ -270,6 +292,8 @@ GET https://{{theHost}}";
         using var kernel = new HttpRequestKernel();
 
         var result = await kernel.SendAsync(new RequestDiagnostics("get https://anotherlocation.com/{{api_endpoint}}"));
+
+        using var _ = new AssertionScope();
 
         result.Events.Should().NotContainErrors();
 
@@ -301,13 +325,15 @@ GET https://example.com/{{unresolved_symbol}}";
 
         var result = await kernel.SendAsync(new RequestDiagnostics(code));
 
+        using var _ = new AssertionScope();
+
         result.Events.Should().NotContainErrors();
 
         var diagnostics = result.Events.Should().ContainSingle<DiagnosticsProduced>().Which;
 
         diagnostics.Diagnostics.Should().ContainSingle().Which.LinePositionSpan.Should().Be(new LinePositionSpan(new LinePosition(2, 26), new LinePosition(2, 43)));
     }
-    
+
     [Fact]
     public async Task diagnostic_positions_are_correct_for_unresolved_symbols_after_other_symbols_were_successfully_resolved()
     {
@@ -318,6 +344,8 @@ GET https://example.com/
 User-Agent: {{unresolved_symbol}}";
 
         var result = await kernel.SendAsync(new RequestDiagnostics(code));
+
+        using var _ = new AssertionScope();
 
         result.Events.Should().NotContainErrors();
 
@@ -337,6 +365,8 @@ User-Agent: {{missing_value_2}}";
 
         var result = await kernel.SendAsync(new RequestDiagnostics(code));
 
+        using var _ = new AssertionScope();
+
         result.Events.Should().NotContainErrors();
 
         var diagnostics = result.Events.Should().ContainSingle<DiagnosticsProduced>().Which;
@@ -345,7 +375,7 @@ User-Agent: {{missing_value_2}}";
     }
 
     [Fact]
-    public async Task produces_json_html_and_plain_text_formatted_values()
+    public async Task produces_html_formatted_display_value()
     {
         HttpRequestMessage request = null;
         var handler = new InterceptingHttpMessageHandler((message, _) =>
@@ -363,12 +393,386 @@ User-Agent: {{missing_value_2}}";
 
         var result = await kernel.SendAsync(new SubmitCode($"GET http://testuri.ninja"));
 
+        result.Events.Should().ContainSingle<DisplayedValueProduced>().Which
+            .FormattedValues.Should().ContainSingle().Which
+            .MimeType.Should().Be(HtmlFormatter.MimeType);
+    }
+
+    [Fact]
+    public async Task produces_json_formatted_return_value()
+    {
+        HttpRequestMessage request = null;
+        var handler = new InterceptingHttpMessageHandler((message, _) =>
+        {
+            request = message;
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.RequestMessage = message;
+            return Task.FromResult(response);
+        });
+        var client = new HttpClient(handler);
+
+        using var root = new CompositeKernel();
+        HttpRequestKernelExtension.Load(root, client);
+        var kernel = root.FindKernels(k => k is HttpRequestKernel).Single();
+
+        var result = await kernel.SendAsync(new SubmitCode($"GET http://testuri.ninja"));
+
+        result.Events.Should().ContainSingle<ReturnValueProduced>().Which
+            .FormattedValues.Should().ContainSingle().Which
+            .MimeType.Should().Be(JsonFormatter.MimeType);
+    }
+
+    [Fact]
+    public async Task display_should_be_suppressed_for_return_value()
+    {
+        HttpRequestMessage request = null;
+        var handler = new InterceptingHttpMessageHandler((message, _) =>
+        {
+            request = message;
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.RequestMessage = message;
+            return Task.FromResult(response);
+        });
+        var client = new HttpClient(handler);
+
+        using var root = new CompositeKernel();
+        HttpRequestKernelExtension.Load(root, client);
+        var kernel = root.FindKernels(k => k is HttpRequestKernel).Single();
+
+        var result = await kernel.SendAsync(new SubmitCode($"GET http://testuri.ninja"));
+
+        result.Events.Should().ContainSingle<ReturnValueProduced>().Which
+            .FormattedValues.Should().ContainSingle().Which
+            .SuppressDisplay.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task produces_initial_displayed_value_that_is_updated_when_response_is_slow()
+    {
+        const int ResponseDelayThresholdInMilliseconds = 5;
+        HttpRequestMessage request = null;
+        var slowResponseHandler = new InterceptingHttpMessageHandler(async (message, _) =>
+        {
+            request = message;
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.RequestMessage = message;
+            await Task.Delay(2 * ResponseDelayThresholdInMilliseconds);
+            return response;
+        });
+        var client = new HttpClient(slowResponseHandler);
+
+        using var root = new CompositeKernel();
+        HttpRequestKernelExtension.Load(root, client, ResponseDelayThresholdInMilliseconds);
+        var kernel = root.FindKernels(k => k is HttpRequestKernel).Single();
+
+        var result = await kernel.SendAsync(new SubmitCode($"GET http://testuri.ninja"));
+
+        using var _ = new AssertionScope();
+
         result.Events.Should().NotContainErrors();
 
-        result.Events.Should().ContainSingle<DisplayEvent>().Which.FormattedValues.Should()
-              .Contain(f => f.MimeType == HtmlFormatter.MimeType).And
-              .Contain(f => f.MimeType == PlainTextFormatter.MimeType).And
-              .Contain(f => f.MimeType == JsonFormatter.MimeType);
+        var displayEvents = result.Events.OfType<DisplayEvent>().ToArray();
+        displayEvents.Length.Should().Be(3);
+        displayEvents[0].Should().BeOfType<DisplayedValueProduced>();
+        displayEvents[1].Should().BeOfType<DisplayedValueUpdated>();
+        displayEvents[2].Should().BeOfType<ReturnValueProduced>();
+    }
+
+    [Fact]
+    public async Task when_response_is_slow_initial_displayed_value_conveys_that_it_is_awaiting_response()
+    {
+        const int ResponseDelayThresholdInMilliseconds = 5;
+        HttpRequestMessage request = null;
+        var slowResponseHandler = new InterceptingHttpMessageHandler(async (message, _) =>
+        {
+            request = message;
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.RequestMessage = message;
+            await Task.Delay(2 * ResponseDelayThresholdInMilliseconds);
+            return response;
+        });
+        var client = new HttpClient(slowResponseHandler);
+
+        using var root = new CompositeKernel();
+        HttpRequestKernelExtension.Load(root, client, ResponseDelayThresholdInMilliseconds);
+        var kernel = root.FindKernels(k => k is HttpRequestKernel).Single();
+
+        var result = await kernel.SendAsync(new SubmitCode($"GET http://testuri.ninja"));
+
+        result.Events.OfType<DisplayEvent>().First()
+            .FormattedValues.Single().Value.Should().Contain("Awaiting response");
+    }
+
+    [Fact]
+    public async Task when_response_is_slow_final_displayed_value_includes_response_details()
+    {
+        const int ResponseDelayThresholdInMilliseconds = 5;
+        HttpRequestMessage request = null;
+        var slowResponseHandler = new InterceptingHttpMessageHandler(async (message, _) =>
+        {
+            request = message;
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.RequestMessage = message;
+            await Task.Delay(2 * ResponseDelayThresholdInMilliseconds);
+            return response;
+        });
+        var client = new HttpClient(slowResponseHandler);
+
+        using var root = new CompositeKernel();
+        HttpRequestKernelExtension.Load(root, client, ResponseDelayThresholdInMilliseconds);
+        var kernel = root.FindKernels(k => k is HttpRequestKernel).Single();
+
+        var result = await kernel.SendAsync(new SubmitCode($"GET http://testuri.ninja"));
+
+        result.Events.OfType<DisplayEvent>().Skip(1).First()
+            .FormattedValues.Single().Value.Should().ContainAll("Response", "Request", "Headers");
+    }
+
+    [Fact]
+    public async Task produces_initial_displayed_value_that_is_updated_when_response_is_large()
+    {
+        const int ContentByteLengthThreshold = 100;
+
+        HttpRequestMessage request = null;
+        var largeResponseHandler = new InterceptingHttpMessageHandler((message, _) =>
+        {
+            request = message;
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.RequestMessage = message;
+            var builder = new StringBuilder();
+            for (int i = 0; i < ContentByteLengthThreshold + 1; ++i)
+            {
+                builder.Append('a');
+            }
+            response.Content = new StringContent(builder.ToString());
+            return Task.FromResult(response);
+        });
+
+        var client = new HttpClient(largeResponseHandler);
+
+        using var root = new CompositeKernel();
+        HttpRequestKernelExtension.Load(root, client, contentByteLengthThreshold: ContentByteLengthThreshold);
+        var kernel = root.FindKernels(k => k is HttpRequestKernel).Single();
+
+        var result = await kernel.SendAsync(new SubmitCode($"GET http://testuri.ninja"));
+
+        using var _ = new AssertionScope();
+
+        result.Events.Should().NotContainErrors();
+
+        var displayEvents = result.Events.OfType<DisplayEvent>().ToArray();
+        displayEvents.Length.Should().Be(3);
+        displayEvents[0].Should().BeOfType<DisplayedValueProduced>();
+        displayEvents[1].Should().BeOfType<DisplayedValueUpdated>();
+        displayEvents[2].Should().BeOfType<ReturnValueProduced>();
+    }
+
+    [Fact]
+    public async Task when_response_is_large_initial_displayed_value_conveys_that_it_is_loading_response()
+    {
+        const int ContentByteLengthThreshold = 100;
+
+        HttpRequestMessage request = null;
+        var largeResponseHandler = new InterceptingHttpMessageHandler((message, _) =>
+        {
+            request = message;
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.RequestMessage = message;
+            var builder = new StringBuilder();
+            for (int i = 0; i < ContentByteLengthThreshold + 1; ++i)
+            {
+                builder.Append('a');
+            }
+            response.Content = new StringContent(builder.ToString());
+            return Task.FromResult(response);
+        });
+
+        var client = new HttpClient(largeResponseHandler);
+
+        using var root = new CompositeKernel();
+        HttpRequestKernelExtension.Load(root, client, contentByteLengthThreshold: ContentByteLengthThreshold);
+        var kernel = root.FindKernels(k => k is HttpRequestKernel).Single();
+
+        var result = await kernel.SendAsync(new SubmitCode($"GET http://testuri.ninja"));
+
+        result.Events.OfType<DisplayEvent>().First()
+            .FormattedValues.Single().Value.Should().Contain("Loading content");
+    }
+
+    [Fact]
+    public async Task when_response_is_large_final_displayed_value_includes_response_details()
+    {
+        const int ContentByteLengthThreshold = 100;
+
+        HttpRequestMessage request = null;
+        var largeResponseHandler = new InterceptingHttpMessageHandler((message, _) =>
+        {
+            request = message;
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.RequestMessage = message;
+            var builder = new StringBuilder();
+            for (int i = 0; i < ContentByteLengthThreshold + 1; ++i)
+            {
+                builder.Append('a');
+            }
+            response.Content = new StringContent(builder.ToString());
+            return Task.FromResult(response);
+        });
+
+        var client = new HttpClient(largeResponseHandler);
+
+        using var root = new CompositeKernel();
+        HttpRequestKernelExtension.Load(root, client, contentByteLengthThreshold: ContentByteLengthThreshold);
+        var kernel = root.FindKernels(k => k is HttpRequestKernel).Single();
+
+        var result = await kernel.SendAsync(new SubmitCode($"GET http://testuri.ninja"));
+
+        result.Events.OfType<DisplayEvent>().Skip(1).First()
+            .FormattedValues.Single().Value.Should().ContainAll("Response", "Request", "Headers");
+    }
+
+    [Fact]
+    public async Task produces_initial_displayed_value_that_is_updated_twice_when_response_is_slow_and_large()
+    {
+        const int ResponseDelayThresholdInMilliseconds = 5;
+        const int ContentByteLengthThreshold = 100;
+
+        HttpRequestMessage request = null;
+        var slowAndLargeResponseHandler = new InterceptingHttpMessageHandler(async (message, _) =>
+        {
+            request = message;
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.RequestMessage = message;
+            var builder = new StringBuilder();
+            for (int i = 0; i < ContentByteLengthThreshold + 1; ++i)
+            {
+                builder.Append('a');
+            }
+            response.Content = new StringContent(builder.ToString());
+            await Task.Delay(2 * ResponseDelayThresholdInMilliseconds);
+            return response;
+        });
+
+        var client = new HttpClient(slowAndLargeResponseHandler);
+
+        using var root = new CompositeKernel();
+        HttpRequestKernelExtension.Load(root, client, ResponseDelayThresholdInMilliseconds, ContentByteLengthThreshold);
+        var kernel = root.FindKernels(k => k is HttpRequestKernel).Single();
+
+        var result = await kernel.SendAsync(new SubmitCode($"GET http://testuri.ninja"));
+
+        using var _ = new AssertionScope();
+
+        result.Events.Should().NotContainErrors();
+
+        var displayEvents = result.Events.OfType<DisplayEvent>().ToArray();
+        displayEvents.Length.Should().Be(4);
+        displayEvents[0].Should().BeOfType<DisplayedValueProduced>();
+        displayEvents[1].Should().BeOfType<DisplayedValueUpdated>();
+        displayEvents[2].Should().BeOfType<DisplayedValueUpdated>();
+        displayEvents[3].Should().BeOfType<ReturnValueProduced>();
+    }
+
+    [Fact]
+    public async Task when_response_is_slow_and_large_first_displayed_value_conveys_that_it_is_awaiting_response()
+    {
+        const int ResponseDelayThresholdInMilliseconds = 5;
+        const int ContentByteLengthThreshold = 100;
+
+        HttpRequestMessage request = null;
+        var slowAndLargeResponseHandler = new InterceptingHttpMessageHandler(async (message, _) =>
+        {
+            request = message;
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.RequestMessage = message;
+            var builder = new StringBuilder();
+            for (int i = 0; i < ContentByteLengthThreshold + 1; ++i)
+            {
+                builder.Append('a');
+            }
+            response.Content = new StringContent(builder.ToString());
+            await Task.Delay(2 * ResponseDelayThresholdInMilliseconds);
+            return response;
+        });
+
+        var client = new HttpClient(slowAndLargeResponseHandler);
+
+        using var root = new CompositeKernel();
+        HttpRequestKernelExtension.Load(root, client, ResponseDelayThresholdInMilliseconds, ContentByteLengthThreshold);
+        var kernel = root.FindKernels(k => k is HttpRequestKernel).Single();
+
+        var result = await kernel.SendAsync(new SubmitCode($"GET http://testuri.ninja"));
+
+        result.Events.OfType<DisplayEvent>().First()
+            .FormattedValues.Single().Value.Should().Contain("Awaiting response");
+    }
+
+    [Fact]
+    public async Task when_response_is_slow_and_large_second_displayed_value_conveys_that_it_is_loading_response()
+    {
+        const int ResponseDelayThresholdInMilliseconds = 5;
+        const int ContentByteLengthThreshold = 100;
+
+        HttpRequestMessage request = null;
+        var slowAndLargeResponseHandler = new InterceptingHttpMessageHandler(async (message, _) =>
+        {
+            request = message;
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.RequestMessage = message;
+            var builder = new StringBuilder();
+            for (int i = 0; i < ContentByteLengthThreshold + 1; ++i)
+            {
+                builder.Append('a');
+            }
+            response.Content = new StringContent(builder.ToString());
+            await Task.Delay(2 * ResponseDelayThresholdInMilliseconds);
+            return response;
+        });
+
+        var client = new HttpClient(slowAndLargeResponseHandler);
+
+        using var root = new CompositeKernel();
+        HttpRequestKernelExtension.Load(root, client, ResponseDelayThresholdInMilliseconds, ContentByteLengthThreshold);
+        var kernel = root.FindKernels(k => k is HttpRequestKernel).Single();
+
+        var result = await kernel.SendAsync(new SubmitCode($"GET http://testuri.ninja"));
+
+        result.Events.OfType<DisplayEvent>().Skip(1).First()
+            .FormattedValues.Single().Value.Should().Contain("Loading content");
+    }
+
+    [Fact]
+    public async Task when_response_is_slow_and_large_final_displayed_value_includes_response_details()
+    {
+        const int ResponseDelayThresholdInMilliseconds = 5;
+        const int ContentByteLengthThreshold = 100;
+
+        HttpRequestMessage request = null;
+        var slowAndLargeResponseHandler = new InterceptingHttpMessageHandler(async (message, _) =>
+        {
+            request = message;
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.RequestMessage = message;
+            var builder = new StringBuilder();
+            for (int i = 0; i < ContentByteLengthThreshold + 1; ++i)
+            {
+                builder.Append('a');
+            }
+            response.Content = new StringContent(builder.ToString());
+            await Task.Delay(2 * ResponseDelayThresholdInMilliseconds);
+            return response;
+        });
+
+        var client = new HttpClient(slowAndLargeResponseHandler);
+
+        using var root = new CompositeKernel();
+        HttpRequestKernelExtension.Load(root, client, ResponseDelayThresholdInMilliseconds, ContentByteLengthThreshold);
+        var kernel = root.FindKernels(k => k is HttpRequestKernel).Single();
+
+        var result = await kernel.SendAsync(new SubmitCode($"GET http://testuri.ninja"));
+
+        result.Events.OfType<DisplayEvent>().Skip(2).First()
+            .FormattedValues.Single().Value.Should().ContainAll("Response", "Request", "Headers");
     }
 
     [Fact(Skip = "Requires updates to HTTP parser")]

--- a/src/Microsoft.DotNet.Interactive.HttpRequest/Formatting/HttpResponseFormatterSource.cs
+++ b/src/Microsoft.DotNet.Interactive.HttpRequest/Formatting/HttpResponseFormatterSource.cs
@@ -14,22 +14,22 @@ internal sealed class HttpResponseFormatterSource : ITypeFormatterSource
         yield return new HttpResponsePlainTextFormatter();
     }
 
-    private sealed class HttpResponseHtmlFormatter : TypeFormatter<HttpResponse>
+    private sealed class HttpResponseHtmlFormatter : TypeFormatter<EmptyHttpResponse>
     {
         public override string MimeType => HtmlFormatter.MimeType;
 
-        public override bool Format(HttpResponse value, FormatContext context)
+        public override bool Format(EmptyHttpResponse value, FormatContext context)
         {
             value.FormatAsHtml(context);
             return true;
         }
     }
 
-    private sealed class HttpResponsePlainTextFormatter : TypeFormatter<HttpResponse>
+    private sealed class HttpResponsePlainTextFormatter : TypeFormatter<EmptyHttpResponse>
     {
         public override string MimeType => PlainTextFormatter.MimeType;
 
-        public override bool Format(HttpResponse value, FormatContext context)
+        public override bool Format(EmptyHttpResponse value, FormatContext context)
         {
             value.FormatAsPlainText(context);
             return true;

--- a/src/Microsoft.DotNet.Interactive.HttpRequest/HttpRequestKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.HttpRequest/HttpRequestKernelExtension.cs
@@ -7,11 +7,20 @@ namespace Microsoft.DotNet.Interactive.HttpRequest;
 
 public class HttpRequestKernelExtension
 {
-    public static void Load(Kernel kernel, HttpClient? httpClient = null)
+    public static void Load(
+        Kernel kernel,
+        HttpClient? httpClient = null,
+        int responseDelayThresholdInMilliseconds = HttpRequestKernel.DefaultResponseDelayThresholdInMilliseconds,
+        int contentByteLengthThreshold = HttpRequestKernel.DefaultContentByteLengthThreshold)
     {
         if (kernel.RootKernel is CompositeKernel compositeKernel)
         {
-            var httpRequestKernel = new HttpRequestKernel(client: httpClient);
+            var httpRequestKernel =
+                new HttpRequestKernel(
+                    client: httpClient,
+                    responseDelayThresholdInMilliseconds: responseDelayThresholdInMilliseconds,
+                    contentByteLengthThreshold: contentByteLengthThreshold);
+
             compositeKernel.Add(httpRequestKernel);
             httpRequestKernel.UseValueSharing();
 

--- a/src/Microsoft.DotNet.Interactive.HttpRequest/Model/EmptyHttpResponse.cs
+++ b/src/Microsoft.DotNet.Interactive.HttpRequest/Model/EmptyHttpResponse.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.Interactive.Formatting;
+
+namespace Microsoft.DotNet.Interactive.HttpRequest;
+
+[TypeFormatterSource(
+    typeof(HttpResponseFormatterSource),
+    PreferredMimeTypes = new[] { HtmlFormatter.MimeType })]
+public class EmptyHttpResponse
+{
+}

--- a/src/Microsoft.DotNet.Interactive.HttpRequest/Model/HttpMessageExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.HttpRequest/Model/HttpMessageExtensions.cs
@@ -87,4 +87,12 @@ internal static class HttpMessageExtensions
 
     private static Dictionary<string, string[]> ToDictionary(this HttpHeaders headers)
         => headers.ToDictionary(header => header.Key, header => header.Value.ToArray());
+
+    internal static PartialHttpResponse ToPartialHttpResponse(this HttpResponse response) =>
+        new PartialHttpResponse(
+            response.StatusCode,
+            response.ReasonPhrase,
+            response.Version,
+            response.ElapsedMilliseconds,
+            response.Content?.ByteLength);
 }

--- a/src/Microsoft.DotNet.Interactive.HttpRequest/Model/HttpResponse.cs
+++ b/src/Microsoft.DotNet.Interactive.HttpRequest/Model/HttpResponse.cs
@@ -8,16 +8,12 @@ namespace Microsoft.DotNet.Interactive.HttpRequest;
 
 [TypeFormatterSource(
     typeof(HttpResponseFormatterSource),
-    PreferredMimeTypes = new[] { HtmlFormatter.MimeType, PlainTextFormatter.MimeType, JsonFormatter.MimeType })]
-public sealed class HttpResponse
+    PreferredMimeTypes = new[] { HtmlFormatter.MimeType })]
+public sealed class HttpResponse : PartialHttpResponse
 {
-    public int StatusCode { get; }
-    public string ReasonPhrase { get; }
-    public string Version { get; }
     public Dictionary<string, string[]> Headers { get; }
     public HttpRequest? Request { get; }
     public HttpContent? Content { get; }
-    public double? ElapsedMilliseconds { get; internal set; }
 
     public HttpResponse(
         int statusCode,
@@ -26,11 +22,8 @@ public sealed class HttpResponse
         Dictionary<string, string[]> headers,
         HttpRequest? request = null,
         HttpContent? content = null,
-        double? elapsedMilliseconds = null)
+        double? elapsedMilliseconds = null) : base(statusCode, reasonPhrase, version, elapsedMilliseconds, content?.ByteLength)
     {
-        StatusCode = statusCode;
-        ReasonPhrase = reasonPhrase;
-        Version = version;
         Headers = headers;
         Request = request;
         Content = content;

--- a/src/Microsoft.DotNet.Interactive.HttpRequest/Model/PartialHttpResponse.cs
+++ b/src/Microsoft.DotNet.Interactive.HttpRequest/Model/PartialHttpResponse.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.Interactive.Formatting;
+
+namespace Microsoft.DotNet.Interactive.HttpRequest;
+
+[TypeFormatterSource(
+    typeof(HttpResponseFormatterSource),
+    PreferredMimeTypes = new[] { HtmlFormatter.MimeType })]
+public class PartialHttpResponse : EmptyHttpResponse
+{
+    public int StatusCode { get; }
+    public string ReasonPhrase { get; }
+    public string Version { get; }
+    public double? ElapsedMilliseconds { get; internal set; }
+    public long? ContentByteLength { get; }
+
+    public PartialHttpResponse(
+        int statusCode,
+        string reasonPhrase,
+        string version,
+        double? elapsedMilliseconds = null,
+        long? contentByteLength = null)
+    {
+        StatusCode = statusCode;
+        ReasonPhrase = reasonPhrase;
+        Version = version;
+        ElapsedMilliseconds = elapsedMilliseconds;
+        ContentByteLength = contentByteLength;
+    }
+}

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Command_contract_has_not_been_broken.approved.DisplayValue.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Command_contract_has_not_been_broken.approved.DisplayValue.json
@@ -5,7 +5,8 @@
   "command": {
     "formattedValue": {
       "mimeType": "text/html",
-      "value": "<b>hi!</b>"
+      "value": "<b>hi!</b>",
+      "suppressDisplay": false
     },
     "valueId": null,
     "targetKernelName": null,

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Command_contract_has_not_been_broken.approved.SendValue.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Command_contract_has_not_been_broken.approved.SendValue.json
@@ -5,7 +5,8 @@
   "command": {
     "formattedValue": {
       "mimeType": "text/plain",
-      "value": "formatted value"
+      "value": "formatted value",
+      "suppressDisplay": false
     },
     "name": "name",
     "targetKernelName": "fsharp",

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Command_contract_has_not_been_broken.approved.UpdateDisplayedValue.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Command_contract_has_not_been_broken.approved.UpdateDisplayedValue.json
@@ -5,7 +5,8 @@
   "command": {
     "formattedValue": {
       "mimeType": "text/html",
-      "value": "<b>hi!</b>"
+      "value": "<b>hi!</b>",
+      "suppressDisplay": false
     },
     "valueId": "the-value-id",
     "targetKernelName": null,

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.DisplayedValueProduced.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.DisplayedValueProduced.json
@@ -3,7 +3,8 @@
     "formattedValues": [
       {
         "mimeType": "text/html",
-        "value": "<b>hi!</b>"
+        "value": "<b>hi!</b>",
+        "suppressDisplay": false
       }
     ],
     "valueId": null

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.DisplayedValueUpdated.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.DisplayedValueUpdated.json
@@ -3,7 +3,8 @@
     "formattedValues": [
       {
         "mimeType": "text/html",
-        "value": "<b>hi!</b>"
+        "value": "<b>hi!</b>",
+        "suppressDisplay": false
       }
     ],
     "valueId": "the-value-id"

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.HoverTextProduced.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.HoverTextProduced.json
@@ -3,7 +3,8 @@
     "content": [
       {
         "mimeType": "text/markdown",
-        "value": "markdown"
+        "value": "markdown",
+        "suppressDisplay": false
       }
     ],
     "linePositionSpan": {

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.ReturnValueProduced.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.ReturnValueProduced.json
@@ -3,7 +3,8 @@
     "formattedValues": [
       {
         "mimeType": "text/html",
-        "value": "<b>hi!</b>"
+        "value": "<b>hi!</b>",
+        "suppressDisplay": false
       }
     ],
     "valueId": null

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.SignatureHelpProduced.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.SignatureHelpProduced.json
@@ -5,21 +5,24 @@
         "label": "label",
         "documentation": {
           "mimeType": "text/html",
-          "value": "sig-help-result"
+          "value": "sig-help-result",
+          "suppressDisplay": false
         },
         "parameters": [
           {
             "label": "param1",
             "documentation": {
               "mimeType": "text/html",
-              "value": "param1"
+              "value": "param1",
+              "suppressDisplay": false
             }
           },
           {
             "label": "param2",
             "documentation": {
               "mimeType": "text/html",
-              "value": "param2"
+              "value": "param2",
+              "suppressDisplay": false
             }
           }
         ]

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.StandardErrorValueProduced.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.StandardErrorValueProduced.json
@@ -3,7 +3,8 @@
     "formattedValues": [
       {
         "mimeType": "text/plain",
-        "value": "oops!"
+        "value": "oops!",
+        "suppressDisplay": false
       }
     ],
     "valueId": null

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.StandardOutputValueProduced.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.StandardOutputValueProduced.json
@@ -3,7 +3,8 @@
     "formattedValues": [
       {
         "mimeType": "text/plain",
-        "value": "123"
+        "value": "123",
+        "suppressDisplay": false
       }
     ],
     "valueId": null

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.ValueInfosProduced.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.ValueInfosProduced.json
@@ -6,7 +6,8 @@
         "name": "a",
         "formattedValue": {
           "mimeType": "text/plain+summary",
-          "value": "a"
+          "value": "a",
+          "suppressDisplay": false
         },
         "preferredMimeTypes": [
           "text/plain"
@@ -17,7 +18,8 @@
         "name": "b",
         "formattedValue": {
           "mimeType": "text/plain+summary",
-          "value": "b"
+          "value": "b",
+          "suppressDisplay": false
         },
         "preferredMimeTypes": [
           "text/html"
@@ -28,7 +30,8 @@
         "name": "c",
         "formattedValue": {
           "mimeType": "text/plain+summary",
-          "value": "c"
+          "value": "c",
+          "suppressDisplay": false
         },
         "preferredMimeTypes": [
           "text/html"

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.ValueProduced.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.ValueProduced.json
@@ -3,7 +3,8 @@
     "name": "a",
     "formattedValue": {
       "mimeType": "text/html",
-      "value": "<span>raw value</span>"
+      "value": "<span>raw value</span>",
+      "suppressDisplay": false
     }
   },
   "eventType": "ValueProduced",

--- a/src/Microsoft.DotNet.Interactive/DisplayedValue.cs
+++ b/src/Microsoft.DotNet.Interactive/DisplayedValue.cs
@@ -15,10 +15,9 @@ public class DisplayedValue
     private readonly string _displayId;
     private readonly HashSet<string> _mimeTypes;
     private KernelInvocationContext _context;
-        
-    public DisplayedValue(string displayId, string mimeType, KernelInvocationContext context): this(displayId, new []{mimeType}, context)
+
+    public DisplayedValue(string displayId, string mimeType, KernelInvocationContext context) : this(displayId, new[] { mimeType }, context)
     {
-           
     }
 
     public DisplayedValue(string displayId, string[] mimeTypes, KernelInvocationContext context)

--- a/src/Microsoft.DotNet.Interactive/FormattedValue.cs
+++ b/src/Microsoft.DotNet.Interactive/FormattedValue.cs
@@ -25,6 +25,8 @@ public class FormattedValue
 
     public string Value { get; }
 
+    public bool SuppressDisplay { get; set; }
+
     public static FormattedValue CreateSingleFromObject(object value, string mimeType = null)
     {
         if (mimeType is null)
@@ -37,17 +39,15 @@ public class FormattedValue
 
     public static IReadOnlyList<FormattedValue> CreateManyFromObject(object value, params string[] mimeTypes)
     {
-        if (mimeTypes is null ||
-            mimeTypes.Length == 0)
+        if (mimeTypes is null || mimeTypes.Length == 0)
         {
             mimeTypes = Formatter.GetPreferredMimeTypesFor(value?.GetType()).ToArray();
         }
 
-        var formattedValues = mimeTypes
-                              .Select(mimeType => new FormattedValue(
-                                          mimeType,
-                                          value.ToDisplayString(mimeType)))
-                              .ToArray();
+        var formattedValues =
+            mimeTypes
+                .Select(mimeType => new FormattedValue(mimeType, value.ToDisplayString(mimeType)))
+                .ToArray();
 
         return formattedValues;
     }

--- a/src/Microsoft.DotNet.Interactive/KernelInvocationContextExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelInvocationContextExtensions.cs
@@ -60,7 +60,7 @@ public static class KernelInvocationContextExtensions
             new DisplayedValueProduced(
                 value,
                 context.Command,
-                new [] { formattedValue },
+                new[] { formattedValue },
                 displayId));
 
         var displayedValue = new DisplayedValue(displayId, mimeType, context);
@@ -101,8 +101,8 @@ public static class KernelInvocationContextExtensions
     }
 
     public static void PublishValueProduced(
-        this KernelInvocationContext context, 
-        RequestValue requestValue, 
+        this KernelInvocationContext context,
+        RequestValue requestValue,
         object value)
     {
         var valueType = value?.GetType();
@@ -115,13 +115,13 @@ public static class KernelInvocationContextExtensions
         formatter.Format(value, writer);
 
         var formatted = new FormattedValue(
-            requestedMimeType, 
+            requestedMimeType,
             writer.ToString());
 
         context.Publish(new ValueProduced(
             value,
             requestValue.Name,
-            formatted, 
+            formatted,
             requestValue));
     }
 }

--- a/src/dotnet-interactive/Pocket/Format.CustomizeLogString.cs
+++ b/src/dotnet-interactive/Pocket/Format.CustomizeLogString.cs
@@ -332,7 +332,7 @@ internal static partial class Format
             return string.Empty;
         }
 
-        var lines = value.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        var lines = value!.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
         var firstLine = lines.FirstOrDefault();
 
         if (string.IsNullOrEmpty(firstLine))

--- a/src/polyglot-notebooks-browser/src/kernel-client-impl.ts
+++ b/src/polyglot-notebooks-browser/src/kernel-client-impl.ts
@@ -93,6 +93,7 @@ class InteractiveConsoleWrapper {
                     {
                         mimeType,
                         value,
+                        suppressDisplay: false
                     }
                 ]
             };

--- a/src/polyglot-notebooks/src/consoleCapture.ts
+++ b/src/polyglot-notebooks/src/consoleCapture.ts
@@ -112,6 +112,7 @@ export class ConsoleCapture implements disposables.Disposable {
                         {
                             mimeType,
                             value,
+                            suppressDisplay: false
                         }
                     ]
                 };

--- a/src/polyglot-notebooks/src/contracts.ts
+++ b/src/polyglot-notebooks/src/contracts.ts
@@ -429,6 +429,7 @@ export enum DocumentSerializationType {
 export interface FormattedValue {
     mimeType: string;
     value: string;
+    suppressDisplay: boolean;
 }
 
 export interface InteractiveDocument {

--- a/src/polyglot-notebooks/src/htmlKernel.ts
+++ b/src/polyglot-notebooks/src/htmlKernel.ts
@@ -36,7 +36,8 @@ export class HtmlKernel extends Kernel {
             const displayedValueProduced: commandsAndEvents.DisplayedValueProduced = {
                 formattedValues: [{
                     mimeType: "text/html",
-                    value: formattedValue
+                    value: formattedValue,
+                    suppressDisplay: false
                 }]
             };
 

--- a/src/polyglot-notebooks/src/javascriptKernel.ts
+++ b/src/polyglot-notebooks/src/javascriptKernel.ts
@@ -150,6 +150,7 @@ export function formatValue(arg: any, mimeType: string): commandsAndEvents.Forma
     return {
         mimeType,
         value,
+        suppressDisplay: false
     };
 }
 


### PR DESCRIPTION
Updates the `HttpRequestKernel` to send leading `DisplayEvent`s with partial information when the complete http response is too slow and / or too large. These leading events are then used to drive progress display to improve end-user perceived performance.