### PR TITLE
Fix devcontainer dotnet image tag

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,8 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.205.2/containers/dotnet/.devcontainer/base.Dockerfile
 
 # [Choice] .NET version: 6.0, 5.0, 3.1, 6.0-bullseye, 5.0-bullseye, 3.1-bullseye, 6.0-focal, 5.0-focal, 3.1-focal
-ARG VARIANT="6.0-bullseye-slim"
-FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
+ARG VARIANT="1-8.0-bookworm-slim"
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:${VARIANT}
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 
 # [Choice] .NET version: 6.0, 5.0, 3.1, 6.0-bullseye, 5.0-bullseye, 3.1-bullseye, 6.0-focal, 5.0-focal, 3.1-focal
 ARG VARIANT="1-8.0-bookworm-slim"
-FROM mcr.microsoft.com/vscode/devcontainers/dotnet:${VARIANT}
+FROM mcr.microsoft.com/devcontainers/dotnet:${VARIANT}
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     "args": {
       // Update 'VARIANT' to pick a .NET Core version: 3.1, 5.0, 6.0
       // Append -bullseye or -focal to pin to an OS version.
-      "VARIANT": "8.0",
+      "VARIANT": "1-8.0-bookworm-slim",
       // Options
       "NODE_VERSION": "16"
     }


### PR DESCRIPTION
I want to pick up two mini-projects with dotnet interactive, namely support for F# 8.0 and Postgresql support #1968. My first test was to start up a the devcontainer and build the project, which failed because [the registry doesn't contain a `devcontainer/dotnet` image with tag `0-8.0`](https://mcr.microsoft.com/en-us/product/devcontainers/dotnet/tags).

This PR changes both default tag in the Dockerfile and `devcontainer.json` file to `1-8.0-bookworm-slim`, and for the `VARIANT` arg in the Dockerfile not to have the implicit prefix `0-.*`.

I had two other problems in my test, one related to VSCode not correctly handling the `.devcontainer.json` file which I was able to fix by adding an `initializeCommand` (see https://github.com/microsoft/vscode-remote-release/issues/9302#issuecomment-1859139566) and the FSharp.Core.xml file couldn't be found in the NuGet cache (cleaning the cache didn't fix the issue but manually writing the file did), I don't think either issue requires a fix in the repo.