### PR TITLE
Always supply operation name when calling OperationLogger and ConfirmationLogger constructors.

### DIFF
--- a/src/Microsoft.DotNet.Interactive/KernelInvocationContext.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelInvocationContext.cs
@@ -40,6 +40,7 @@ public class KernelInvocationContext : IDisposable
     private KernelInvocationContext(KernelCommand command)
     {
         var operation = new OperationLogger(
+            operationName: nameof(KernelInvocationContext),
             args: new object[] { command },
             category: nameof(KernelInvocationContext),
             logOnStart: true);

--- a/src/dotnet-interactive/PackageDirectoryExtensionLoader.cs
+++ b/src/dotnet-interactive/PackageDirectoryExtensionLoader.cs
@@ -47,17 +47,18 @@ internal class PackageDirectoryExtensionLoader
         }
 
         using var op = new ConfirmationLogger(
-            Log.Category,
+            operationName: nameof(LoadFromDirectoryAsync),
+            category: Log.Category,
             message: $"Loading extensions in directory {directory}",
             logOnStart: true,
             args: new object[] { directory });
 
-        await LoadFromDllsInDirectory(
+        await LoadFromDllsInDirectoryAsync(
             directory,
             kernel,
             context);
 
-        await LoadFromExtensionDibScript(
+        await LoadFromExtensionDibScriptAsync(
             directory,
             kernel,
             context);
@@ -65,7 +66,7 @@ internal class PackageDirectoryExtensionLoader
         op.Succeed();
     }
 
-    public async Task LoadFromDllsInDirectory(
+    private async Task LoadFromDllsInDirectoryAsync(
         DirectoryInfo directory,
         Kernel kernel,
         KernelInvocationContext context)
@@ -128,7 +129,7 @@ internal class PackageDirectoryExtensionLoader
         }
     }
 
-    private async Task LoadFromExtensionDibScript(
+    private async Task LoadFromExtensionDibScriptAsync(
         DirectoryInfo directory,
         Kernel kernel,
         KernelInvocationContext context)
@@ -140,7 +141,8 @@ internal class PackageDirectoryExtensionLoader
             var logMessage = $"Loading extension script from `{extensionFile.FullName}`";
 
             using var op = new ConfirmationLogger(
-                Log.Category,
+                operationName: nameof(LoadFromExtensionDibScriptAsync),
+                category: Log.Category,
                 message: logMessage,
                 logOnStart: true,
                 args: new object[] { extensionFile });
@@ -148,6 +150,8 @@ internal class PackageDirectoryExtensionLoader
             context.Display(logMessage);
 
             await kernel.LoadAndRunInteractiveDocument(extensionFile);
+
+            op.Succeed();
         }
     }
 }


### PR DESCRIPTION
Underlying System.Diagnostics.Activity constructor throws a (mostly benign) first-chance ArgumentException (that is handled immediately) when it is passed a null operation name. See https://github.com/dotnet/runtime/blob/main/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs#L445

This commit prevents this exception and makes it impossible to encounter it in the debugger (when first-chance exceptions are tuned on).
