### PR TITLE
Manually fix mismatch in localization files

### DIFF
--- a/src/Microsoft.DotNet.Interactive/xlf/Resources.xlf
+++ b/src/Microsoft.DotNet.Interactive/xlf/Resources.xlf
@@ -17,6 +17,11 @@
         <target state="new">Runs another notebook or source code file inline.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Magics_import_file_Description">
+        <source>The path to the file to be imported. Supported file extensions include notebooks (.ipynb, .dib) as well as source code for supported languages (.cs, .csx, .fs, .fsx, .ps1, .html, .http, .js).</source>
+        <target state="new">The path to the file to be imported. Supported file extensions include notebooks (.ipynb, .dib) as well as source code for supported languages (.cs, .csx, .fs, .fsx, .ps1, .html, .http, .js).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Magics_log_Description">
         <source>Enables session logging.</source>
         <target state="new">Enables session logging.</target>


### PR DESCRIPTION
The localization team suggested to manually fix the mismatch given that we are not executing Arcade Tasks to generate the config files.