### PR TITLE
Change for more accurate url error

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/HttpRequestParser.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/HttpRequestParser.cs
@@ -131,17 +131,17 @@ internal class HttpRequestParser
             {
                 if (node is null)
                 {
-                    if (CurrentToken is ({ Kind: HttpTokenKind.Word }) or ({ Kind: HttpTokenKind.Punctuation} and { Text: "/"}))
+                    if (CurrentToken is ({ Kind: HttpTokenKind.Word }) or ({ Kind: HttpTokenKind.Punctuation } and { Text: "/" }))
                     {
                         node = new HttpVariableValueNode(_sourceText, _syntaxTree);
 
                         ParseLeadingWhitespaceAndComments(node);
-                    } 
+                    }
                     else if (IsAtStartOfEmbeddedExpression())
                     {
                         node = new HttpVariableValueNode(_sourceText, _syntaxTree);
                         node.Add(ParseEmbeddedExpression());
-                        if(CurrentToken is { Kind: HttpTokenKind.NewLine })
+                        if (CurrentToken is { Kind: HttpTokenKind.NewLine })
                         {
                             break;
                         }
@@ -447,6 +447,10 @@ internal class HttpRequestParser
                     {
                         node = new HttpUrlNode(_sourceText, _syntaxTree);
                         node.Add(ParseEmbeddedExpression());
+                    }
+                    else if (CurrentToken is { Kind: HttpTokenKind.Punctuation })
+                    {
+                        node = new HttpUrlNode(_sourceText, _syntaxTree);
                     }
                     else
                     {

--- a/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.Lexer.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.Lexer.cs
@@ -46,7 +46,7 @@ public partial class HttpParserTests
         {
             var result = Parse(".!?.:/");
             
-            var requestNode = result.SyntaxTree.RootNode.DescendantNodesAndTokens().Should().ContainSingle<HttpBodyNode>().Which;
+            var requestNode = result.SyntaxTree.RootNode.DescendantNodesAndTokens().Should().ContainSingle<HttpUrlNode>().Which;
             requestNode
                   .ChildTokens.Select(t => new { t.Text, t.Kind })
                   .Should().BeEquivalentSequenceTo(

--- a/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.Url.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.Url.cs
@@ -145,5 +145,20 @@ public partial class HttpParserTests
             lineSpan.EndLinePosition.Line.Should().Be(0);
             lineSpan.EndLinePosition.Character.Should().Be(12);
         }
+
+
+        [Fact]
+        public void Punctuation_at_url_start_produces_a_diagnostic()
+        {
+            var code = """
+                GET /https://example.com
+                """;
+
+            var result = Parse(code);
+
+            var diagnostic = result.SyntaxTree.RootNode.DescendantNodesAndTokens().Should().ContainSingle<HttpUrlNode>()
+                                   .Which.GetDiagnostics().Should().ContainSingle()
+                                   .Which;
+        }
     }
 }


### PR DESCRIPTION
This change allows for a punctuation in the start of a url node so that we are able to produce a more descriptive error message.