### PR TITLE
Support for saving named requests in variables and improved json parsing

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/HttpRequestParser.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/HttpRequestParser.cs
@@ -137,7 +137,7 @@ internal class HttpRequestParser
             {
                 if (node is null)
                 {
-                    if (CurrentToken is { Kind: TokenKind.Word } or ({ Kind: TokenKind.Punctuation } and { Text: "/" }))
+                    if (CurrentToken is { Kind: TokenKind.Word } or ({ Kind: TokenKind.Punctuation } and ({ Text: "/" } or {Text: "'" } or { Text: "\""})))
                     {
                         node = new HttpVariableValueNode(_sourceText, _syntaxTree);
 

--- a/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/HttpRequestParser.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/HttpRequestParser.cs
@@ -671,7 +671,7 @@ internal class HttpRequestParser
             while (MoreTokens() && CurrentToken is not { Kind: TokenKind.NewLine })
             {
 
-                if (CurrentToken is not null && (!(CurrentToken is { Kind: TokenKind.Word or TokenKind.Whitespace } or { Text: "_" or "@" or "." }) || CurrentToken is { Kind: TokenKind.Word } && wordParsedOnce))
+                if (CurrentToken is not ({ Kind: TokenKind.Word or TokenKind.Whitespace } or { Text: "_" or "@" or "." }) || CurrentToken is { Kind: TokenKind.Word } && wordParsedOnce)
                 {
                     var diagnostic = CurrentToken.CreateDiagnostic(HttpDiagnostics.InvalidNamedRequestName());
                     node.AddDiagnostic(diagnostic);

--- a/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/HttpRequestParser.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/HttpRequestParser.cs
@@ -668,12 +668,13 @@ internal class HttpRequestParser
                 node.AddDiagnostic(diagnostic);
             }
             bool wordParsedOnce = false;
-            while (MoreTokens() && CurrentToken is not { Kind: TokenKind.NewLine })
+            while (MoreTokens() && CurrentToken is not { Kind: TokenKind.NewLine } or null)
             {
-
-                if (CurrentToken is not ({ Kind: TokenKind.Word or TokenKind.Whitespace } or { Text: "_" or "@" or "." }) || CurrentToken is { Kind: TokenKind.Word } && wordParsedOnce)
+                var currentToken = CurrentToken;
+                if (currentToken is not null && (currentToken is not ({ Kind: TokenKind.Word or TokenKind.Whitespace } or 
+                    { Text: "_" or "@" or "." }) || currentToken is { Kind: TokenKind.Word } && wordParsedOnce))
                 {
-                    var diagnostic = CurrentToken.CreateDiagnostic(HttpDiagnostics.InvalidNamedRequestName());
+                    var diagnostic = currentToken.CreateDiagnostic(HttpDiagnostics.InvalidNamedRequestName());
                     node.AddDiagnostic(diagnostic);
                     wordParsedOnce = false;
                 }

--- a/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/HttpRequestParser.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/HttpRequestParser.cs
@@ -137,7 +137,7 @@ internal class HttpRequestParser
             {
                 if (node is null)
                 {
-                    if (CurrentToken is { Kind: TokenKind.Word } or ({ Kind: TokenKind.Punctuation} and { Text: "/"}))
+                    if (CurrentToken is { Kind: TokenKind.Word } or ({ Kind: TokenKind.Punctuation } and { Text: "/" }))
                     {
                         node = new HttpVariableValueNode(_sourceText, _syntaxTree);
 
@@ -268,7 +268,7 @@ internal class HttpRequestParser
                     foreach (var commentNode in ParseComments())
                     {
                         node.Add(commentNode, addBefore: true);
-                        
+
                     }
                 }
                 else
@@ -668,25 +668,21 @@ internal class HttpRequestParser
                 node.AddDiagnostic(diagnostic);
             }
             bool wordParsedOnce = false;
-            while (MoreTokens() && CurrentToken is not {Kind: TokenKind.NewLine })
-                {
+            while (MoreTokens() && CurrentToken is not { Kind: TokenKind.NewLine })
+            {
 
-                    if (CurrentToken is not null && (!(CurrentToken is { Kind: TokenKind.Word or TokenKind.Whitespace} or { Text: "_" or "@" or "."}) || CurrentToken is {Kind: TokenKind.Word } && wordParsedOnce)) 
-                    {
-                        var diagnostic = CurrentToken.CreateDiagnostic(HttpDiagnostics.InvalidNamedRequestName());
-                        node.AddDiagnostic(diagnostic);
-                        wordParsedOnce = false;
-                    }
-
-                    if (CurrentToken is { Kind: TokenKind.Word })
-                    {
-                        wordParsedOnce = true;
-                    }
-                    ConsumeCurrentTokenInto(node);
-                /*if (CurrentToken is { Kind: TokenKind.Whitespace })
+                if (CurrentToken is not null && (!(CurrentToken is { Kind: TokenKind.Word or TokenKind.Whitespace } or { Text: "_" or "@" or "." }) || CurrentToken is { Kind: TokenKind.Word } && wordParsedOnce))
                 {
-                    ParseTrailingWhitespace(node, stopBeforeNewLine: true);
-                }*/
+                    var diagnostic = CurrentToken.CreateDiagnostic(HttpDiagnostics.InvalidNamedRequestName());
+                    node.AddDiagnostic(diagnostic);
+                    wordParsedOnce = false;
+                }
+
+                if (CurrentToken is { Kind: TokenKind.Word })
+                {
+                    wordParsedOnce = true;
+                }
+                ConsumeCurrentTokenInto(node);
 
             }
 
@@ -697,7 +693,7 @@ internal class HttpRequestParser
         {
             var nextTokenIndicatesName = CurrentTokenPlus(1) != null ? CurrentTokenPlus(1)!.Text.StartsWith("name") : false;
             return (CurrentToken is { Text: "@" } &&
-                nextTokenIndicatesName  &&
+                nextTokenIndicatesName &&
                 CurrentTokenPlus(2) is { Kind: TokenKind.Whitespace }
                     );
         }

--- a/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/HttpRootSyntaxNode.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/HttpRootSyntaxNode.cs
@@ -55,7 +55,7 @@ internal class HttpRootSyntaxNode : HttpSyntaxNode
                 var embeddedExpressionNodes = node.ValueNode.ChildNodes.OfType<HttpEmbeddedExpressionNode>();
                 if (!embeddedExpressionNodes.Any())
                 {
-                    foundVariableValues.Add(node.DeclarationNode.VariableName, node.ValueNode.Text);
+                    foundVariableValues[node.DeclarationNode.VariableName] = node.ValueNode.Text;
                     declaredVariables[node.DeclarationNode.VariableName] = new DeclaredVariable(node.DeclarationNode.VariableName, node.ValueNode.Text, HttpBindingResult<string>.Success(Text));
                 }
                 else

--- a/src/Microsoft.DotNet.Interactive.Http.Tests/HttpKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Tests/HttpKernelTests.cs
@@ -2234,9 +2234,9 @@ public class HttpKernelTests
     }
 
     [Theory]
-    [InlineData("json.response.body.$.slideshow.slides.title")]
-    [InlineData("json.response.body.$.slideshow.slides.type")]
-    public async Task json_named_requests_with_sub_routes_can_be_accessed_correctly(string path)
+    [InlineData("json.response.body.$.slideshow.slides.title", "Wake up to WonderWidgets!")]
+    [InlineData("json.response.body.$.slideshow.slides.type", "all")]
+    public async Task json_named_requests_with_sub_routes_can_be_accessed_correctly(string path, string end)
     {
         // Request Variables
         // Request variables are similar to file variables in some aspects like scope and definition location.However, they have some obvious differences.The definition syntax of request variables is just like a single-line comment, and follows // @name requestName or # @name requestName just before the desired request url. 
@@ -2267,7 +2267,7 @@ public class HttpKernelTests
             Content-Type: application/json
             
             {
-                "path" : {{pathContents}}
+                "path" :{{pathContents}}
             }
             
             ###
@@ -2276,6 +2276,13 @@ public class HttpKernelTests
         var secondResult = await kernel.SendAsync(new SubmitCode(secondCode));
 
         secondResult.Events.Should().NotContainErrors();
+
+        var returnValue = secondResult.Events.OfType<ReturnValueProduced>().First();
+
+        var response = (HttpResponse)returnValue.Value;
+
+        response.Request.Content.Raw.Split(":").Last().TrimEnd("\r\n}".ToCharArray()).Should().Be(end);
+
     }
 
     [Theory]

--- a/src/Microsoft.DotNet.Interactive.Http.Tests/HttpKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Tests/HttpKernelTests.cs
@@ -2234,6 +2234,51 @@ public class HttpKernelTests
     }
 
     [Theory]
+    [InlineData("json.response.body.$.slideshow.slides.title")]
+    [InlineData("json.response.body.$.slideshow.slides.type")]
+    public async Task json_named_requests_with_sub_routes_can_be_accessed_correctly(string path)
+    {
+        // Request Variables
+        // Request variables are similar to file variables in some aspects like scope and definition location.However, they have some obvious differences.The definition syntax of request variables is just like a single-line comment, and follows // @name requestName or # @name requestName just before the desired request url. 
+
+        var client = new HttpClient();
+        using var kernel = new HttpKernel(client: client);
+
+        var code = """
+            @baseUrl = https://httpbin.org/json
+
+            # @name json
+            GET {{baseUrl}}
+            Content-Type: application/json
+
+            ###
+            """;
+
+        var result = await kernel.SendAsync(new SubmitCode(code));
+        result.Events.Should().NotContainErrors();
+
+        var secondCode = $$$"""
+
+            @pathContents = {{{{{path}}}}}
+            
+            
+            # @name createComment
+            POST https://example.com/api/comments HTTP/1.1
+            Content-Type: application/json
+            
+            {
+                "path" : {{pathContents}}
+            }
+            
+            ###
+            """;
+
+        var secondResult = await kernel.SendAsync(new SubmitCode(secondCode));
+
+        secondResult.Events.Should().NotContainErrors();
+    }
+
+    [Theory]
     [InlineData("login.response.$")]
     [InlineData("login.response.//")]
     [InlineData("login.request.$")]

--- a/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.Variables.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.Variables.cs
@@ -313,5 +313,20 @@ public partial class HttpParserTests
             variables.Should().Contain(n => n.Key == "host").Which.Value.Should().BeOfType<DeclaredVariable>().Which.Value.Should().Be("\"https://httpbin.org\"");
 
         }
+
+        [Fact]
+        public void spaces_in_variable_values_are_supported()
+        {
+            var result = Parse(
+                """
+
+                @host = one two three
+                """
+                );
+
+            var variables = result.SyntaxTree.RootNode.TryGetDeclaredVariables().declaredVariables;
+            variables.Should().Contain(n => n.Key == "host").Which.Value.Should().BeOfType<DeclaredVariable>().Which.Value.Should().Be("one two three");
+
+        }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.Variables.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Tests/ParserTests.Variables.cs
@@ -283,5 +283,35 @@ public partial class HttpParserTests
 
             result.SyntaxTree.RootNode.ChildNodes.Count().Should().Be(1);
         }
+
+        [Fact]
+        public void single_quotes_in_variable_values_are_supported()
+        {
+            var result = Parse(
+                """
+
+                @host='https://httpbin.org'
+                """
+                );
+
+            var variables = result.SyntaxTree.RootNode.TryGetDeclaredVariables().declaredVariables;
+            variables.Should().Contain(n => n.Key == "host").Which.Value.Should().BeOfType<DeclaredVariable>().Which.Value.Should().Be("'https://httpbin.org'");
+
+        }
+
+        [Fact]
+        public void double_quotes_in_variable_values_are_supported()
+        {
+            var result = Parse(
+                """
+
+                @host="https://httpbin.org"
+                """
+                );
+
+            var variables = result.SyntaxTree.RootNode.TryGetDeclaredVariables().declaredVariables;
+            variables.Should().Contain(n => n.Key == "host").Which.Value.Should().BeOfType<DeclaredVariable>().Which.Value.Should().Be("\"https://httpbin.org\"");
+
+        }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Http/Model/HttpNamedRequest.cs
+++ b/src/Microsoft.DotNet.Interactive.Http/Model/HttpNamedRequest.cs
@@ -152,7 +152,9 @@ internal class HttpNamedRequest
 
                         try
                         {
-                            var responseJSON = JsonNode.Parse(Response.Content.Raw);
+                            var jsonOptions = new JsonNodeOptions { PropertyNameCaseInsensitive = true};
+
+                            var responseJSON = JsonNode.Parse(Response.Content.Raw, jsonOptions);
 
                             if (responseJSON is not null)
                             {
@@ -242,7 +244,7 @@ internal class HttpNamedRequest
                 case JsonObject jsonObject:
                     return jsonObject[path[currentIndex]]?.ToString();
                 default:
-                    return null;
+                    return responseJSON.ToString();
             }
         }
 

--- a/src/Microsoft.DotNet.Interactive.Http/Model/HttpNamedRequest.cs
+++ b/src/Microsoft.DotNet.Interactive.Http/Model/HttpNamedRequest.cs
@@ -101,7 +101,7 @@ internal class HttpNamedRequest
                             {
                                 return node.CreateBindingFailure(HttpDiagnostics.InvalidXmlNodeInNamedRequest(path[3]));
                             }
-                            
+
                         }
                         catch (XmlException)
                         {
@@ -234,19 +234,15 @@ internal class HttpNamedRequest
     {
         if (currentIndex + 1 == path.Length)
         {
-            if(responseJSON.GetType() == typeof(JsonArray))
+            switch (responseJSON)
             {
-                var jsonArray = (JsonArray)responseJSON;
-                return jsonArray.FirstOrDefault(n => n?[path[currentIndex]] != null)?.ToJsonString();
-            } 
-            else if(responseJSON.GetType() == typeof(JsonObject))
-            {
-                var jsonObject = (JsonObject)responseJSON;
-                return jsonObject[path[currentIndex]]?.ToString();
-            }
-            else
-            {
-                return null;
+                case JsonArray jsonArray:
+                    var node = jsonArray.FirstOrDefault(n => n?[path[currentIndex]] != null);
+                    return node?[path[currentIndex]]?.ToString();
+                case JsonObject jsonObject:
+                    return jsonObject[path[currentIndex]]?.ToString();
+                default:
+                    return null;
             }
         }
 
@@ -254,12 +250,12 @@ internal class HttpNamedRequest
         try
         {
             newResponseJSON = responseJSON[path[currentIndex]];
-        } 
-        catch (Exception)
+        }
+        catch (InvalidOperationException)
         {
             return null;
         }
-        
+
         if (newResponseJSON is null)
         {
             return null;


### PR DESCRIPTION
This PR introduces variable support for the kernel and changes the flow of Json grandchildren parsing 

Highlights: 

- HandleAsync looks if a submit code has the entire associated document in which case it will use that in creating declared variables which enables the support for saving the named request values in variables 
- Changed the chaining of the Json parsing that at the last node to evaluate one of the derived types and then convert to a string 
- Miscellaneous reformatting in the request parser 

PR: #3632