### PR TITLE
support for collection shuffle

### DIFF
--- a/src/Microsoft.DotNet.Interactive.AIUtilities.Tests/SamplingTest.cs
+++ b/src/Microsoft.DotNet.Interactive.AIUtilities.Tests/SamplingTest.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Xunit;
+
+namespace Microsoft.DotNet.Interactive.AIUtilities.Tests;
+
+public class SamplingTest
+{
+    [Fact]
+    public void can_shuffle_collection()
+    {
+        var src = Enumerable.Range(0, 10);
+        var shuffled = src.RandomOrder().ToArray();
+        shuffled.Should().NotBeInAscendingOrder();
+    }
+
+    [Fact]
+    public void does_not_duplicate_items()
+    {
+        var src = Enumerable.Range(0, 10).ToArray();
+        var shuffled = src.RandomOrder().Distinct().ToArray();
+        shuffled.Should().HaveCount(src.Length);
+    }
+}

--- a/src/Microsoft.DotNet.Interactive.AIUtilities.Tests/SamplingTest.cs
+++ b/src/Microsoft.DotNet.Interactive.AIUtilities.Tests/SamplingTest.cs
@@ -12,7 +12,7 @@ public class SamplingTest
     public void can_shuffle_collection()
     {
         var src = Enumerable.Range(0, 10);
-        var shuffled = src.RandomOrder().ToArray();
+        var shuffled = src.Shuffle().ToArray();
         shuffled.Should().NotBeInAscendingOrder();
     }
 
@@ -20,7 +20,7 @@ public class SamplingTest
     public void does_not_duplicate_items()
     {
         var src = Enumerable.Range(0, 10).ToArray();
-        var shuffled = src.RandomOrder().Distinct().ToArray();
+        var shuffled = src.Shuffle().Distinct().ToArray();
         shuffled.Should().HaveCount(src.Length);
     }
 }

--- a/src/Microsoft.DotNet.Interactive.AIUtilities/Sampling.cs
+++ b/src/Microsoft.DotNet.Interactive.AIUtilities/Sampling.cs
@@ -5,7 +5,7 @@ namespace Microsoft.DotNet.Interactive.AIUtilities;
 
 public static class Sampling
 {
-    public static IEnumerable<T> RandomOrder<T>(this IEnumerable<T> source)
+    public static IEnumerable<T> Shuffle<T>(this IEnumerable<T> source)
     {
         var rnd = new Random();
         var list = new List<T>(source);

--- a/src/Microsoft.DotNet.Interactive.AIUtilities/Sampling.cs
+++ b/src/Microsoft.DotNet.Interactive.AIUtilities/Sampling.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Interactive.AIUtilities;
+
+public static class Sampling
+{
+    public static IEnumerable<T> RandomOrder<T>(this IEnumerable<T> source)
+    {
+        var rnd = new Random();
+        var list = new List<T>(source);
+        while (list.Count > 0)
+        {
+            var pos = rnd.Next(list.Count);
+            var sample = list.ElementAt(pos);
+            list.RemoveAt(pos);
+            yield return sample;
+
+        }
+    }
+}


### PR DESCRIPTION
to go from 
```csharp 
var rnd = new Random(42);

var examples = centroids.Select(c => {
    var embedding = c.GetValues().ToArray();
    var reviews = new LinkedList<DataRow>(foodReviewsData
        .ScoreBySimilarityTo(embedding, new CosineSimilarityComparer<float[]>(v => v), r => r.Embedding )
        .OrderByDescending(e => e.Value)
        .Select(e => e.Key)
        .Take(200));

    var samples = new List<DataRow>();
    for(var i = 0; i < 5; i++)
    {
        var sample = reviews.ElementAt(rnd.Next(reviews.Count));
        samples.Add(sample);
        reviews.Remove(sample);
    }
    return new {
            CenstroidEmbedding = embedding,
            Reviews = samples
            };
    }
).ToArray();
```

to 
```csharp

var examples = centroids.Select(c => {
    var embedding = c.GetValues().ToArray();
    var reviews = new LinkedList<DataRow>(foodReviewsData
        .ScoreBySimilarityTo(embedding, new CosineSimilarityComparer<float[]>(v => v), r => r.Embedding )
        .OrderByDescending(e => e.Value)
        .Select(e => e.Key)
        .Take(200)
        .Shuffle()
        .Take(5));

    return new {
            CenstroidEmbedding = embedding,
            Reviews = examples 
            };
    }
).ToArray();
```

can see more in the PR  [azure-samples/openai#63](https://github.com/Azure-Samples/openai/pull/63)