### PR TITLE
[WIP] Update Connect WPF Sample?

### DIFF
--- a/dotnet-interactive.sln
+++ b/dotnet-interactive.sln
@@ -123,6 +123,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Interactiv
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Interactive.Parsing.Tests", "src\Microsoft.DotNet.Interactive.Parsing.Tests\Microsoft.DotNet.Interactive.Parsing.Tests.csproj", "{55138BD7-111A-43A5-BFBB-326606C4C1B5}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{49E6C2EA-FE81-47DF-B206-F818669BEFB1}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WpfConnect", "samples\connect-wpf\WpfConnect.csproj", "{98689A19-6B13-4EA9-8C0E-6CB665322531}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -709,6 +713,18 @@ Global
 		{55138BD7-111A-43A5-BFBB-326606C4C1B5}.Release|x64.Build.0 = Release|Any CPU
 		{55138BD7-111A-43A5-BFBB-326606C4C1B5}.Release|x86.ActiveCfg = Release|Any CPU
 		{55138BD7-111A-43A5-BFBB-326606C4C1B5}.Release|x86.Build.0 = Release|Any CPU
+		{98689A19-6B13-4EA9-8C0E-6CB665322531}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{98689A19-6B13-4EA9-8C0E-6CB665322531}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{98689A19-6B13-4EA9-8C0E-6CB665322531}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{98689A19-6B13-4EA9-8C0E-6CB665322531}.Debug|x64.Build.0 = Debug|Any CPU
+		{98689A19-6B13-4EA9-8C0E-6CB665322531}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{98689A19-6B13-4EA9-8C0E-6CB665322531}.Debug|x86.Build.0 = Debug|Any CPU
+		{98689A19-6B13-4EA9-8C0E-6CB665322531}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{98689A19-6B13-4EA9-8C0E-6CB665322531}.Release|Any CPU.Build.0 = Release|Any CPU
+		{98689A19-6B13-4EA9-8C0E-6CB665322531}.Release|x64.ActiveCfg = Release|Any CPU
+		{98689A19-6B13-4EA9-8C0E-6CB665322531}.Release|x64.Build.0 = Release|Any CPU
+		{98689A19-6B13-4EA9-8C0E-6CB665322531}.Release|x86.ActiveCfg = Release|Any CPU
+		{98689A19-6B13-4EA9-8C0E-6CB665322531}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -762,6 +778,7 @@ Global
 		{BF68D266-500C-49AB-80EB-1B673E37E13A} = {B95A8485-8C53-4F56-B0CE-19C0726B5805}
 		{B12834B8-373E-4932-852B-90E332A4BCED} = {11BA3480-4584-435C-BA9A-8C554DB60E9F}
 		{55138BD7-111A-43A5-BFBB-326606C4C1B5} = {11BA3480-4584-435C-BA9A-8C554DB60E9F}
+		{98689A19-6B13-4EA9-8C0E-6CB665322531} = {49E6C2EA-FE81-47DF-B206-F818669BEFB1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6D05A9AF-CFFB-4187-8599-574387B76727}

--- a/samples/connect-wpf/Directory.Build.props
+++ b/samples/connect-wpf/Directory.Build.props
@@ -1,0 +1,3 @@
+<Project>
+    <!-- Only here so that the default Directory.Build.props will not be used. -->
+</Project>

--- a/samples/connect-wpf/DispatcherCommand.cs
+++ b/samples/connect-wpf/DispatcherCommand.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.DotNet.Interactive.Commands;
+using System.Threading.Tasks;
+using System;
+
+namespace WpfConnect;
+
+public class DispatcherCommand : KernelCommand
+{
+    public DispatcherCommand(
+        string enabled,
+        string targetKernelName = null) : base(targetKernelName)
+    {
+        if (string.IsNullOrWhiteSpace(enabled))
+        {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(enabled));
+        }
+
+        Enabled = enabled;
+    }
+
+    public string Enabled { get; }
+}

--- a/samples/connect-wpf/WpfConnect.csproj
+++ b/samples/connect-wpf/WpfConnect.csproj
@@ -8,7 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Interactive.CSharp" Version="1.0.0-beta.23403.1" />
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.Interactive.CSharp\Microsoft.DotNet.Interactive.CSharp.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.Interactive.NamedPipeConnector\Microsoft.DotNet.Interactive.NamedPipeConnector.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.Interactive.PackageManagement\Microsoft.DotNet.Interactive.PackageManagement.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/connect-wpf/readme.ipynb
+++ b/samples/connect-wpf/readme.ipynb
@@ -59,6 +59,9 @@
         }
       ],
       "source": [
+        "#i \"nuget:I:\\oss\\dotnetinteractive\\artifacts\\packages\\Debug\\Shipping\"\n",
+        "#r \"nuget:Microsoft.DotNet.Interactive.Documents,*-*\"\n",
+        "#r \"nuget:Microsoft.DotNet.Interactive.NamedPipeConnector,*-*\"\n",
         "#!connect named-pipe --kernel-name wpf --pipe-name InteractiveWpf"
       ]
     },

--- a/src/Microsoft.DotNet.Interactive.NamedPipeConnector/ConnectNamedPipeDirective.cs
+++ b/src/Microsoft.DotNet.Interactive.NamedPipeConnector/ConnectNamedPipeDirective.cs
@@ -37,4 +37,13 @@ public class ConnectNamedPipeDirective : ConnectKernelDirective<ConnectNamedPipe
 
         return new Kernel[] { proxyKernel };
     }
+
+    public static void AddToRootKernel()
+    {
+        if (KernelInvocationContext.Current is { } context &&
+            context.HandlingKernel.RootKernel is CompositeKernel root)
+        {
+            root.AddKernelConnector(new ConnectNamedPipeDirective());
+        }
+    }
 }

--- a/src/Microsoft.DotNet.Interactive.NamedPipeConnector/Microsoft.DotNet.Interactive.NamedPipeConnector.csproj
+++ b/src/Microsoft.DotNet.Interactive.NamedPipeConnector/Microsoft.DotNet.Interactive.NamedPipeConnector.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <PackageId Condition="'$(PackageId)'==''">Microsoft.DotNet.Interactive.NamedPipeConnectorConnector</PackageId>

--- a/src/Microsoft.DotNet.Interactive.NamedPipeConnector/Microsoft.DotNet.Interactive.NamedPipeConnector.csproj
+++ b/src/Microsoft.DotNet.Interactive.NamedPipeConnector/Microsoft.DotNet.Interactive.NamedPipeConnector.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
-    <PackageId Condition="'$(PackageId)'==''">Microsoft.DotNet.Interactive.NamedPipeConnectorConnector</PackageId>
+    <PackageId Condition="'$(PackageId)'==''">Microsoft.DotNet.Interactive.NamedPipeConnector</PackageId>
     <NoWarn>$(NoWarn);8002;CS8002</NoWarn>
     <NoWarn>$(NoWarn);CA1416</NoWarn> <!-- Ignore: This call site is reachable on all platforms. 'PipeTransmissionMode.Message' is supported on: 'windows'. -->
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Interactive.NamedPipeConnector/extension.dib
+++ b/src/Microsoft.DotNet.Interactive.NamedPipeConnector/extension.dib
@@ -1,3 +1,4 @@
 #!csharp
 
-Microsoft.DotNet.Interactive.NamedPipeConnector.ConnectNamedPipeCommand.AddToRootKernel();
+await Microsoft.DotNet.Interactive.NamedPipeConnector.ConnectNamedPipeDirective.AddToRootKernel();
+


### PR DESCRIPTION
Requires #3723 and dependent probably on #3720

This is an initial start for updating the Connect WPF sample:

- Add to the main solution and allow building it there alongside the rest of the code (use a dummy props file to prevent the arcade issue) Fixes #2582
- Use ProjectReference to build against the project (at least for now while working on this)
- Updates code to use the new NuGetDirective pattern (grabbed code from the extension in the browser project, not sure why that extension isn't just part of the core library)
- Updates code to use the refactored out NamedPipeConnector project
- Updates to use new KernalActionDirective pattern (seems likes some refactor/change happened to avoid conflicts with cmdline parsing, but this project was never updated)
- Temp? Add packages needed to the notebook for testing

That's as far as I could get, it seems to connect to the WPF app (maybe) and then stalls out? The connect command just continues to 'run' and ignores the request to stop in the notebook from VS Code (with no output/status).

![image](https://github.com/user-attachments/assets/30fd5a04-2d84-48df-a467-ef9563fae940)

I'm out-of-my-depth now trying to just update the code as best as I can with the internals of how .NET Interactive works, but figured putting an update together to share what I had as a starting point for others to jump on would be useful.

Thanks!