### PR TITLE
Fix TryDotnet issue "Compile errors are duplicated in output"

### DIFF
--- a/src/Microsoft.DotNet.Interactive.CSharpProject/CSharpProjectKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/CSharpProjectKernel.cs
@@ -291,9 +291,17 @@ public class CSharpProjectKernel :
             projectDiagnostics = projectDiags;
         }
 
-        var allDiagnostics = diagnostics.Concat(projectDiagnostics);
+        var uniqueDiagnostics = diagnostics.ToDictionary(d => d.Id, d => d);
 
-        var finalDiagnostics = allDiagnostics.Select(d => new Diagnostic(new LinePositionSpan(GetLinePositionFromPosition(code, d.Start), GetLinePositionFromPosition(code, d.End)), d.Severity, d.Id, d.Message));
+        foreach (var projDiag in projectDiagnostics)
+        {
+            if (!uniqueDiagnostics.ContainsKey(projDiag.Id))
+            {
+                uniqueDiagnostics.Add(projDiag.Id, projDiag);
+            }
+        }
+
+        var finalDiagnostics = uniqueDiagnostics.Values.Select(d => new Diagnostic(new LinePositionSpan(GetLinePositionFromPosition(code, d.Start), GetLinePositionFromPosition(code, d.End)), d.Severity, d.Id, d.Message));
 
         return finalDiagnostics;
     }

--- a/src/Microsoft.DotNet.Interactive.CSharpProject/CSharpProjectKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject/CSharpProjectKernel.cs
@@ -277,7 +277,6 @@ public class CSharpProjectKernel :
     private static IEnumerable<Diagnostic> GetDiagnostics(string code, CompileResult result)
     {
         var diagnostics = Enumerable.Empty<SerializableDiagnostic>();
-        var projectDiagnostics = Enumerable.Empty<SerializableDiagnostic>();
 
         if (result.Features.TryGetValue(nameof(Diagnostics), out var candidateDiagnostics) &&
             candidateDiagnostics is Diagnostics diags)
@@ -285,23 +284,7 @@ public class CSharpProjectKernel :
             diagnostics = diags;
         }
 
-        if (result.Features.TryGetValue(nameof(ProjectDiagnostics), out var candidateProjectDiagnostics) &&
-            candidateProjectDiagnostics is ProjectDiagnostics projectDiags)
-        {
-            projectDiagnostics = projectDiags;
-        }
-
-        var uniqueDiagnostics = diagnostics.ToDictionary(d => d.Id, d => d);
-
-        foreach (var projDiag in projectDiagnostics)
-        {
-            if (!uniqueDiagnostics.ContainsKey(projDiag.Id))
-            {
-                uniqueDiagnostics.Add(projDiag.Id, projDiag);
-            }
-        }
-
-        var finalDiagnostics = uniqueDiagnostics.Values.Select(d => new Diagnostic(new LinePositionSpan(GetLinePositionFromPosition(code, d.Start), GetLinePositionFromPosition(code, d.End)), d.Severity, d.Id, d.Message));
+        var finalDiagnostics = diagnostics.Select(d => new Diagnostic(new LinePositionSpan(GetLinePositionFromPosition(code, d.Start), GetLinePositionFromPosition(code, d.End)), d.Severity, d.Id, d.Message));
 
         return finalDiagnostics;
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/try/issues/1184

This fixes a bug in TryDotNet that occurs when a user enters invalid code.

- Ensured project diagnostics are added only if their Id is not already present in the main diagnostics collection

![image](https://github.com/dotnet/interactive/assets/510598/1d1e0e4e-0bb8-451c-949a-6330dff69dae)
