### PR TITLE
add diagnostics for missing header names or values

### DIFF
--- a/src/Microsoft.DotNet.Interactive.HttpRequest.Tests/ParserTests.Headers.cs
+++ b/src/Microsoft.DotNet.Interactive.HttpRequest.Tests/ParserTests.Headers.cs
@@ -183,5 +183,21 @@ public partial class ParserTests
                          .Which.Message.Should().Be("oops!");
         }
 
+
+        [Fact]
+        public void Missing_header_value_produces_a_diagnostic()
+        {
+            var result = Parse(
+                """
+                GET https://example.com 
+                Accept:
+                """);
+
+            result.SyntaxTree.RootNode.DescendantNodesAndTokens()
+                  .Should().ContainSingle<HttpHeaderNode>()
+                  .Which.GetDiagnostics()
+                  .Should().ContainSingle()
+                  .Which.Message.Should().Be("Missing header value");
+        }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.HttpRequest.Tests/ParserTests.Headers.cs
+++ b/src/Microsoft.DotNet.Interactive.HttpRequest.Tests/ParserTests.Headers.cs
@@ -1,7 +1,6 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Linq;
 using FluentAssertions;
 using Microsoft.DotNet.Interactive.HttpRequest.Tests.Utility;
@@ -183,6 +182,19 @@ public partial class ParserTests
                          .Which.Message.Should().Be("oops!");
         }
 
+        [Fact]
+        public void Missing_header_name_produces_a_diagnostic()
+        {
+            var result = Parse(
+                """
+                GET https://example.com 
+                : {{accept}}
+                """);
+
+            var headerNode = result.SyntaxTree.RootNode.DescendantNodesAndTokens().Should().ContainSingle<HttpHeaderNode>().Which;
+
+            headerNode.GetDiagnostics().Should().ContainSingle().Which.Message.Should().Be("Missing header name");
+        }
 
         [Fact]
         public void Missing_header_value_produces_a_diagnostic()

--- a/src/Microsoft.DotNet.Interactive.HttpRequestParser/HttpHeaderNameNode.cs
+++ b/src/Microsoft.DotNet.Interactive.HttpRequestParser/HttpHeaderNameNode.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.DotNet.Interactive.HttpRequest;
@@ -11,5 +12,18 @@ internal class HttpHeaderNameNode : HttpSyntaxNode
 {
     internal HttpHeaderNameNode(SourceText sourceText, HttpSyntaxTree? syntaxTree) : base(sourceText, syntaxTree)
     {
+    }
+
+    public override IEnumerable<Diagnostic> GetDiagnostics()
+    {
+        foreach (var diagnostic in base.GetDiagnostics())
+        {
+            yield return diagnostic;
+        }
+
+        if (Span.Length == 0)
+        {
+            yield return CreateDiagnostic("Missing header name");
+        }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.HttpRequestParser/HttpHeaderValueNode.cs
+++ b/src/Microsoft.DotNet.Interactive.HttpRequestParser/HttpHeaderValueNode.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.DotNet.Interactive.HttpRequest;
@@ -18,5 +19,18 @@ internal class HttpHeaderValueNode : HttpSyntaxNode
     public HttpBindingResult<string> TryGetValue(HttpBindingDelegate bind)
     {
         return BindByInterpolation(bind);
+    }
+
+    public override IEnumerable<Diagnostic> GetDiagnostics()
+    {
+        foreach (var diagnostic in base.GetDiagnostics())
+        {
+            yield return diagnostic;
+        }
+
+        if (Span.Length == 0)
+        {
+            yield return CreateDiagnostic("Missing header value");
+        }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.HttpRequestParser/HttpRequestNode.cs
+++ b/src/Microsoft.DotNet.Interactive.HttpRequestParser/HttpRequestNode.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #nullable enable

--- a/src/Microsoft.DotNet.Interactive.HttpRequestParser/HttpRequestParser.cs
+++ b/src/Microsoft.DotNet.Interactive.HttpRequestParser/HttpRequestParser.cs
@@ -310,10 +310,14 @@ internal class HttpRequestParser
                 {
                     return token;
                 }
-                else
+                else if (_currentTokenIndex + i == _tokens!.Count)
                 {
                     i++;
                     token = _tokens![_currentTokenIndex + i];
+                }
+                else
+                {
+                    break;
                 }
             }
 
@@ -399,8 +403,7 @@ internal class HttpRequestParser
             HttpHeadersNode? headersNode = null;
 
             while (MoreTokens() &&
-                   CurrentToken.Kind is (HttpTokenKind.Word) &&
-                   !IsRequestSeparator())
+                   (CurrentToken is { Kind: HttpTokenKind.Word } || GetNextSignificantToken() is { Text: ":" }))
             {
                 headersNode ??= new HttpHeadersNode(_sourceText, _syntaxTree);
 
@@ -425,7 +428,7 @@ internal class HttpRequestParser
         {
             var node = new HttpHeaderNameNode(_sourceText, _syntaxTree);
 
-            if (MoreTokens())
+            if (MoreTokens() && CurrentToken.Kind is HttpTokenKind.Word)
             {
                 ParseLeadingTrivia(node);
 

--- a/src/Microsoft.DotNet.Interactive.HttpRequestParser/HttpSyntaxNode.cs
+++ b/src/Microsoft.DotNet.Interactive.HttpRequestParser/HttpSyntaxNode.cs
@@ -67,6 +67,15 @@ internal abstract class HttpSyntaxNode : HttpSyntaxNodeOrToken
         }
         else
         {
+            // if the child span is empty and uninitialized, then set it to the end of the current node's span.
+            if (child.FullSpan is { Start: 0, End: 0 })
+            {
+                if (child is HttpSyntaxNode childNode)
+                {
+                    childNode._fullSpan = new TextSpan(FullSpan.End, 0);
+                }
+            }
+
             var fullSpanStart = Math.Min(_fullSpan.Start, child.FullSpan.Start);
             var fullSpanEnd = Math.Max(_fullSpan.End, child.FullSpan.End);
             _fullSpan = new TextSpan(fullSpanStart, fullSpanEnd - _fullSpan.Start);


### PR DESCRIPTION
This adds diagnostics for missing header names or values.

It also fixes a bug in `HttpSyntaxNode.GrowSpan` when adding a child node with an uninitialized span to a parent node.