### PR TITLE
Improve a couple of http kernel error messages

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/HttpDiagnostics.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/HttpDiagnostics.cs
@@ -127,7 +127,7 @@ internal static class HttpDiagnostics
     {
         var id = $"HTTP0015";
         var severity = DiagnosticSeverity.Error;
-        var messageFormat = "The supplied offset '{1}' in the expression '{0}' is not a valid integer.";
+        var messageFormat = "The supplied offset '{1}' in the expression '{0}' is not a valid integer. See https://aka.ms/http-date-time-format for more details.";
         return new HttpDiagnosticInfo(id, messageFormat, severity, expression, offset);
     }
 
@@ -135,7 +135,7 @@ internal static class HttpDiagnostics
     {
         var id = $"HTTP0016";
         var severity = DiagnosticSeverity.Error;
-        var messageFormat = "The supplied option '{1}' in the expression '{0}' is not supported.";
+        var messageFormat = "The supplied option '{1}' in the expression '{0}' is not supported. The following options are supported: ms, s, m, h, d, w, M, Q, y. See https://aka.ms/http-date-time-format for more details.";
         return new HttpDiagnosticInfo(id, messageFormat, severity, expression, option);
     }
 

--- a/src/Microsoft.DotNet.Interactive.Http.Tests/HttpKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Tests/HttpKernelTests.cs
@@ -802,7 +802,7 @@ public class HttpKernelTests
 
         var diagnostics = result.Events.Should().ContainSingle<DiagnosticsProduced>().Which;
 
-        diagnostics.Diagnostics.First().Message.Should().Be("The supplied option 'q' in the expression '$timestamp -1 q' is not supported.");
+        diagnostics.Diagnostics.First().Message.Should().Be("The supplied option 'q' in the expression '$timestamp -1 q' is not supported. The following options are supported: ms, s, m, h, d, w, M, Q, y. See https://aka.ms/http-date-time-format for more details.");
     }
 
 
@@ -834,7 +834,7 @@ public class HttpKernelTests
 
         var diagnostics = result.Events.Should().ContainSingle<DiagnosticsProduced>().Which;
 
-        diagnostics.Diagnostics.First().Message.Should().Be("The supplied offset '33.2' in the expression '$timestamp 33.2 d' is not a valid integer.");
+        diagnostics.Diagnostics.First().Message.Should().Be("The supplied offset '33.2' in the expression '$timestamp 33.2 d' is not a valid integer. See https://aka.ms/http-date-time-format for more details.");
     }
 
     [Fact]
@@ -862,7 +862,7 @@ public class HttpKernelTests
 
         var result = await kernel.SendAsync(new SubmitCode(code));
 
-        result.Events.Should().ContainSingle<DiagnosticsProduced>().Which.Diagnostics.Should().ContainSingle().Which.Message.Should().Be("The supplied offset '~1' in the expression '$timestamp ~1 d' is not a valid integer.");
+        result.Events.Should().ContainSingle<DiagnosticsProduced>().Which.Diagnostics.Should().ContainSingle().Which.Message.Should().Be("The supplied offset '~1' in the expression '$timestamp ~1 d' is not a valid integer. See https://aka.ms/http-date-time-format for more details.");
     }
 
     [Fact]
@@ -1194,7 +1194,7 @@ public class HttpKernelTests
             """;
 
         var result = await kernel.SendAsync(new SubmitCode(code));
-        result.Events.Should().ContainSingle<DiagnosticsProduced>().Which.Diagnostics.Should().ContainSingle().Which.Message.Should().Be("The supplied option 't' in the expression '$datetime 'yyyy-MM-dd' -1 t' is not supported.");
+        result.Events.Should().ContainSingle<DiagnosticsProduced>().Which.Diagnostics.Should().ContainSingle().Which.Message.Should().Be("The supplied option 't' in the expression '$datetime 'yyyy-MM-dd' -1 t' is not supported. The following options are supported: ms, s, m, h, d, w, M, Q, y. See https://aka.ms/http-date-time-format for more details.");
     }
 
     [Fact]


### PR DESCRIPTION
Including hyperlink that explains the expected format for the `$datetime` and `$timestamp` dynamic variables in a couple more error messages.