### PR TITLE
Noop languages services commands in Typescript

### DIFF
--- a/src/polyglot-notebooks-vscode-common/src/vscodeNotebookManagement.ts
+++ b/src/polyglot-notebooks-vscode-common/src/vscodeNotebookManagement.ts
@@ -77,7 +77,8 @@ function hashBangConnectPrivate(clientMapper: ClientMapper, hostUri: string, ker
             messageHandlerMap.set(documentUriString, messageHandler);
         }
         let extensionHostToWebviewSender = KernelCommandAndEventSender.FromFunction(envelope => {
-            controllerPostMessage({ envelope: envelope.toJson() });
+            const commandOrEventForWebview = { envelope: envelope.toJson() };
+            controllerPostMessage(commandOrEventForWebview);
         });
 
         let WebviewToExtensionHostReceiver = KernelCommandAndEventReceiver.FromObservable(messageHandler);


### PR DESCRIPTION
If there are no handlers for langauge service commands in typescript the command is immediately completed with no events.

This prevents parenting to commands that are failing