### PR TITLE
Magic command completion and hover refinements

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/CompletionTests.MagicCommands.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/CompletionTests.MagicCommands.cs
@@ -49,6 +49,17 @@ public partial class CompletionTests
                     #!set --name x [||]
                     
                     """, "--value")]
+        [InlineData("""
+                    
+                    #!connect signalr
+                    
+                    
+                    #!set [||]
+                    
+                    
+                    #!share  
+                    
+                    """, "--value")]
         // subcommands
         public async Task Completions_are_available_for_magic_commands(
             string markupCode,

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/HoverTextTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/HoverTextTests.cs
@@ -66,9 +66,9 @@ public class HoverTextTests : LanguageKernelTestBase
     }
 
     [Theory]
-    [InlineData("#!s$$et --value", "Sets a value in the current kernel")]
-    [InlineData("#!set --valu$$e", "The value to be set")]
-    [InlineData("#!connect sign$$alr --kernel-name blah", "Connects to a kernel using SignalR")]
+    [InlineData("#!s$$et --value", "Sets a value in the current kernel*--name*--value*")]
+    [InlineData("#!set --valu$$e", "The value to be set*")]
+    [InlineData("#!connect sign$$alr --kernel-name blah", "Connects to a kernel using SignalR*")]
     public async Task hover_request_returns_expected_result_for_magic_commands(
         string markupCode,
         string expectedContent)
@@ -89,7 +89,7 @@ public class HoverTextTests : LanguageKernelTestBase
                      .Which
                      .Value
                      .Should()
-                     .Contain(expectedContent);
+                     .Match(expectedContent);
     }
 
     [Theory]

--- a/src/Microsoft.DotNet.Interactive/Parsing/PolyglotSyntaxParser.cs
+++ b/src/Microsoft.DotNet.Interactive/Parsing/PolyglotSyntaxParser.cs
@@ -73,7 +73,7 @@ internal class PolyglotSyntaxParser
     {
         if (IsAtStartOfDirective())
         {
-            var directiveNameNode = ParseParameterName();
+            var directiveNameNode = ParseDirectiveName();
 
             var targetKernelName = _currentKernelName ?? _compositeKernelInfo?.LocalName;
 
@@ -151,7 +151,7 @@ internal class PolyglotSyntaxParser
                             ConsumeCurrentTokenInto(subcommandNameNode);
                         }
 
-                        ParseTrailingWhitespace(subcommandNode);
+                        ParseTrailingWhitespace(subcommandNode, stopBeforeNewLine: true);
                         directiveNode.Add(subcommandNode);
                     }
                     else if (ParseParameterValue() is { } parameterValueNode)
@@ -207,7 +207,7 @@ internal class PolyglotSyntaxParser
 
         return null;
 
-        DirectiveNameNode ParseParameterName()
+        DirectiveNameNode ParseDirectiveName()
         {
             var directiveNameNode = new DirectiveNameNode(_sourceText, _syntaxTree);
 


### PR DESCRIPTION
This fixes a bug with magic command completions due to subcommand parsing sometimes consuming tokens past a newline, and also adds an overall summary to the magic command hover text:

![image](https://github.com/user-attachments/assets/594569bc-1569-42c7-9fc2-df77e15306ba)
