### PR TITLE
Preserve case for HTTP header names

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/DynamicExpressionUtilities.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/DynamicExpressionUtilities.cs
@@ -10,7 +10,7 @@ using System.Threading;
 namespace Microsoft.DotNet.Interactive.Http.Parsing
 {
 #nullable enable
-    internal static class DynamicExpressionUtilites
+    internal static class DynamicExpressionUtilities
     {
         const string DateTimeMacroName = "$datetime";
         const string LocalDateTimeMacroName = "$localDatetime";

--- a/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/HttpRequestNode.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/HttpRequestNode.cs
@@ -97,8 +97,11 @@ internal class HttpRequestNode : HttpSyntaxNode
                 if (declaredVariables.TryGetValue(node.Text, out var declaredValue))
                 {
                     return HttpBindingResult<object?>.Success(declaredValue.Value);
-                } 
-                else { return originalBind(node); }
+                }
+                else
+                {
+                    return originalBind(node);
+                }
             };
         }
         var request = new HttpRequestMessage();
@@ -153,7 +156,7 @@ internal class HttpRequestNode : HttpSyntaxNode
                     continue;
                 }
 
-                var headerName = headerNode.NameNode.Text.ToLowerInvariant();
+                var headerName = headerNode.NameNode.Text;
                 var headerValueResult = headerNode.ValueNode.TryGetValue(bind);
 
                 diagnostics.AddRange(headerValueResult.Diagnostics);

--- a/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/HttpRootSyntaxNode.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/HttpRootSyntaxNode.cs
@@ -3,10 +3,10 @@
 
 #nullable enable
 
-using Microsoft.CodeAnalysis.Text;
-using Microsoft.DotNet.Interactive.Http.Parsing.Parsing;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.DotNet.Interactive.Http.Parsing.Parsing;
 
 namespace Microsoft.DotNet.Interactive.Http.Parsing;
 
@@ -24,7 +24,7 @@ internal class HttpRootSyntaxNode : HttpSyntaxNode
     public void Add(HttpCommentNode commentNode)
     {
         AddInternal(commentNode);
-    } 
+    }
 
     public void Add(HttpVariableDeclarationAndAssignmentNode variableNode)
     {
@@ -64,7 +64,7 @@ internal class HttpRootSyntaxNode : HttpSyntaxNode
                         }
                         else
                         {
-                            return DynamicExpressionUtilites.ResolveExpressionBinding(node, node.Text);
+                            return DynamicExpressionUtilities.ResolveExpressionBinding(node, node.Text);
                         }
 
                     });
@@ -73,10 +73,10 @@ internal class HttpRootSyntaxNode : HttpSyntaxNode
                     {
                         declaredVariables[node.DeclarationNode.VariableName] = new DeclaredVariable(node.DeclarationNode.VariableName, value.Value, value);
                     }
-                    
                 }
             }
         }
+
         return declaredVariables;
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.DynamicExpressions.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.DynamicExpressions.cs
@@ -26,7 +26,7 @@ public partial class HttpParserTests
             var currentTime = DateTimeOffset.UtcNow;
             var node = result.SyntaxTree.RootNode.DescendantNodesAndTokens().OfType<HttpExpressionNode>().Single();
 
-            var binding = DynamicExpressionUtilites.ResolveExpressionBinding(node, () => currentTime, expression);
+            var binding = DynamicExpressionUtilities.ResolveExpressionBinding(node, () => currentTime, expression);
             binding.Value.As<string>().Should().Be(currentTime.AddDays(1.0).ToString("dd-MM-yyyy").ToString());
         }
 
@@ -42,7 +42,7 @@ public partial class HttpParserTests
             var currentTime = DateTimeOffset.UtcNow;
             var node = result.SyntaxTree.RootNode.DescendantNodesAndTokens().OfType<HttpExpressionNode>().Single();
 
-            var binding = DynamicExpressionUtilites.ResolveExpressionBinding(node, () => currentTime, expression);
+            var binding = DynamicExpressionUtilities.ResolveExpressionBinding(node, () => currentTime, expression);
             binding.Value.As<string>().Should().Be(currentTime.ToString("o").ToString());
         }
 
@@ -58,7 +58,7 @@ public partial class HttpParserTests
             var currentTime = DateTimeOffset.UtcNow;
             var node = result.SyntaxTree.RootNode.DescendantNodesAndTokens().OfType<HttpExpressionNode>().Single();
 
-            var binding = DynamicExpressionUtilites.ResolveExpressionBinding(node, () => currentTime, expression);
+            var binding = DynamicExpressionUtilities.ResolveExpressionBinding(node, () => currentTime, expression);
             binding.Value.As<string>().Should().Be(currentTime.AddYears(1).ToString("o").ToString());
         }
 
@@ -74,7 +74,7 @@ public partial class HttpParserTests
             var currentTime = DateTimeOffset.UtcNow;
             var node = result.SyntaxTree.RootNode.DescendantNodesAndTokens().OfType<HttpExpressionNode>().Single();
 
-            var binding = DynamicExpressionUtilites.ResolveExpressionBinding(node, () => currentTime, expression);
+            var binding = DynamicExpressionUtilities.ResolveExpressionBinding(node, () => currentTime, expression);
             binding.Value.As<string>().Should().Be(currentTime.ToString("r").ToString());
         }
 
@@ -90,7 +90,7 @@ public partial class HttpParserTests
             var currentTime = DateTimeOffset.UtcNow;
             var node = result.SyntaxTree.RootNode.DescendantNodesAndTokens().OfType<HttpExpressionNode>().Single();
 
-            var binding = DynamicExpressionUtilites.ResolveExpressionBinding(node, () => currentTime, expression);
+            var binding = DynamicExpressionUtilities.ResolveExpressionBinding(node, () => currentTime, expression);
             binding.Value.As<string>().Should().Be(currentTime.AddDays(1).ToString("r").ToString());
         }
 
@@ -106,7 +106,7 @@ public partial class HttpParserTests
             var currentTime = DateTimeOffset.Now;
             var node = result.SyntaxTree.RootNode.DescendantNodesAndTokens().OfType<HttpExpressionNode>().Single();
 
-            var binding = DynamicExpressionUtilites.ResolveExpressionBinding(node, () => currentTime, expression);
+            var binding = DynamicExpressionUtilities.ResolveExpressionBinding(node, () => currentTime, expression);
             binding.Value.As<string>().Should().Be(currentTime.AddDays(1.0).ToString("dd-MM-yyyy").ToString());
         }
 
@@ -122,7 +122,7 @@ public partial class HttpParserTests
             var currentTime = DateTimeOffset.Now;
             var node = result.SyntaxTree.RootNode.DescendantNodesAndTokens().OfType<HttpExpressionNode>().Single();
 
-            var binding = DynamicExpressionUtilites.ResolveExpressionBinding(node, () => currentTime, expression);
+            var binding = DynamicExpressionUtilities.ResolveExpressionBinding(node, () => currentTime, expression);
             binding.Value.As<string>().Should().Be(currentTime.ToString("o").ToString());
         }
 
@@ -138,7 +138,7 @@ public partial class HttpParserTests
             var currentTime = DateTimeOffset.Now;
             var node = result.SyntaxTree.RootNode.DescendantNodesAndTokens().OfType<HttpExpressionNode>().Single();
 
-            var binding = DynamicExpressionUtilites.ResolveExpressionBinding(node, () => currentTime, expression);
+            var binding = DynamicExpressionUtilities.ResolveExpressionBinding(node, () => currentTime, expression);
             binding.Value.As<string>().Should().Be(currentTime.AddYears(1).ToString("o").ToString());
         }
 
@@ -154,7 +154,7 @@ public partial class HttpParserTests
             var currentTime = DateTimeOffset.Now;
             var node = result.SyntaxTree.RootNode.DescendantNodesAndTokens().OfType<HttpExpressionNode>().Single();
 
-            var binding = DynamicExpressionUtilites.ResolveExpressionBinding(node, () => currentTime, expression);
+            var binding = DynamicExpressionUtilities.ResolveExpressionBinding(node, () => currentTime, expression);
             binding.Value.As<string>().Should().Be(currentTime.ToString("r").ToString());
         }
 
@@ -170,7 +170,7 @@ public partial class HttpParserTests
             var currentTime = DateTimeOffset.Now;
             var node = result.SyntaxTree.RootNode.DescendantNodesAndTokens().OfType<HttpExpressionNode>().Single();
 
-            var binding = DynamicExpressionUtilites.ResolveExpressionBinding(node, () => currentTime, expression);
+            var binding = DynamicExpressionUtilities.ResolveExpressionBinding(node, () => currentTime, expression);
             binding.Value.As<string>().Should().Be(currentTime.ToUnixTimeSeconds().ToString());
         }
 
@@ -186,7 +186,7 @@ public partial class HttpParserTests
             var currentTime = DateTimeOffset.Now;
             var node = result.SyntaxTree.RootNode.DescendantNodesAndTokens().OfType<HttpExpressionNode>().Single();
 
-            var binding = DynamicExpressionUtilites.ResolveExpressionBinding(node, () => currentTime, expression);
+            var binding = DynamicExpressionUtilities.ResolveExpressionBinding(node, () => currentTime, expression);
             binding.Value.As<string>().Should().Be(currentTime.AddMonths(7).ToUnixTimeSeconds().ToString());
         }
 
@@ -202,7 +202,7 @@ public partial class HttpParserTests
             var currentTime = DateTimeOffset.Now;
             var node = result.SyntaxTree.RootNode.DescendantNodesAndTokens().OfType<HttpExpressionNode>().Single();
 
-            var binding = DynamicExpressionUtilites.ResolveExpressionBinding(node, () => currentTime, expression);
+            var binding = DynamicExpressionUtilities.ResolveExpressionBinding(node, () => currentTime, expression);
             var stringValue = binding.Value.As<string>();
             Assert.True(int.TryParse(stringValue, out int value));
             value.Should().BeGreaterThanOrEqualTo(2).And.BeLessThan(10);
@@ -220,7 +220,7 @@ public partial class HttpParserTests
             var currentTime = DateTimeOffset.Now;
             var node = result.SyntaxTree.RootNode.DescendantNodesAndTokens().OfType<HttpExpressionNode>().Single();
 
-            var binding = DynamicExpressionUtilites.ResolveExpressionBinding(node, () => currentTime, expression);
+            var binding = DynamicExpressionUtilities.ResolveExpressionBinding(node, () => currentTime, expression);
             var stringValue = binding.Value.As<string>();
             Assert.True(int.TryParse(stringValue, out int value));
             value.Should().BeGreaterThanOrEqualTo(0).And.BeLessThan(3);
@@ -238,7 +238,7 @@ public partial class HttpParserTests
             var currentTime = DateTimeOffset.Now;
             var node = result.SyntaxTree.RootNode.DescendantNodesAndTokens().OfType<HttpExpressionNode>().Single();
 
-            var binding = DynamicExpressionUtilites.ResolveExpressionBinding(node, () => currentTime, expression);
+            var binding = DynamicExpressionUtilities.ResolveExpressionBinding(node, () => currentTime, expression);
             var stringValue = binding.Value.As<string>();
             Assert.True(int.TryParse(stringValue, out int value));
             value.Should().BeGreaterThanOrEqualTo(0);
@@ -256,7 +256,7 @@ public partial class HttpParserTests
             var currentTime = DateTimeOffset.Now;
             var node = result.SyntaxTree.RootNode.DescendantNodesAndTokens().OfType<HttpExpressionNode>().Single();
 
-            var binding = DynamicExpressionUtilites.ResolveExpressionBinding(node, () => currentTime, expression);
+            var binding = DynamicExpressionUtilities.ResolveExpressionBinding(node, () => currentTime, expression);
             var stringValue = binding.Value.As<string>();
             Assert.True(Guid.TryParse(stringValue, out Guid value));
             value.Should().NotBeEmpty();

--- a/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.Headers.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.Headers.cs
@@ -268,5 +268,43 @@ public partial class HttpParserTests
                   .Should().ContainSingle()
                   .Which.GetMessage().Should().Be("Missing header value.");
         }
+
+        [Fact]
+        public void Case_is_preserved_for_header_name()
+        {
+            var result = Parse(
+                """
+                GET https://example.com 
+                HEadEr: value
+                """);
+
+            var bindingResult =
+                result.SyntaxTree.RootNode.ChildNodes.OfType<HttpRequestNode>().Single().TryGetHttpRequestMessage(
+                    node => HttpBindingResult<object>.Failure(node.CreateDiagnostic(CreateDiagnosticInfo("oops!"))));
+
+            bindingResult.Diagnostics.Should().BeEmpty();
+            
+            var request = bindingResult.Value;
+            request.Headers.Should().ContainSingle().Which.Key.Should().Be("HEadEr");
+        }
+
+        [Fact]
+        public void Case_is_preserved_for_header_value()
+        {
+            var result = Parse(
+                """
+                GET https://example.com 
+                header: ValUE
+                """);
+
+            var bindingResult =
+                result.SyntaxTree.RootNode.ChildNodes.OfType<HttpRequestNode>().Single().TryGetHttpRequestMessage(
+                    node => HttpBindingResult<object>.Failure(node.CreateDiagnostic(CreateDiagnosticInfo("oops!"))));
+
+            bindingResult.Diagnostics.Should().BeEmpty();
+
+            var request = bindingResult.Value;
+            request.Headers.Should().ContainSingle().Which.Value.Should().ContainSingle().Which.Should().Be("ValUE");
+        }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Http/HttpKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.Http/HttpKernel.cs
@@ -1,13 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.CodeAnalysis;
-using Microsoft.DotNet.Interactive.Commands;
-using Microsoft.DotNet.Interactive.Connection;
-using Microsoft.DotNet.Interactive.Events;
-using Microsoft.DotNet.Interactive.Formatting;
-using Microsoft.DotNet.Interactive.Http.Parsing;
-using Microsoft.DotNet.Interactive.ValueSharing;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -15,6 +8,13 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.DotNet.Interactive.Commands;
+using Microsoft.DotNet.Interactive.Connection;
+using Microsoft.DotNet.Interactive.Events;
+using Microsoft.DotNet.Interactive.Formatting;
+using Microsoft.DotNet.Interactive.Http.Parsing;
+using Microsoft.DotNet.Interactive.ValueSharing;
 
 namespace Microsoft.DotNet.Interactive.Http;
 
@@ -328,9 +328,7 @@ public class HttpKernel :
         }
         else
         {
-            return DynamicExpressionUtilites.ResolveExpressionBinding(node, expression);
+            return DynamicExpressionUtilities.ResolveExpressionBinding(node, expression);
         }
-
-
     }
 }


### PR DESCRIPTION
Also fixes a typo in a type name.