### PR TITLE
Honor `JsonPropertyNameAttribute` in TypeScript contract serialization

### DIFF
--- a/repack.ps1
+++ b/repack.ps1
@@ -1,24 +1,33 @@
 
-# clean up the previously-cached NuGet packages
-Remove-Item -Recurse ~\.nuget\packages\microsoft.dotnet.interactive* -Force
+Push-Location $PSScriptRoot
 
-# build and pack dotnet-interactive 
-dotnet clean -c debug
-dotnet build -c debug
-dotnet pack -c debug /p:PackageVersion=2.0.0
+try
+{
+    # clean up the previously-cached NuGet packages
+    Remove-Item -Recurse ~\.nuget\packages\microsoft.dotnet.interactive* -Force
 
-# copy the dotnet-interactive packages to the temp directory
-$destinationPath = "C:\temp\packages"
-if (-not (Test-Path -Path $destinationPath -PathType Container)) {
-    New-Item -Path $destinationPath -ItemType Directory -Force
+    # build and pack dotnet-interactive 
+    dotnet clean -c debug
+    dotnet build -c debug
+    dotnet pack -c debug /p:PackageVersion=2.0.0
+
+    # copy the dotnet-interactive packages to the temp directory
+    $destinationPath = "C:\temp\packages"
+    if (-not (Test-Path -Path $destinationPath -PathType Container)) {
+        New-Item -Path $destinationPath -ItemType Directory -Force
+    }
+    Get-ChildItem -Recurse -Filter *.nupkg | Move-Item -Destination $destinationPath -Force
+
+    # delete the #r nuget caches
+    if (Test-Path -Path ~\.packagemanagement\nuget\Cache -PathType Container) {
+        Remove-Item -Recurse -Force ~\.packagemanagement\nuget\Cache
+    }
+
+    if (Test-Path -Path ~\.packagemanagement\nuget\Projects -PathType Container) {
+        Remove-Item -Recurse -Force ~\.packagemanagement\nuget\Projects
+    }
 }
-Get-ChildItem -Recurse -Filter *.nupkg | Move-Item -Destination $destinationPath -Force
-
-# delete the #r nuget caches
-if (Test-Path -Path ~\.packagemanagement\nuget\Cache -PathType Container) {
-    Remove-Item -Recurse -Force ~\.packagemanagement\nuget\Cache
-}
-
-if (Test-Path -Path ~\.packagemanagement\nuget\Projects -PathType Container) {
-    Remove-Item -Recurse -Force ~\.packagemanagement\nuget\Projects
+finally
+{
+    $PopLocation
 }

--- a/src/Microsoft.DotNet.Interactive.Parsing.Tests/PolyglotParserConfigurationTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Parsing.Tests/PolyglotParserConfigurationTests.cs
@@ -57,6 +57,11 @@ public class PolyglotParserConfigurationTests
                             Parameters =
                             {
                                 new KernelDirectiveParameter("file")
+                                {
+                                    AllowImplicitName = true,
+                                    Required = true,
+                                    TypeHint = "file"
+                                }
                             }
                         },
                         new KernelActionDirective("#!connect")
@@ -105,6 +110,10 @@ public class PolyglotParserConfigurationTests
                                         {
                                             AllowImplicitName = true,
                                             Required = true
+                                        },
+                                        new KernelDirectiveParameter("--create-dbcontext")
+                                        {
+                                            Flag = true
                                         }
                                     },
                                     KernelCommandType = typeof(ConnectMsSql)
@@ -188,6 +197,8 @@ internal class KernelCommand
 internal class ConnectMsSql : KernelCommand
 {
     public string ConnectionString { get; set; }
+
+    public bool CreateDbContext { get; set; }
 }
 
 internal class SendValue : KernelCommand

--- a/src/Microsoft.DotNet.Interactive.Tests/SingleInputsWithinMagicCommandsTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/SingleInputsWithinMagicCommandsTests.cs
@@ -145,6 +145,33 @@ public class SingleInputsWithinMagicCommandsTests : IDisposable
     }
 
     [Fact]
+    public async Task Type_hint_is_set_based_on_inline_JSON_configuration_of_the_input_token()
+    {
+        _shimCommand.Parameters.Add(new KernelDirectiveParameter("--file"));
+
+        await _kernel.SendAsync(new SubmitCode("""
+                                               #!shim --file @input:{"type":"file"}
+                                               """, "csharp"));
+
+        _receivedRequestInput.InputTypeHint.Should().Be("file");
+    }
+
+    [Fact]
+    public async Task Type_hint_is_overridden_based_on_inline_JSON_configuration_of_the_input_token()
+    {
+        _shimCommand.Parameters.Add(new KernelDirectiveParameter("--file")
+        {
+            TypeHint = "file"
+        });
+
+        await _kernel.SendAsync(new SubmitCode("""
+                                               #!shim --file @input:{"type":"number"}
+                                               """, "csharp"));
+
+        _receivedRequestInput.InputTypeHint.Should().Be("number");
+    }
+
+    [Fact]
     public async Task multiple_set_commands_with_inputs_can_be_used_in_single_submission()
     {
         using var kernel = new CompositeKernel

--- a/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive/KernelExtensions.cs
@@ -92,7 +92,8 @@ public static class KernelExtensions
                 {
                     AllowImplicitName = true,
                     Required = true,
-                    Description = LocalizationResources.Magics_import_file_Description()
+                    Description = LocalizationResources.Magics_import_file_Description(),
+                    TypeHint = "file"
                 }
             },
             TryGetKernelCommandAsync = ImportDocument.TryParseImportDirectiveAsync

--- a/src/interface-generator/InterfaceGenerator.cs
+++ b/src/interface-generator/InterfaceGenerator.cs
@@ -131,10 +131,13 @@ public class InterfaceGenerator
 
         var emittedTypes = new HashSet<Type>(WellKnownTypes.Keys);
 
-        builder.AppendLine(@"// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+        builder.AppendLine(
+            """
+            // Copyright (c) .NET Foundation and contributors. All rights reserved.
+            // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-// Generated TypeScript interfaces and types.");
+            // Generated TypeScript interfaces and types.
+            """);
 
         var requiredTypes = new List<Type>();
 
@@ -271,6 +274,12 @@ public class InterfaceGenerator
                          OptionalFields.Contains($"{type.Name}.{propertyInfo.Name}");
 
         var propertyName = propertyInfo.Name.CamelCase();
+
+        if (propertyInfo.GetCustomAttribute<JsonPropertyNameAttribute>() is {} jsonPropertyNameAttribute)
+        {
+            propertyName = jsonPropertyNameAttribute.Name;
+        }
+
         return isOptional
             ? propertyName + "?"
             : propertyName;

--- a/src/polyglot-notebooks-vscode-common/src/extension.ts
+++ b/src/polyglot-notebooks-vscode-common/src/extension.ts
@@ -181,14 +181,25 @@ export async function activate(context: vscode.ExtensionContext) {
                 const password = requestInput.isPassword;
 
                 let value;
-                let customInputRequest = await vscodeNotebookManagement.handleCustomInputRequest(prompt, requestInput.inputTypeHint, password);
+                let customInputRequest = await vscodeNotebookManagement.handleCustomInputRequest(prompt, requestInput.type, password);
                 if (customInputRequest.handled) {
                     value = customInputRequest.result;
                 } else {
-                    value = (requestInput.inputTypeHint === "file")
-                        ? await vscode.window.showOpenDialog({ canSelectFiles: true, canSelectFolders: false, title: prompt, canSelectMany: false })
-                            .then(v => typeof v?.[0].fsPath === 'undefined' ? null : v[0].fsPath)
-                        : await vscode.window.showInputBox({ prompt, password, ignoreFocusOut: true });
+                    switch (requestInput.type) {
+                        case "file":
+                            value = await vscode.window.showOpenDialog({
+                                canSelectFiles: true,
+                                canSelectFolders: false,
+                                title: prompt,
+                                canSelectMany: false
+                            })
+                                .then(v => typeof v?.[0].fsPath === 'undefined' ? null : v[0].fsPath);
+                            break;
+
+                        default:
+                            value = await vscode.window.showInputBox({ prompt, password, ignoreFocusOut: true });
+                            break;
+                    }
                 }
 
                 if (!value) {

--- a/src/polyglot-notebooks/src/contracts.ts
+++ b/src/polyglot-notebooks/src/contracts.ts
@@ -85,7 +85,7 @@ export interface DisplayValue extends KernelCommand {
 }
 
 export interface ImportDocument extends KernelCommand {
-    filePath: string;
+    file: string;
 }
 
 export interface OpenDocument extends KernelCommand {
@@ -116,7 +116,7 @@ export interface RequestHoverText extends LanguageServiceCommand {
 }
 
 export interface RequestInput extends KernelCommand {
-    inputTypeHint: string;
+    type: string;
     isPassword: boolean;
     parameterName: string;
     prompt: string;
@@ -456,7 +456,7 @@ export interface InputDescription {
     name: string;
     prompt: string;
     saveAs: string;
-    typeHint: string;
+    type: string;
 }
 
 export interface InteractiveDocument {


### PR DESCRIPTION
This fixes a regression (affecting only the Insiders release of Polyglot Notebooks) due to a contract mismatch between the TypeScript and C# versions of the `RequestInput` command.