### PR TITLE
Create a dedicated script for the dotnet portion of the build

### DIFF
--- a/build-dotnet.cmd
+++ b/build-dotnet.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell -noprofile -executionPolicy RemoteSigned -file "%~dp0eng\build.ps1" -noJS -build -restore -binaryLog %*

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -2,6 +2,7 @@
 param (
     [switch]$ci,
     [switch]$noDotnet,
+    [switch]$noJS,
     [switch]$test,
     [Parameter(ValueFromRemainingArguments = $true)][String[]]$arguments
 )
@@ -10,47 +11,49 @@ Set-StrictMode -version 2.0
 $ErrorActionPreference = "Stop"
 
 try {
-    $repoRoot = Resolve-Path "$PSScriptRoot\.."
-    $symlinkDirectories = @(
-        "$repoRoot\src\polyglot-notebooks-browser\src\polyglot-notebooks",
-        "$repoRoot\src\polyglot-notebooks-vscode-common\src\polyglot-notebooks",
-        "$repoRoot\src\polyglot-notebooks-vscode\src\vscode-common",
-        "$repoRoot\src\polyglot-notebooks-vscode\tests\vscode-common-tests",
-        "$repoRoot\src\polyglot-notebooks-vscode-insiders\src\vscode-common",
-        "$repoRoot\src\polyglot-notebooks-vscode-insiders\tests\vscode-common-tests"
-    )
+    if (-Not $noJS) {
+        $repoRoot = Resolve-Path "$PSScriptRoot\.."
+        $symlinkDirectories = @(
+            "$repoRoot\src\polyglot-notebooks-browser\src\polyglot-notebooks",
+            "$repoRoot\src\polyglot-notebooks-vscode-common\src\polyglot-notebooks",
+            "$repoRoot\src\polyglot-notebooks-vscode\src\vscode-common",
+            "$repoRoot\src\polyglot-notebooks-vscode\tests\vscode-common-tests",
+            "$repoRoot\src\polyglot-notebooks-vscode-insiders\src\vscode-common",
+            "$repoRoot\src\polyglot-notebooks-vscode-insiders\tests\vscode-common-tests"
+        )
 
-    foreach ($symlinkDir in $symlinkDirectories) {
-        $candidate = Get-Item $symlinkDir -ErrorAction SilentlyContinue
-        if (($null -eq $candidate) -Or (-Not($candidate.Attributes -match "ReparsePoint"))) {
-            throw "The directory '$symlinkDir' was not a symlink.  Please run the script '$repoRoot\src\ensure-symlinks.ps1' **AS ADMIN**."
+        foreach ($symlinkDir in $symlinkDirectories) {
+            $candidate = Get-Item $symlinkDir -ErrorAction SilentlyContinue
+            if (($null -eq $candidate) -Or (-Not($candidate.Attributes -match "ReparsePoint"))) {
+                throw "The directory '$symlinkDir' was not a symlink.  Please run the script '$repoRoot\src\ensure-symlinks.ps1' **AS ADMIN**."
+            }
         }
-    }
 
-    # build and test NPM
-    $npmDirs = @(
-        "src\polyglot-notebooks",
-        "src\polyglot-notebooks-browser",
-        "src\polyglot-notebooks-ui-components",
-        "src\polyglot-notebooks-vscode",
-        "src\polyglot-notebooks-vscode-insiders"
-        
-    )
-    foreach ($npmDir in $npmDirs) {
-        Push-Location "$repoRoot\$npmDir"
-        Write-Host "Building NPM in directory $npmDir"
-        npm ci
-        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-        npm run compile
-        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-        if ($test) {
-            Write-Host "Testing NPM in directory $npmDir"
-            npm run ciTest
+        # build and test NPM
+        $npmDirs = @(
+            "src\polyglot-notebooks",
+            "src\polyglot-notebooks-browser",
+            "src\polyglot-notebooks-ui-components",
+            "src\polyglot-notebooks-vscode",
+            "src\polyglot-notebooks-vscode-insiders"
+            
+        )
+        foreach ($npmDir in $npmDirs) {
+            Push-Location "$repoRoot\$npmDir"
+            Write-Host "Building NPM in directory $npmDir"
+            npm ci
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-        }
+            npm run compile
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-        Pop-Location
+            if ($test) {
+                Write-Host "Testing NPM in directory $npmDir"
+                npm run ciTest
+                if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+            }
+
+            Pop-Location
+        }
     }
 
     if (-Not $noDotnet) {
@@ -62,7 +65,7 @@ try {
             # CI runs unit tests elsewhere, so only promote the `-test` switch if we're not running CI
             $arguments += '-test'
         }
-
+        
         # invoke regular build/test script
         $buildScript = (Join-Path $PSScriptRoot "common\build.ps1")
         Invoke-Expression "$buildScript -projects ""$PSScriptRoot\..\dotnet-interactive.sln"" $arguments"


### PR DESCRIPTION
Adds a new `build-dotnet.cmd` next to the existing `build-js.cmd`.

This helps save some time when I am testing changes that only impact dotnet side (such as updating dotnet sdk or other arcade settings, or when trying to build NuGet packages locally by passing the `-pack` argument).