### PR TITLE
Don't treat #r "<assembly path>" as #r "nuget:<package reference>" in the case where <assembly path> happens to contain the word 'nuget'

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
@@ -257,28 +257,6 @@ Formatter.Register<DataFrame>((df, writer) =>
             .NotContain("DNI");
     }
 
-    [Fact]
-    public async Task Pound_r_is_not_treated_as_pound_r_nuget_by_fsharp_kernel_if_assembly_path_happens_to_contain_the_string_nuget()
-    {
-        var kernel = CreateKernel(Language.FSharp);
-
-        var result =
-            await kernel.SubmitCodeAsync(
-                """
-                #r @"C:/Users/abcde/.nuget/packages/package/1.0.0/package.dll"
-                """);
-
-        result.Events
-            .Should()
-            .ContainSingle<CommandFailed>()
-            .Which
-            .Message
-            .Should()
-            .Contain("Unable to find the file")
-            .And
-            .NotContain("DNI");
-    }
-
     [Theory]
     [InlineData(Language.CSharp)]
     [InlineData(Language.FSharp)]

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
@@ -240,13 +240,13 @@ Formatter.Register<DataFrame>((df, writer) =>
     {
         var kernel = CreateCSharpKernel();
 
-        using var events = kernel.KernelEvents.ToSubscribedList();
+        var result =
+            await kernel.SubmitCodeAsync(
+                """
+                #r "C:\Users\abcde\.nuget\packages\package\1.0.0\package.dll"
+                """);
 
-        await kernel.SubmitCodeAsync("""
-                                     #r "C:\Users\abcde\.nuget\packages\package\1.0.0\package.dll"
-                                     """);
-
-        events
+        result.Events
             .Should()
             .ContainSingle<CommandFailed>()
             .Which
@@ -262,13 +262,13 @@ Formatter.Register<DataFrame>((df, writer) =>
     {
         var kernel = CreateKernel(Language.FSharp);
 
-        using var events = kernel.KernelEvents.ToSubscribedList();
+        var result =
+            await kernel.SubmitCodeAsync(
+                """
+                #r "C:\Users\abcde\.nuget\packages\package\1.0.0\package.dll"
+                """);
 
-        await kernel.SubmitCodeAsync("""
-                                     #r "C:\Users\abcde\.nuget\packages\package\1.0.0\package.dll"
-                                     """);
-
-        events
+        result.Events
             .Should()
             .ContainSingle<CommandFailed>()
             .Which

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
@@ -265,7 +265,7 @@ Formatter.Register<DataFrame>((df, writer) =>
         var result =
             await kernel.SubmitCodeAsync(
                 """
-                #r "C:\Users\abcde\.nuget\packages\package\1.0.0\package.dll"
+                #r @"C:\Users\abcde\.nuget\packages\package\1.0.0\package.dll"
                 """);
 
         result.Events
@@ -274,7 +274,7 @@ Formatter.Register<DataFrame>((df, writer) =>
             .Which
             .Message
             .Should()
-            .Contain("is not a valid assembly name")
+            .Contain("Unable to find the file")
             .And
             .NotContain("DNI");
     }

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
@@ -243,7 +243,7 @@ Formatter.Register<DataFrame>((df, writer) =>
         var result =
             await kernel.SubmitCodeAsync(
                 """
-                #r "C:\Users\abcde\.nuget\packages\package\1.0.0\package.dll"
+                #r "C:/Users/abcde/.nuget/packages/package/1.0.0/package.dll"
                 """);
 
         result.Events
@@ -265,7 +265,7 @@ Formatter.Register<DataFrame>((df, writer) =>
         var result =
             await kernel.SubmitCodeAsync(
                 """
-                #r @"C:\Users\abcde\.nuget\packages\package\1.0.0\package.dll"
+                #r @"C:/Users/abcde/.nuget/packages/package/1.0.0/package.dll"
                 """);
 
         result.Events

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelPackageTests.cs
@@ -252,9 +252,7 @@ Formatter.Register<DataFrame>((df, writer) =>
             .Which
             .Message
             .Should()
-            .Contain("Metadata file")
-            .And
-            .Contain("could not be found")
+            .ContainAll("Metadata file", "could not be found")
             .And
             .NotContain("DNI");
     }

--- a/src/Microsoft.DotNet.Interactive/Parsing/SubmissionParser.cs
+++ b/src/Microsoft.DotNet.Interactive/Parsing/SubmissionParser.cs
@@ -142,7 +142,8 @@ public class SubmissionParser
                                                              .OfType<DirectiveParameterValueNode>()
                                                              .SingleOrDefault();
 
-                                if (valueNode.ChildTokens.Any(t => t is { Kind: TokenKind.Word } and { Text: "nuget" }))
+                                if (valueNode.ChildTokens.FirstOrDefault(t => t is { Kind: TokenKind.Word }) is SyntaxToken firstWordToken &&
+                                    firstWordToken.Text is "nuget")
                                 {
                                     if (await CreateActionDirectiveCommand(directiveNode, targetKernelName) is { } actionDirectiveCmd)
                                     {


### PR DESCRIPTION
This fixes the issue where we end up doing the wrong thing in the case where `<assembly path>` points to a path under the user's '.nuget' folder.

Fixes #3617 