### PR TITLE
Fix encoding problem

### DIFF
--- a/src/dotnet-interactive.Tests/StdIoKernelConnectorTests.cs
+++ b/src/dotnet-interactive.Tests/StdIoKernelConnectorTests.cs
@@ -222,6 +222,20 @@ namespace Microsoft.DotNet.Interactive.App.Tests
             HasProcessExited(process).Should().BeTrue();
         }
 
+        [Fact]
+        public async Task encoding_is_preserved()
+        {
+            var connector = CreateConnector();
+            using var rootProxyKernel = await connector.CreateRootProxyKernelAsync();
+            using var csharpProxyKernel = await connector.CreateProxyKernelAsync("csharp");
+
+            var result = await csharpProxyKernel.SendAsync(new SubmitCode("""var x = "abáéíőúűóüÁÉÍŐÚŰÓÜ"; x"""));
+
+            result.Events.OfType<ReturnValueProduced>().Should().ContainSingle()
+                .Which.FormattedValues.Should().ContainSingle()
+                .Which.Value.Should().Be("abáéíőúűóüÁÉÍŐÚŰÓÜ");
+        }
+
         private static bool HasProcessExited(Process process)
         {
             if (process.HasExited)

--- a/src/dotnet-interactive/Connection/StdIoKernelConnector.cs
+++ b/src/dotnet-interactive/Connection/StdIoKernelConnector.cs
@@ -141,15 +141,17 @@ public class StdIoKernelConnector
                                        UpdateRemoteKernelInfoCache(e.KernelInfo);
                                    });
 
+            var writer = new StreamWriter(_process.StandardInput.BaseStream);
             _sender = KernelCommandAndEventSender.FromTextWriter(
-               _process.StandardInput,
+               writer,
                _kernelHostUri);
 
             _refCountDisposable = new RefCountDisposable(new CompositeDisposable
             {
                 SendQuitCommand,
                 KillRemoteKernelProcess,
-                _receiver.Dispose
+                _receiver.Dispose,
+                writer
             });
 
             rootProxyKernel = new ProxyKernel(

--- a/src/dotnet-interactive/Connection/StdIoKernelConnector.cs
+++ b/src/dotnet-interactive/Connection/StdIoKernelConnector.cs
@@ -142,16 +142,13 @@ public class StdIoKernelConnector
                                    });
 
             var writer = new StreamWriter(_process.StandardInput.BaseStream);
-            _sender = KernelCommandAndEventSender.FromTextWriter(
-               writer,
-               _kernelHostUri);
+            _sender = KernelCommandAndEventSender.FromTextWriter(writer, _kernelHostUri);
 
             _refCountDisposable = new RefCountDisposable(new CompositeDisposable
             {
                 SendQuitCommand,
                 KillRemoteKernelProcess,
-                _receiver.Dispose,
-                writer
+                _receiver.Dispose
             });
 
             rootProxyKernel = new ProxyKernel(


### PR DESCRIPTION
`StdioKernelConnector` was using the `Process.StandardInput` `StreamWriter` to talk to kernels running inside the backing dotnet.exe process. The encoding for this `StreamWriter` however defaults to the OS default encoding for consoles. On my machine this is code page 437 - which is different from UTF8 (code page 65001). This meant that code submitted via `SubmitCode` commands ended up arriving mis-encoded in the kernels.

This was only a problem for stdin - we were correctly setting `Process.StandardOutputEncoding` and `Process.StandardErrorEncoding` to `Encoding.UTF8` for the backing dotnet.exe process. But we were not setting `Process.StandardInputEncoding` since this property is only available in *netstandard2.1* and not in *nestandard2.0* (which is what we need for *Microsoft.DotNet.Interactive.VisualStudio*).

The fix is to use a new `StreamWriter` with default encoding (i.e., UTF8 with no BOM) over the same underlying `Process.StandardInput.BaseStream` instead. Also added a test to validate that this works correctly in both *netstandard2.0* and *netstandard2.1*.