### PR TITLE
Fix extraction of 'kernelInfo' from the document -- fixes #3527

### DIFF
--- a/src/polyglot-notebooks-vscode-common/src/metadataUtilities.ts
+++ b/src/polyglot-notebooks-vscode-common/src/metadataUtilities.ts
@@ -96,7 +96,7 @@ export function getNotebookCellMetadataFromNotebookCellElement(notebookCell: vsc
 
 export function getNotebookDocumentMetadataFromInteractiveDocument(interactiveDocument: commandsAndEvents.InteractiveDocument): NotebookDocumentMetadata {
     const notebookMetadata = createDefaultNotebookDocumentMetadata();
-    const kernelInfo = interactiveDocument.metadata.kernelInfo;
+    const kernelInfo = interactiveDocument.metadata.kernelInfo || interactiveDocument.metadata.plyglot_notebook.kernelInfo
     if (typeof kernelInfo === 'object') {
         if (typeof kernelInfo.defaultKernelName === 'string') {
             notebookMetadata.kernelInfo.defaultKernelName = kernelInfo.defaultKernelName;


### PR DESCRIPTION
This is a proposed fix for the #3527 -- it fixes the problem for me.

I wrote the code in a bit defensive manner, because I was not sure if the old code might still be correct in some cases (e.g. in case some .ipynb files are formatted in the way the code was initially written).  
So I tried both options: if the old way doesn't work, then try the new structure format.

If all loaded documents are expected to be written in new format (`metadata.polyglot_notebook.kernelInfo` instead of `metadata.kernelInfo`),  
then the left side of that 'or' (`||`) statement can be omitted.