### PR TITLE
Recognize VS as a well known front end

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Telemetry/StartupTelemetryEventBuilder.cs
+++ b/src/Microsoft.DotNet.Interactive.Telemetry/StartupTelemetryEventBuilder.cs
@@ -277,7 +277,8 @@ public sealed class StartupTelemetryEventBuilder
                     return directive.Key;
             }
 
-            if (directive.Key.StartsWith("vs")) // VS also appends the process id to the string.
+            if (directive.Key.StartsWith("vs") &&
+                int.TryParse(directive.Key.Substring(2), out _)) // VS appends the process id after the "vs" prefix.
             {
                 return "vs";
             }

--- a/src/Microsoft.DotNet.Interactive.Telemetry/StartupTelemetryEventBuilder.cs
+++ b/src/Microsoft.DotNet.Interactive.Telemetry/StartupTelemetryEventBuilder.cs
@@ -18,7 +18,7 @@ public sealed class StartupTelemetryEventBuilder
     public StartupTelemetryEventBuilder(Func<string, string> hash)
     {
         _hash = hash ?? throw new ArgumentNullException(nameof(hash));
-     
+
     }
 
     public IEnumerable<TelemetryEvent> GetTelemetryEventsFrom(ParseResult parseResult)
@@ -275,6 +275,11 @@ public sealed class StartupTelemetryEventBuilder
                 case "synapse":
                 case "vscode":
                     return directive.Key;
+            }
+
+            if (directive.Key.StartsWith("vs")) // VS also appends the process id to the string.
+            {
+                return "vs";
             }
         }
 


### PR DESCRIPTION
This will allow us to see usages that originate inside VS within our telemetry dashboards.