### PR TITLE
Fix bug related to resetting of KernelScheduler._currentlyRunningTopLevelOperation

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
@@ -267,6 +267,7 @@ Microsoft.DotNet.Interactive
     public System.Threading.Tasks.Task Invoke(Microsoft.DotNet.Interactive.Commands.KernelCommand command, KernelInvocationContext context)
   public class KernelScheduler<T,TResult>, IKernelScheduler<T,TResult>, System.IDisposable
     .ctor()
+    public T CurrentValue { get;}
     public System.Void CancelCurrentOperation()
     public System.Void Dispose()
     protected System.Boolean IsChildOperation(T current, T incoming)

--- a/src/Microsoft.DotNet.Interactive.Tests/KernelSchedulerTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/KernelSchedulerTests.cs
@@ -4,10 +4,11 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using FluentAssertions;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Execution;
 using Microsoft.DotNet.Interactive.Tests.Utility;
 using Microsoft.DotNet.Interactive.Utility;
 using Pocket;
@@ -90,7 +91,7 @@ public class KernelSchedulerTests : IDisposable
 
         maxObservedParallelism.Should().Be(1);
     }
-    
+
     public class TestKernelScheduler<T> : KernelScheduler<T, T>
     {
         private readonly Func<T, T, bool> _isChildOperation;
@@ -495,7 +496,7 @@ public class KernelSchedulerTests : IDisposable
                          "inner 2",
                          "outer 2");
     }
-    
+
     [Fact]
     public async Task CurrentValue_reflects_the_work_that_is_in_progress()
     {
@@ -555,6 +556,43 @@ public class KernelSchedulerTests : IDisposable
                 return default;
             });
 
+            return default;
+        });
+
+        scheduler.CurrentValue.Should().BeNull();
+    }
+
+    [Fact(Skip = "Disabled pending https://github.com/dotnet/interactive/issues/3236")]
+    public async Task CurrentValue_reflects_correct_value_within_parent_child_as_well_as_grand_child_operations()
+    {
+        using var scheduler =
+            new TestKernelScheduler<string>(
+                (o, i) => o == "parent" && i == "child" || o == "child" && i == "grandchild" || o == "parent" && i == "grandchild");
+
+        using var _ = new AssertionScope();
+
+        scheduler.CurrentValue.Should().BeNull();
+
+        await scheduler.RunAsync("parent", async _ =>
+        {
+            scheduler.CurrentValue.Should().Be("parent");
+
+            await scheduler.RunAsync("child", async _ =>
+            {
+                scheduler.CurrentValue.Should().Be("child");
+
+                await scheduler.RunAsync("grandchild", async _ =>
+                {
+                    scheduler.CurrentValue.Should().Be("grandchild");
+                    return default;
+                });
+
+                // See https://github.com/dotnet/interactive/issues/3236
+                scheduler.CurrentValue.Should().Be("child");
+                return default;
+            });
+
+            scheduler.CurrentValue.Should().Be("parent");
             return default;
         });
 

--- a/src/Microsoft.DotNet.Interactive/KernelScheduler.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelScheduler.cs
@@ -49,7 +49,7 @@ public class KernelScheduler<T, TResult> : IDisposable, IKernelScheduler<T, TRes
         }
     }
 
-    public T CurrentValue => 
+    public T CurrentValue =>
         (_currentlyRunningOperation ?? _currentlyRunningTopLevelOperation) is { } currentOperation
             ? currentOperation.Value
             : default;

--- a/src/Microsoft.DotNet.Interactive/KernelScheduler.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelScheduler.cs
@@ -44,14 +44,15 @@ public class KernelScheduler<T, TResult> : IDisposable, IKernelScheduler<T, TRes
     {
         if (_currentlyRunningTopLevelOperation is { } operation)
         {
-            operation.TaskCompletionSource.TrySetCanceled(_schedulerDisposalSource.Token);
             _currentlyRunningTopLevelOperation = null;
+            operation.TaskCompletionSource.TrySetCanceled(_schedulerDisposalSource.Token);
         }
     }
 
-    internal T CurrentValue => (_currentlyRunningOperation ?? _currentlyRunningTopLevelOperation) is { } currentOperation
-                                   ? currentOperation.Value
-                                   : default;
+    public T CurrentValue => 
+        (_currentlyRunningOperation ?? _currentlyRunningTopLevelOperation) is { } currentOperation
+            ? currentOperation.Value
+            : default;
 
     public Task<TResult> RunAsync(
         T value,
@@ -182,7 +183,7 @@ public class KernelScheduler<T, TResult> : IDisposable, IKernelScheduler<T, TRes
 
         void ResetCurrentlyRunning()
         {
-            if (ReferenceEquals(_currentlyRunningTopLevelOperation, _currentlyRunningOperation))
+            if (ReferenceEquals(_currentlyRunningTopLevelOperation, operation))
             {
                 _currentlyRunningTopLevelOperation = null;
             }


### PR DESCRIPTION
`_currentlyRunningTopLevelOperation` was not being reset in the case where a top-level operation would schedule child operations. In this case, `_currentlyRunningOperation` was correctly being reset when each child operation was completed. However, when the parent operation was completed, we would fail to reset `_currentlyRunningTopLevelOperation` since we were comparing `_currentlyRunningTopLevelOperation` with the value of `_currentlyRunningOperation` (and `_currentlyRunningOperation` would have a value null because it was reset to null when the child operation was completed above).

The above bug was breaking parenting (and command token assignment) for subsequent commands. Subsequent commands were being incorrectly parented to the stale value reflected in `_currentlyRunningTopLevelOperation`. And this in turn was leading to hangs.

This was an unfortunate regression triggered by #3222 that fixed a race condition. The regression happened because were missing a test for the above scenario. I have included some tests for this as part of the current commit.