### PR TITLE
Parsing restructuring

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/DynamicExpressionUtilities.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/DynamicExpressionUtilities.cs
@@ -193,7 +193,7 @@ namespace Microsoft.DotNet.Interactive.Http.Parsing
                         string text = currentDateTimeOffset.ToString(format, formatProvider);
                         return node.CreateBindingSuccess(text);
                     }
-                    catch(FormatException)
+                    catch (FormatException)
                     {
                         return node.CreateBindingFailure(HttpDiagnostics.IncorrectDateTimeCustomFormat(format));
                     }

--- a/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.Comments.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.Comments.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Management.Automation.Internal;
 using FluentAssertions;
 using Microsoft.DotNet.Interactive.Http.Parsing;
@@ -49,7 +50,7 @@ public partial class HttpParserTests
         [Fact]
         public void Comment_node_can_immediately_follow_headers()
         {
-             var code = """
+            var code = """
                 GET https://example.com
                 Accept: text/plain
                 # This is a comment
@@ -102,6 +103,26 @@ public partial class HttpParserTests
 
             result.GetDiagnostics().Should().BeEmpty();
 
+        }
+
+        [Fact]
+        public void comment_after_request_separator_is_parsed_correctly()
+        {
+            var code = """
+                @MyRestaurantApi_HostAddress = https://localhost:7094
+
+                GET {{MyRestaurantApi_HostAddress}}/api/Contact
+
+                ###
+
+                # get a specific contact
+                """;
+
+            var result = Parse(code);
+
+            result.SyntaxTree.RootNode.DescendantNodesAndTokens().Should()
+                  .ContainSingle<HttpCommentNode>()
+                  .Which.Text.Should().Be("# get a specific contact");
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.Comments.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.Comments.cs
@@ -120,9 +120,7 @@ public partial class HttpParserTests
 
             var result = Parse(code);
 
-            result.SyntaxTree.RootNode.DescendantNodesAndTokens().Should()
-                  .ContainSingle<HttpCommentNode>()
-                  .Which.Text.Should().Be("# get a specific contact");
+            result.SyntaxTree.RootNode.ChildNodes.Last().Should().BeOfType<HttpCommentNode>().Which.Text.Should().Be("# get a specific contact");
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.Lexer.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.Lexer.cs
@@ -20,11 +20,9 @@ public partial class HttpParserTests
             var result = Parse("  \t  ");
 
             result.SyntaxTree.RootNode
-                  .ChildNodes.Should().ContainSingle<HttpRequestNode>().Which
                   .ChildTokens.First().Should().BeOfType<HttpSyntaxToken>();
 
             result.SyntaxTree.RootNode
-                  .ChildNodes.Should().ContainSingle<HttpRequestNode>().Which
                   .ChildTokens.Single().Text.Should().Be("  \t  ");
         }
 
@@ -33,7 +31,7 @@ public partial class HttpParserTests
         {
             var result = Parse("\n\v\r\n\n");
 
-            result.SyntaxTree.RootNode.ChildNodes.Should().ContainSingle<HttpRequestNode>().Which
+            result.SyntaxTree.RootNode
                   .ChildTokens.Select(t => new { t.Text, t.Kind }).Should().BeEquivalentSequenceTo(
                       new { Text = "\n", Kind = HttpTokenKind.NewLine },
                       new { Text = "\v", Kind = HttpTokenKind.NewLine },
@@ -45,7 +43,7 @@ public partial class HttpParserTests
         public void multiple_punctuations_are_parsed_into_different_tokens()
         {
             var result = Parse(".!?.:/");
-            
+
             var requestNode = result.SyntaxTree.RootNode.DescendantNodesAndTokens().Should().ContainSingle<HttpUrlNode>().Which;
             requestNode
                   .ChildTokens.Select(t => new { t.Text, t.Kind })

--- a/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.RequestSeparator.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.RequestSeparator.cs
@@ -45,7 +45,7 @@ public partial class HttpParserTests
         }
 
         [Fact]
-        public void tokens_on_request_separator_nodes()
+        public void request_separator_nodes_after_various_nodes_are_parsed_correctly()
         {
             var result = Parse(
                 """

--- a/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.RequestSeparator.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.RequestSeparator.cs
@@ -43,5 +43,34 @@ public partial class HttpParserTests
                                     .Should().ContainSingle<HttpRequestSeparatorNode>()
                                     .Which.Text.Should().Be("### Slow Response (Json)");
         }
+
+        [Fact]
+        public void tokens_on_request_separator_nodes()
+        {
+            var result = Parse(
+                """
+                @MyRestaurantApi_HostAddress = https://localhost:7293
+
+                GET {{MyRestaurantApi_HostAddress}}/api/Contact
+                ###
+
+                @Somevar = hello
+
+                ###
+
+                PUT https://httpbin.org/anything
+                Content-Type: application/json
+
+                {
+                    "content": "content here",
+                    "message": {{Message}}
+                }
+
+                ###
+                """
+                );
+
+            result.SyntaxTree.RootNode.ChildNodes.OfType<HttpRequestSeparatorNode>().Count().Should().Be(3);
+        }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.Trivia.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.Trivia.cs
@@ -26,7 +26,6 @@ public partial class HttpParserTests
             var result = Parse(" \t ");
 
             result.SyntaxTree.RootNode
-                  .ChildNodes.Should().ContainSingle<HttpRequestNode>().Which
                   .ChildTokens.First().Text.Should().Be(" \t ");
         }
 
@@ -36,7 +35,6 @@ public partial class HttpParserTests
             var result = Parse("\r\n\n\r\n");
 
             result.SyntaxTree.RootNode
-                  .ChildNodes.Should().ContainSingle<HttpRequestNode>().Which
                   .FullText.Should().Be("\r\n\n\r\n");
         }
     }

--- a/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.Trivia.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.Trivia.cs
@@ -30,7 +30,7 @@ public partial class HttpParserTests
         }
 
         [Fact]
-        public void it_can_parse_a_string_with_only_newlines()
+        public void string_with_only_newlines_is_parsed_into_root_node()
         {
             var result = Parse("\r\n\n\r\n");
 

--- a/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.Variables.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.Variables.cs
@@ -250,5 +250,21 @@ public partial class HttpParserTests
             variables.Should().Contain(n => n.Key == "host").Which.Value.Should().BeOfType<DeclaredVariable>().Which.Value.Should().Be("https://httpbin.org");
 
         }
+
+        [Fact]
+        public void spaces_after_variable_do_not_produce_diagnostics()
+        {
+            var result = Parse(
+                """
+                @host=https://httpbin.org
+                
+                
+                
+                
+                
+                """);
+
+            result.SyntaxTree.RootNode.ChildNodes.Count().Should().Be(1);
+        }
     }
 }


### PR DESCRIPTION
Change to the parser to search for significant tokens and parsing request separators before parsing requests. In the event of additional whitespaces tokens, they are attached to the root node instead of creating a null request node