### PR TITLE
Add DevContainer setup for Python and Jupyter kernel support

### DIFF
--- a/docs/jupyter-in-polyglot-notebooks.md
+++ b/docs/jupyter-in-polyglot-notebooks.md
@@ -102,3 +102,19 @@ Or, you can get similar experience by adding `condaenvpython3.9` as a kernel spe
 ```
 #!connect jupyter --kernel-name pythonkernel --conda-env base --kernel-spec condaenvpython3.9
 ```
+
+## Using DevContainers 
+
+The default Python3 configuration does not include the kernel, so you need to modify the devcontainer.json file to use a Dockerfile:
+
+```
+FROM mcr.microsoft.com/devcontainers/dotnet:1-8.0
+
+RUN apt update
+RUN apt install -y python3 python3-pip python3-ipykernel
+```
+
+After loading the DevContainer, run the following command in a cell:
+```
+#!connect jupyter --kernel-name pythonkernel --conda-env base --kernel-spec python3
+```


### PR DESCRIPTION
### Summary
This PR introduces documentation for setting up Python and Jupyter kernels within a DevContainer.

### Changes
- Added a section explaining the Dockerfile in `devcontainer.json` that installs Python3, pip, and ipykernel.

### Why
This update facilitates seamless integration of Jupyter notebooks within the DevContainer environment, making it easier to work with Python in Polyglot notebooks.

### Testing
Tested by loading the DevContainer and confirming that the Jupyter kernel connection works as expected.
