### PR TITLE
add quotes to example code for removing a secret

### DIFF
--- a/src/dotnet-interactive/KernelExtensions.cs
+++ b/src/dotnet-interactive/KernelExtensions.cs
@@ -149,7 +149,7 @@ public static class KernelExtensions
                      Using saved value '{requestInput.SaveAs}'. To remove this value, run the following command in a PowerShell cell:
                      
                      ```powershell
-                         Remove-Secret -Name {requestInput.SaveAs} -Vault {secretManager.VaultName}
+                         Remove-Secret -Name "{requestInput.SaveAs}" -Vault {secretManager.VaultName}
                      ```
                      """;
                 context.Publish(new DisplayedValueProduced(
@@ -170,7 +170,7 @@ public static class KernelExtensions
                              Saving your response for value '{saveAs}'. To remove this value, run the following command in a PowerShell cell:
 
                              ```powershell
-                                 Remove-Secret -Name {requestInput.SaveAs} -Vault {secretManager.VaultName}
+                                 Remove-Secret -Name "{requestInput.SaveAs}" -Vault {secretManager.VaultName}
                              ```
                              """;
                         context.Publish(new DisplayedValueProduced(


### PR DESCRIPTION
This is a small fix to the example PowerShell code displayed when accessing secrets. Without quotes around the secret name, secret names containing spaces would cause the example code to be incorrect.