### PR TITLE
amend cursor position decrement logic & create language service command kernel test

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Tests/KernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/KernelTests.cs
@@ -14,7 +14,6 @@ using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Tests.Utility;
 using Xunit;
-using Microsoft.DotNet.Interactive.App;
 
 #if !NETFRAMEWORK
 using Microsoft.DotNet.Interactive.CSharp;
@@ -171,7 +170,7 @@ public partial class KernelTests
     [Fact]
     public async Task language_service_command_with_empty_buffer_doesnt_crash()
     {
-        var kernel = new CompositeKernel() { new CSharpKernel() };
+        using var kernel = new CompositeKernel() { new CSharpKernel() };
 
         var request = new RequestCompletions(
             string.Empty,

--- a/src/Microsoft.DotNet.Interactive.Tests/KernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/KernelTests.cs
@@ -14,6 +14,7 @@ using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Tests.Utility;
 using Xunit;
+using Microsoft.DotNet.Interactive.App;
 
 #if !NETFRAMEWORK
 using Microsoft.DotNet.Interactive.CSharp;
@@ -165,6 +166,30 @@ public partial class KernelTests
 
         var lastEvent = await events;
         lastEvent.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task language_service_command_with_empty_buffer_doesnt_crash()
+    {
+        var kernel = new CompositeKernel() { new CSharpKernel() };
+
+        var request = new RequestCompletions(
+            string.Empty,
+            new LinePosition(0, 0),
+            "csharp");
+
+        bool fail = false;
+
+        try
+        {
+            await kernel.SendAsync(request);
+        }
+        catch
+        {
+            fail = true;
+        }
+
+        fail.Should().BeFalse(because: "there were no unhandled exceptions emitted");
     }
 
 #if !NETFRAMEWORK

--- a/src/Microsoft.DotNet.Interactive.Tests/KernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/KernelTests.cs
@@ -167,6 +167,7 @@ public partial class KernelTests
         lastEvent.Should().BeNull();
     }
 
+#if !NETFRAMEWORK
     [Fact]
     public async Task language_service_command_with_empty_buffer_doesnt_crash()
     {
@@ -191,7 +192,6 @@ public partial class KernelTests
         fail.Should().BeFalse(because: "there were no unhandled exceptions emitted");
     }
 
-#if !NETFRAMEWORK
     [Fact]
     public async Task Awaiting_a_disposed_task_does_not_deadlock()
     {

--- a/src/Microsoft.DotNet.Interactive/Kernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Kernel.cs
@@ -264,7 +264,7 @@ public abstract partial class Kernel :
             adjustedCommand = null;
             // need to return false to notify caller of failure
             // otherwise caller assumes out param is valid ref
-            //return false;
+            return false;
         }
 
         return true;

--- a/src/Microsoft.DotNet.Interactive/Kernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Kernel.cs
@@ -228,13 +228,16 @@ public abstract partial class Kernel :
         var absolutePosition = tree.GetAbsolutePosition(command.LinePosition);
 
         // don't let abs position drop below 0
-        if (absolutePosition >= tree.Length && absolutePosition > 0)
+        if (absolutePosition > 0)
         {
-            absolutePosition--;
-        }
-        else if (char.IsWhiteSpace(rootNode.Text[absolutePosition]))
-        {
-            absolutePosition--;
+            if (absolutePosition >= tree.Length)
+            {
+                absolutePosition--;
+            }
+            else if (char.IsWhiteSpace(rootNode.Text[absolutePosition]))
+            {
+                absolutePosition--;
+            }
         }
 
         if (rootNode.FindNode(absolutePosition) is LanguageNode node)
@@ -261,7 +264,7 @@ public abstract partial class Kernel :
             adjustedCommand = null;
             // need to return false to notify caller of failure
             // otherwise caller assumes out param is valid ref
-            return false;
+            //return false;
         }
 
         return true;


### PR DESCRIPTION
### Changes:
* Refactored the logic around cursor position decrement to skip conditionals altogether if cursor position is at pos 0
* Added a test to catch a kernel crash on submission of a language service command where the cursor position is set to 0 in a 0-length buffer