### PR TITLE
Add support for auto-recall for input prompts

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -60,6 +60,9 @@
     <FileSignInfo Include="Microsoft.PowerShell.Archive.psm1" CertificateName="None" />
     <FileSignInfo Include="ArchiveResources.psd1" CertificateName="None" />
 
+    <!-- Microsoft.PowerShell.SecretManagement -->
+    <FileSignInfo Include="Microsoft.PowerShell.SecretManagement.psd1" CertificateName="None" />
+
     <!-- PackageManagement -->
     <FileSignInfo Include="PackageManagement.cat" CertificateName="None" />
     <FileSignInfo Include="PackageManagement.format.ps1xml" CertificateName="None" />

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -62,6 +62,11 @@
 
     <!-- Microsoft.PowerShell.SecretManagement -->
     <FileSignInfo Include="Microsoft.PowerShell.SecretManagement.psd1" CertificateName="None" />
+    <FileSignInfo Include="Microsoft.PowerShell.SecretStore.Extension.psd1" CertificateName="None" />
+    <FileSignInfo Include="Microsoft.PowerShell.SecretStore.Extension.psm1" CertificateName="None" />
+
+    <!-- Microsoft.PowerShell.SecretStore -->
+    <FileSignInfo Include="Microsoft.PowerShell.SecretStore.psd1" CertificateName="None" />
 
     <!-- PackageManagement -->
     <FileSignInfo Include="PackageManagement.cat" CertificateName="None" />

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -62,11 +62,12 @@
 
     <!-- Microsoft.PowerShell.SecretManagement -->
     <FileSignInfo Include="Microsoft.PowerShell.SecretManagement.psd1" CertificateName="None" />
-    <FileSignInfo Include="Microsoft.PowerShell.SecretStore.Extension.psd1" CertificateName="None" />
-    <FileSignInfo Include="Microsoft.PowerShell.SecretStore.Extension.psm1" CertificateName="None" />
-
+    <FileSignInfo Include="Microsoft.PowerShell.SecretManagement.format.ps1xml" CertificateName="None" />
+    
     <!-- Microsoft.PowerShell.SecretStore -->
     <FileSignInfo Include="Microsoft.PowerShell.SecretStore.psd1" CertificateName="None" />
+    <FileSignInfo Include="Microsoft.PowerShell.SecretStore.Extension.psd1" CertificateName="None" />
+    <FileSignInfo Include="Microsoft.PowerShell.SecretStore.Extension.psm1" CertificateName="None" />
 
     <!-- PackageManagement -->
     <FileSignInfo Include="PackageManagement.cat" CertificateName="None" />

--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
@@ -93,8 +93,8 @@ Microsoft.DotNet.Interactive
     public static Kernel Root { get;}
     public static System.Void CSS(System.String content)
     public static DisplayedValue display(System.Object value, System.String[] mimeTypes)
-    public static System.Threading.Tasks.Task<System.String> GetInputAsync(System.String prompt = , System.String typeHint = text, System.String valueName = null)
-    public static System.Threading.Tasks.Task<PasswordString> GetPasswordAsync(System.String prompt = , System.String valueName = null)
+    public static System.Threading.Tasks.Task<System.String> GetInputAsync(System.String prompt = , System.String typeHint = text)
+    public static System.Threading.Tasks.Task<PasswordString> GetPasswordAsync(System.String prompt = )
     public static Microsoft.AspNetCore.Html.IHtmlContent HTML(System.String content)
     public static System.Void Javascript(System.String scriptContent)
     public FrontendEnvironment FrontendEnvironment { get; set;}
@@ -397,12 +397,11 @@ Microsoft.DotNet.Interactive.Commands
   public class RequestHoverText : LanguageServiceCommand, System.IEquatable<KernelCommand>
     .ctor(System.String code, Microsoft.DotNet.Interactive.LinePosition linePosition, System.String targetKernelName = null)
   public class RequestInput : KernelCommand, System.IEquatable<KernelCommand>
-    .ctor(System.String prompt, System.String targetKernelName = null, System.String inputTypeHint = null, System.String valueName = null)
+    .ctor(System.String prompt, System.String targetKernelName = null, System.String inputTypeHint = null)
     public System.String InputTypeHint { get; set;}
     public System.Boolean IsPassword { get;}
     public System.String Prompt { get;}
     public System.String SaveAs { get; set;}
-    public System.String ValueName { get;}
   public class RequestKernelInfo : KernelCommand, System.IEquatable<KernelCommand>
     .ctor(System.String targetKernelName = null)
     .ctor(System.Uri destinationUri)

--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
@@ -126,7 +126,7 @@ Microsoft.DotNet.Interactive
     public System.Threading.Tasks.Task<KernelCommandResult> SendAsync(Microsoft.DotNet.Interactive.Commands.KernelCommand command, System.Threading.CancellationToken cancellationToken = null)
     protected System.Void SetHandlingKernel(Microsoft.DotNet.Interactive.Commands.KernelCommand command, KernelInvocationContext context)
      System.Void SetScheduler(KernelScheduler<Microsoft.DotNet.Interactive.Commands.KernelCommand,KernelCommandResult> scheduler)
-    protected System.Threading.Tasks.Task SetValueAsync(Microsoft.DotNet.Interactive.Commands.SendValue command, KernelInvocationContext context, SetValueAsyncDelegate setValueAsync)
+    protected System.Threading.Tasks.Task SetValueAsync(Microsoft.DotNet.Interactive.Commands.SendValue command, KernelInvocationContext context, SetValueAsyncDelegate onSetValueAsync)
     public System.Boolean SupportsCommandType(System.Type commandType)
     public System.String ToString()
   public class KernelCollection, System.Collections.Generic.IEnumerable<Kernel>, System.Collections.Generic.IReadOnlyCollection<Kernel>, System.Collections.IEnumerable
@@ -401,7 +401,7 @@ Microsoft.DotNet.Interactive.Commands
     public System.String InputTypeHint { get; set;}
     public System.Boolean IsPassword { get;}
     public System.String Prompt { get;}
-    public System.Boolean Save { get; set;}
+    public System.String SaveAs { get; set;}
     public System.String ValueName { get;}
   public class RequestKernelInfo : KernelCommand, System.IEquatable<KernelCommand>
     .ctor(System.String targetKernelName = null)

--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.cs
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.ComponentModel;
 using System.Diagnostics;
 using Assent;
 using Microsoft.DotNet.Interactive.CSharp;
@@ -22,6 +23,7 @@ using Xunit;
 
 namespace Microsoft.DotNet.Interactive.ApiCompatibility.Tests;
 
+[Trait("Category", "Contracts and serialization")]
 public class ApiCompatibilityTests
 {
     private readonly Configuration _configuration;

--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.powershell_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.powershell_api_is_not_changed.approved.txt
@@ -11,6 +11,7 @@ Microsoft.DotNet.Interactive.PowerShell
     public static PowerShellKernel UseProfiles()
   public class SecretManager
     .ctor(PowerShellKernel kernel)
+    public System.String VaultName { get;}
     public System.Void SetSecret(System.String name, System.String value, System.String command = null, System.String source = null)
     public System.Boolean TryGetSecret(System.String secretName, ref System.String& value)
 Microsoft.DotNet.Interactive.PowerShell.Commands

--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.powershell_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.powershell_api_is_not_changed.approved.txt
@@ -9,6 +9,10 @@ Microsoft.DotNet.Interactive.PowerShell
     public System.Boolean TryGetValue<T>(System.String name, ref T& value)
   public static class PowerShellKernelExtensions
     public static PowerShellKernel UseProfiles()
+  public class SecretManager
+    .ctor(PowerShellKernel kernel)
+    public System.Void SetSecret(System.String name, System.String value, System.String command = null, System.String source = null)
+    public System.Boolean TryGetSecret(System.String secretName, ref System.String& value)
 Microsoft.DotNet.Interactive.PowerShell.Commands
   public class EnterAzShellCommand : System.Management.Automation.PSCmdlet
     .ctor()

--- a/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/SerializationTests.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharpProject.Tests/SerializationTests.cs
@@ -23,6 +23,7 @@ using System.Text.Encodings.Web;
 
 namespace Microsoft.DotNet.Interactive.CSharpProject.Tests;
 
+[Trait("Category", "Contracts and serialization")]
 public class SerializationTests
 {
     private readonly ITestOutputHelper _output;

--- a/src/Microsoft.DotNet.Interactive.Documents.Tests/NotebookParserServerTests_Serialization.cs
+++ b/src/Microsoft.DotNet.Interactive.Documents.Tests/NotebookParserServerTests_Serialization.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 namespace Microsoft.DotNet.Interactive.Documents.Tests;
 
+[Trait("Category", "Contracts and serialization")]
 public class NotebookParserServerTests_Serialization
 {
     private readonly Configuration _configuration =

--- a/src/Microsoft.DotNet.Interactive.Formatting/HtmlFormatter.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/HtmlFormatter.cs
@@ -25,7 +25,7 @@ public static class HtmlFormatter
         }
     }
 
-    // FIX: (HtmlFormatter) this can return a formatter with the wrong MIME type
+    // TODO: (HtmlFormatter) this can return a formatter with the wrong MIME type
     public static ITypeFormatter GetPreferredFormatterFor(Type type) =>
         Formatter.GetPreferredFormatterFor(type, MimeType);
 

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/HistorySerializationTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/HistorySerializationTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace Microsoft.DotNet.Interactive.Jupyter.Tests;
 
+[Trait("Category", "Contracts and serialization")]
 public class HistorySerializationTests
 {
     [Fact]

--- a/src/Microsoft.DotNet.Interactive.Jupyter/JupyterClientKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/JupyterClientKernelExtension.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter;
 
 public class JupyterClientKernelExtension
 {
-    public static  Task LoadAsync(Kernel kernel)
+    public static Task LoadAsync(Kernel kernel)
     {
         if (kernel is CompositeKernel root)
         {

--- a/src/Microsoft.DotNet.Interactive.Jupyter/KernelExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/KernelExtensions.cs
@@ -46,6 +46,7 @@ using static {typeof(TopLevelMethods).FullName};
     public static PowerShellKernel UseJupyterHelpers(
         this PowerShellKernel kernel)
     {
+        // TODO: (UseJupyterHelpers) remove Powershell package reference?
         kernel.ReadInput = TopLevelMethods.input;
         kernel.ReadPassword = TopLevelMethods.password;
         return kernel;

--- a/src/Microsoft.DotNet.Interactive.NamedPipeConnector/NamedPipeKernelConnector.cs
+++ b/src/Microsoft.DotNet.Interactive.NamedPipeConnector/NamedPipeKernelConnector.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Interactive.NamedPipeConnector;
 
 public class NamedPipeKernelConnector : IDisposable
 {
-    // FIX: (NamedPipeKernelConnector) make this internal and inline into ConnectNamedPipe
+    // TODO: (NamedPipeKernelConnector) make this internal and inline into ConnectNamedPipe
     private KernelCommandAndEventReceiver? _receiver;
     private KernelCommandAndEventSender? _sender;
     private NamedPipeClientStream? _clientStream;

--- a/src/Microsoft.DotNet.Interactive.Parsing.Tests/Language.cs
+++ b/src/Microsoft.DotNet.Interactive.Parsing.Tests/Language.cs
@@ -5,7 +5,6 @@ namespace Microsoft.DotNet.Interactive.Parsing.Tests;
 
 public enum Language
 {
-    // FIX: (Language) simplify
     CSharp = 0,
     FSharp = 1,
     PowerShell = 2,

--- a/src/Microsoft.DotNet.Interactive.Parsing.Tests/Microsoft.DotNet.Interactive.Parsing.Tests.csproj
+++ b/src/Microsoft.DotNet.Interactive.Parsing.Tests/Microsoft.DotNet.Interactive.Parsing.Tests.csproj
@@ -22,7 +22,7 @@
     <Compile Include="..\Microsoft.DotNet.Interactive\LinePosition.cs" Link="LinePosition.cs" LinkBase="Parsing" />
     <Compile Include="..\Microsoft.DotNet.Interactive\LinePositionSpan.cs" Link="LinePositionSpan.cs" LinkBase="Parsing" />
     
-    <Compile Include="..\Microsoft.DotNet.Interactive\Utility\SourceUtilities.cs" Link="SourceUtilities.cs" LinkBase="Parsing" />
+    <Compile Include="..\Microsoft.DotNet.Interactive\Utility\SourceUtilities.cs" Link="Utility\SourceUtilities.cs" LinkBase="Parsing" />
 
     <Compile Include="..\Microsoft.DotNet.Interactive\Directives\KernelActionDirective.cs" Link="KernelActionDirective.cs" LinkBase="Parsing" />
     <Compile Include="..\Microsoft.DotNet.Interactive\Directives\KernelDirective.cs" Link="KernelDirective.cs" LinkBase="Parsing" />
@@ -65,7 +65,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="$(xunitVersion)"  />
+    <PackageReference Include="xunit" Version="$(xunitVersion)" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisCommonVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />

--- a/src/Microsoft.DotNet.Interactive.Parsing.Tests/PolyglotSyntaxParserTests.Completions.cs
+++ b/src/Microsoft.DotNet.Interactive.Parsing.Tests/PolyglotSyntaxParserTests.Completions.cs
@@ -323,8 +323,5 @@ public partial class PolyglotSyntaxParserTests
             completions.Should().Contain(c => c.InsertText == "--value");
             completions.Should().NotContain(c => c.InsertText == "--name");
         }
-
-        // FIX: (Completions) test partial words and filtering
-        // FIX: (Completions) test values for parameters allowing implicit names
     }
 }

--- a/src/Microsoft.DotNet.Interactive.PowerShell.Tests/Microsoft.DotNet.Interactive.PowerShell.Tests.v3.ncrunchproject
+++ b/src/Microsoft.DotNet.Interactive.PowerShell.Tests/Microsoft.DotNet.Interactive.PowerShell.Tests.v3.ncrunchproject
@@ -1,5 +1,10 @@
 ﻿<ProjectConfiguration>
   <Settings>
     <DefaultTestTimeout>10000</DefaultTestTimeout>
+    <IgnoredTests>
+      <FixtureTestSelector>
+        <FixtureName>Microsoft.DotNet.Interactive.PowerShell.Tests.SecretManagerTests</FixtureName>
+      </FixtureTestSelector>
+    </IgnoredTests>
   </Settings>
 </ProjectConfiguration>

--- a/src/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell.Tests/PowerShellKernelTests.cs
@@ -86,7 +86,23 @@ for ($j = 0; $j -le 4; $j += 4 ) {
 
         var result = await kernel.SendAsync(new SubmitCode("Get-ChildItem oops"));
 
-        result.Events.Last().Should().BeOfType<CommandFailed>();
+        result.Events.Last().Should().BeOfType<CommandFailed>()
+              .Which.Message
+              .Should().Match("Cannot find path '*oops' because it does not exist.");
+    }
+
+    [Fact]
+    public async Task Errors_from_previous_submissions_are_not_shown()
+    {
+        using var kernel = CreateKernel(Language.PowerShell);
+
+        await kernel.SendAsync(new SubmitCode("Get-ChildItem oops1"));
+
+        var result = await kernel.SendAsync(new SubmitCode("Get-ChildItem oops2"));
+
+        result.Events.Last().Should().BeOfType<CommandFailed>()
+              .Which.Message
+              .Should().NotContain("oops1");
     }
 
     [Fact]

--- a/src/Microsoft.DotNet.Interactive.PowerShell.Tests/SecretManagerTests.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell.Tests/SecretManagerTests.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Microsoft.DotNet.Interactive.Commands;
+using Microsoft.DotNet.Interactive.Events;
+using Xunit;
+
+namespace Microsoft.DotNet.Interactive.PowerShell.Tests;
+
+public class SecretManagerTests
+{
+    [Theory]
+    [InlineData("SECRET_NAME", "s33kr1t!!!")]
+    [InlineData("SECRET NAME with a space", "s33kr1t!!!")]
+    [InlineData("SecretJson",
+                """
+                {
+                    "what": "how about some JSON?",
+                    "howMuch": 1
+                }
+                """)]
+    public void It_can_register_and_retrieve_a_secret(string secretName, string value)
+    {
+        using var kernel = new PowerShellKernel();
+
+        var secretManager = new SecretManager(kernel);
+
+        // make the secret name unique across runs
+        secretName += DateTime.UtcNow.Ticks;
+
+        secretManager.SetSecret(name: secretName, value: value);
+
+        var success = secretManager.TryGetSecret(secretName, out var secret);
+
+        using var _ = new AssertionScope();
+
+        success.Should().BeTrue();
+        secret.Should().Be(value);
+    }
+
+    [Fact]
+    public async Task Temporary_variables_are_cleaned_up_after_retrieving_secrets()
+    {
+        using var kernel = new PowerShellKernel();
+
+        var secretManager = new SecretManager(kernel);
+
+        var secretName = nameof(Temporary_variables_are_cleaned_up_after_retrieving_secrets) + DateTime.UtcNow.Ticks;
+        var value = "s33kr1t!!!";
+
+        secretManager.SetSecret(name: secretName, value: value);
+
+        var valueInfosResultBefore = await kernel.SendAsync(new RequestValueInfos());
+
+        secretManager.TryGetSecret(secretName, out var secret);
+
+        var valueInfosResultAfter = await kernel.SendAsync(new RequestValueInfos());
+
+        var variableNamesAfter = valueInfosResultAfter.Events
+                                                      .OfType<ValueInfosProduced>()
+                                                      .Single()
+                                                      .ValueInfos
+                                                      .Select(i => i.Name);
+        var variableNamesBefore = valueInfosResultBefore.Events
+                                                        .OfType<ValueInfosProduced>()
+                                                        .Single()
+                                                        .ValueInfos
+                                                        .Select(i => i.Name);
+        variableNamesAfter.Should().BeEquivalentTo(variableNamesBefore);
+    }
+}

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -87,7 +87,7 @@
     <Content Include="$(PkgMicrosoft_PowerShell_SecretStore)\**" 
              Exclude="$(PkgMicrosoft_PowerShell_SecretStore)\**\*.nupkg;$(PkgMicrosoft_PowerShell_SecretStore)\**\*.nuspec;$(PkgMicrosoft_PowerShell_SecretStore)\**\*.sha512" 
              Link="Modules\Microsoft.PowerShell.SecretStore\%(RecursiveDir)%(FileName)%(Extension)" 
-             PackagePath="contentFiles/any/any/Modules/Microsoft.PowerShell.SecretStore" 
+             PackagePath="contentFiles/any/any/Modules/M.P.S" 
              PackageCopyToOutput="true"
              CopyToOutputDirectory="PreserveNewest" 
              Condition="'$(PkgMicrosoft_PowerShell_SecretStore)' != ''" />

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -73,7 +73,7 @@
              Link="Modules\Microsoft.PowerShell.Archive\%(RecursiveDir)%(FileName)%(Extension)" 
              PackagePath="contentFiles/any/any/Modules/Microsoft.PowerShell.Archive" 
              PackageCopyToOutput="true" 
-             CopyToOutputDirectory="PreserveNewest" 
+             CopyToOutputDirectory="PreserveNewest"
              Condition="'$(PkgMicrosoft_PowerShell_Archive)' != ''" />
 
     <Content Include="$(PkgMicrosoft_PowerShell_SecretManagement)\**" 

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -17,12 +17,25 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <NoWarn>$(NoWarn);NU5104;NU5100;2003;8002</NoWarn>
   </PropertyGroup>
+  
+  <!-- The dependencies for this project -->
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.DotNet.Interactive.Formatting\Microsoft.DotNet.Interactive.Formatting.csproj" />
+    <ProjectReference Include="..\Microsoft.DotNet.Interactive\Microsoft.DotNet.Interactive.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="JsonSchema.Net" Version="7.1.2" />
+    <PackageReference Include="System.IO.Pipelines" Version="8.0.0" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="$(SystemSecurityCryptographyPkcsVersion)" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.3" />
+  </ItemGroup>
 
   <!-- PowerShell Module Package References -->
   <ItemGroup>
-    <PackageReference Include="JsonSchema.Net" Version="6.0.7" />
-    <PackageReference Include="PackageManagement" Version="1.4.6" PrivateAssets="all" GeneratePathProperty="true" />
-    <PackageReference Include="PowerShellGet" Version="2.2.3" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="PackageManagement" Version="1.4.8.1" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="PowerShellGet" Version="2.2.5" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.PowerShell.SecretManagement" Version="1.1.2" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.PowerShell.SecretStore" Version="1.0.6" PrivateAssets="all" GeneratePathProperty="true" />
@@ -86,19 +99,6 @@
              PackageCopyToOutput="true" 
              CopyToOutputDirectory="PreserveNewest" 
              Condition="'$(PkgThreadJob)' != ''" />
-  </ItemGroup>
-
-  <!-- The dependencies for this project -->
-  <ItemGroup>
-    <ProjectReference Include="..\Microsoft.DotNet.Interactive.Formatting\Microsoft.DotNet.Interactive.Formatting.csproj" />
-    <ProjectReference Include="..\Microsoft.DotNet.Interactive\Microsoft.DotNet.Interactive.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.IO.Pipelines" Version="8.0.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="$(SystemSecurityCryptographyPkcsVersion)" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="PackageManagement" Version="1.4.6" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="PowerShellGet" Version="2.2.3" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.PowerShell.SecretManagement" Version="1.1.2" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="ThreadJob" Version="2.0.3" PrivateAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
@@ -60,6 +61,14 @@
              PackageCopyToOutput="true" 
              CopyToOutputDirectory="PreserveNewest" 
              Condition="'$(PkgMicrosoft_PowerShell_Archive)' != ''" />
+
+    <Content Include="$(PkgMicrosoft_PowerShell_SecretManagement)\**" 
+             Exclude="$(PkgMicrosoft_PowerShell_SecretManagement)\**\*.nupkg;$(PkgMicrosoft_PowerShell_SecretManagement)\**\*.nuspec;$(PkgMicrosoft_PowerShell_SecretManagement)\**\*.sha512" 
+             Link="Modules\Microsoft.PowerShell.SecretManagement\%(RecursiveDir)%(FileName)%(Extension)" 
+             PackagePath="contentFiles/any/any/Modules/Microsoft.PowerShell.SecretManagement" 
+             PackageCopyToOutput="true"
+             CopyToOutputDirectory="PreserveNewest" 
+             Condition="'$(PkgMicrosoft_PowerShell_SecretManagement)' != ''" />
 
     <Content Include="$(PkgThreadJob)\**" 
              Exclude="$(PkgThreadJob)\**\*.nupkg;$(PkgThreadJob)\**\*.nuspec;$(PkgThreadJob)\**\*.sha512" 

--- a/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/Microsoft.DotNet.Interactive.PowerShell.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="PowerShellGet" Version="2.2.3" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.PowerShell.SecretManagement" Version="1.1.2" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.PowerShell.SecretStore" Version="1.0.6" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="ThreadJob" Version="2.0.3" PrivateAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
@@ -69,6 +70,14 @@
              PackageCopyToOutput="true"
              CopyToOutputDirectory="PreserveNewest" 
              Condition="'$(PkgMicrosoft_PowerShell_SecretManagement)' != ''" />
+
+    <Content Include="$(PkgMicrosoft_PowerShell_SecretStore)\**" 
+             Exclude="$(PkgMicrosoft_PowerShell_SecretStore)\**\*.nupkg;$(PkgMicrosoft_PowerShell_SecretStore)\**\*.nuspec;$(PkgMicrosoft_PowerShell_SecretStore)\**\*.sha512" 
+             Link="Modules\Microsoft.PowerShell.SecretStore\%(RecursiveDir)%(FileName)%(Extension)" 
+             PackagePath="contentFiles/any/any/Modules/Microsoft.PowerShell.SecretStore" 
+             PackageCopyToOutput="true"
+             CopyToOutputDirectory="PreserveNewest" 
+             Condition="'$(PkgMicrosoft_PowerShell_SecretStore)' != ''" />
 
     <Content Include="$(PkgThreadJob)\**" 
              Exclude="$(PkgThreadJob)\**\*.nupkg;$(PkgThreadJob)\**\*.nuspec;$(PkgThreadJob)\**\*.sha512" 

--- a/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -374,7 +374,7 @@ public class PowerShellKernel :
         }
     }
 
-    internal bool RunLocally(string code, out string errorMessage)
+    internal bool RunLocally(string code, out string errorMessage, bool suppressOutput = false)
     {
         var command = new Command(code, isScript: true);
 
@@ -386,7 +386,10 @@ public class PowerShellKernel :
             Pwsh.Commands.AddCommand(command);
             Pwsh.AddCommand(_outDefaultCommand);
 
-            Pwsh.Commands.Commands[0].MergeMyResults(PipelineResultTypes.Error, PipelineResultTypes.Output);
+            if (!suppressOutput)
+            {
+                Pwsh.Commands.Commands[0].MergeMyResults(PipelineResultTypes.Error, PipelineResultTypes.Output);
+            }
 
             Pwsh.InvokeAndClear();
 

--- a/src/Microsoft.DotNet.Interactive.PowerShell/SecretManager.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/SecretManager.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System;
+
+namespace Microsoft.DotNet.Interactive.PowerShell;
+
+public class SecretManager
+{
+    private readonly PowerShellKernel _kernel;
+    private bool _initialized;
+    private const string VaultName = "DotnetInteractiveVault";
+
+    public SecretManager(PowerShellKernel kernel)
+    {
+        if (kernel.KernelInfo.IsProxy)
+        {
+            throw new InvalidOperationException("Cannot create a SecretManager for a proxy kernel.");
+        }
+
+        _kernel = kernel;
+    }
+
+    private void EnsureInitialized()
+    {
+        if (_initialized)
+        {
+            return;
+        }
+
+        var code = $"""
+                    Get-SecretVault -Name '{VaultName}' | Out-Null
+                    """;
+
+        if (!_kernel.RunLocally(code, out var errorMessage))
+        {
+            // initialize the SecretVault
+
+            var registrationCode =
+                $$"""
+                  Register-SecretVault -Name {{VaultName}} -ModuleName Microsoft.PowerShell.SecretStore
+                   
+                  $storeConfiguration = @{
+                      Authentication = 'None'
+                      Interaction = 'None'
+                      Password = ConvertTo-SecureString "P@ssW0rD!" -AsPlainText -Force
+                      Confirm = $false
+                  }
+                  Set-SecretStoreConfiguration @storeConfiguration
+                  """;
+
+            if (!_kernel.RunLocally(registrationCode, out errorMessage))
+            {
+                throw new InvalidOperationException(errorMessage);
+            }
+
+            _initialized = true;
+        }
+    }
+
+    public void SetSecret(
+        string name,
+        string value,
+        string? command = null,
+        string? source = null)
+    {
+        EnsureInitialized();
+
+        var code =
+            $$"""
+              Set-Secret -Name '{{name}}' -Secret '{{value}}' -Vault '{{VaultName}}' -Metadata @{
+                  Command = '{{command}}'
+                  Source = '{{source}}'
+              }
+              """;
+
+        if (!_kernel.RunLocally(code, out var errorMessage))
+        {
+            throw new InvalidOperationException(errorMessage);
+        }
+    }
+
+    public bool TryGetSecret(string secretName, out string? value)
+    {
+        EnsureInitialized();
+
+        var temporaryVariableName = Guid.NewGuid().ToString("N");
+
+        try
+        {
+            var code = $"""
+                        ${temporaryVariableName} = Get-Secret -Name '{secretName}' -Vault '{VaultName}' -AsPlainText
+                        """;
+
+            if (!_kernel.RunLocally(code, out var errorMessage))
+            {
+                value = null;
+                return false;
+            }
+
+            if (_kernel.TryGetValue(temporaryVariableName, out value))
+            {
+                return true;
+            }
+            else
+            {
+            }
+        }
+        finally
+        {
+            if (!_kernel.RunLocally($"""
+                                     Remove-Variable -Name '{temporaryVariableName}'
+                                     """,
+                                    out var errorMessage))
+            {
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Microsoft.DotNet.Interactive.PowerShell/SecretManager.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/SecretManager.cs
@@ -11,7 +11,6 @@ public class SecretManager
 {
     private readonly PowerShellKernel _kernel;
     private bool _initialized;
-    private const string VaultName = "DotnetInteractiveVault";
 
     public SecretManager(PowerShellKernel kernel)
     {
@@ -34,7 +33,7 @@ public class SecretManager
                     Get-SecretVault -Name '{VaultName}' | Out-Null
                     """;
 
-        if (!_kernel.RunLocally(code, out var errorMessage))
+        if (!_kernel.RunLocally(code, out var errorMessage, true))
         {
             // initialize the SecretVault
 
@@ -51,7 +50,7 @@ public class SecretManager
                   Set-SecretStoreConfiguration @storeConfiguration
                   """;
 
-            if (!_kernel.RunLocally(registrationCode, out errorMessage))
+            if (!_kernel.RunLocally(registrationCode, out errorMessage, true))
             {
                 throw new InvalidOperationException(errorMessage);
             }
@@ -59,6 +58,8 @@ public class SecretManager
             _initialized = true;
         }
     }
+
+    public string VaultName => "DotnetInteractive";
 
     public void SetSecret(
         string name,
@@ -76,7 +77,7 @@ public class SecretManager
               }
               """;
 
-        if (!_kernel.RunLocally(code, out var errorMessage))
+        if (!_kernel.RunLocally(code, out var errorMessage, true))
         {
             throw new InvalidOperationException(errorMessage);
         }
@@ -94,7 +95,7 @@ public class SecretManager
                         ${temporaryVariableName} = Get-Secret -Name '{secretName}' -Vault '{VaultName}' -AsPlainText
                         """;
 
-            if (!_kernel.RunLocally(code, out var errorMessage))
+            if (!_kernel.RunLocally(code, out _, true))
             {
                 value = null;
                 return false;
@@ -113,7 +114,7 @@ public class SecretManager
             if (!_kernel.RunLocally($"""
                                      Remove-Variable -Name '{temporaryVariableName}'
                                      """,
-                                    out var errorMessage))
+                                    out _, true))
             {
             }
         }

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Command_contract_has_not_been_broken.approved.RequestInput.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Command_contract_has_not_been_broken.approved.RequestInput.json
@@ -6,7 +6,7 @@
     "isPassword": true,
     "type": "password",
     "valueName": "yourPassword",
-    "save": false,
+    "saveAs": null,
     "targetKernelName": "vscode",
     "originUri": null,
     "destinationUri": null

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Command_contract_has_not_been_broken.approved.RequestInput.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Command_contract_has_not_been_broken.approved.RequestInput.json
@@ -5,7 +5,6 @@
     "prompt": "provide answer",
     "isPassword": true,
     "type": "password",
-    "valueName": "yourPassword",
     "saveAs": null,
     "targetKernelName": "vscode",
     "originUri": null,

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.InputProduced.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.InputProduced.json
@@ -11,7 +11,7 @@
       "isPassword": false,
       "type": "file",
       "valueName": "logfile",
-      "save": false,
+      "saveAs": null,
       "targetKernelName": "vscode",
       "originUri": null,
       "destinationUri": null

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.InputProduced.json
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.Event_contract_has_not_been_broken.approved.InputProduced.json
@@ -10,7 +10,6 @@
       "prompt": "What is the path to the log file?",
       "isPassword": false,
       "type": "file",
-      "valueName": "logfile",
       "saveAs": null,
       "targetKernelName": "vscode",
       "originUri": null,

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.cs
@@ -30,6 +30,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.Interactive.Tests.Connection;
 
+[Trait("Category", "Contracts and serialization")]
 public class SerializationTests
 {
     private readonly ITestOutputHelper _output;

--- a/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/Connection/SerializationTests.cs
@@ -230,7 +230,7 @@ public class SerializationTests
 
             yield return new RequestValue("a", mimeType: HtmlFormatter.MimeType, targetKernelName: "csharp");
 
-            yield return new RequestInput(prompt: "provide answer", valueName: "yourPassword", inputTypeHint: "password", targetKernelName: "vscode");
+            yield return new RequestInput(prompt: "provide answer", inputTypeHint: "password", targetKernelName: "vscode");
 
             yield return new SendValue(
                 "name",
@@ -454,7 +454,7 @@ public class SerializationTests
                     "<span>raw value</span>"),
                 new RequestValue("a", mimeType: HtmlFormatter.MimeType, targetKernelName: "csharp"));
 
-            yield return new InputProduced("user input", new RequestInput(valueName: "logfile", prompt: "What is the path to the log file?", inputTypeHint: "file", targetKernelName: "vscode"));
+            yield return new InputProduced("user input", new RequestInput(prompt: "What is the path to the log file?", inputTypeHint: "file", targetKernelName: "vscode"));
         }
     }
 

--- a/src/Microsoft.DotNet.Interactive.Tests/InputsWithinMagicCommandsTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/InputsWithinMagicCommandsTests.cs
@@ -84,22 +84,6 @@ public class InputsWithinMagicCommandsTests : IDisposable
     }
 
     [Fact]
-    public async Task Input_token_in_magic_command_includes_requested_value_name()
-    {
-        await _kernel.SendAsync(new SubmitCode("#!shim --value @input:input-please", "csharp"));
-
-        _receivedRequestInput.IsPassword.Should().BeFalse();
-
-        _receivedRequestInput
-            .Should()
-            .BeOfType<RequestInput>()
-            .Which
-            .ValueName
-            .Should()
-            .Be("input-please");
-    }
-
-    [Fact]
     public async Task Input_token_in_magic_command_prompts_user_passes_user_input_to_directive_to_handler()
     {
         _responses.Enqueue("one");

--- a/src/Microsoft.DotNet.Interactive.Tests/InputsWithinMagicCommandsTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/InputsWithinMagicCommandsTests.cs
@@ -227,13 +227,13 @@ public class InputsWithinMagicCommandsTests : IDisposable
         });
 
         var magicCommand = """
-            #!test @input:{ "prompt": "pick a number", "save": true, "type": "file" } 
+            #!test @input:{ "prompt": "pick a number", "saveAs": "this-is-the-save-key", "type": "file" } 
             """;
 
         await kernel.SendAsync(new SubmitCode(magicCommand));
 
         requestInput.Prompt.Should().Be("pick a number");
-        requestInput.Save.Should().BeTrue();
+        requestInput.SaveAs.Should().Be("this-is-the-save-key");
         requestInput.InputTypeHint.Should().Be("file");
     }
 

--- a/src/Microsoft.DotNet.Interactive.Tests/Microsoft.DotNet.Interactive.Tests.v3.ncrunchproject
+++ b/src/Microsoft.DotNet.Interactive.Tests/Microsoft.DotNet.Interactive.Tests.v3.ncrunchproject
@@ -64,6 +64,9 @@ var x = 123; // with some intervening code
       <NamedTestSelector>
         <TestName>Microsoft.DotNet.Interactive.Tests.Connection.SerializationTests.Event_contract_has_not_been_broken</TestName>
       </NamedTestSelector>
+      <FixtureTestSelector>
+        <FixtureName>Microsoft.DotNet.Interactive.Tests.RequestInputTests</FixtureName>
+      </FixtureTestSelector>
     </IgnoredTests>
   </Settings>
 </ProjectConfiguration>

--- a/src/Microsoft.DotNet.Interactive.Tests/RequestInputTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/RequestInputTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.DotNet.Interactive.App;
@@ -9,6 +10,7 @@ using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.CSharp;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.PowerShell;
+using Microsoft.DotNet.Interactive.Tests.Utility;
 using Xunit;
 
 namespace Microsoft.DotNet.Interactive.Tests;
@@ -41,6 +43,69 @@ public class RequestInputTests
         });
 
         inputRequestCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task When_a_value_is_saved_then_the_user_is_notified()
+    {
+        var kernel = CreateKernel();
+
+        kernel.RegisterCommandHandler<RequestInput>((requestInput, context) =>
+        {
+            context.Publish(new InputProduced("hello!", requestInput));
+            return Task.CompletedTask;
+        });
+
+        var saveAs = nameof(When_a_value_is_saved_then_the_user_is_notified) + DateTime.Now.Ticks;
+
+        var valueName = "the-name-of-the-value";
+
+        var result = await kernel.SendAsync(new RequestInput("Enter a value", valueName)
+        {
+            SaveAs = saveAs
+        });
+
+        result.Events.Should().ContainSingle<DisplayedValueProduced>()
+              .Which
+              .FormattedValues
+              .Should()
+              .ContainSingle()
+              .Which
+              .Value
+              .Should()
+              .Contain($"Saving your response for value '{saveAs}'. To remove this value, run the following command in a PowerShell cell:");
+    }
+
+    [Fact]
+    public async Task When_a_saved_value_is_used_then_the_user_is_notified()
+    {
+        var kernel = CreateKernel();
+        var secretManager = new SecretManager(kernel.ChildKernels.OfType<PowerShellKernel>().Single());
+
+        kernel.RegisterCommandHandler<RequestInput>((requestInput, context) =>
+        {
+            context.Publish(new InputProduced("hello", requestInput));
+            return Task.CompletedTask;
+        });
+
+        var saveAs = nameof(When_a_saved_value_is_used_then_the_user_is_notified) + DateTime.Now.Ticks;
+
+        secretManager.SetSecret(saveAs, "the-value");
+
+        var result = await kernel.SendAsync(new RequestInput("Enter a value")
+        {
+            SaveAs = saveAs
+        });
+
+        result.Events.Should().ContainSingle<DisplayedValueProduced>()
+              .Which
+              .FormattedValues
+              .Should()
+              .ContainSingle()
+              .Which
+              .Value
+              .Should()
+              .Contain($"Using saved value '{saveAs}'. To remove this value, run the following command in a PowerShell cell:");
     }
 
     private static CompositeKernel CreateKernel()

--- a/src/Microsoft.DotNet.Interactive.Tests/RequestInputTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/RequestInputTests.cs
@@ -1,0 +1,62 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.DotNet.Interactive.App;
+using Microsoft.DotNet.Interactive.Commands;
+using Microsoft.DotNet.Interactive.CSharp;
+using Microsoft.DotNet.Interactive.Events;
+using Microsoft.DotNet.Interactive.PowerShell;
+using Xunit;
+
+namespace Microsoft.DotNet.Interactive.Tests;
+
+public class RequestInputTests
+{
+    [Fact]
+    public async Task When_Save_is_specified_then_subsequent_requests_reuse_the_saved_value()
+    {
+        var inputRequestCount = 0;
+        var kernel = CreateKernel();
+
+        kernel.RegisterCommandHandler<RequestInput>((requestInput, context) =>
+        {
+            inputRequestCount++;
+            context.Publish(new InputProduced($"Response #{inputRequestCount}", requestInput));
+            return Task.CompletedTask;
+        });
+
+        var saveAs = nameof(When_Save_is_specified_then_subsequent_requests_reuse_the_saved_value) + DateTime.Now.Ticks;
+
+        await kernel.SendAsync(new RequestInput("Enter a value")
+        {
+            SaveAs = saveAs
+        });
+
+        await kernel.SendAsync(new RequestInput("Enter a value")
+        {
+            SaveAs = saveAs
+        });
+
+        inputRequestCount.Should().Be(1);
+    }
+
+    private static CompositeKernel CreateKernel()
+    {
+        var kernel = new CompositeKernel
+        {
+            new CSharpKernel()
+                .UseNugetDirective()
+                .UseKernelHelpers()
+                .UseValueSharing(),
+            new PowerShellKernel(),
+            new KeyValueStoreKernel()
+        }.UseSecretManager();
+
+        kernel.SetDefaultTargetKernelNameForCommand(typeof(RequestInput), kernel.Name);
+
+        return kernel;
+    }
+}

--- a/src/Microsoft.DotNet.Interactive.Tests/VariableSharingTests.SetMagicCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/VariableSharingTests.SetMagicCommand.cs
@@ -189,33 +189,7 @@ public partial class VariableSharingTests
                         .Should().BeTrue();
             newVar3.Should().Be("three");
         }
-
-        [Fact]
-        public async Task RequestInput_ValueName_is_initialized_from_name_option()
-        {
-            var kernel = CreateKernel(Language.CSharp);
-
-            using var composite = new CompositeKernel
-            {
-                kernel
-            };
-
-            RequestInput receivedRequestInputCommand = null;
-
-            composite.RegisterCommandHandler<RequestInput>((requestInput, context) =>
-            {
-                receivedRequestInputCommand = requestInput;
-                context.Publish(new InputProduced("hello!", requestInput));
-                return Task.CompletedTask;
-            });
-
-            composite.SetDefaultTargetKernelNameForCommand(typeof(RequestInput), composite.Name);
-
-            await composite.SendAsync(new SubmitCode("#!set --name x --value @input:input-please"));
-
-            receivedRequestInputCommand.ValueName.Should().Be("x");
-        }
-
+        
         [Theory]
         [InlineData(
             """

--- a/src/Microsoft.DotNet.Interactive.Tests/VariableSharingTests.SetMagicCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/VariableSharingTests.SetMagicCommand.cs
@@ -7,7 +7,6 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.DotNet.Interactive.App;
@@ -45,36 +44,6 @@ public partial class VariableSharingTests
             var valueProduced = await kernel.RequestValueAsync("x");
 
             valueProduced.Value.Should().Be("hello!");
-        }
-
-        [Fact]
-        public async Task When_JSON_array_is_set_directly_it_is_deserialized()
-        {
-            var kernel = CreateKernel(Language.CSharp);
-
-            await kernel.SendAsync(
-                new SubmitCode(
-                    """
-                    #!set --name x --value [ 1, 2, 3 ]
-                    """));
-            var valueProduced = await kernel.RequestValueAsync("x");
-
-            valueProduced.Value.Should().BeOfType<JsonDocument>();
-        }
-
-        [Fact]
-        public async Task When_JSON_object_is_set_directly_it_is_deserialized()
-        {
-            var kernel = CreateKernel(Language.CSharp);
-
-            await kernel.SendAsync(
-                new SubmitCode(
-                    """
-                    #!set --name x --value { "value": 123 }
-                    """));
-            var valueProduced = await kernel.RequestValueAsync("x");
-
-            valueProduced.Value.Should().BeOfType<JsonDocument>();
         }
 
         [Fact]

--- a/src/Microsoft.DotNet.Interactive.Tests/VariableSharingTests.SetMagicCommand.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/VariableSharingTests.SetMagicCommand.cs
@@ -7,6 +7,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.DotNet.Interactive.App;
@@ -38,14 +39,42 @@ public partial class VariableSharingTests
                 kernel
             };
 
-            composite.SetDefaultTargetKernelNameForCommand(typeof(RequestInput), composite.Name);
-
             await composite.SendAsync(new SubmitCode("""
                 #!set --name x --value hello!
                 """));
             var valueProduced = await kernel.RequestValueAsync("x");
 
             valueProduced.Value.Should().Be("hello!");
+        }
+
+        [Fact]
+        public async Task When_JSON_array_is_set_directly_it_is_deserialized()
+        {
+            var kernel = CreateKernel(Language.CSharp);
+
+            await kernel.SendAsync(
+                new SubmitCode(
+                    """
+                    #!set --name x --value [ 1, 2, 3 ]
+                    """));
+            var valueProduced = await kernel.RequestValueAsync("x");
+
+            valueProduced.Value.Should().BeOfType<JsonDocument>();
+        }
+
+        [Fact]
+        public async Task When_JSON_object_is_set_directly_it_is_deserialized()
+        {
+            var kernel = CreateKernel(Language.CSharp);
+
+            await kernel.SendAsync(
+                new SubmitCode(
+                    """
+                    #!set --name x --value { "value": 123 }
+                    """));
+            var valueProduced = await kernel.RequestValueAsync("x");
+
+            valueProduced.Value.Should().BeOfType<JsonDocument>();
         }
 
         [Fact]

--- a/src/Microsoft.DotNet.Interactive/Commands/RequestInput.cs
+++ b/src/Microsoft.DotNet.Interactive/Commands/RequestInput.cs
@@ -11,11 +11,9 @@ public class RequestInput : KernelCommand
     public RequestInput(
         string prompt,
         string targetKernelName = null,
-        string inputTypeHint = null,
-        string valueName = null)
+        string inputTypeHint = null)
         : base(targetKernelName)
     {
-        ValueName = valueName;
         Prompt = prompt;
         InputTypeHint = inputTypeHint;
     }
@@ -26,8 +24,6 @@ public class RequestInput : KernelCommand
 
     [JsonPropertyName("type")] 
     public string InputTypeHint { get; set; }
-
-    public string ValueName { get; }
 
     public string SaveAs { get; set; }
 }

--- a/src/Microsoft.DotNet.Interactive/Commands/RequestInput.cs
+++ b/src/Microsoft.DotNet.Interactive/Commands/RequestInput.cs
@@ -11,7 +11,7 @@ public class RequestInput : KernelCommand
     public RequestInput(
         string prompt,
         string targetKernelName = null,
-        string inputTypeHint = "text",
+        string inputTypeHint = null,
         string valueName = null)
         : base(targetKernelName)
     {

--- a/src/Microsoft.DotNet.Interactive/Commands/RequestInput.cs
+++ b/src/Microsoft.DotNet.Interactive/Commands/RequestInput.cs
@@ -11,7 +11,7 @@ public class RequestInput : KernelCommand
     public RequestInput(
         string prompt,
         string targetKernelName = null,
-        string inputTypeHint = null,
+        string inputTypeHint = "text",
         string valueName = null)
         : base(targetKernelName)
     {
@@ -29,5 +29,5 @@ public class RequestInput : KernelCommand
 
     public string ValueName { get; }
 
-    public bool Save { get; set; }
+    public string SaveAs { get; set; }
 }

--- a/src/Microsoft.DotNet.Interactive/Kernel.Static.cs
+++ b/src/Microsoft.DotNet.Interactive/Kernel.Static.cs
@@ -40,30 +40,25 @@ public partial class Kernel
     /// <returns>The user input value.</returns>
     public static async Task<string> GetInputAsync(
         string prompt = "",
-        string typeHint = "text", 
-        string valueName = null)
+        string typeHint = "text")
     {
-        return await GetInputAsync(prompt, false, typeHint, valueName);
+        return await GetInputAsync(prompt, false, typeHint);
     }
         
-    public static async Task<PasswordString> GetPasswordAsync(
-        string prompt = "",
-        string valueName = null)
+    public static async Task<PasswordString> GetPasswordAsync(string prompt = "")
     {
-        var password = await GetInputAsync(prompt, true, valueName: valueName);
+        var password = await GetInputAsync(prompt, true);
         return new PasswordString(password);
     }
 
     private static async Task<string> GetInputAsync(
         string prompt,
         bool isPassword,
-        string typeHint = "text",
-        string valueName = null)
+        string typeHint = "text")
     {
         var command = new RequestInput(
             prompt,
-            inputTypeHint: isPassword ? "password" : typeHint,
-            valueName: valueName);
+            inputTypeHint: isPassword ? "password" : typeHint);
 
         var result = await Root.SendAsync(command, CancellationToken.None);
 

--- a/src/Microsoft.DotNet.Interactive/Kernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Kernel.cs
@@ -1049,7 +1049,7 @@ public abstract partial class Kernel :
     protected async Task SetValueAsync(
         SendValue command,
         KernelInvocationContext context,
-        SetValueAsyncDelegate setValueAsync)
+        SetValueAsyncDelegate onSetValueAsync)
     {
         object value = null;
 
@@ -1062,7 +1062,6 @@ public abstract partial class Kernel :
                     break;
 
                 default:
-
                     value = command.Value;
                     break;
             }
@@ -1070,7 +1069,7 @@ public abstract partial class Kernel :
 
         if (value is null)
         {
-            if (command.FormattedValue.MimeType == JsonFormatter.MimeType)
+            if (command.FormattedValue.MimeType is JsonFormatter.MimeType)
             {
                 var jsonDoc = JsonDocument.Parse(command.FormattedValue.Value);
 
@@ -1095,7 +1094,7 @@ public abstract partial class Kernel :
             }
         }
 
-        await setValueAsync(command.Name, value);
+        await onSetValueAsync(command.Name, value);
     }
 
     public override string ToString()

--- a/src/Microsoft.DotNet.Interactive/Kernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Kernel.cs
@@ -25,7 +25,6 @@ using Pocket;
 using static Pocket.Logger<Microsoft.DotNet.Interactive.Kernel>;
 using CompositeDisposable = System.Reactive.Disposables.CompositeDisposable;
 using Disposable = System.Reactive.Disposables.Disposable;
-using static Microsoft.DotNet.Interactive.Formatting.PocketViewTags;
 
 namespace Microsoft.DotNet.Interactive;
 

--- a/src/Microsoft.DotNet.Interactive/PackageReference.cs
+++ b/src/Microsoft.DotNet.Interactive/PackageReference.cs
@@ -32,6 +32,7 @@ public class PackageReference
             reference = null;
             return false;
         }
+
         var parts = value.Split([','], 2)
             .Select(v => v.Trim())
             .ToArray();

--- a/src/Microsoft.DotNet.Interactive/Parsing/SubmissionParser.cs
+++ b/src/Microsoft.DotNet.Interactive/Parsing/SubmissionParser.cs
@@ -680,17 +680,13 @@ public class SubmissionParser
                 parametersNodeText = JsonSerializer.Deserialize<string>(parametersNode.Text);
             }
 
-            var valueName = GetValueNameFromNameParameter();
-
             if (parametersNodeText?.Contains(" ") is true)
             {
-                requestInput = new(prompt: parametersNodeText,
-                                   valueName: valueName);
+                requestInput = new(prompt: parametersNodeText);
             }
             else
             {
-                requestInput = new(prompt: $"Please enter a value for field \"{parametersNodeText}\".",
-                                   valueName: valueName ?? parametersNodeText);
+                requestInput = new(prompt: $"Please enter a value for field \"{parametersNodeText}\".");
             }
         }
 
@@ -742,19 +738,6 @@ public class SubmissionParser
 
             default:
                 throw new ArgumentOutOfRangeException();
-        }
-
-        string GetValueNameFromNameParameter()
-        {
-            if (expressionNode.Ancestors().OfType<DirectiveNode>().FirstOrDefault() is { } directiveNode)
-            {
-                if (directiveNode.ChildNodes.OfType<DirectiveParameterNode>().FirstOrDefault(n => n.NameNode?.Text == "--name") is { } nameParameterNode)
-                {
-                    return nameParameterNode.ValueNode?.Text;
-                }
-            }
-
-            return null;
         }
     }
 

--- a/src/Microsoft.DotNet.Interactive/ValueSharing/SetDirectiveCommand.cs
+++ b/src/Microsoft.DotNet.Interactive/ValueSharing/SetDirectiveCommand.cs
@@ -76,26 +76,26 @@ internal class SetDirectiveCommand : KernelCommand
             command.DestinationValueName = (string)destinationValueNameBinding.Value;
         }
 
-        if (bindingResult.InputsProduced?.TryGetValue("--value", out var inputProduced1) is true)
+        if (bindingResult.InputsProduced.TryGetValue("--value", out var inputProduced))
         {
-            if (((RequestInput)inputProduced1.Command).IsPassword)
+            if (((RequestInput)inputProduced.Command).IsPassword)
             {
-                command.ReferenceValue = new PasswordString(inputProduced1.Value);
+                command.ReferenceValue = new PasswordString(inputProduced.Value);
             }
             else
             {
-                command.ReferenceValue = inputProduced1.Value;
+                command.ReferenceValue = inputProduced.Value;
             }
         }
-        else if (bindingResult.ValuesProduced?.TryGetValue("--value", out var valueProduced1) is true)
+        else if (bindingResult.ValuesProduced.TryGetValue("--value", out var valueProduced))
         {
-            command.SourceValueName = valueProduced1.Name;
-            command.SourceKernelName = (valueProduced1.Command as RequestValue)?.TargetKernelName;
-            command.FormattedValue = valueProduced1.FormattedValue;
+            command.SourceValueName = valueProduced.Name;
+            command.SourceKernelName = (valueProduced.Command as RequestValue)?.TargetKernelName;
+            command.FormattedValue = valueProduced.FormattedValue;
             
-            if (valueProduced1.Value is not null && command.ShareByRef)
+            if (valueProduced.Value is not null && command.ShareByRef)
             {
-                command.ReferenceValue = valueProduced1.Value;
+                command.ReferenceValue = valueProduced.Value;
             }
         }
         else if (parameterValues.TryGetValue("--value", out var parsedLiteralValueBinding))

--- a/src/dotnet-interactive.Tests/TypeScriptInterfacesContractTests.cs
+++ b/src/dotnet-interactive.Tests/TypeScriptInterfacesContractTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Microsoft.DotNet.Interactive.App.Tests;
 
+[Trait("Category", "Contracts and serialization")]
 public class TypeScriptInterfacesContractTests
 {
     private string GetTypeScriptContractFullPath(string subPath, [CallerFilePath] string thisDir = null)

--- a/src/dotnet-interactive/CommandLine/CommandLineParser.cs
+++ b/src/dotnet-interactive/CommandLine/CommandLineParser.cs
@@ -509,6 +509,7 @@ public static class CommandLineParser
             .UseDefaultMagicCommands()
             .UseAboutMagicCommand()
             .UseImportMagicCommand()
+            .UseSecretManager()
             .UseNuGetExtensions(telemetrySender);
 
         kernel.AddKernelConnector(new ConnectSignalRDirective());

--- a/src/dotnet-interactive/Pocket/Format.CustomizeLogString.cs
+++ b/src/dotnet-interactive/Pocket/Format.CustomizeLogString.cs
@@ -75,7 +75,6 @@ internal static partial class Format
             case RequestInput requestInput:
                 writer.Write(requestInput.Prompt);
                 writer.AppendProperties(
-                    (nameof(requestInput.ValueName), requestInput.ValueName),
                     (nameof(requestInput.IsPassword), requestInput.IsPassword.ToString()),
                     (nameof(requestInput.InputTypeHint), requestInput.InputTypeHint),
                     (nameof(requestInput.SaveAs), requestInput.SaveAs));

--- a/src/dotnet-interactive/Pocket/Format.CustomizeLogString.cs
+++ b/src/dotnet-interactive/Pocket/Format.CustomizeLogString.cs
@@ -77,7 +77,8 @@ internal static partial class Format
                 writer.AppendProperties(
                     (nameof(requestInput.ValueName), requestInput.ValueName),
                     (nameof(requestInput.IsPassword), requestInput.IsPassword.ToString()),
-                    (nameof(requestInput.InputTypeHint), requestInput.InputTypeHint));
+                    (nameof(requestInput.InputTypeHint), requestInput.InputTypeHint),
+                    (nameof(requestInput.SaveAs), requestInput.SaveAs));
                 break;
 
             case RequestValue requestValue:

--- a/src/polyglot-notebooks/src/contracts.ts
+++ b/src/polyglot-notebooks/src/contracts.ts
@@ -117,7 +117,7 @@ export interface RequestInput extends KernelCommand {
     inputTypeHint: string;
     isPassword: boolean;
     prompt: string;
-    save: boolean;
+    saveAs: string;
     valueName: string;
 }
 

--- a/src/polyglot-notebooks/src/contracts.ts
+++ b/src/polyglot-notebooks/src/contracts.ts
@@ -118,7 +118,6 @@ export interface RequestInput extends KernelCommand {
     isPassword: boolean;
     prompt: string;
     saveAs: string;
-    valueName: string;
 }
 
 export interface RequestKernelInfo extends KernelCommand {


### PR DESCRIPTION
This PR addresses #3323. 

⁠I've also removed the `RequestInput.ValueName` property. It is no longer needed. It's a minor breaking change for people directly using the input request APIs, but has no effect on magic command usage.
