### PR TITLE
Fixed tpyos, added some instructions, and fixed an AI example.

### DIFF
--- a/samples/notebooks/ai/AI prompt playground.ipynb
+++ b/samples/notebooks/ai/AI prompt playground.ipynb
@@ -77,6 +77,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note: If your deployment names are different, you will need to change `--deployment` from `text-embedding-ada-002` and `gpt-35-turbo-16k` in the lines below:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -309,6 +316,37 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "fb3f1135",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "using Microsoft.DotNet.Interactive;\n",
+    "using Microsoft.DotNet.Interactive.Commands;\n",
+    "using Microsoft.DotNet.Interactive.Events;\n",
+    "\n",
+    "var prompts = new List<string>();\n",
+    "\n",
+    "Kernel.Root.KernelEvents.Subscribe(e =>\n",
+    "{\n",
+    "    if (e is ReturnValueProduced rvp &&\n",
+    "        e.Command.TargetKernelName.Contains(\"chat(text)\") &&\n",
+    "        rvp.FormattedValues.SingleOrDefault(v => v.MimeType == \"text/plain\") is { } plainTextValue)\n",
+    "    {\n",
+    "        prompts.Add(plainTextValue.Value);\n",
+    "    }\n",
+    "});"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "dotnet_interactive": {
      "language": "chat(skill)"
@@ -377,37 +415,6 @@
     "#!use-skills function.image.make_image_prompt function.image.safe function.image.improve \n",
     "\n",
     "A cat flying a red biplane, in the style of Hiyao Miyazaki."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fb3f1135",
-   "metadata": {
-    "dotnet_interactive": {
-     "language": "csharp"
-    },
-    "polyglot_notebook": {
-     "kernelName": "csharp"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "using Microsoft.DotNet.Interactive;\n",
-    "using Microsoft.DotNet.Interactive.Commands;\n",
-    "using Microsoft.DotNet.Interactive.Events;\n",
-    "\n",
-    "var prompts = new List<string>();\n",
-    "\n",
-    "Kernel.Root.KernelEvents.Subscribe(e =>\n",
-    "{\n",
-    "    if (e is ReturnValueProduced rvp &&\n",
-    "        e.Command.TargetKernelName.Contains(\"chat(text)\") &&\n",
-    "        rvp.FormattedValues.SingleOrDefault(v => v.MimeType == \"text/plain\") is { } plainTextValue)\n",
-    "    {\n",
-    "        prompts.Add(plainTextValue.Value);\n",
-    "    }\n",
-    "});"
    ]
   },
   {

--- a/samples/notebooks/ai/Audio processing.ipynb
+++ b/samples/notebooks/ai/Audio processing.ipynb
@@ -77,14 +77,14 @@
    },
    "outputs": [],
    "source": [
-"#r \"nuget:Microsoft.DotNet.Interactive.AI, 1.0.0-beta.23567.4\"\n"
+    "#r \"nuget:Microsoft.DotNet.Interactive.AI, 1.0.0-beta.23567.4\"\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Lading Whisper.net"
+    "## Loading Whisper.net"
    ]
   },
   {

--- a/samples/notebooks/ai/Chat Agent.ipynb
+++ b/samples/notebooks/ai/Chat Agent.ipynb
@@ -30,7 +30,7 @@
    },
    "outputs": [],
    "source": [
-"#r \"nuget:Microsoft.DotNet.Interactive.AI, 1.0.0-beta.23567.4\"\n"
+    "#r \"nuget:Microsoft.DotNet.Interactive.AI, 1.0.0-beta.23567.4\"\n"
    ]
   },
   {
@@ -65,6 +65,13 @@
    "source": [
     "#!value --name endpoint\n",
     "https://your-enpoint.openai.azure.com/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note: If your deployment names are different, you will need to change `--deployment` from `text-embedding-ada-002` and `gpt-35-turbo-16k` in the lines below:"
    ]
   },
   {

--- a/samples/notebooks/ai/E2E.ipynb
+++ b/samples/notebooks/ai/E2E.ipynb
@@ -31,7 +31,7 @@
    },
    "outputs": [],
    "source": [
-"#r \"nuget:Microsoft.DotNet.Interactive.AI, 1.0.0-beta.23567.4\"\n"
+    "#r \"nuget:Microsoft.DotNet.Interactive.AI, 1.0.0-beta.23567.4\"\n"
    ]
   },
   {
@@ -66,6 +66,13 @@
    "source": [
     "#!value --name endpoint\n",
     "https://your-enpoint.openai.azure.com/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note: If your deployment names are different, you will need to change `--deployment` from `text-embedding-ada-002` and `gpt-35-turbo-16k` in the lines below:"
    ]
   },
   {

--- a/samples/notebooks/ai/Knowledge kernel.ipynb
+++ b/samples/notebooks/ai/Knowledge kernel.ipynb
@@ -14,7 +14,7 @@
    },
    "outputs": [],
    "source": [
-"#r \"nuget:Microsoft.DotNet.Interactive.AI, 1.0.0-beta.23567.4\"\n"
+    "#r \"nuget:Microsoft.DotNet.Interactive.AI, 1.0.0-beta.23567.4\"\n"
    ]
   },
   {
@@ -49,6 +49,13 @@
    "source": [
     "#!value --name endpoint\n",
     "https://your-enpoint.openai.azure.com/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note: If your deployment names are different, you will need to change `--deployment` from `text-embedding-ada-002` and `gpt-35-turbo-16k` in the lines below:"
    ]
   },
   {
@@ -445,7 +452,7 @@
    "id": "1b6f4854",
    "metadata": {},
    "source": [
-    "## use the knowlegde to augment prompts (RAG)"
+    "## use the knowledge to augment prompts using Retrieval Augmentation Generation (RAG)"
    ]
   },
   {


### PR DESCRIPTION
I went over the AI samples yesterday and noticed a few tpyos. This commit addresses those.

Additionally, I got tripped up in a few places because I didn't customize the deployment name. Even though the getting started notebook talks about this, I thought it'd be better to add a brief reminder on this where relevant.

Finally, I noticed an error with one of the notebooks where the `prompts.Last` would result in a sequence contains no elements LINQ error with the sequence of cells as currently written. I pulled the cell to track prompts up higher in the notebook so the prompts in that section get added to the list before the `.Last` call is made.

Also, I love these examples and what's possible with Polyglot and AI; this makes it easy to demonstrate / teach AI concepts, semantic kernel, RAG, and general OpenAI integration. Beyond that, though, I think this is now my preferred way of working with DALL-E. Also: kudos to you on the Hello DALL-E reference.