### PR TITLE
Add access to NuGet API key token

### DIFF
--- a/vscode-nuget-release-pipeline.yml
+++ b/vscode-nuget-release-pipeline.yml
@@ -8,9 +8,13 @@ resources:
       branch: main
 
 variables:
-  simulate: $(isSimulated)
-  DotNetNugetApiKey: $(DotNetNugetApiKey-A1)
-  vscodeTargets: $(listVSCodeTargets)
+- group: '.NET Core Nuget API Keys'
+- name : simulate
+  value: $(isSimulated)
+- name : DotNetNugetApiKey
+  value: $(DotNetNugetApiKey-A1)
+- name : vscodeTargets
+  value: $(listVSCodeTargets)
 
 pool:
   vmImage: 'windows-2022'


### PR DESCRIPTION
DNCENG internal team granted access to the '.NET Core Nuget API Keys' variable group for this pipeline.

- Integrated the '.NET Core Nuget API Keys' variable group to provide access to the DotNetNugetApiKey-A1 variable.
- Mapped DotNetNugetApiKey to use DotNetNugetApiKey-A1 for NuGet publishing.
