### PR TITLE
Adding in a separate pipeline just for our internal signed builds on top of Compliant templates

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -23,30 +23,6 @@ trigger:
     - '*.txt'
     - '*.github-issues'
 
-pr:
-  branches:
-    include:
-    - main
-    - feature/*
-    - hotfix/*
-    - release/*
-  paths:
-    include:
-    - '*'
-    exclude:
-    - '**/*.md'
-    - .config/*
-    - .devcontainer/*
-    - .github/*
-    - .vscode/*
-    - assets/*
-    - docs/*
-    - images/*
-    - .editorconfig
-    - .gitignore
-    - '*.txt'
-    - '*.github-issues'
-
 # Scheduled trigger that will run at 8:00 AM every Monday and Wednesday
 schedules:
 - cron: "0 8 * * Mon"
@@ -81,45 +57,48 @@ variables:
   value: ${{ eq(variables['Build.Reason'], 'Schedule') }}
 - name: Codeql.Enabled
   value: true
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - name: _DotNetValidationArtifactsCategory
-    value: .NETCoreValidation
-  - group: DotNet-Interactive-SDLValidation-Params
+- name: _DotNetValidationArtifactsCategory
+  value: .NETCoreValidation
+- group: DotNet-Interactive-SDLValidation-Params
 - template: /eng/common/templates-official/variables/pool-providers.yml@self
 
 resources:
   repositories:
-  - repository: MicroBuildTemplate
+  - repository: 1esPipelines
     type: git
-    name: 1ESPipelineTemplates/MicroBuildTemplate
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
 
 extends:
-  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     sdl:
       sourceAnalysisPool: 
-        name: AzurePipelines-EO
-        image: 1ESPT-Windows2022
-    pool:
-      name: AzurePipelines-EO
-      image: AzurePipelinesWindows2022compliantGPT
-      os: windows
-    customBuildTags:
-    - ES365AIMigrationTooling
+        name: $(DncEngInternalBuildPool)
+        image: 1es-windows-2022-pt
+        os: windows
+      binskim:
+        enabled: true
+        scanOutputDirectoryOnly: true
+      policheck:
+        enabled: true
+      apiScan:
+        break: false
+        severity: error
+      sbom:
+        enabled: false
     stages:
     - stage: build
       displayName: Build and Test
       jobs:
-      - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        - template: /eng/common/templates-official/job/onelocbuild.yml@self
-          parameters:
-            MirrorRepo: interactive
-            MirrorBranch: main
-            SkipLocProjectJsonGeneration: true
-            LclSource: lclFilesfromPackage
-            LclPackageId: 'LCL-JUNO-PROD-INTERACTIVE'
-            CreatePr: $(LocPRCreationEnabled)
+      - template: /eng/common/templates-official/job/onelocbuild.yml@self
+        parameters:
+          MirrorRepo: interactive
+          MirrorBranch: main
+          SkipLocProjectJsonGeneration: true
+          LclSource: lclFilesfromPackage
+          LclPackageId: 'LCL-JUNO-PROD-INTERACTIVE'
+          CreatePr: $(LocPRCreationEnabled)
       - template: /eng/common/templates-official/jobs/jobs.yml@self
         parameters:
           enableMicrobuild: true
@@ -130,12 +109,9 @@ extends:
           jobs:
           - job: Windows_NT
             pool:
-              ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-                name: $(DncEngPublicBuildPool)
-                demands: ImageOverride -equals windows.vs2022.amd64.open
-              ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-                name: $(DncEngInternalBuildPool)
-                demands: ImageOverride -equals windows.vs2022.amd64
+              name: $(DncEngInternalBuildPool)
+              demands: ImageOverride -equals 1es-windows-2022-pt
+              os: windows
             timeoutInMinutes: 90
             variables:
               - group: DotNet-Symbol-Server-Pats
@@ -257,12 +233,9 @@ extends:
           jobs:
           - job: Linux
             pool:
-              ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-                name: $(DncEngPublicBuildPool)
-                demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
-              ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-                name: $(DncEngInternalBuildPool)
-                demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+              name: $(DncEngInternalBuildPool)
+              os: linux
+              demands: ImageOverride -equals 1es-ubuntu-2204
             
             outputs:
               - output: pipelineArtifact
@@ -329,36 +302,35 @@ extends:
     #---------------------------------------------------------------------------------------------------------------------#
     #                                                    Post Build                                                       #
     #---------------------------------------------------------------------------------------------------------------------#
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - template: /eng/common/templates-official/post-build/post-build.yml@self
-        parameters:
-          publishingInfraVersion: 3
-          # signing validation currently has issues with dotnet 7; disabling as per internal guidance
-          enableSigningValidation: false
-          # Symbol validation is not entirely reliable as of yet, so should be turned off until https://github.com/dotnet/arcade/issues/2871 is resolved.
-          enableSymbolValidation: false
-          # SourceLink improperly looks for generated files.  See https://github.com/dotnet/arcade/issues/3069
-          enableSourceLinkValidation: false
-          # Enable SDL validation, passing through values from the 'DotNet-FSharp-SDLValidation-Params' group.
-          SDLValidationParameters:
-            enable: true
-            params: >-
-              -SourceToolsList @("policheck","credscan")
-              -TsaInstanceURL $(_TsaInstanceURL)
-              -TsaProjectName $(_TsaProjectName)
-              -TsaNotificationEmail $(_TsaNotificationEmail)
-              -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
-              -TsaBugAreaPath $(_TsaBugAreaPath)
-              -TsaIterationPath $(_TsaIterationPath)
-              -TsaRepositoryName "Interactive"
-              -TsaCodebaseName "Interactive-GitHub"
-              -TsaPublish $True
-              -PoliCheckAdditionalRunConfigParams @("UserExclusionPath < $(Build.SourcesDirectory)/eng/policheck_exclusions.xml")
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - template: /eng/publish/publish-npm.yml@self
-        parameters:
-          packageName: microsoft-polyglot-notebooks-*.tgz
-          registryUrl: pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/npm/registry/
-          registryUser: dnceng
-          registryEmail: dnceng@microsoft.com
-          publishingBranch: main
+    - template: /eng/common/templates-official/post-build/post-build.yml@self
+      parameters:
+        publishingInfraVersion: 3
+        # signing validation currently has issues with dotnet 7; disabling as per internal guidance
+        enableSigningValidation: false
+        # Symbol validation is not entirely reliable as of yet, so should be turned off until https://github.com/dotnet/arcade/issues/2871 is resolved.
+        enableSymbolValidation: false
+        # SourceLink improperly looks for generated files.  See https://github.com/dotnet/arcade/issues/3069
+        enableSourceLinkValidation: false
+        # Enable SDL validation, passing through values from the 'DotNet-FSharp-SDLValidation-Params' group.
+        SDLValidationParameters:
+          enable: true
+          params: >-
+            -SourceToolsList @("policheck","credscan")
+            -TsaInstanceURL $(_TsaInstanceURL)
+            -TsaProjectName $(_TsaProjectName)
+            -TsaNotificationEmail $(_TsaNotificationEmail)
+            -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
+            -TsaBugAreaPath $(_TsaBugAreaPath)
+            -TsaIterationPath $(_TsaIterationPath)
+            -TsaRepositoryName "Interactive"
+            -TsaCodebaseName "Interactive-GitHub"
+            -TsaPublish $True
+            -PoliCheckAdditionalRunConfigParams @("UserExclusionPath < $(Build.SourcesDirectory)/eng/policheck_exclusions.xml")
+  
+    - template: /eng/publish/publish-npm.yml@self
+      parameters:
+        packageName: microsoft-polyglot-notebooks-*.tgz
+        registryUrl: pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/npm/registry/
+        registryUser: dnceng
+        registryEmail: dnceng@microsoft.com
+        publishingBranch: main

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -1,0 +1,364 @@
+# CI trigger
+trigger:
+  branches:
+    include:
+    - main
+    - feature/*
+    - hotfix/*
+    - release/*
+  paths:
+    include:
+    - '*'
+    exclude:
+    - '**/*.md'
+    - .config/*
+    - .devcontainer/*
+    - .github/*
+    - .vscode/*
+    - assets/*
+    - docs/*
+    - images/*
+    - .editorconfig
+    - .gitignore
+    - '*.txt'
+    - '*.github-issues'
+
+pr:
+  branches:
+    include:
+    - main
+    - feature/*
+    - hotfix/*
+    - release/*
+  paths:
+    include:
+    - '*'
+    exclude:
+    - '**/*.md'
+    - .config/*
+    - .devcontainer/*
+    - .github/*
+    - .vscode/*
+    - assets/*
+    - docs/*
+    - images/*
+    - .editorconfig
+    - .gitignore
+    - '*.txt'
+    - '*.github-issues'
+
+# Scheduled trigger that will run at 8:00 AM every Monday and Wednesday
+schedules:
+- cron: "0 8 * * Mon"
+  displayName: Weekly build for Localization Updates (Monday)
+  branches:
+    include:
+    - main
+- cron: "0 8 * * Wed"
+  displayName: Weekly build for Localization Updates (Wednesday)
+  branches:
+    include:
+    - main
+
+variables:
+- name: _TeamName
+  value: DotNetInteractive
+- name: _BuildConfig
+  value: Release
+- name: _PublishUsingPipelines
+  value: true
+- name: _DotNetArtifactsCategory
+  value: .NETCore
+- name: DisableDockerDetector
+  value: true
+- name: PocketLoggerLogPath
+  value: $(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)
+- name: TryDotNetPackagesPath
+  value: $(Build.SourcesDirectory)/artifacts/.trydotnet/packages
+- name: NodeJSVersion
+  value: '16.13.0'
+- name: LocPRCreationEnabled
+  value: ${{ eq(variables['Build.Reason'], 'Schedule') }}
+- name: Codeql.Enabled
+  value: true
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - name: _DotNetValidationArtifactsCategory
+    value: .NETCoreValidation
+  - group: DotNet-Interactive-SDLValidation-Params
+- template: /eng/common/templates-official/variables/pool-providers.yml@self
+
+resources:
+  repositories:
+  - repository: MicroBuildTemplate
+    type: git
+    name: 1ESPipelineTemplates/MicroBuildTemplate
+    ref: refs/tags/release
+
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  parameters:
+    sdl:
+      sourceAnalysisPool: 
+        name: AzurePipelines-EO
+        image: 1ESPT-Windows2022
+    pool:
+      name: AzurePipelines-EO
+      image: AzurePipelinesWindows2022compliantGPT
+      os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
+    stages:
+    - stage: build
+      displayName: Build and Test
+      jobs:
+      - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+        - template: /eng/common/templates-official/job/onelocbuild.yml@self
+          parameters:
+            MirrorRepo: interactive
+            MirrorBranch: main
+            SkipLocProjectJsonGeneration: true
+            LclSource: lclFilesfromPackage
+            LclPackageId: 'LCL-JUNO-PROD-INTERACTIVE'
+            CreatePr: $(LocPRCreationEnabled)
+      - template: /eng/common/templates-official/jobs/jobs.yml@self
+        parameters:
+          enableMicrobuild: true
+          enablePublishBuildArtifacts: true
+          enablePublishTestResults: true
+          enablePublishBuildAssets: true
+          enablePublishUsingPipelines: $(_PublishUsingPipelines)
+          jobs:
+          - job: Windows_NT
+            pool:
+              ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+                name: $(DncEngPublicBuildPool)
+                demands: ImageOverride -equals windows.vs2022.amd64.open
+              ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+                name: $(DncEngInternalBuildPool)
+                demands: ImageOverride -equals windows.vs2022.amd64
+            timeoutInMinutes: 90
+            variables:
+              - group: DotNet-Symbol-Server-Pats
+              - name: _SignType
+                value: Real
+              - name: _BuildArgs
+                value: /p:SignType=$(_SignType)
+                      /p:DotNetSignType=$(_SignType)
+                      /p:MicroBuild_SigningEnabled=true
+                      /p:TeamName=$(_TeamName)
+                      /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+                      /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
+                      /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+                      /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+                      /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+                      /p:PublishToSymbolServer=true
+
+            outputs:
+              - output: pipelineArtifact
+                displayName: 'Publish Test results and Blame dumps'
+                condition: failed()
+                targetPath: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+                artifactName: 'Windows_test_results_and_dumps'
+                publishLocation: Container
+              - output: pipelineArtifact
+                displayName: 'Publish VSCode extension artifacts'
+                targetPath: '$(Build.ArtifactStagingDirectory)\vscode'
+                artifactName: 'vscode'
+                publishLocation: Container
+              - output: pipelineArtifact
+                displayName: 'Publish NPM package artifacts'
+                targetPath: '$(Build.ArtifactStagingDirectory)\npm'
+                artifactName: 'npm'
+                publishLocation: Container
+              - output: pipelineArtifact
+                displayName: 'Publish packages to artifacts container'
+                targetPath: '$(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)'
+                artifactName: 'packages'
+                publishLocation: Container
+
+            steps:
+            - checkout: self
+              clean: true
+
+              # Azure DevOps doesn't support git symlinks on Windows so we have to fake it
+            - pwsh: . "$(Build.SourcesDirectory)\src\ensure-symlinks.ps1"
+              displayName: ensure symlinks
+
+            - task: NodeTool@0
+              displayName: Add NodeJS/npm
+              inputs:
+                versionSpec: $(NodeJSVersion)
+
+            - script: |
+                robocopy "eng\resources" "$(Build.SourcesDirectory)\artifacts"
+                :: robocopy return codes are terrible; 1 means files were copied
+                if "%errorlevel%" == "1" exit /b 0
+                exit /b 1
+              displayName: Prevent test directory crawling
+
+            - pwsh: |
+                $testArg = if ($env:SKIPTESTS -ne "true") { "-test" } else { "" }
+                Write-Host "##vso[task.setvariable variable=_TestArgs]$testArg"
+              displayName: Promote variables
+
+            - script: eng\CIBuild.cmd
+                -configuration $(_BuildConfig)
+                -prepareMachine
+                -sign
+                $(_BuildArgs)
+                $(_TestArgs)
+              displayName: Build
+              env:
+                POCKETLOGGER_LOG_PATH: $(PocketLoggerLogPath)
+                TRYDOTNET_PACKAGES_PATH: $(TryDotNetPackagesPath)
+                DOTNET_INTERACTIVE_FRONTEND_NAME: CI
+
+            - pwsh: ./test-retry-runner.ps1 -buildConfig $env:BUILDCONFIG
+              displayName: Test / Blame
+              workingDirectory: $(Build.SourcesDirectory)
+              env:
+                BUILDCONFIG: $(_BuildConfig)
+              condition: ne(variables['SkipTests'], 'true')
+
+            - pwsh: Get-ChildItem *.dmp -Recurse | Remove-Item
+              displayName: Delete dump files
+              workingDirectory: $(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)
+              condition: and(ne(variables['KeepDumps'], 'true'), ne(variables['SkipTests'], 'true'))
+
+              # publish VS Code and npm test results
+            - task: PublishTestResults@2
+              displayName: Publish VS Code extension and npm test results
+              inputs:
+                testResultsFormat: VSTest
+                testResultsFiles: '**/*.trx'
+                searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
+              condition: always()
+
+            - task: PowerShell@2
+              displayName: Pack NPM package
+              inputs:
+                filePath: $(Build.SourcesDirectory)/eng/package/PackNpmPackage.ps1
+                arguments: -packageVersionNumber $(StableToolVersionNumber) -outDir "$(Build.ArtifactStagingDirectory)\npm"
+                workingDirectory: "$(Build.SourcesDirectory)/src/polyglot-notebooks"
+                pwsh: true
+
+            # Prevent symbols packages from being saved in the following `packages` artifact because they're incomplete.
+            # See `eng/AfterSolutionBuild.targets:StripFilesFromSymbolPackages` for details.
+            - script: del /S $(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)\*.symbols.nupkg
+              displayName: Clean symbol packages
+
+      - template: /eng/common/templates-official/jobs/jobs.yml@self
+        parameters:
+          enableMicrobuild: true
+          enablePublishBuildArtifacts: true
+          enablePublishTestResults: true
+          enablePublishBuildAssets: false
+          enablePublishUsingPipelines: false
+          jobs:
+          - job: Linux
+            pool:
+              ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+                name: $(DncEngPublicBuildPool)
+                demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
+              ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+                name: $(DncEngInternalBuildPool)
+                demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+            
+            outputs:
+              - output: pipelineArtifact
+                displayName: 'Publish Test results and Blame dumps'
+                condition: failed()
+                targetPath: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+                artifactName: 'Linux_test_results_and_dumps'
+                publishLocation: Container
+
+            steps:
+            - script: git config --global core.longpaths true
+              displayName: Enable `git clean` to handle long paths
+
+            - checkout: self
+              clean: true
+
+            - task: NodeTool@0
+              displayName: Add NodeJS/npm
+              inputs:
+                versionSpec: $(NodeJSVersion)
+
+            - script: |
+                mkdir -p "$(Build.SourcesDirectory)/artifacts"
+                rm -rf "$(Build.SourcesDirectory)/artifacts/*"
+                cp eng/resources/* "$(Build.SourcesDirectory)/artifacts"
+              displayName: Prevent test directory crawling
+
+            - pwsh: |
+                $testArg = if ($env:SKIPTESTS -ne "true") { "--test" } else { "" }
+                Write-Host "##vso[task.setvariable variable=_TestArgs]$testArg"
+              displayName: Promote variables
+
+            - script: ./eng/cibuild.sh
+                --configuration $(_BuildConfig)
+                --prepareMachine
+                $(_TestArgs)
+              displayName: Run tests
+              env:
+                POCKETLOGGER_LOG_PATH: $(PocketLoggerLogPath)
+                TRYDOTNET_PACKAGES_PATH: $(TryDotNetPackagesPath)
+                DOTNET_INTERACTIVE_FRONTEND_NAME: CI
+
+            - pwsh: ./test-retry-runner.ps1 -buildConfig $env:BUILDCONFIG
+              displayName: Test / Blame
+              workingDirectory: $(Build.SourcesDirectory)
+              env:
+                BUILDCONFIG: $(_BuildConfig)
+              condition: ne(variables['SkipTests'], 'true')
+
+            - pwsh: Get-ChildItem *.dmp -Recurse | Remove-Item
+              displayName: Delete dump files
+              workingDirectory: $(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)
+              condition: and(ne(variables['KeepDumps'], 'true'), ne(variables['SkipTests'], 'true'))
+
+              # publish VS Code and npm test results
+            - task: PublishTestResults@2
+              displayName: Publish VS Code extension and npm test results
+              inputs:
+                testResultsFormat: VSTest
+                testResultsFiles: '**/*.trx'
+                searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
+              condition: always()
+
+    #---------------------------------------------------------------------------------------------------------------------#
+    #                                                    Post Build                                                       #
+    #---------------------------------------------------------------------------------------------------------------------#
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - template: /eng/common/templates-official/post-build/post-build.yml@self
+        parameters:
+          publishingInfraVersion: 3
+          # signing validation currently has issues with dotnet 7; disabling as per internal guidance
+          enableSigningValidation: false
+          # Symbol validation is not entirely reliable as of yet, so should be turned off until https://github.com/dotnet/arcade/issues/2871 is resolved.
+          enableSymbolValidation: false
+          # SourceLink improperly looks for generated files.  See https://github.com/dotnet/arcade/issues/3069
+          enableSourceLinkValidation: false
+          # Enable SDL validation, passing through values from the 'DotNet-FSharp-SDLValidation-Params' group.
+          SDLValidationParameters:
+            enable: true
+            params: >-
+              -SourceToolsList @("policheck","credscan")
+              -TsaInstanceURL $(_TsaInstanceURL)
+              -TsaProjectName $(_TsaProjectName)
+              -TsaNotificationEmail $(_TsaNotificationEmail)
+              -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
+              -TsaBugAreaPath $(_TsaBugAreaPath)
+              -TsaIterationPath $(_TsaIterationPath)
+              -TsaRepositoryName "Interactive"
+              -TsaCodebaseName "Interactive-GitHub"
+              -TsaPublish $True
+              -PoliCheckAdditionalRunConfigParams @("UserExclusionPath < $(Build.SourcesDirectory)/eng/policheck_exclusions.xml")
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - template: /eng/publish/publish-npm.yml@self
+        parameters:
+          packageName: microsoft-polyglot-notebooks-*.tgz
+          registryUrl: pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/npm/registry/
+          registryUser: dnceng
+          registryEmail: dnceng@microsoft.com
+          publishingBranch: main


### PR DESCRIPTION
A separate pipeline is what is being recommended centrally. Here is a PR that diffs the contents of the official yml file with what we have in our repo yml today: https://dev.azure.com/dnceng/internal/_git/dotnet-interactive/pullrequest/38525?_a=files&path=/azure-pipelines.yml.

Here is a signed build that I used to validate that this is actually going to work: https://dev.azure.com/dnceng/internal/_build/results?buildId=2414181&view=results. I'll wait for this to be complete before considering merging this PR in. Here's an older build before the latest iteration which succeeded: https://dev.azure.com/dnceng/internal/_build/results?buildId=2413293&view=results

Post merge:
- I will update the internal signed pipeline to use this official yml once the mirror updates