### PR TITLE
.NET Interactive extension loads using script boostrapping

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.jupyter_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.jupyter_api_is_not_changed.approved.txt
@@ -50,9 +50,9 @@ Microsoft.DotNet.Interactive.Jupyter
     .ctor(Microsoft.DotNet.Interactive.Kernel kernel, System.Reactive.Concurrency.IScheduler scheduler = null)
     public System.Threading.Tasks.Task Handle(JupyterRequestContext context)
     protected System.Void OnKernelEventReceived(Microsoft.DotNet.Interactive.Events.KernelEvent event, JupyterRequestContext context)
-  public class JupyterClientKernelExtension, Microsoft.DotNet.Interactive.IKernelExtension
+  public class JupyterClientKernelExtension
+    public static System.Threading.Tasks.Task LoadAsync(Microsoft.DotNet.Interactive.Kernel kernel)
     .ctor()
-    public System.Threading.Tasks.Task OnLoadAsync(Microsoft.DotNet.Interactive.Kernel kernel)
   public class JupyterHttpKernelConnectionOptions, Microsoft.DotNet.Interactive.Jupyter.Connection.IJupyterKernelConnectionOptions
     .ctor()
     public System.CommandLine.Option<System.String> TargetUrl { get;}

--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.kql_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.kql_api_is_not_changed.approved.txt
@@ -13,9 +13,9 @@ Microsoft.DotNet.Interactive.Kql
     public System.String Cluster { get; set;}
     public System.String Database { get; set;}
     public System.String Token { get; set;}
-  public class KqlKernelExtension, Microsoft.DotNet.Interactive.IKernelExtension
+  public class KqlKernelExtension
+    public static System.Threading.Tasks.Task LoadAsync(Microsoft.DotNet.Interactive.Kernel kernel)
     .ctor()
-    public System.Threading.Tasks.Task OnLoadAsync(Microsoft.DotNet.Interactive.Kernel kernel)
 Microsoft.DotNet.Interactive.SqlServer
   public class BatchSummary
     .ctor()

--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.mssql_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.mssql_api_is_not_changed.approved.txt
@@ -106,9 +106,9 @@ Microsoft.DotNet.Interactive.SqlServer
     .ctor()
     public ResultMessage Message { get; set;}
     public System.String OwnerUri { get; set;}
-  public class MsSqlKernelExtension, Microsoft.DotNet.Interactive.IKernelExtension
+  public class MsSqlKernelExtension
+    public static System.Threading.Tasks.Task LoadAsync(Microsoft.DotNet.Interactive.Kernel kernel)
     .ctor()
-    public System.Threading.Tasks.Task OnLoadAsync(Microsoft.DotNet.Interactive.Kernel kernel)
   public class Position
     .ctor()
     public System.Int32 Character { get; set;}

--- a/src/Microsoft.DotNet.Interactive.AspNetCore.Tests/AspNetCoreTests.cs
+++ b/src/Microsoft.DotNet.Interactive.AspNetCore.Tests/AspNetCoreTests.cs
@@ -24,7 +24,7 @@ public class AspNetCoreTests : IDisposable
             new CSharpKernel(),
         };
 
-        var loadTask = new AspNetCoreKernelExtension().OnLoadAsync(_kernel);
+        var loadTask = AspNetCoreKernelExtension.LoadAsync(_kernel);
         Assert.Same(Task.CompletedTask, loadTask);
 
         HttpResponseMessageFormattingExtensions.RegisterFormatters();

--- a/src/Microsoft.DotNet.Interactive.AspNetCore/AspNetCoreKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.AspNetCore/AspNetCoreKernelExtension.cs
@@ -6,9 +6,9 @@ using Microsoft.DotNet.Interactive.CSharp;
 
 namespace Microsoft.DotNet.Interactive.AspNetCore;
 
-public class AspNetCoreKernelExtension : IKernelExtension
+public class AspNetCoreKernelExtension
 {
-    public Task OnLoadAsync(Kernel kernel)
+    public static Task LoadAsync(Kernel kernel)
     {
         kernel.VisitSubkernelsAndSelf(kernel =>
         {

--- a/src/Microsoft.DotNet.Interactive.AspNetCore/Microsoft.DotNet.Interactive.AspNetCore.csproj
+++ b/src/Microsoft.DotNet.Interactive.AspNetCore/Microsoft.DotNet.Interactive.AspNetCore.csproj
@@ -14,10 +14,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="$(OutputPath)/Microsoft.DotNet.Interactive.AspNetCore.dll" Pack="true" PackagePath="interactive-extensions/dotnet" />
-  </ItemGroup>
-
-  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
@@ -28,7 +24,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="extension.dib" Pack="true" PackagePath="interactive-extensions/dotnet" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.Interactive.CSharp\Microsoft.DotNet.Interactive.CSharp.csproj" />
+    <ProjectReference Include="..\Microsoft.DotNet.Interactive\Microsoft.DotNet.Interactive.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Interactive.AspNetCore/extension.dib
+++ b/src/Microsoft.DotNet.Interactive.AspNetCore/extension.dib
@@ -1,0 +1,3 @@
+#!csharp
+
+await Microsoft.DotNet.Interactive.AspNetCore.AspNetCoreKernelExtension.LoadAsync(Microsoft.DotNet.Interactive.Kernel.Root);

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/DataFrameKernelExtensionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/DataFrameKernelExtensionTests.cs
@@ -31,9 +31,7 @@ public class DataFrameKernelExtensionTests : IDisposable
     {
         using var kernel = new CompositeKernel();
 
-        var kernelExtension = new DataFrameKernelExtension();
-
-        await kernelExtension.OnLoadAsync(kernel);
+        await DataFrameKernelExtension.LoadAsync(kernel);
 
         var stream = @"id,name,color,deliciousness
 1,apple,green,10

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/DataFrameTypeGeneratorTests.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/DataFrameTypeGeneratorTests.cs
@@ -83,7 +83,7 @@ public class DataFrameTypeGeneratorTests
         var kernel = new CSharpKernel()
             .UseNugetDirective();
 
-        await new DataFrameKernelExtension().OnLoadAsync(kernel);
+        await DataFrameKernelExtension.LoadAsync(kernel);
 
         await kernel.SubmitCodeAsync($@"
 #r ""{typeof(DataFrame).Assembly.Location}""
@@ -120,7 +120,7 @@ using Microsoft.Data.Analysis;
         var kernel = new CSharpKernel()
             .UseNugetDirective();
 
-        await new DataFrameKernelExtension().OnLoadAsync(kernel);
+        await DataFrameKernelExtension.LoadAsync(kernel);
 
         await kernel.SubmitCodeAsync($@"
 #r ""{typeof(DataFrame).Assembly.Location}""
@@ -148,7 +148,7 @@ using Microsoft.Data.Analysis;
         var kernel = new CSharpKernel()
             .UseNugetDirective();
 
-        await new DataFrameKernelExtension().OnLoadAsync(kernel);
+        await DataFrameKernelExtension.LoadAsync(kernel);
 
         await kernel.SubmitCodeAsync($@"
 #r ""{typeof(DataFrame).Assembly.Location}""

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/ExplainCodeExtensionTest.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/ExplainCodeExtensionTest.cs
@@ -22,9 +22,8 @@ public class ExplainCodeExtensionTest
             new CSharpKernel(),
         };
         
-        var extension = new ExplainCodeExtension();
 
-        var executeTask = () => extension.OnLoadAsync(kernel);
+        var executeTask = () => ExplainCodeExtension.LoadAsync(kernel);
         await executeTask.Should().ThrowAsync<KernelException>();
 
     }
@@ -40,7 +39,7 @@ public class ExplainCodeExtensionTest
 
         var events = kernel.KernelEvents.ToSubscribedList();
         var extension = new ExplainCodeExtension();
-        await extension.OnLoadAsync(kernel);
+        await ExplainCodeExtension.LoadAsync(kernel);
 
         await kernel.SendAsync(new SubmitCode(@"
 #!explain

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/InspectTests.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/InspectTests.cs
@@ -21,7 +21,7 @@ public sealed class InspectTests
             new CSharpKernel()
         };
 
-        await new InspectExtension().OnLoadAsync(kernel);
+        await InspectExtension.LoadAsync(kernel);
 
         var submission = @"
 #!inspect
@@ -49,7 +49,7 @@ public class A
             new CSharpKernel()
         };
 
-        await new InspectExtension().OnLoadAsync(kernel);
+        await InspectExtension.LoadAsync(kernel);
 
         var submission = @"
 #!inspect
@@ -90,7 +90,7 @@ public class A
             new CSharpKernel()
         };
 
-        await new InspectExtension().OnLoadAsync(kernel);
+        await InspectExtension.LoadAsync(kernel);
 
         var submission = @"
 #!inspect -c Release -k Regular
@@ -147,7 +147,7 @@ public static class A {
             new CSharpKernel()
         };
 
-        await new InspectExtension().OnLoadAsync(kernel);
+        await InspectExtension.LoadAsync(kernel);
 
         var submission = @$"
 #!inspect -c {configuration}
@@ -190,7 +190,7 @@ public class A
             new CSharpKernel()
         };
 
-        await new InspectExtension().OnLoadAsync(kernel);
+        await InspectExtension.LoadAsync(kernel);
 
         var submission = @$"
 #!inspect -k {kind}
@@ -235,7 +235,7 @@ public class A
             new CSharpKernel()
         };
 
-        await new InspectExtension().OnLoadAsync(kernel);
+        await InspectExtension.LoadAsync(kernel);
 
         var submission = @"
 #!inspect

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/TranscriptTests.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab.Tests/TranscriptTests.cs
@@ -25,7 +25,7 @@ public class TranscriptTests : IDisposable
             new FSharpKernel()
         };
 
-        await new RecordTranscriptExtension().OnLoadAsync(kernel);
+        await RecordTranscriptExtension.LoadAsync(kernel);
 
         var filePath = Path.Combine(
             Directory.GetCurrentDirectory(),

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/DataFrameKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/DataFrameKernelExtension.cs
@@ -21,9 +21,8 @@ using Microsoft.ML;
 
 namespace Microsoft.DotNet.Interactive.ExtensionLab
 {
-    public class DataFrameKernelExtension : IKernelExtension
-    {
-        public Task OnLoadAsync(Kernel rootKernel)
+    public class DataFrameKernelExtension{
+        public static Task LoadAsync(Kernel rootKernel)
         {
             RegisterFormatters();
 
@@ -88,7 +87,7 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
             return Task.CompletedTask;
         }
 
-        private void RegisterFormatters()
+        private static void RegisterFormatters()
         {
             Formatter.Register<IDataView>((dataView, writer) =>
             {
@@ -97,7 +96,7 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
             }, TabularDataResourceFormatter.MimeType);
         }
 
-        public string BuildTypedDataFrameCode(
+        public static string BuildTypedDataFrameCode(
             DataFrame sourceDataFrame,
             string variableName)
         {
@@ -145,7 +144,7 @@ var {variableName} = new {frameTypeName}();
             return sb.ToString();
         }
 
-        private string MakeValidMethodName(string value)
+        private static string MakeValidMethodName(string value)
         {
             value = Regex.Replace(value, @"^[0-9]", "_");
             value = Regex.Replace(value, @"([^a-zA-Z]+)", "_");

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/ExplainCodeExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/ExplainCodeExtension.cs
@@ -8,9 +8,9 @@ using Microsoft.DotNet.Interactive.CSharp;
 
 namespace Microsoft.DotNet.Interactive.ExtensionLab;
 
-public class ExplainCodeExtension : IKernelExtension
+public class ExplainCodeExtension
 {
-    public Task OnLoadAsync(Kernel kernel)
+    public static Task LoadAsync(Kernel kernel)
     {
         var mermaidKernel = kernel
             .FindKernels(k => k.KernelInfo.LanguageName == "Mermaid")

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/InspectExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/InspectExtension.cs
@@ -17,10 +17,10 @@ using static Microsoft.DotNet.Interactive.Formatting.PocketViewTags;
 
 namespace Microsoft.DotNet.Interactive.ExtensionLab;
 
-public class InspectExtension : IKernelExtension
+public class InspectExtension
 {
     private const string InspectCommand = "inspect";
-    public Task OnLoadAsync(Kernel kernel)
+    public static Task LoadAsync(Kernel kernel)
     {
         var inspect = new Command($"#!{InspectCommand}", "Inspect the following code in the submission")
         {
@@ -48,7 +48,7 @@ public class InspectExtension : IKernelExtension
         return Task.CompletedTask;
     }
 
-    private void Inspect(OptimizationLevel configuration, SourceCodeKind kind, Platform platform, KernelInvocationContext context)
+    private static void Inspect(OptimizationLevel configuration, SourceCodeKind kind, Platform platform, KernelInvocationContext context)
     {
         if (context.Command is not SubmitCode command)
         {

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.DotNet.Interactive.ExtensionLab.csproj
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.DotNet.Interactive.ExtensionLab.csproj
@@ -39,10 +39,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="bin\Debug\net7.0\/Microsoft.DotNet.Interactive.ExtensionLab.dll" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Include="extension.dib" Pack="true" PackagePath="interactive-extensions/dotnet" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.DotNet.Interactive.ExtensionLab.csproj
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/Microsoft.DotNet.Interactive.ExtensionLab.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="$(OutputPath)/Microsoft.DotNet.Interactive.ExtensionLab.dll" Pack="true" PackagePath="interactive-extensions/dotnet" />
+    <None Include="extension.dib" Pack="true" PackagePath="interactive-extensions/dotnet" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/RecordTranscriptExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/RecordTranscriptExtension.cs
@@ -11,9 +11,9 @@ using Microsoft.DotNet.Interactive.Connection;
 
 namespace Microsoft.DotNet.Interactive.ExtensionLab;
 
-public class RecordTranscriptExtension : IKernelExtension
+public class RecordTranscriptExtension
 {
-    public Task OnLoadAsync(Kernel kernel)
+    public static Task LoadAsync(Kernel kernel)
     {
         if (kernel is CompositeKernel compositeKernel)
         {

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/extension.dib
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/extension.dib
@@ -1,0 +1,6 @@
+#!csharp
+
+await Microsoft.DotNet.Interactive.ExtensionLab.DataFrameKernelExtension.LoadAsync(Microsoft.DotNet.Interactive.Kernel.Root);
+await Microsoft.DotNet.Interactive.ExtensionLab.ExplainCodeExtension.LoadAsync(Microsoft.DotNet.Interactive.Kernel.Root);
+await Microsoft.DotNet.Interactive.ExtensionLab.InspectExtension.LoadAsync(Microsoft.DotNet.Interactive.Kernel.Root);
+await Microsoft.DotNet.Interactive.ExtensionLab.RecordTranscriptExtension.LoadAsync(Microsoft.DotNet.Interactive.Kernel.Root);

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterRequestHandlerTestBase{T}.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterRequestHandlerTestBase{T}.cs
@@ -52,7 +52,7 @@ public abstract class JupyterRequestHandlerTestBase : IDisposable
             }
             .UseDefaultMagicCommands();
 
-        Task.Run(() => new JupyterClientKernelExtension().OnLoadAsync(_compositeKernel)).Wait(5000);
+        Task.Run(() => JupyterClientKernelExtension.LoadAsync(_compositeKernel)).Wait(5000);
 
         SetKernelLanguage(Language.CSharp);
 

--- a/src/Microsoft.DotNet.Interactive.Jupyter/JupyterClientKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/JupyterClientKernelExtension.cs
@@ -9,9 +9,9 @@ using Microsoft.DotNet.Interactive.PowerShell;
 
 namespace Microsoft.DotNet.Interactive.Jupyter;
 
-public class JupyterClientKernelExtension : IKernelExtension
+public class JupyterClientKernelExtension
 {
-    public Task OnLoadAsync(Kernel kernel)
+    public static  Task LoadAsync(Kernel kernel)
     {
         if (kernel is CompositeKernel root)
         {

--- a/src/Microsoft.DotNet.Interactive.Kql.Tests/KqlConnectionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql.Tests/KqlConnectionTests.cs
@@ -37,8 +37,7 @@ public class KqlConnectionTests : IDisposable
 
         kernel.DefaultKernelName = csharpKernel.Name;
 
-        var kqlKernelExtension = new KqlKernelExtension();
-        await kqlKernelExtension.OnLoadAsync(kernel);
+        await KqlKernelExtension.LoadAsync(kernel);
 
         return kernel;
     }

--- a/src/Microsoft.DotNet.Interactive.Kql/KqlKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql/KqlKernelExtension.cs
@@ -9,9 +9,9 @@ using Microsoft.DotNet.Interactive.Utility;
 
 namespace Microsoft.DotNet.Interactive.Kql;
 
-public class KqlKernelExtension : IKernelExtension
+public class KqlKernelExtension
 {
-    public async Task OnLoadAsync(Kernel kernel)
+    public static async Task LoadAsync(Kernel kernel)
     {
         if (kernel is CompositeKernel compositeKernel)
         {

--- a/src/Microsoft.DotNet.Interactive.Kql/Microsoft.DotNet.Interactive.Kql.csproj
+++ b/src/Microsoft.DotNet.Interactive.Kql/Microsoft.DotNet.Interactive.Kql.csproj
@@ -39,11 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="bin\Debug\$(TargetFramework)\Microsoft.DotNet.Interactive.Kql.dll" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="$(OutputPath)/Microsoft.DotNet.Interactive.Kql.dll" Pack="true" PackagePath="interactive-extensions/dotnet" />
+    <None Include="extension.dib" Pack="true" PackagePath="interactive-extensions/dotnet" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Interactive.Kql/extension.dib
+++ b/src/Microsoft.DotNet.Interactive.Kql/extension.dib
@@ -1,0 +1,3 @@
+#!csharp
+
+await Microsoft.DotNet.Interactive.Kql.KqlKernelExtension.LoadAsync(Microsoft.DotNet.Interactive.Kernel.Root);

--- a/src/Microsoft.DotNet.Interactive.SqlServer.Tests/MsSqlConnectionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer.Tests/MsSqlConnectionTests.cs
@@ -36,8 +36,7 @@ public class MsSqlConnectionTests : IDisposable
 
         kernel.DefaultKernelName = csharpKernel.Name;
 
-        var sqlKernelExtension = new MsSqlKernelExtension();
-        await sqlKernelExtension.OnLoadAsync(kernel);
+        await MsSqlKernelExtension.LoadAsync(kernel);
 
         return kernel;
     }

--- a/src/Microsoft.DotNet.Interactive.SqlServer/Microsoft.DotNet.Interactive.SqlServer.csproj
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/Microsoft.DotNet.Interactive.SqlServer.csproj
@@ -42,11 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="bin\Debug\net7.0\/Microsoft.DotNet.Interactive.SqlServer.dll" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="$(OutputPath)/Microsoft.DotNet.Interactive.SqlServer.dll" Pack="true" PackagePath="interactive-extensions/dotnet" />
+    <None Include="extension.dib" Pack="true" PackagePath="interactive-extensions/dotnet" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelExtension.cs
@@ -8,9 +8,9 @@ using Microsoft.DotNet.Interactive.Utility;
 
 namespace Microsoft.DotNet.Interactive.SqlServer;
 
-public class MsSqlKernelExtension : IKernelExtension
+public class MsSqlKernelExtension
 {
-    public async Task OnLoadAsync(Kernel kernel)
+    public static async Task LoadAsync(Kernel kernel)
     {
         if (kernel is CompositeKernel compositeKernel)
         {

--- a/src/Microsoft.DotNet.Interactive.SqlServer/extension.dib
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/extension.dib
@@ -1,0 +1,3 @@
+#!csharp
+
+await Microsoft.DotNet.Interactive.SqlServer.MsSqlKernelExtension.LoadAsync(Microsoft.DotNet.Interactive.Kernel.Root);

--- a/src/Microsoft.DotNet.Interactive.VSCode/VSCodeClientKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.VSCode/VSCodeClientKernelExtension.cs
@@ -7,9 +7,9 @@ using Microsoft.DotNet.Interactive.Commands;
 
 namespace Microsoft.DotNet.Interactive.VSCode;
 
-public class VSCodeClientKernelExtension : IKernelExtension
+public class VSCodeClientKernelExtension
 {
-    public async Task OnLoadAsync(Kernel kernel)
+    public static async Task LoadAsync(Kernel kernel)
     {
         if (kernel is CompositeKernel root)
         {

--- a/src/dotnet-interactive/CommandLine/CommandLineParser.cs
+++ b/src/dotnet-interactive/CommandLine/CommandLineParser.cs
@@ -216,7 +216,7 @@ public static class CommandLineParser
                 var kernel = CreateKernel(options.DefaultKernel, frontendEnvironment, startupOptions, telemetrySender);
                 cancellationToken.Register(kernel.Dispose);
 
-                await new JupyterClientKernelExtension().OnLoadAsync(kernel);
+                await JupyterClientKernelExtension.LoadAsync(kernel);
 
                 services.AddKernel(kernel);
 
@@ -364,8 +364,7 @@ public static class CommandLineParser
 
                     if (isVSCode)
                     {
-                        var vscodeSetup = new VSCodeClientKernelExtension();
-                        await vscodeSetup.OnLoadAsync(kernel);
+                        await VSCodeClientKernelExtension.LoadAsync(kernel);
                     }
 
                     if (startupOptions.EnableHttpApi)


### PR DESCRIPTION
ExtensionLab, Asp.NET Core, Kql, MSSql extension are now loading using dib script instead of the `IKernelExtension` interface