### PR TITLE
Moving off the -pt images.

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -75,7 +75,7 @@ extends:
     sdl:
       sourceAnalysisPool: 
         name: $(DncEngInternalBuildPool)
-        image: 1es-windows-2022-pt
+        image: 1es-windows-2022
         os: windows
       binskim:
         enabled: true
@@ -110,7 +110,7 @@ extends:
           - job: Windows_NT
             pool:
               name: $(DncEngInternalBuildPool)
-              demands: ImageOverride -equals 1es-windows-2022-pt
+              demands: ImageOverride -equals 1es-windows-2022
               os: windows
             timeoutInMinutes: 90
             variables:

--- a/eng/publish/publish-npm.yml
+++ b/eng/publish/publish-npm.yml
@@ -13,7 +13,7 @@ stages:
   - job: Publish_NPM
     pool:
       name: $(DncEngInternalBuildPool)
-      demands: ImageOverride -equals 1es-windows-2022-pt
+      demands: ImageOverride -equals 1es-windows-2022
       os: windows
     variables:
     - group: AzureDevOps-Artifact-Feeds-Pats


### PR DESCRIPTION
The -pt images seem to have been removed. Moving to an image that is working based on other pipelines. 
Triggered build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2445424&view=results