### PR TITLE
NamedPipeConnector Fixes

### DIFF
--- a/src/Microsoft.DotNet.Interactive.NamedPipeConnector/ConnectNamedPipeDirective.cs
+++ b/src/Microsoft.DotNet.Interactive.NamedPipeConnector/ConnectNamedPipeDirective.cs
@@ -37,4 +37,13 @@ public class ConnectNamedPipeDirective : ConnectKernelDirective<ConnectNamedPipe
 
         return new Kernel[] { proxyKernel };
     }
+
+    public static void AddToRootKernel()
+    {
+        if (KernelInvocationContext.Current is { } context &&
+            context.HandlingKernel.RootKernel is CompositeKernel root)
+        {
+            root.AddKernelConnector(new ConnectNamedPipeDirective());
+        }
+    }
 }

--- a/src/Microsoft.DotNet.Interactive.NamedPipeConnector/Microsoft.DotNet.Interactive.NamedPipeConnector.csproj
+++ b/src/Microsoft.DotNet.Interactive.NamedPipeConnector/Microsoft.DotNet.Interactive.NamedPipeConnector.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <PackageId Condition="'$(PackageId)'==''">Microsoft.DotNet.Interactive.NamedPipeConnectorConnector</PackageId>

--- a/src/Microsoft.DotNet.Interactive.NamedPipeConnector/Microsoft.DotNet.Interactive.NamedPipeConnector.csproj
+++ b/src/Microsoft.DotNet.Interactive.NamedPipeConnector/Microsoft.DotNet.Interactive.NamedPipeConnector.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
-    <PackageId Condition="'$(PackageId)'==''">Microsoft.DotNet.Interactive.NamedPipeConnectorConnector</PackageId>
+    <PackageId Condition="'$(PackageId)'==''">Microsoft.DotNet.Interactive.NamedPipeConnector</PackageId>
     <NoWarn>$(NoWarn);8002;CS8002</NoWarn>
     <NoWarn>$(NoWarn);CA1416</NoWarn> <!-- Ignore: This call site is reachable on all platforms. 'PipeTransmissionMode.Message' is supported on: 'windows'. -->
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Interactive.NamedPipeConnector/extension.dib
+++ b/src/Microsoft.DotNet.Interactive.NamedPipeConnector/extension.dib
@@ -1,3 +1,4 @@
 #!csharp
 
-Microsoft.DotNet.Interactive.NamedPipeConnector.ConnectNamedPipeCommand.AddToRootKernel();
+await Microsoft.DotNet.Interactive.NamedPipeConnector.ConnectNamedPipeDirective.AddToRootKernel();
+


### PR DESCRIPTION
Contributes to #3720 (not sure why it's not uploaded to NuGet, but noticed some issues while investigating the WPF Connect sample, so figured I'd push these up as a separate PR here so it'd be more ready at least!)

This PR does 3 things:
- Use straight `net8.0` as the TFM. 
  - The `net8.0-windows` TFM, I think is the old way from .NET 5 only? Generally, it should have a version number after it for targeting modern Windows, this happened in .NET 6, see https://learn.microsoft.com/windows/apps/desktop/modernize/desktop-to-uwp-enhance
  - Regardless, from what I can tell anyway, the `NamedPipeClientStream` which is the main part of this code is still just a pure .NET API and _doesn't need the Windows specific TFM_ https://learn.microsoft.com/dotnet/api/system.io.pipes.namedpipeclientstream
  - Having a windows TFM breaks the connect-wpf sample as the notebook in VS Code can't load the windows TFM (I have a draft PR to update the connect-wpf sample, and I think it can connect now with some help, but stalls out, so I think I'm stuck, but this was the first step, so figured would make it an independent PR as the wpf sample is pinned in the past anyway.)
- Update the Package name to match the project name (extra Connector was on there for some reason, copy/paste bug?)
  - Looked later, this may be the root cause of #3720 and the package missing on NuGet as the publish script (see comment below) looks for the expected name
- When loading this extension in a notebook, it would fail as the code in the `extension.dib` wasn't updated alongside the other code in this project
  - This is where I had to guess a bit, but tried to pattern off the SQL Lite extension, and just created a new static method to add the directive to the root when the extension is initialized.