### PR TITLE
[Telemetry] Remove process id suffix from command line directive for VS

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Telemetry/StartupTelemetryEventBuilder.cs
+++ b/src/Microsoft.DotNet.Interactive.Telemetry/StartupTelemetryEventBuilder.cs
@@ -274,13 +274,8 @@ public sealed class StartupTelemetryEventBuilder
                 case "jupyter":
                 case "synapse":
                 case "vscode":
+                case "vs":
                     return directive.Key;
-            }
-
-            if (directive.Key.StartsWith("vs") &&
-                int.TryParse(directive.Key.Substring(2), out _)) // VS appends the process id after the "vs" prefix.
-            {
-                return "vs";
             }
         }
 

--- a/src/dotnet-interactive.Tests/CommandLine/StartupTelemetryTests.cs
+++ b/src/dotnet-interactive.Tests/CommandLine/StartupTelemetryTests.cs
@@ -244,7 +244,7 @@ public class StartupTelemetryTests : IDisposable
     {
         await _parser.InvokeAsync(
             """
-            [vs9628] stdio --working-dir D:\Notebooks --kernel-host 9628-5c7e913f-8966-4afe-8d37-cc863292a352
+            [vs] stdio --working-dir D:\Notebooks --kernel-host 9628-5c7e913f-8966-4afe-8d37-cc863292a352
             """,
             _console);
 

--- a/src/dotnet-interactive/dotnet-interactive.csproj
+++ b/src/dotnet-interactive/dotnet-interactive.csproj
@@ -161,6 +161,10 @@
     <Folder Include="Http\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <LiveUnitTestingTestDependency Include="$(OutputPath)" />
+  </ItemGroup>
+
   <Target Name="CopyKernelSpecificFiles" DependsOnTargets="PrepareKernels;CopyLogoFiles">
     <CreateItem Include="%(KernelFolders.Identity)/**/*.json" AdditionalMetadata="Destination=$([System.IO.Path]::GetFileName(%(KernelFolders.Identity)))">
       <Output TaskParameter="Include" ItemName="KernelSpecificJsonFiles" />


### PR DESCRIPTION
The process id suffix was included in the directive so that it is easy to figure out which parent VS (devenv.exe) process started the dotnet.exe for a particular instance of the tool by looking at the command line arguments that were used to launch it (to make local debugging easier).

However, I realized that I was already including the VS process id as a prefix as part of the `kernelhostUri` supplied to `StdIoKernelConnector` constructor on the VS side. And this URI is already available on the dotnet.exe tool command line via a --`kernel-host` command line argument (see example command line in the unit test that is being fixed in this PR). This makes the suffix in the directive redundant, and I decided to remove it to make the `frontend` telemetry computation for VS identical with the other hosts.

Note: I don't think this fixes the missing telemetry issue that I am investigating - that is still a mystery. However, it makes sense to align VS with the other hosts here. I'll fix up the VS side when I consume this PR in the internal repo.

The PR also includes a minor Live Unit Testing specific configuration change that allows the `StdIoKernelConnectorTests` to pass when running under Live Unit Testing.