### PR TITLE
Correctly set `@input` field names when `#!set --name` is used

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Documents.Tests/CodeSubmissionFormatTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Documents.Tests/CodeSubmissionFormatTests.cs
@@ -576,7 +576,9 @@ Console.Write(""hello"");
     [Fact]
     public void Input_tokens_are_parsed_from_dib_files()
     {
-        var dib = "#!value --from-file @input:filename --name myfile";
+        var dib = """
+          #!value --from-file @input:"Enter a filename" --name myfile
+          """;
 
         var document = CodeSubmission.Parse(dib);
 
@@ -586,7 +588,7 @@ Console.Write(""hello"");
                 .Which
                 .ValueName
                 .Should()
-                .Be("filename");
+                .Be("myfile");
     }
 
     [Fact]
@@ -620,6 +622,40 @@ Console.Write(""hello"");
                 .Which
                 .Should()
                 .BeEquivalentTo(new InputField("the-password", "password"));
+    }
+
+    [Fact]
+    public void When_using_set_magic_then_input_field_names_are_set_using_name_option()
+    {
+        var dib = """
+            #!set --name value_name --value @input:"This is the prompt" 
+            """;
+
+        var document = CodeSubmission.Parse(dib);
+
+        document.GetInputFields()
+                .Should()
+                .ContainSingle()
+                .Which
+                .Should()
+                .BeEquivalentTo(new InputField("value_name", "text"));
+    }
+    
+    [Fact]
+    public void When_using_set_magic_then_password_field_names_are_set_using_name_option()
+    {
+        var dib = """
+            #!set --name value_name --value @password:"This is the prompt" 
+            """;
+
+        var document = CodeSubmission.Parse(dib);
+
+        document.GetInputFields()
+                .Should()
+                .ContainSingle()
+                .Which
+                .Should()
+                .BeEquivalentTo(new InputField("value_name", "password"));
     }
 
     private async Task<string> RoundTripDib(string filePath)

--- a/src/Microsoft.DotNet.Interactive.Documents.Tests/JupyterFormatTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Documents.Tests/JupyterFormatTests.cs
@@ -1611,7 +1611,9 @@ public class JupyterFormatTests : DocumentFormatTestsBase
     {
         var ipynbJson = new InteractiveDocument
         {
-            new("#!value --from-file @input:filename --name myfile")
+            new("""
+                #!value --from-file @input:"Enter a filename" --name myfile
+                """)
         }.ToJupyterJson();
 
         var document = Notebook.Parse(ipynbJson);
@@ -1622,7 +1624,7 @@ public class JupyterFormatTests : DocumentFormatTestsBase
                 .Which
                 .ValueName
                 .Should()
-                .Be("filename");
+                .Be("myfile");
     }
 
     private async Task<string> RoundTripIpynb(string filePath)

--- a/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.Variables.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.Variables.cs
@@ -106,8 +106,7 @@ public partial class ParserTests
             var variableNodes = result.SyntaxTree.RootNode.DescendantNodesAndTokens()
                                        .OfType<HttpVariableDeclarationAndAssignmentNode>();
 
-
-            var variableDeclarationNode = variableNodes.Select(v => v.DeclarationNode.VariableName).Should()
+            variableNodes.Select(v => v.DeclarationNode.VariableName).Should()
                 .BeEquivalentSequenceTo(new[] { "hostname", "host" });
 
             variableNodes.Select(e => e.ValueNode.Text).Should().BeEquivalentSequenceTo(new[] { "httpbin.org", "https://{{hostname}}/" });


### PR DESCRIPTION
This fixes #3301.