### PR TITLE
Bump minimum version for SQL Tools and Kusto packages

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Kql/KqlKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql/KqlKernelExtension.cs
@@ -16,7 +16,7 @@ public class KqlKernelExtension
         if (kernel is CompositeKernel compositeKernel)
         {
             var kqlToolName = "MicrosoftKustoServiceLayer";
-            await Utils.CheckAndInstallGlobalToolAsync(kqlToolName, "1.3.0", "Microsoft.SqlServer.KustoServiceLayer.Tool");
+            await Utils.CheckAndInstallGlobalToolAsync(kqlToolName, "2.0.0", "Microsoft.SqlServer.KustoServiceLayer.Tool");
 
             var kqlToolPath = Path.Combine(Paths.DotnetToolsPath, kqlToolName);
             compositeKernel

--- a/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelExtension.cs
@@ -15,7 +15,7 @@ public class MsSqlKernelExtension
         if (kernel is CompositeKernel compositeKernel)
         {
             var sqlToolName = "MicrosoftSqlToolsServiceLayer";
-            await Utils.CheckAndInstallGlobalToolAsync(sqlToolName, "1.3.0", "Microsoft.SqlServer.SqlToolsServiceLayer.Tool");
+            await Utils.CheckAndInstallGlobalToolAsync(sqlToolName, "2.0.0", "Microsoft.SqlServer.SqlToolsServiceLayer.Tool");
 
             var sqlToolPath = Path.Combine(Paths.DotnetToolsPath, sqlToolName);
             compositeKernel


### PR DESCRIPTION
The 2.0.0 packages upgrade the SQL Tools and Kusto services to net8.0 and also add a rollForward property to help with SDK updates in the future.