### PR TITLE
Improve Variable Grid for screen reader

### DIFF
--- a/src/polyglot-notebooks-ui-components/src/components/VariableGrid.tsx
+++ b/src/polyglot-notebooks-ui-components/src/components/VariableGrid.tsx
@@ -45,7 +45,7 @@ const defaultGridLocalization: GridLocalization = {
     typeColumnHeader: 'Type',
     kernelNameColumnHeader: 'Kernel',
     shareTemplate: 'Share value "{value-name}" from kernel "{kernel-name}"',
-    gridCaption: 'Polyglot notebook varialbes'
+    gridCaption: 'Polyglot Notebook variables'
 }
 
 export class VariableGrid extends React.Component<VariableGridProps, VariableGridState> {

--- a/src/polyglot-notebooks-ui-components/src/components/VariableGrid.tsx
+++ b/src/polyglot-notebooks-ui-components/src/components/VariableGrid.tsx
@@ -44,7 +44,8 @@ const defaultGridLocalization: GridLocalization = {
     valueColumnHeader: 'Value',
     typeColumnHeader: 'Type',
     kernelNameColumnHeader: 'Kernel',
-    shareTemplate: 'Share value {value-name} from {kernel-name} kernel'
+    shareTemplate: 'Share value {value-name} from {kernel-name} kernel',
+    gridCaption: 'Polyglot notebook varialbes'
 }
 
 export class VariableGrid extends React.Component<VariableGridProps, VariableGridState> {
@@ -363,6 +364,9 @@ export class VariableGrid extends React.Component<VariableGridProps, VariableGri
                 </div>
                 <div className="table-container" >
                     <table id="table-root">
+                        <caption>
+                            {this.state.gridLocalization!.gridCaption}
+                        </caption>
                         <colgroup>
                             <col id="name-column" className="name-column"></col>
                             <col id="value-column" className="value-column"></col>
@@ -370,9 +374,10 @@ export class VariableGrid extends React.Component<VariableGridProps, VariableGri
                             <col id="kernel-column" className="kernel-column"></col>
                             <col id="actions-column" className="actions-column"></col>
                         </colgroup>
-                        <tbody>
+                        <thead>
                             <tr>
                                 <th
+                                    scope="col"
                                     key={0}
                                     id={`0-0`}
                                     className="header name-column"
@@ -386,6 +391,7 @@ export class VariableGrid extends React.Component<VariableGridProps, VariableGri
                                     />
                                 </th>
                                 <th
+                                    scope="col"
                                     key={1}
                                     id={`0-1`}
                                     className="header value-column"
@@ -399,6 +405,7 @@ export class VariableGrid extends React.Component<VariableGridProps, VariableGri
                                     />
                                 </th>
                                 <th
+                                    scope="col"
                                     key={2}
                                     id={`0-2`}
                                     className="header type-column"
@@ -412,6 +419,7 @@ export class VariableGrid extends React.Component<VariableGridProps, VariableGri
                                     />
                                 </th>
                                 <th
+                                    scope="col"
                                     key={3}
                                     id={`0-3`}
                                     className="header kernel-column"
@@ -425,6 +433,7 @@ export class VariableGrid extends React.Component<VariableGridProps, VariableGri
                                     />
                                 </th>
                                 <th
+                                    scope="col"
                                     key={4}
                                     id={`0-4`}
                                     className="header actions-column"
@@ -432,6 +441,8 @@ export class VariableGrid extends React.Component<VariableGridProps, VariableGri
                                     {this.state.gridLocalization!.actionsColumnHeader}
                                 </th>
                             </tr>
+                        </thead>
+                        <tbody>
                             {rows.map((row: VariableGridRow, i) =>
                                 <tr key={i + 1}>
                                     <td key={0} id={`${row.id}-${0}`} className="name-column">

--- a/src/polyglot-notebooks-ui-components/src/components/VariableGrid.tsx
+++ b/src/polyglot-notebooks-ui-components/src/components/VariableGrid.tsx
@@ -44,7 +44,7 @@ const defaultGridLocalization: GridLocalization = {
     valueColumnHeader: 'Value',
     typeColumnHeader: 'Type',
     kernelNameColumnHeader: 'Kernel',
-    shareTemplate: 'Share value {value-name} from {kernel-name} kernel',
+    shareTemplate: 'Share value "{value-name}" from kernel "{kernel-name}"',
     gridCaption: 'Polyglot notebook varialbes'
 }
 

--- a/src/polyglot-notebooks-ui-components/src/contracts/types.ts
+++ b/src/polyglot-notebooks-ui-components/src/contracts/types.ts
@@ -22,4 +22,5 @@ export interface GridLocalization {
     actionsColumnHeader: string;
     kernelNameColumnHeader: string;
     shareTemplate: string;
+    gridCaption: string;
 }

--- a/src/polyglot-notebooks-vscode-common/src/extension.ts
+++ b/src/polyglot-notebooks-vscode-common/src/extension.ts
@@ -40,7 +40,7 @@ import { ActiveNotebookTracker } from './activeNotebookTracker';
 import * as metadataUtilities from './metadataUtilities';
 import * as constants from './constants';
 import { ServiceCollection } from './serviceCollection';
-import { SurveyBanner } from './surveyBanner'
+import { SurveyBanner } from './surveyBanner';
 
 export class CachedDotNetPathManager {
     private dotNetPath: string = 'dotnet'; // default to global tool if possible

--- a/src/polyglot-notebooks-vscode-common/src/variableExplorer.ts
+++ b/src/polyglot-notebooks-vscode-common/src/variableExplorer.ts
@@ -160,7 +160,7 @@ class WatchWindowTableViewProvider implements vscode.WebviewViewProvider {
                 typeColumnHeader: this.translate('VariableGridColumnType', 'Type'),
                 kernelNameColumnHeader: this.translate('VariableGridColumnKernel', 'Kernel'),
                 shareTemplate: this.translate('VariableGridshareTemplate', 'Share value "{value-name}" from kernel "{kernel-name}"'),
-                gridCaption: this.translate('VariableGridCaption', 'Polyglot notebook varialbes')
+                gridCaption: this.translate('VariableGridCaption', 'Polyglot Notebook variables')
             };
 
             const jsonRows = JSON.parse(connection.Serialize(rows));

--- a/src/polyglot-notebooks-vscode-common/src/variableExplorer.ts
+++ b/src/polyglot-notebooks-vscode-common/src/variableExplorer.ts
@@ -159,7 +159,7 @@ class WatchWindowTableViewProvider implements vscode.WebviewViewProvider {
                 valueColumnHeader: this.translate('VariableGridColumnValue', 'Value'),
                 typeColumnHeader: this.translate('VariableGridColumnType', 'Type'),
                 kernelNameColumnHeader: this.translate('VariableGridColumnKernel', 'Kernel'),
-                shareTemplate: this.translate('VariableGridshareTemplate', 'Share value {value-name} from {kernel-name} kernel'),
+                shareTemplate: this.translate('VariableGridshareTemplate', 'Share value "{value-name}" from kernel "{kernel-name}"'),
                 gridCaption: this.translate('VariableGridCaption', 'Polyglot notebook varialbes')
             };
 

--- a/src/polyglot-notebooks-vscode-common/src/variableExplorer.ts
+++ b/src/polyglot-notebooks-vscode-common/src/variableExplorer.ts
@@ -159,7 +159,8 @@ class WatchWindowTableViewProvider implements vscode.WebviewViewProvider {
                 valueColumnHeader: this.translate('VariableGridColumnValue', 'Value'),
                 typeColumnHeader: this.translate('VariableGridColumnType', 'Type'),
                 kernelNameColumnHeader: this.translate('VariableGridColumnKernel', 'Kernel'),
-                shareTemplate: this.translate('VariableGridshareTemplate', 'Share value {value-name} from {kernel-name} kernel')
+                shareTemplate: this.translate('VariableGridshareTemplate', 'Share value {value-name} from {kernel-name} kernel'),
+                gridCaption: this.translate('VariableGridCaption', 'Polyglot notebook varialbes')
             };
 
             const jsonRows = JSON.parse(connection.Serialize(rows));

--- a/src/polyglot-notebooks-vscode-insiders/l10n/bundle.l10n.json
+++ b/src/polyglot-notebooks-vscode-insiders/l10n/bundle.l10n.json
@@ -5,7 +5,7 @@
     "VariableGridColumnType": "Type",
     "VariableGridColumnKernel": "Kernel",
     "VariableGridshareTemplate": "Share value {value-name} from {kernel-name} kernel",
-    "'VariableGridCaption": "Polyglot notebook varialbes",
+    "'VariableGridCaption": "Polyglot Notebook variables",
     "survey.yes": "Yes, take me to the survey",
     "survey.no": "No",
     "survey.message": "We would love to hear your feedback on the notebooks experience! Please take a few minutes to give feedback on using Polyglot Notebooks."

--- a/src/polyglot-notebooks-vscode-insiders/l10n/bundle.l10n.json
+++ b/src/polyglot-notebooks-vscode-insiders/l10n/bundle.l10n.json
@@ -5,6 +5,7 @@
     "VariableGridColumnType": "Type",
     "VariableGridColumnKernel": "Kernel",
     "VariableGridshareTemplate": "Share value {value-name} from {kernel-name} kernel",
+    "'VariableGridCaption": "Polyglot notebook varialbes",
     "survey.yes": "Yes, take me to the survey",
     "survey.no": "No",
     "survey.message": "We would love to hear your feedback on the notebooks experience! Please take a few minutes to give feedback on using Polyglot Notebooks."


### PR DESCRIPTION
- Updated the `VariableGrid.tsx` file to add a new grid caption for the Polyglot notebook variables.
- Added a new property `gridCaption` in the `GridLocalization` interface in the `types.ts` file.
- Updated the `variableExplorer.ts` file to include the new grid caption in the translation for sharing values from different kernels.
- Updated the localization bundle with a new key-value pair for the grid caption.
- Use `thead` and `scope` to improve screen reader accessibility.
