### PR TITLE
Tolerance of punctuation for leading request

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/HttpRequestParser.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/HttpRequestParser.cs
@@ -126,7 +126,7 @@ internal class HttpRequestParser
             {
                 if (node is null)
                 {
-                    if (CurrentToken is { Kind: HttpTokenKind.Word })
+                    if (CurrentToken is ({ Kind: HttpTokenKind.Word }) or ({ Kind: HttpTokenKind.Punctuation} and { Text: "/"}))
                     {
                         node = new HttpVariableValueNode(_sourceText, _syntaxTree);
 


### PR DESCRIPTION
This pr allows for there to be leading punctuation in the case of a / in a variable which is useful in the case of content-type like /application/json 