### PR TITLE
Fix input prompt quoting issue

### DIFF
--- a/src/Microsoft.DotNet.Interactive.PowerShell.Tests/Microsoft.DotNet.Interactive.PowerShell.Tests.v3.ncrunchproject
+++ b/src/Microsoft.DotNet.Interactive.PowerShell.Tests/Microsoft.DotNet.Interactive.PowerShell.Tests.v3.ncrunchproject
@@ -29,9 +29,6 @@
       <NamedTestSelector>
         <TestName>Microsoft.DotNet.Interactive.PowerShell.Tests.PowerShellKernelTests.GetCorrectProfilePaths</TestName>
       </NamedTestSelector>
-      <NamedTestSelector>
-        <TestName>Microsoft.DotNet.Interactive.PowerShell.Tests.PowerShellKernelTests.When_code_produces_errors_then_the_command_fails</TestName>
-      </NamedTestSelector>
     </IgnoredTests>
   </Settings>
 </ProjectConfiguration>

--- a/src/Microsoft.DotNet.Interactive.Tests/InputsWithinMagicCommandsTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/InputsWithinMagicCommandsTests.cs
@@ -19,9 +19,13 @@ namespace Microsoft.DotNet.Interactive.Tests;
 public class InputsWithinMagicCommandsTests : IDisposable
 {
     private readonly CompositeKernel kernel;
+
     private RequestInput _receivedRequestInput = null;
+
     private readonly List<string> _receivedUserInput = new();
+
     private readonly Command _shimCommand;
+
     private readonly Queue<string> _responses = new();
 
     public InputsWithinMagicCommandsTests()
@@ -110,7 +114,7 @@ public class InputsWithinMagicCommandsTests : IDisposable
 
         _receivedUserInput.Should().BeEquivalentTo("one", "two");
     }
-    
+
     [Fact]
     public async Task Input_token_in_magic_command_prompts_user_for_password()
     {

--- a/src/Microsoft.DotNet.Interactive.Tests/InputsWithinMagicCommandsTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/InputsWithinMagicCommandsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.CommandLine;
 using System.IO;
 using System.Threading.Tasks;
@@ -10,6 +11,7 @@ using Microsoft.DotNet.Interactive.App;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.CSharp;
 using Microsoft.DotNet.Interactive.Events;
+using Microsoft.DotNet.Interactive.Tests.Utility;
 using Xunit;
 
 namespace Microsoft.DotNet.Interactive.Tests;
@@ -18,8 +20,9 @@ public class InputsWithinMagicCommandsTests : IDisposable
 {
     private readonly CompositeKernel kernel;
     private RequestInput _receivedRequestInput = null;
-    private string _receivedUserInput = null;
+    private readonly List<string> _receivedUserInput = new();
     private readonly Command _shimCommand;
+    private readonly Queue<string> _responses = new();
 
     public InputsWithinMagicCommandsTests()
     {
@@ -28,7 +31,7 @@ public class InputsWithinMagicCommandsTests : IDisposable
         kernel.RegisterCommandHandler<RequestInput>((requestInput, context) =>
         {
             _receivedRequestInput = requestInput;
-            context.Publish(new InputProduced("hello!", requestInput));
+            context.Publish(new InputProduced(_responses.Dequeue(), requestInput));
             return Task.CompletedTask;
         });
 
@@ -41,7 +44,7 @@ public class InputsWithinMagicCommandsTests : IDisposable
         };
         _shimCommand.SetHandler(context =>
         {
-            _receivedUserInput = context.ParseResult.GetValueForOption(stringOption);
+            _receivedUserInput.Add(context.ParseResult.GetValueForOption(stringOption));
         });
 
         kernel.FindKernelByName("csharp").AddDirective(_shimCommand);
@@ -85,13 +88,29 @@ public class InputsWithinMagicCommandsTests : IDisposable
     }
 
     [Fact]
-    public async Task Input_token_in_magic_command_prompts_user_passes_user_input_to_directive__to_handler()
+    public async Task Input_token_in_magic_command_prompts_user_passes_user_input_to_directive_to_handler()
     {
+        _responses.Enqueue("one");
+
         await kernel.SendAsync(new SubmitCode("#!shim --string @input:input-please", "csharp"));
 
-        _receivedUserInput.Should().Be("hello!");
+        _receivedUserInput.Should().ContainSingle().Which.Should().Be("one");
     }
 
+    [Fact]
+    public async Task Input_token_in_magic_command_prompts_user_passes_user_input_to_directive_to_handler_when_there_are_multiple_inputs()
+    {
+        _responses.Enqueue("one");
+        _responses.Enqueue("two");
+
+        await kernel.SendAsync(new SubmitCode("""
+            #!shim --string @input:input-please
+            #!shim --string @input:input-please
+            """, "csharp"));
+
+        _receivedUserInput.Should().BeEquivalentTo("one", "two");
+    }
+    
     [Fact]
     public async Task Input_token_in_magic_command_prompts_user_for_password()
     {
@@ -126,6 +145,48 @@ public class InputsWithinMagicCommandsTests : IDisposable
         await kernel.SendAsync(new SubmitCode("#!shim --file @input:file-please\n// some more stuff", "csharp"));
 
         _receivedRequestInput.InputTypeHint.Should().Be("text");
+    }
+
+    [Fact]
+    public async Task multiple_set_commands_with_inputs_can_be_used_in_single_submission()
+    {
+        using var kernel = new CompositeKernel
+        {
+            new CSharpKernel().UseValueSharing()
+        };
+
+        var responses = new Queue<string>();
+        responses.Enqueue("one");
+        responses.Enqueue("two");
+        responses.Enqueue("three");
+
+        kernel.RegisterCommandHandler<RequestInput>((requestInput, context) =>
+        {
+            context.Publish(new InputProduced(responses.Dequeue(), requestInput));
+            return Task.CompletedTask;
+        });
+
+        var result = await kernel.SendAsync(new SubmitCode("""
+                #!set --name value1 --value @input:input-please 
+                #!set --name value2 --value @input:input-please 
+                #!set --name value3 --value @input:input-please
+                """, targetKernelName: "csharp"));
+
+        result.Events.Should().NotContainErrors();
+
+        var csharpKernel = (CSharpKernel)kernel.FindKernelByName("csharp");
+
+        csharpKernel.TryGetValue("value1", out object value1)
+                    .Should().BeTrue();
+        value1.Should().Be("one");
+
+        csharpKernel.TryGetValue("value2", out object value2)
+                    .Should().BeTrue();
+        value2.Should().Be("two");
+
+        csharpKernel.TryGetValue("value3", out object value3)
+                    .Should().BeTrue();
+        value3.Should().Be("three");
     }
 
     private static CompositeKernel CreateKernel() =>

--- a/src/Microsoft.DotNet.Interactive.Tests/Microsoft.DotNet.Interactive.Tests.v3.ncrunchproject
+++ b/src/Microsoft.DotNet.Interactive.Tests/Microsoft.DotNet.Interactive.Tests.v3.ncrunchproject
@@ -12,6 +12,9 @@
       <FixtureTestSelector>
         <FixtureName>Microsoft.DotNet.Interactive.Tests.LanguageKernelPackageTests</FixtureName>
       </FixtureTestSelector>
+      <FixtureTestSelector>
+        <FixtureName>Microsoft.DotNet.Interactive.Tests.StdIoKernelConnectorTests</FixtureName>
+      </FixtureTestSelector>
     </IgnoredTests>
   </Settings>
 </ProjectConfiguration>

--- a/src/Microsoft.DotNet.Interactive/KernelScheduler.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelScheduler.cs
@@ -96,7 +96,7 @@ public class KernelScheduler<T, TResult> : IDisposable, IKernelScheduler<T, TRes
 
     internal async Task IdleAsync()
     {
-        if (_currentlyRunningTopLevelOperation is { } currentlyRunning && !currentlyRunning.IsCompleted)
+        if (_currentlyRunningTopLevelOperation is { IsCompleted: false } currentlyRunning)
         {
             await currentlyRunning.TaskCompletionSource.Task;
         }

--- a/src/Microsoft.DotNet.Interactive/Parsing/SubmissionParser.cs
+++ b/src/Microsoft.DotNet.Interactive/Parsing/SubmissionParser.cs
@@ -551,7 +551,7 @@ public class SubmissionParser
                 rawTokenText = rawTokenTextPlusRawTrailingText;
             }
 
-            bool persistent = false;
+            // FIX: (InterpolateValueFromKernel)    bool persistent = false;
 
             foreach (var annotation in ParseInputProperties(rawTokenText))
             {
@@ -564,7 +564,7 @@ public class SubmissionParser
                         valueName ??= annotation.value;
                         break;
                     case "save":
-                        persistent = true;
+                        // FIX: (InterpolateValueFromKernel) persistent = true;
                         break;
                     case "type":
                         typeHint = annotation.value;

--- a/src/Microsoft.DotNet.Interactive/PasswordString.cs
+++ b/src/Microsoft.DotNet.Interactive/PasswordString.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.DotNet.Interactive.Formatting;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.DotNet.Interactive;

--- a/src/dotnet-interactive/KernelExtensionLoader.cs
+++ b/src/dotnet-interactive/KernelExtensionLoader.cs
@@ -3,15 +3,12 @@
 
 using System;
 using System.Collections.Concurrent;    
-using System.Collections.Generic;
 using System.IO;
 using System.Reactive.Linq;
-using System.Reflection;
 using System.Runtime.Loader;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Telemetry;
-using Pocket;
 
 namespace Microsoft.DotNet.Interactive.App;
 


### PR DESCRIPTION
This fixes a couple of issues:

* Type hints weren't correctly inferred when input prompts weren't in quotes. 
* Multiple `#!set` commands with `@input` tokens in a single submission were all getting the same value.

There's also some work here refactoring toward #3323 but the design is just a sketch and will be refactored toward a more ergonomic syntax. (See the discussion [here](https://github.com/dotnet/interactive/issues/3323#issuecomment-1836439383).

