### PR TITLE
[feature/dotnet8] Fix bug related to resetting of KernelScheduler._currentlyRunningTopLevelOperation 

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
@@ -267,6 +267,7 @@ Microsoft.DotNet.Interactive
     public System.Threading.Tasks.Task Invoke(Microsoft.DotNet.Interactive.Commands.KernelCommand command, KernelInvocationContext context)
   public class KernelScheduler<T,TResult>, IKernelScheduler<T,TResult>, System.IDisposable
     .ctor()
+    public T CurrentValue { get;}
     public System.Void CancelCurrentOperation()
     public System.Void Dispose()
     protected System.Boolean IsChildOperation(T current, T incoming)

--- a/src/Microsoft.DotNet.Interactive/KernelScheduler.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelScheduler.cs
@@ -44,14 +44,15 @@ public class KernelScheduler<T, TResult> : IDisposable, IKernelScheduler<T, TRes
     {
         if (_currentlyRunningTopLevelOperation is { } operation)
         {
-            operation.TaskCompletionSource.TrySetCanceled(_schedulerDisposalSource.Token);
             _currentlyRunningTopLevelOperation = null;
+            operation.TaskCompletionSource.TrySetCanceled(_schedulerDisposalSource.Token);
         }
     }
 
-    internal T CurrentValue => (_currentlyRunningOperation ?? _currentlyRunningTopLevelOperation) is { } currentOperation
-                                   ? currentOperation.Value
-                                   : default;
+    public T CurrentValue =>
+        (_currentlyRunningOperation ?? _currentlyRunningTopLevelOperation) is { } currentOperation
+            ? currentOperation.Value
+            : default;
 
     public Task<TResult> RunAsync(
         T value,
@@ -182,7 +183,7 @@ public class KernelScheduler<T, TResult> : IDisposable, IKernelScheduler<T, TRes
 
         void ResetCurrentlyRunning()
         {
-            if (ReferenceEquals(_currentlyRunningTopLevelOperation, _currentlyRunningOperation))
+            if (ReferenceEquals(_currentlyRunningTopLevelOperation, operation))
             {
                 _currentlyRunningTopLevelOperation = null;
             }


### PR DESCRIPTION
Cherry-picked from #3235.

`_currentlyRunningTopLevelOperation` was not being reset in the case where a top-level operation would schedule child operations. In this case, `_currentlyRunningOperation` was correctly being reset when each child operation was completed. However, when the parent operation was completed, we would fail to reset `_currentlyRunningTopLevelOperation` since we were comparing `_currentlyRunningTopLevelOperation` with the value of `_currentlyRunningOperation` (and `_currentlyRunningOperation` would have a value null at this point because it was reset to null when the child operation was completed above).

The above bug was breaking parenting (and command token assignment) for subsequent commands. Subsequent commands were being incorrectly parented to the stale value reflected in `_currentlyRunningTopLevelOperation`. And this in turn was leading to hangs.

This was an unfortunate regression triggered by the changes in #3222 that fixed a race condition. The regression happened because were missing tests that exercised the above scenario. I have included some tests for this as part of the current commit.

Also add a skipped test for related issue #3236.