### PR TITLE
[main] Fix race in KernelScheduler

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Tests/DirectiveTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/DirectiveTests.cs
@@ -8,7 +8,6 @@ using System.CommandLine.NamingConventionBinder;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.CSharp;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Formatting;
@@ -216,9 +215,33 @@ i");
     [Fact]
     public async Task OnComplete_can_be_used_to_act_on_completion_of_commands()
     {
+        var onCompleteWasCalled = false;
         using var kernel = new FakeKernel();
 
-        using var events = kernel.KernelEvents.ToSubscribedList();
+        kernel.AddDirective(new Command("#!wrap")
+        {
+            Handler = CommandHandler.Create((InvocationContext ctx) =>
+            {
+                var c = ctx.GetService<KernelInvocationContext>();
+
+                c.OnComplete(context =>
+                {
+                    onCompleteWasCalled = true;
+                });
+
+                return Task.CompletedTask;
+            })
+        });
+
+        await kernel.SubmitCodeAsync("#!wrap");
+
+        onCompleteWasCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task OnComplete_can_be_used_to_publish_events_before_context_is_completed()
+    {
+        using var kernel = new FakeKernel();
 
         kernel.AddDirective(new Command("#!wrap")
         {
@@ -236,9 +259,9 @@ i");
             })
         });
 
-        await kernel.SubmitCodeAsync("#!wrap");
+        var result = await kernel.SubmitCodeAsync("#!wrap");
 
-        events
+        result.Events
             .OfType<DisplayedValueProduced>()
             .Select(e => e.Value)
             .Should()

--- a/src/Microsoft.DotNet.Interactive.Tests/Microsoft.DotNet.Interactive.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.Tests/Microsoft.DotNet.Interactive.Tests.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\dotnet-interactive\Pocket\Format.CustomizeLogString.cs" Link="Pocket\Format.CustomizeLogString.cs" />
     <Compile Include="..\dotnet-interactive\Utility\KernelDiagnostics.cs" Link="Utility\KernelDiagnostics.cs" />
     <Compile Include="..\Microsoft.DotNet.Interactive.CSharpProject\%28Recipes%29\AsyncLazy{T}.cs" Link="Utility\AsyncLazy{T}.cs" />
     <Compile Include="..\Microsoft.DotNet.Interactive.Jupyter\(Recipes)\BareObjectConverter.cs" />

--- a/src/Microsoft.DotNet.Interactive.VisualStudio.Tests/Microsoft.DotNet.Interactive.VisualStudio.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.VisualStudio.Tests/Microsoft.DotNet.Interactive.VisualStudio.Tests.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\dotnet-interactive\Pocket\Format.CustomizeLogString.cs" Link="Pocket\Format.CustomizeLogString.cs" />
     <Compile Include="..\Microsoft.DotNet.Interactive.Tests\Utility\ConnectHost.cs" Link="Utility\ConnectHost.cs" />
     <Compile Include="..\Microsoft.DotNet.Interactive.Tests\Utility\FactSkipLinux.cs" Link="Utility\FactSkipLinux.cs" />
     <Compile Include="..\Microsoft.DotNet.Interactive.Tests\Utility\FactSkipNetFramework.cs" Link="Utility\FactSkipNetFramework.cs" />


### PR DESCRIPTION
Cherry-picked from #3222 

* Use KernelCommandResult.Events in place of Kernel.Events.

* Fix race.

* Enable more complete logging for commands and events in tests.

* Add a test.