### PR TITLE
Enable flags for localization

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -99,6 +99,8 @@ extends:
           LclSource: lclFilesfromPackage
           LclPackageId: 'LCL-JUNO-PROD-INTERACTIVE'
           CreatePr: $(LocPRCreationEnabled)
+          AutocompletePr: true
+          ReusePr : true
       - template: /eng/common/templates-official/jobs/jobs.yml@self
         parameters:
           enableMicrobuild: true


### PR DESCRIPTION
enabling the flag AutocompletePr to enable PRs coming from loc can be completed on-time.

enabling the flag ReusePr to keep the PR opened while the loc team addresses issues.