### PR TITLE
SubmitCode can specify mimetype to use in trainiling expression formatting

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
@@ -446,8 +446,9 @@ Microsoft.DotNet.Interactive.Commands
     public System.String Name { get;}
     public System.Object Value { get;}
   public class SubmitCode : KernelCommand, System.IEquatable<KernelCommand>
-    .ctor(System.String code, System.String targetKernelName = null)
+    .ctor(System.String code, System.String targetKernelName = null, System.String[] mimeTypes = null)
     public System.String Code { get;}
+    public System.String[] MimeTypes { get;}
     public System.String ToString()
   public class UpdateDisplayedValue : KernelCommand, System.IEquatable<KernelCommand>
     .ctor(Microsoft.DotNet.Interactive.FormattedValue formattedValue, System.String valueId)

--- a/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
@@ -336,7 +336,7 @@ public class CSharpKernel :
             {
                 if (ScriptState is not null && HasReturnValue)
                 {
-                    var formattedValues = FormattedValue.CreateManyFromObject(ScriptState.ReturnValue);
+                    var formattedValues = FormattedValue.CreateManyFromObject(ScriptState.ReturnValue, submitCode.MimeTypes);
                     context.Publish(
                         new ReturnValueProduced(
                             ScriptState.ReturnValue,

--- a/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
@@ -216,7 +216,7 @@ type FSharpKernel () as this =
                 match result with
                 | Some(value) when value.ReflectionType <> typeof<unit> ->
                     let value = value.ReflectionValue
-                    let formattedValues = FormattedValue.CreateManyFromObject(value)
+                    let formattedValues = FormattedValue.CreateManyFromObject(value, codeSubmission.MimeTypes)
                     context.Publish(ReturnValueProduced(value, codeSubmission, formattedValues))
                 | Some _
                 | None -> ()

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Command_contract_has_not_been_broken.approved.SubmitCode.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Command_contract_has_not_been_broken.approved.SubmitCode.json
@@ -2,6 +2,7 @@
   "token": "the-token",
   "commandType": "SubmitCode",
   "command": {
+    "mimeTypes": null,
     "code": "123",
     "targetKernelName": "csharp",
     "originUri": null,

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.CodeSubmissionReceived.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.CodeSubmissionReceived.json
@@ -7,6 +7,7 @@
     "token": "the-token",
     "commandType": "SubmitCode",
     "command": {
+      "mimeTypes": null,
       "code": "123",
       "targetKernelName": null,
       "originUri": null,

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.CommandFailed.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.CommandFailed.json
@@ -8,6 +8,7 @@
     "token": "the-token",
     "commandType": "SubmitCode",
     "command": {
+      "mimeTypes": null,
       "code": "123",
       "targetKernelName": null,
       "originUri": null,

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.CommandSucceeded.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.CommandSucceeded.json
@@ -7,6 +7,7 @@
     "token": "the-token",
     "commandType": "SubmitCode",
     "command": {
+      "mimeTypes": null,
       "code": "123",
       "targetKernelName": null,
       "originUri": null,

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.CompleteCodeSubmissionReceived.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.CompleteCodeSubmissionReceived.json
@@ -7,6 +7,7 @@
     "token": "the-token",
     "commandType": "SubmitCode",
     "command": {
+      "mimeTypes": null,
       "code": "123",
       "targetKernelName": null,
       "originUri": null,

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.DiagnosticsProduced.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.DiagnosticsProduced.json
@@ -24,6 +24,7 @@
     "token": "the-token",
     "commandType": "SubmitCode",
     "command": {
+      "mimeTypes": null,
       "code": "123",
       "targetKernelName": null,
       "originUri": null,

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.DisplayedValueProduced.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.DisplayedValueProduced.json
@@ -14,6 +14,7 @@
     "token": "the-token",
     "commandType": "SubmitCode",
     "command": {
+      "mimeTypes": null,
       "code": "b(\"hi!\")",
       "targetKernelName": "csharp",
       "originUri": null,

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.DisplayedValueUpdated.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.DisplayedValueUpdated.json
@@ -14,6 +14,7 @@
     "token": "the-token",
     "commandType": "SubmitCode",
     "command": {
+      "mimeTypes": null,
       "code": "b(\"hi!\")",
       "targetKernelName": "csharp",
       "originUri": null,

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.ErrorProduced.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.ErrorProduced.json
@@ -9,6 +9,7 @@
     "token": "the-token",
     "commandType": "SubmitCode",
     "command": {
+      "mimeTypes": null,
       "code": "123",
       "targetKernelName": null,
       "originUri": null,

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.IncompleteCodeSubmissionReceived.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.IncompleteCodeSubmissionReceived.json
@@ -5,6 +5,7 @@
     "token": "the-token",
     "commandType": "SubmitCode",
     "command": {
+      "mimeTypes": null,
       "code": "123",
       "targetKernelName": null,
       "originUri": null,

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.KernelExtensionLoaded.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.KernelExtensionLoaded.json
@@ -5,6 +5,7 @@
     "token": "the-token",
     "commandType": "SubmitCode",
     "command": {
+      "mimeTypes": null,
       "code": "#r \"nuget:package\" ",
       "targetKernelName": null,
       "originUri": null,

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.PackageAdded.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.PackageAdded.json
@@ -19,6 +19,7 @@
     "token": "the-token",
     "commandType": "SubmitCode",
     "command": {
+      "mimeTypes": null,
       "code": "#r \"nuget:ThePackage,1.2.3\"",
       "targetKernelName": null,
       "originUri": null,

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.ReturnValueProduced.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.ReturnValueProduced.json
@@ -14,6 +14,7 @@
     "token": "the-token",
     "commandType": "SubmitCode",
     "command": {
+      "mimeTypes": null,
       "code": "b(\"hi!\")",
       "targetKernelName": "csharp",
       "originUri": null,

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.StandardErrorValueProduced.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.StandardErrorValueProduced.json
@@ -14,6 +14,7 @@
     "token": "the-token",
     "commandType": "SubmitCode",
     "command": {
+      "mimeTypes": null,
       "code": "123",
       "targetKernelName": null,
       "originUri": null,

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.StandardOutputValueProduced.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.StandardOutputValueProduced.json
@@ -14,6 +14,7 @@
     "token": "the-token",
     "commandType": "SubmitCode",
     "command": {
+      "mimeTypes": null,
       "code": "Console.Write(123);",
       "targetKernelName": "csharp",
       "originUri": null,

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
@@ -865,6 +865,23 @@ $${languageSpecificCode}
             .Be(25);
     }
 
+    [Theory]
+    [InlineData(Language.CSharp, "20")]
+    [InlineData(Language.FSharp, "20")]
+    [InlineData(Language.CSharp, "new int[] {1,2,3}")]
+    [InlineData(Language.FSharp, "[|1;2;3|]")]
+    public async Task it_returns_a_result_with_specified_mimetype(Language language, string expression)
+    {
+        var kernel = CreateKernel(language);
+
+        var command = new SubmitCode(expression, mimeTypes: new []{JsonFormatter.MimeType});
+        await kernel.SendAsync(command);
+
+        var returnedValue =  KernelEvents.Should().ContainSingle<ReturnValueProduced>().Which;
+
+        returnedValue.FormattedValues.Should().ContainSingle(f => f.MimeType == JsonFormatter.MimeType);
+    }
+
 
     [Theory]
     [InlineData(Language.CSharp)]

--- a/src/Microsoft.DotNet.Interactive/Commands/SubmitCode.cs
+++ b/src/Microsoft.DotNet.Interactive/Commands/SubmitCode.cs
@@ -10,11 +10,15 @@ public class SubmitCode : KernelCommand
 {
     public SubmitCode(
         string code,
-        string targetKernelName = null) : base(targetKernelName)
+        string targetKernelName = null,
+        string[] mimeTypes = null) : base(targetKernelName)
     {
         Code = code ?? throw new ArgumentNullException(nameof(code));
+        MimeTypes = mimeTypes;
     }
-      
+
+    public string[] MimeTypes { get; }
+
     internal SubmitCode(
         LanguageNode languageNode,
         KernelNameDirectiveNode kernelNameDirectiveNode = null)

--- a/src/interface-generator/InterfaceGenerator.cs
+++ b/src/interface-generator/InterfaceGenerator.cs
@@ -64,6 +64,8 @@ public class InterfaceGenerator
 
     private static readonly HashSet<string> OptionalFields = new()
     {
+        $"{nameof(SubmitCode)}.{nameof(SubmitCode.MimeTypes)}",
+
         $"{nameof(CompletionsProduced)}.{nameof(CompletionsProduced.LinePositionSpan)}",
         $"{nameof(DisplayEvent)}.{nameof(DisplayEvent.ValueId)}",
         $"{nameof(DocumentOpened)}.{nameof(DocumentOpened.RegionName)}",
@@ -268,7 +270,7 @@ public class InterfaceGenerator
 
         var isOptional = nullabilityContext.ReadState == NullabilityState.Nullable ||
                          OptionalFields.Contains($"{type.Name}.{propertyInfo.Name}");
-
+        
         var propertyName = propertyInfo.Name.CamelCase();
         return isOptional
             ? propertyName + "?"

--- a/src/polyglot-notebooks/src/contracts.ts
+++ b/src/polyglot-notebooks/src/contracts.ts
@@ -128,6 +128,7 @@ export interface SendValue extends KernelCommand {
 
 export interface SubmitCode extends KernelCommand {
     code: string;
+    mimeTypes?: Array<string>;
 }
 
 export interface UpdateDisplayedValue extends KernelCommand {

--- a/src/polyglot-notebooks/src/javascriptKernel.ts
+++ b/src/polyglot-notebooks/src/javascriptKernel.ts
@@ -59,9 +59,19 @@ export class JavascriptKernel extends Kernel {
             const evaluator = AsyncFunction("console", "polyglotNotebooks", code);
             result = await evaluator(this.capture, polyglotNotebooksApi);
             if (result !== undefined) {
-                const formattedValue = formatValue(result, 'application/json');
+                var formattedValues = [];
+                if (submitCode.mimeTypes && submitCode.mimeTypes.length > 0) {
+                    for (let mimeType of submitCode.mimeTypes) {
+                        const formattedValue = formatValue(result, mimeType);
+                        formattedValues.push(formattedValue);
+                    }
+                } else {
+                    const formattedValue = formatValue(result, 'application/json');
+                    formattedValues.push(formattedValue);
+                }
+
                 const event: commandsAndEvents.ReturnValueProduced = {
-                    formattedValues: [formattedValue]
+                    formattedValues: formattedValues
                 };
                 const returnValueProducedEvent = new commandsAndEvents.KernelEventEnvelope(commandsAndEvents.ReturnValueProducedType, event, invocation.commandEnvelope);
                 invocation.context.publish(returnValueProducedEvent);

--- a/src/polyglot-notebooks/tests/javascriptKernel.test.ts
+++ b/src/polyglot-notebooks/tests/javascriptKernel.test.ts
@@ -237,6 +237,29 @@ return command.toJson();`
         expect(events.find(e => e.eventType === commandsAndEvents.ReturnValueProducedType)).to.not.be.undefined;
     });
 
+    it("emits ReturnValueProduced when evaluation return a value and honours mime types", async () => {
+        let events: commandsAndEvents.KernelEventEnvelope[] = [];
+        const kernel = new JavascriptKernel();
+        kernel.subscribeToKernelEvents((e) => {
+            events.push(e);
+        });
+
+        const submitCode = new commandsAndEvents.KernelCommandEnvelope(commandsAndEvents.SubmitCodeType, <commandsAndEvents.SubmitCode>{ code: "return 1+1;", mimeTypes: ["text/plain"] });
+
+        await kernel.send(submitCode);
+
+        const event = events.find(e => e.eventType === commandsAndEvents.ReturnValueProducedType)?.event as commandsAndEvents.ReturnValueProduced;
+        expect(event).to.not.be.undefined;
+        expect(event.formattedValues).to.deep.equal(
+            [
+                {
+                    mimeType: "text/plain",
+                    suppressDisplay: false,
+                    value: "2"
+                }
+            ]);
+    });
+
     it("handles async code", async () => {
         let events: commandsAndEvents.KernelEventEnvelope[] = [];
         const kernel = new JavascriptKernel();


### PR DESCRIPTION
SubmitCode can specify a list of mimetypes to be used when formatting trailing expressions for the 'ReturnValueProduced' event