### PR TITLE
[feature/dotnet8] Fix race in KernelScheduler

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Tests/DirectiveTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/DirectiveTests.cs
@@ -8,7 +8,6 @@ using System.CommandLine.NamingConventionBinder;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.CSharp;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Formatting;
@@ -215,6 +214,32 @@ i");
 
     [Fact]
     public async Task OnComplete_can_be_used_to_act_on_completion_of_commands()
+    {
+        var onCompleteWasCalled = false;
+        using var kernel = new FakeKernel();
+
+        kernel.AddDirective(new Command("#!wrap")
+        {
+            Handler = CommandHandler.Create((InvocationContext ctx) =>
+            {
+                var c = ctx.GetService<KernelInvocationContext>();
+
+                c.OnComplete(context =>
+                {
+                    onCompleteWasCalled = true;
+                });
+
+                return Task.CompletedTask;
+            })
+        });
+
+        await kernel.SubmitCodeAsync("#!wrap");
+
+        onCompleteWasCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task OnComplete_can_be_used_to_publish_events_before_context_is_completed()
     {
         using var kernel = new FakeKernel();
 

--- a/src/Microsoft.DotNet.Interactive.Tests/DirectiveTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/DirectiveTests.cs
@@ -218,8 +218,6 @@ i");
     {
         using var kernel = new FakeKernel();
 
-        using var events = kernel.KernelEvents.ToSubscribedList();
-
         kernel.AddDirective(new Command("#!wrap")
         {
             Handler = CommandHandler.Create((InvocationContext ctx) =>
@@ -236,9 +234,9 @@ i");
             })
         });
 
-        await kernel.SubmitCodeAsync("#!wrap");
+        var result = await kernel.SubmitCodeAsync("#!wrap");
 
-        events
+        result.Events
             .OfType<DisplayedValueProduced>()
             .Select(e => e.Value)
             .Should()

--- a/src/Microsoft.DotNet.Interactive.Tests/Microsoft.DotNet.Interactive.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.Tests/Microsoft.DotNet.Interactive.Tests.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\dotnet-interactive\Pocket\Format.CustomizeLogString.cs" Link="Pocket\Format.CustomizeLogString.cs" />
     <Compile Include="..\dotnet-interactive\Utility\KernelDiagnostics.cs" Link="Utility\KernelDiagnostics.cs" />
     <Compile Include="..\Microsoft.DotNet.Interactive.CSharpProject\%28Recipes%29\AsyncLazy{T}.cs" Link="Utility\AsyncLazy{T}.cs" />
     <Compile Include="..\Microsoft.DotNet.Interactive.Jupyter\(Recipes)\BareObjectConverter.cs" />

--- a/src/Microsoft.DotNet.Interactive.VisualStudio.Tests/Microsoft.DotNet.Interactive.VisualStudio.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.VisualStudio.Tests/Microsoft.DotNet.Interactive.VisualStudio.Tests.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\dotnet-interactive\Pocket\Format.CustomizeLogString.cs" Link="Pocket\Format.CustomizeLogString.cs" />
     <Compile Include="..\Microsoft.DotNet.Interactive.Tests\Utility\ConnectHost.cs" Link="Utility\ConnectHost.cs" />
     <Compile Include="..\Microsoft.DotNet.Interactive.Tests\Utility\FactSkipLinux.cs" Link="Utility\FactSkipLinux.cs" />
     <Compile Include="..\Microsoft.DotNet.Interactive.Tests\Utility\FactSkipNetFramework.cs" Link="Utility\FactSkipNetFramework.cs" />


### PR DESCRIPTION
`KernelScheduler._currentlyRunningOperation` and / or `KernelScheduler._currentlyRunningTopLevelOperation` (both of which impact the value returned from `KernelScheduler.CurrentValue`) can sometimes point to the command that scheduler was running (instead of having value `null`) even after the `operation.TaskCompletionSource.Task` is complete.

This PR updates the scheduler to always ensure that `KernelScheduler._currentlyRunningOperation` (and
`KernelScheduler._currentlyRunningTopLevelOperation` if applicable) are always reset to `null` right before `operation.TaskCompletionSource.Task` is completed. This in turn ensures that `KernelScheduler.CurrentValue` will always have the value `null` after the task returned from `Kernel.RunAsync()` (i.e. `operation.TaskCompletionSource.Task`) has been awaited.

NOTE: I will port the same fix to `main` once I have validated that the race no longer exists in CI in the `feature/dotnet8` branch (where the race was first encountered).