### PR TITLE
a couple small API cleanups

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
@@ -179,7 +179,6 @@ Microsoft.DotNet.Interactive
     public System.Threading.Tasks.Task EndInvoke(System.IAsyncResult result)
     public System.Threading.Tasks.Task Invoke(Microsoft.DotNet.Interactive.Commands.KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation next)
   public class KernelCommandResult
-    .ctor(Microsoft.DotNet.Interactive.Commands.KernelCommand command)
     public Microsoft.DotNet.Interactive.Commands.KernelCommand Command { get;}
     public System.Collections.Generic.IReadOnlyList<Microsoft.DotNet.Interactive.Events.KernelEvent> Events { get;}
   public class KernelCommandScheduler : KernelScheduler<Microsoft.DotNet.Interactive.Commands.KernelCommand,KernelCommandResult>, IKernelScheduler<Microsoft.DotNet.Interactive.Commands.KernelCommand,KernelCommandResult>, System.IDisposable
@@ -390,7 +389,6 @@ Microsoft.DotNet.Interactive.Commands
     public System.CommandLine.Parsing.ParseResult KernelChooserParseResult { get;}
     public System.Uri OriginUri { get; set;}
     public KernelCommand Parent { get;}
-    public System.Collections.Generic.IDictionary<System.String,System.Object> Properties { get;}
     public Microsoft.DotNet.Interactive.CommandRoutingSlip RoutingSlip { get;}
     public System.String TargetKernelName { get;}
     public System.Boolean Equals(KernelCommand other)

--- a/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/SerializationTests.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/SerializationTests.cs
@@ -55,8 +55,7 @@ public class SerializationTests
             .Should()
             .BeEquivalentToRespectingRuntimeTypes(
                 originalEnvelope,
-                o => o.Excluding(e => e.Command.Properties)
-                    .Excluding(e => e.Command.Handler));
+                o => o.Excluding(e => e.Command.Handler));
     }
 
     [Theory]
@@ -84,8 +83,7 @@ public class SerializationTests
             .Should()
             .BeEquivalentToRespectingRuntimeTypes(
                 originalEnvelope,
-                o => o.Excluding(envelope => envelope.Event.Command.Properties)
-                    .Excluding(memberInfo => ignoredProperties.Contains($"{memberInfo.DeclaringType.Name}.{memberInfo.Name}"))
+                o => o.Excluding(memberInfo => ignoredProperties.Contains($"{memberInfo.DeclaringType.Name}.{memberInfo.Name}"))
             );
     }
 

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.cs
@@ -55,9 +55,8 @@ public class SerializationTests
             .Should()
             .BeEquivalentToRespectingRuntimeTypes(
                 originalEnvelope,
-                o => o.Excluding(e => e.Command.Properties)
-                    .Excluding(e => e.Command.Handler)
-                    .Excluding(info => ignoredProperties.Contains($"{info.DeclaringType.Name}.{info.Name}")));
+                o => o.Excluding(e => e.Command.Handler)
+                      .Excluding(info => ignoredProperties.Contains($"{info.DeclaringType.Name}.{info.Name}")));
     }
 
     [Theory]
@@ -85,8 +84,7 @@ public class SerializationTests
             .Should()
             .BeEquivalentToRespectingRuntimeTypes(
                 originalEnvelope,
-                o => o.Excluding(envelope => envelope.Event.Command.Properties)
-                    .Excluding(info => ignoredProperties.Contains($"{info.DeclaringType.Name}.{info.Name}")));
+                o => o.Excluding(info => ignoredProperties.Contains($"{info.DeclaringType.Name}.{info.Name}")));
     }
 
     [Theory]

--- a/src/Microsoft.DotNet.Interactive/Commands/KernelCommand.cs
+++ b/src/Microsoft.DotNet.Interactive/Commands/KernelCommand.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.CommandLine.Parsing;
 using System.Threading.Tasks;
 using System.Text.Json.Serialization;
@@ -15,10 +14,8 @@ public abstract class KernelCommand : IEquatable<KernelCommand>
     private KernelCommand _parent;
     private string _token;
 
-    protected KernelCommand(
-        string targetKernelName = null)
+    protected KernelCommand(string targetKernelName = null)
     {
-        Properties = new Dictionary<string, object>(StringComparer.InvariantCultureIgnoreCase);
         TargetKernelName = targetKernelName;
         RoutingSlip = new CommandRoutingSlip();
     }
@@ -51,9 +48,6 @@ public abstract class KernelCommand : IEquatable<KernelCommand>
             throw new InvalidOperationException("Parent cannot be changed.");
         }
     }
-
-    [JsonIgnore]
-    public IDictionary<string, object> Properties { get; }
 
     public string TargetKernelName { get; internal set; }
 

--- a/src/Microsoft.DotNet.Interactive/KernelCommandResult.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelCommandResult.cs
@@ -13,7 +13,7 @@ public class KernelCommandResult
 {
     private readonly List<KernelEvent> _events = new();
 
-    public KernelCommandResult(KernelCommand command)
+    internal KernelCommandResult(KernelCommand command)
     {
         Command = command;
     }


### PR DESCRIPTION
This PR:

* Removes `KernelCommand.Properties`
* Makes the `KernelCommandResult` constructor internal.