### PR TITLE
Fix StdIoKernelConnectorTests

### DIFF
--- a/src/Microsoft.DotNet.Interactive.NetFramework.Tests/Microsoft.DotNet.Interactive.NetFramework.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.NetFramework.Tests/Microsoft.DotNet.Interactive.NetFramework.Tests.csproj
@@ -33,6 +33,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="..\Microsoft.DotNet.Interactive.Tests\xunit.runner.json" Link="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.8.0" />
     <PackageReference Include="Pocket.Disposable" Version="1.1.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Microsoft.DotNet.Interactive.Tests/Microsoft.DotNet.Interactive.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.Tests/Microsoft.DotNet.Interactive.Tests.csproj
@@ -82,6 +82,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Update="xunit.runner.visualstudio" Version="$(xunitrunnervisualstudioVersion)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Microsoft.DotNet.Interactive.Tests/StdIoKernelConnectorTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/StdIoKernelConnectorTests.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -25,28 +26,28 @@ namespace Microsoft.DotNet.Interactive.Tests
                 loggingArgs = $"--verbose --log-path {logDir}";
             }
 
-            var toolAppDllPath = typeof(StdIoKernelConnector).Assembly.Location;
+            var currentAssemblyPath = Assembly.GetExecutingAssembly().Location;
+            var currentAssemblyProjectName = Path.GetFileNameWithoutExtension(currentAssemblyPath);
+            var currentAssemblyName = Path.GetFileName(currentAssemblyPath);
 
-            if (Environment.GetEnvironmentVariable("DisableArcade") != "1")
-            {
-                var arcadeAssemblyLocation =
-                    Path.GetDirectoryName(
-                        Path.GetDirectoryName(
-                            Path.GetDirectoryName(
-                                Path.GetDirectoryName(
-                                    toolAppDllPath))));
+            // Go from current test assembly path to the location of Microsoft.DotNet.Interactive.App.dll.
+            //
+            // When arcade is disabled:
+            // D:\interactive\src\Microsoft.DotNet.Interactive.NetFramework.Tests\bin\Debug\net472\Microsoft.DotNet.Interactive.NetFramework.Tests.dll ->
+            //     D:\interactive\src\dotnet-interactive\bin\debug\net8.0\Microsoft.DotNet.Interactive.App.dll.
+            // D:\interactive\src\Microsoft.DotNet.Interactive.Tests\bin\Debug\net8.0\Microsoft.DotNet.Interactive.Tests.dll ->
+            //     D:\interactive\src\dotnet-interactive\bin\debug\net8.0\Microsoft.DotNet.Interactive.App.dll.
+            //
+            // When arcade is enabled:
+            // D:\interactive2\artifacts\bin\Microsoft.DotNet.Interactive.NetFramework.Tests\Debug\net472\Microsoft.DotNet.Interactive.NetFramework.Tests.dll ->
+            //     D:\interactive\artifacts\bin\dotnet-interactive\Debug\net8.0\Microsoft.DotNet.Interactive.App.dll.
+            // D:\interactive2\artifacts\bin\Microsoft.DotNet.Interactive.Tests\Debug\net8.0\Microsoft.DotNet.Interactive.Tests.dll ->
+            //     D:\interactive\artifacts\bin\dotnet-interactive\Debug\net8.0\Microsoft.DotNet.Interactive.App.dll.
 
-                toolAppDllPath =
-                    Directory.GetFiles(
-                                 Path.Combine(arcadeAssemblyLocation, "dotnet-interactive"),
-                                 "Microsoft.DotNet.Interactive.App.dll",
-                                 SearchOption.AllDirectories)
-                             .Single(filePath =>
-                                         !string.Equals(
-                                             Path.GetFileName(Path.GetDirectoryName(filePath)),
-                                             "publish",
-                                             StringComparison.OrdinalIgnoreCase));
-            }
+            var toolAppDllPath =
+                currentAssemblyPath.Replace(currentAssemblyName, "Microsoft.DotNet.Interactive.App.dll");
+            toolAppDllPath = toolAppDllPath.Replace(currentAssemblyProjectName, "dotnet-interactive");
+            toolAppDllPath = toolAppDllPath.Replace("net472", "net8.0");
 
             var hostUri = KernelHost.CreateHostUri("host");
             var connector = new StdIoKernelConnector(

--- a/src/Microsoft.DotNet.Interactive.Tests/xunit.runner.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+	"shadowCopy": false
+}


### PR DESCRIPTION
The tests were still assuming that `StdIoKernelConnector` type still lives in the `Microsoft.DotNet.Interactive.App.dll`. The type was recently moved into the core assembly (and we plan to relayer it to a different assembly in the future).

Also explicitly disable xUnit shadow copy for these tests. Shadow copy is disabled automatically when arcade is enabled - with this change we also disable it when arcade is disabled. This is required because `StdIoKernelConnectorTests` rely on being run from a predictable output path so that they can find the location of `Microsoft.DotNet.Interactive.App.dll` to launch the dotnet-interactive tool at runtime.

I have validated that the tests pass both with and without arcade after the changes in the current PR. I have not validated against NCrunch though.
