### PR TITLE
Create release pipeline to use managed identity

### DIFF
--- a/eng/publish/PublishVSCodeExtensionUsingMI.ps1
+++ b/eng/publish/PublishVSCodeExtensionUsingMI.ps1
@@ -1,0 +1,108 @@
+[CmdletBinding(PositionalBinding = $false)]
+param (
+    [string]$artifactsPath,
+    [string]$vscodeTargetsList,
+    [string]$nugetToken,
+    [string]$isSimulated
+)
+
+$vscodeTargets = $vscodeTargetsList -split ','
+
+Set-StrictMode -version 2.0
+$ErrorActionPreference = "Stop"
+
+$simulate = if ($isSimulated -eq "true") { $true } else { $false }
+Write-Host "Simulate switch is set to: $simulate"
+
+try {
+    $vscodeTargets | ForEach-Object {
+        $vscodeTarget = $_
+        Write-Host "vscode target: $vscodeTarget"
+
+        Write-Host "Find extension vsix..."
+        $extension = Get-ChildItem "$artifactsPath\vscode\$vscodeTarget\dotnet-interactive-vscode-*.vsix" | Select-Object -First 1
+        Write-Host "Found extension: $extension"
+
+        Write-Host "Verify the extension..."
+        if ($simulate) {
+            Write-Host "Simulated command: . '$PSScriptRoot\VerifyVSCodeExtension.ps1' -extensionPath $extension"
+        } else {
+            . "$PSScriptRoot\VerifyVSCodeExtension.ps1" -extensionPath $extension
+            if ($LASTEXITCODE -ne 0) {
+                exit $LASTEXITCODE
+            }
+        }
+
+        if ($vscodeTarget -eq "stable") {
+            Write-Host "Publish to NuGet (only for 'stable' target)"
+
+            $packagestoPublish = @(
+                "Microsoft.dotnet-interactive",
+                "Microsoft.DotNet.Interactive",
+                "Microsoft.DotNet.Interactive.AspNetCore",                
+                "Microsoft.DotNet.Interactive.Browser",
+                "Microsoft.DotNet.Interactive.CSharp",
+                "Microsoft.DotNet.Interactive.Documents",
+                "Microsoft.DotNet.Interactive.ExtensionLab",
+                "Microsoft.DotNet.Interactive.Formatting",
+                "Microsoft.DotNet.Interactive.FSharp",
+                "Microsoft.DotNet.Interactive.Http",
+                "Microsoft.DotNet.Interactive.Journey",
+                "Microsoft.DotNet.Interactive.Jupyter",
+                "Microsoft.DotNet.Interactive.Kql",
+                "Microsoft.DotNet.Interactive.Mermaid",
+                "Microsoft.DotNet.Interactive.NamedPipeConnector",
+                "Microsoft.DotNet.Interactive.PackageManagement",
+                "Microsoft.DotNet.Interactive.PowerShell",
+                "Microsoft.DotNet.Interactive.SQLite",
+                "Microsoft.DotNet.Interactive.SqlServer"
+            )
+
+            Get-ChildItem "$artifactsPath\packages\Shipping\Microsoft.DotNet*.nupkg" | ForEach-Object {
+                $nugetPackagePath = $_.ToString()
+                $nugetPackageName = $_.Name
+                if ($nugetPackageName -match '(?<=(?<id>.+))\.(?<version>((\d+\.\d+(\.\d+)?))(?<suffix>(-.*)?))\.nupkg')
+                {
+                    $packageId = $Matches.id
+                    $packageVersion = $Matches.version
+
+                    Write-Host "Publish only listed packages..."
+                    if ($packagestoPublish.Contains($packageId)) {
+                        Write-Host "Publishing nuget package $nugetPackagePath"
+                        if ($simulate) {
+                            Write-Host "Simulated command: dotnet nuget push $nugetPackagePath --source https://api.nuget.org/v3/index.json --api-key $nugetToken --no-symbols"
+                        } else {
+                            dotnet nuget push $nugetPackagePath --source https://api.nuget.org/v3/index.json --api-key $nugetToken --no-symbols
+                            if ($LASTEXITCODE -ne 0) {
+                                exit $LASTEXITCODE
+                            }
+                        }
+                    } else {
+                        Write-Host "Skipping publishing nuget package $nugetPackagePath"
+                    }
+                }
+            }
+        }
+
+        Write-Host "Publishing extension $extension to VS Code Marketplace using Managed Identity..."
+        if ($simulate) {
+            if ($vscodeTarget -eq "insiders") {
+                Write-Host "Simulated command: vsce publish --pre-release --packagePath $extension --noVerify --azure-credential"
+            } else {
+                Write-Host "Simulated command: vsce publish --packagePath $extension --noVerify --azure-credential"
+            }
+        } else {
+            if ($vscodeTarget -eq "insiders") {
+                vsce publish --pre-release --packagePath $extension --noVerify --azure-credential
+            } else {
+                vsce publish --packagePath $extension --noVerify --azure-credential
+            }
+        }
+    }
+}
+catch {
+    Write-Host $_
+    Write-Host $_.Exception
+    Write-Host $_.ScriptStackTrace
+    exit 1
+}

--- a/vscode-nuget-release-pipeline.yml
+++ b/vscode-nuget-release-pipeline.yml
@@ -1,0 +1,61 @@
+﻿trigger: none
+pr: none
+
+resources:
+  pipelines:
+    - pipeline: interactive-ci  # alias
+      source: dotnet/interactive/interactive-ci
+      branch: main
+
+variables:
+  simulate: $(isSimulated)
+  DotNetNugetApiKey: $(DotNetNugetApiKey-A1)
+  vscodeTargets: $(listVSCodeTargets)
+
+pool:
+  vmImage: 'windows-2022'
+
+stages:
+- stage: Publish
+  jobs:
+  - job: PublishExtension
+    displayName: 'Publish VS Code Extension'
+    steps:
+    - task: AzureCLI@2
+      displayName: 'Authenticate with Azure'
+      inputs:
+        azureSubscription: 'VSCode Marketplace Publishing'
+        scriptType: 'pscore'
+        scriptLocation: 'inlineScript'
+        inlineScript: 'echo "Azure CLI authenticated."'
+
+    # Download pipeline artifacts
+    - task: DownloadPipelineArtifact@2
+      displayName: '📦 Download artifacts from build pipeline'
+      inputs:
+        buildType: 'specific'
+        project: 'internal'
+        definition: 743
+        buildVersionToDownload: 'specific'
+        buildId: '$(resources.pipeline.interactive-ci.runID)'  # Dynamically fetch the latest build ID
+        branchName: '$(resources.pipeline.officialBuildCI.sourceBranch)'
+        path: '$(Pipeline.Workspace)/artifacts'  # Specify a clear download path
+
+    # List files and folders under ArtifactsDirectory for debugging
+    - pwsh: |
+        Get-ChildItem -Path '$(Pipeline.Workspace)/artifacts' -Recurse
+      displayName: 'List files and folders under ArtifactsDirectory'
+
+    - pwsh: |
+        npm install --global @vscode/vsce
+      displayName: 'Install VSCE'
+
+    # Publish Extension using the downloaded artifacts
+    - task: PowerShell@2
+      displayName: 'Publish Extension'
+      inputs:
+        targetType: 'filePath'
+        filePath: '$(Pipeline.Workspace)\artifacts\vscode\PublishVSCodeExtensionUsingMI.ps1'
+        arguments: '-artifactsPath $(Pipeline.Workspace)\artifacts -vscodeTargetsList "$(vscodeTargets)" -nugetToken "$(DotNetNugetApiKey)" -isSimulated $(simulate)'
+        pwsh: true
+        verbose: true


### PR DESCRIPTION
New files:
- PublishVSCodeExtensionUsingMI.ps1
- vscode-nuget-release-pipeline.yml

This pull request introduces a new release pipeline using Managed Identity for authentication, which is intended for experimentation. The goal is to test and validate this new release process without impacting the existing pipeline used for production releases.

Why this change is necessary:

- We are required to move all release pipelines to YAML as part of Wave 3 pipeline migrations.
- The new pipeline requires access to group variables.
- This pipeline serves as a proof of concept to implement Managed Identity for secure access and deployment.
- It avoids disruptions to the ongoing release pipeline while allowing iterative improvements and testing.

Next steps:

Once the new pipeline has been validated, older release pipelines will be deprecated and removed.