### PR TITLE
formatted values in trailing expressions

### DIFF
--- a/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
@@ -336,7 +336,12 @@ public class CSharpKernel :
             {
                 if (ScriptState is not null && HasReturnValue)
                 {
-                    var formattedValues = FormattedValue.CreateManyFromObject(ScriptState.ReturnValue);
+                    IReadOnlyList<FormattedValue> formattedValues = ScriptState.ReturnValue switch
+                    {
+                        FormattedValue formattedValue => new[] { formattedValue },
+                        IEnumerable<FormattedValue> formattedValueEnumerable => formattedValueEnumerable.ToArray(),
+                        _ => FormattedValue.CreateManyFromObject(ScriptState.ReturnValue)
+                    };
                     context.Publish(
                         new ReturnValueProduced(
                             ScriptState.ReturnValue,

--- a/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
@@ -215,9 +215,13 @@ type FSharpKernel () as this =
             | Ok(result) when not isError ->
                 match result with
                 | Some(value) when value.ReflectionType <> typeof<unit> ->
-                    let value = value.ReflectionValue
-                    let formattedValues = FormattedValue.CreateManyFromObject(value)
-                    context.Publish(ReturnValueProduced(value, codeSubmission, formattedValues))
+                    let resultValue = value.ReflectionValue
+                    let formattedValues : IReadOnlyList<FormattedValue> = 
+                        match resultValue with
+                        | :? FormattedValue as formattedValue -> new List<FormattedValue>([| formattedValue |])
+                        | :? IEnumerable<FormattedValue> as formattedValues -> formattedValues.ToImmutableList()
+                        | _ -> FormattedValue.CreateManyFromObject(resultValue)
+                    context.Publish(ReturnValueProduced(resultValue, codeSubmission, formattedValues))
                 | Some _
                 | None -> ()
             | _ ->

--- a/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
@@ -218,8 +218,8 @@ type FSharpKernel () as this =
                     let resultValue = value.ReflectionValue
                     let formattedValues : IReadOnlyList<FormattedValue> = 
                         match resultValue with
-                        | :? FormattedValue as formattedValue -> new List<FormattedValue>([| formattedValue |])
-                        | :? IEnumerable<FormattedValue> as formattedValues -> formattedValues.ToImmutableList()
+                        | :? FormattedValue as formattedValue -> Seq.singleton( formattedValue ).ToImmutableList()
+                        | :? IEnumerable<FormattedValue> as formattedValueEnumerable -> formattedValueEnumerable.ToImmutableList()
                         | _ -> FormattedValue.CreateManyFromObject(resultValue)
                     context.Publish(ReturnValueProduced(resultValue, codeSubmission, formattedValues))
                 | Some _


### PR DESCRIPTION
When trailing expressions in C# and F# kernel produces FormattedValues they are passed without additional formatting