### PR TITLE
fix proxy forwarding of unknown magic commands

### DIFF
--- a/src/Microsoft.DotNet.Interactive/Connection/ProxyKernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Connection/ProxyKernel.cs
@@ -64,6 +64,8 @@ public sealed class ProxyKernel : Kernel
         RegisterForDisposal(subscription);
     }
 
+    internal override bool AcceptsUnknownDirectives => true;
+
     private void UpdateKernelInfoFromEvent(KernelInfoProduced kernelInfoProduced)
     {
         var kernelInfo = kernelInfoProduced.KernelInfo;

--- a/src/Microsoft.DotNet.Interactive/Parsing/SubmissionParser.cs
+++ b/src/Microsoft.DotNet.Interactive/Parsing/SubmissionParser.cs
@@ -117,9 +117,9 @@ public class SubmissionParser
                             }
                             else
                             {
-                                sendExtraDiagnostics = new((c, context) =>
+                                sendExtraDiagnostics = new((_, context) =>
                                 {
-                                    var diagnostic = new Interactive.Diagnostic(
+                                    var diagnostic = new Diagnostic(
                                         adn.GetLinePositionSpan(),
                                         CodeAnalysis.DiagnosticSeverity.Error,
                                         "NI0001", // QUESTION: (SplitSubmission) what code should this be?


### PR DESCRIPTION
This addresses an issue where unknown magic commands are split in the `ProxyKernel`, resulting in an error, even though the remote kernel is able to parse the command.