### PR TITLE
Completion and input API improvements

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
@@ -19,7 +19,7 @@ Microsoft.DotNet.Interactive
     public System.String DefaultKernelName { get; set;}
     public KernelHost Host { get;}
     public System.Void Add(Kernel kernel, System.Collections.Generic.IEnumerable<System.String> aliases = null)
-    public System.Void AddKernelConnector<T>(ConnectKernelDirective<T> connectDirective)
+    public System.Void AddConnectDirective<T>(ConnectKernelDirective<T> connectDirective)
     public System.Collections.Generic.IEnumerator<Kernel> GetEnumerator()
      Kernel GetHandlingKernel(Microsoft.DotNet.Interactive.Commands.KernelCommand command, KernelInvocationContext context)
      System.Threading.Tasks.Task HandleRequestKernelInfoAsync(Microsoft.DotNet.Interactive.Commands.RequestKernelInfo command, KernelInvocationContext context)

--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
@@ -94,6 +94,7 @@ Microsoft.DotNet.Interactive
     public static System.Void CSS(System.String content)
     public static DisplayedValue display(System.Object value, System.String[] mimeTypes)
     public static System.Threading.Tasks.Task<System.String> GetInputAsync(System.String prompt = , System.String typeHint = text)
+    public static System.Threading.Tasks.Task<System.Collections.Generic.IDictionary<System.String,System.String>> GetInputsAsync(System.Collections.Generic.IEnumerable<Microsoft.DotNet.Interactive.Commands.InputDescription> inputDescriptions)
     public static System.Threading.Tasks.Task<PasswordString> GetPasswordAsync(System.String prompt = )
     public static Microsoft.AspNetCore.Html.IHtmlContent HTML(System.String content)
     public static System.Void Javascript(System.String scriptContent)

--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
@@ -562,7 +562,7 @@ Microsoft.DotNet.Interactive.Directives
     public System.String ToString()
   public class KernelDirectiveCompletionContext
     .ctor()
-    public System.Collections.Generic.IList<Microsoft.DotNet.Interactive.Events.CompletionItem> Completions { get;}
+    public System.Collections.Generic.IList<Microsoft.DotNet.Interactive.Events.CompletionItem> CompletionItems { get;}
   public class KernelDirectiveParameter
     .ctor(System.String name, System.String description = null)
     public System.Boolean AllowImplicitName { get; set;}
@@ -572,9 +572,8 @@ Microsoft.DotNet.Interactive.Directives
     public System.String Name { get;}
     public System.Boolean Required { get; set;}
     public System.String TypeHint { get; set;}
-    public KernelDirectiveParameter AddCompletions(System.Func<KernelDirectiveCompletionContext,System.Collections.Generic.IEnumerable<Microsoft.DotNet.Interactive.Events.CompletionItem>> getCompletions)
-    public KernelDirectiveParameter AddCompletions(System.Func<KernelDirectiveCompletionContext,System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.DotNet.Interactive.Events.CompletionItem>>> getCompletions)
-    public KernelDirectiveParameter AddCompletions(System.Func<KernelDirectiveCompletionContext,System.Collections.Generic.IEnumerable<System.String>> getCompletions)
+    public KernelDirectiveParameter AddCompletions(System.Func<KernelDirectiveCompletionContext,System.Threading.Tasks.Task> getCompletions)
+    public KernelDirectiveParameter AddCompletions(System.Func<System.Collections.Generic.IEnumerable<System.String>> getCompletions)
     public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Microsoft.DotNet.Interactive.Events.CompletionItem>> GetValueCompletionsAsync()
     public System.String ToString()
   public class KernelSpecifierDirective : KernelDirective

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/DataFrameKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/DataFrameKernelExtension.cs
@@ -43,13 +43,19 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
                         AllowImplicitName = true
                     };
 
-                    variableNameParameter.AddCompletions(_ =>
+                    variableNameParameter.AddCompletions(context =>
                     {
                         var completionItems = cSharpKernel.ScriptState
                                                           .Variables
                                                           .Where(v => v.Value is DataFrame)
                                                           .Select(v => new CompletionItem(v.Name, WellKnownTags.Parameter));
-                        return Task.FromResult(completionItems);
+
+                        foreach (var item in completionItems)
+                        {
+                            context.CompletionItems.Add(item);
+                        }
+
+                        return Task.CompletedTask;
                     });
 
                     var directive = new KernelActionDirective("#!linqify")

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/DataFrameKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/DataFrameKernelExtension.cs
@@ -43,10 +43,14 @@ namespace Microsoft.DotNet.Interactive.ExtensionLab
                         AllowImplicitName = true
                     };
 
-                    variableNameParameter.AddCompletions(_ => cSharpKernel.ScriptState
-                                                                          .Variables
-                                                                          .Where(v => v.Value is DataFrame)
-                                                                          .Select(v => new CompletionItem(v.Name, WellKnownTags.Parameter)));
+                    variableNameParameter.AddCompletions(_ =>
+                    {
+                        var completionItems = cSharpKernel.ScriptState
+                                                          .Variables
+                                                          .Where(v => v.Value is DataFrame)
+                                                          .Select(v => new CompletionItem(v.Name, WellKnownTags.Parameter));
+                        return Task.FromResult(completionItems);
+                    });
 
                     var directive = new KernelActionDirective("#!linqify")
                     {

--- a/src/Microsoft.DotNet.Interactive.ExtensionLab/InspectExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.ExtensionLab/InspectExtension.cs
@@ -28,7 +28,7 @@ public class InspectExtension
         inspect.Parameters.Add(new KernelDirectiveParameter("--configuration")
                                    {
                                        Description = "Build configuration to use. Debug or Release."
-                                   }.AddCompletions(_ => [ "Debug", "Release" ]));
+                                   }.AddCompletions(() => [ "Debug", "Release" ]));
         inspect.Parameters.Add(new KernelDirectiveParameter("--kind")
                                    {
                                        Description = "Source code kind. Script or Regular."

--- a/src/Microsoft.DotNet.Interactive.Http.Tests/HttpKernelTests.NamedRequest.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Tests/HttpKernelTests.NamedRequest.cs
@@ -556,7 +556,7 @@ namespace Microsoft.DotNet.Interactive.Http.Tests
             [Fact]
             public async Task xml_with_json_content_type_produces_errors()
             {
-                using var kernel = new HttpKernel();
+                using var kernel = new HttpKernel("http");
 
                 var firstCode = """
                     @baseUrl = https://httpbin.org/anything
@@ -594,7 +594,7 @@ namespace Microsoft.DotNet.Interactive.Http.Tests
 
                 var diagnostics = secondResult.Events.Should().ContainSingle<DiagnosticsProduced>().Which;
 
-                diagnostics.Diagnostics.First().Message.Should().Be($$$"""The supplied named request has content type of 'application/json' which differs from the required content type of 'application/xml'.""");
+                diagnostics.Diagnostics.First().Message.Should().Be("""The supplied named request has content type of 'application/json' which differs from the required content type of 'application/xml'.""");
             }
 
             [Theory]

--- a/src/Microsoft.DotNet.Interactive.Http/HttpKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.Http/HttpKernel.cs
@@ -144,6 +144,7 @@ public class HttpKernel :
             {
                 var docVariableNodes = parsedDoc.SyntaxTree.RootNode.ChildNodes.OfType<HttpVariableDeclarationAndAssignmentNode>();
                 var docVariableNames = docVariableNodes.Where(n => n.Span.Start < lastSpan?.Start).Select(n => n.DeclarationNode?.VariableName).ToHashSet();
+
                 foreach (DeclaredVariable dv in parsedDoc.SyntaxTree.RootNode.TryGetDeclaredVariables(BindExpressionValues).declaredVariables.Values)
                 {
                     if (docVariableNames.Contains(dv.Name))
@@ -152,7 +153,6 @@ public class HttpKernel :
                     }
                 }
             }
-
         }
         else
         {

--- a/src/Microsoft.DotNet.Interactive.Http/Model/HttpNamedRequest.cs
+++ b/src/Microsoft.DotNet.Interactive.Http/Model/HttpNamedRequest.cs
@@ -1,20 +1,16 @@
-﻿#nullable enable
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.CodeAnalysis.Text;
-using System;
+#nullable enable
+
 using Microsoft.DotNet.Interactive.Http.Parsing;
-using Microsoft.CodeAnalysis;
+using System;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using System.Reactive.Concurrency;
-using System.Xml.XPath;
 using System.Xml;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Microsoft.DotNet.Interactive.Http;
-
-using Diagnostic = CodeAnalysis.Diagnostic;
 
 internal class HttpNamedRequest
 {
@@ -25,7 +21,7 @@ internal class HttpNamedRequest
         Response = response;
     }
 
-    public string? Name { get; private set; }
+    public string? Name { get; }
 
     private readonly HttpRequestNode RequestNode;
 

--- a/src/Microsoft.DotNet.Interactive.Http/Model/HttpResponse.cs
+++ b/src/Microsoft.DotNet.Interactive.Http/Model/HttpResponse.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.Interactive.Http;
 
 [TypeFormatterSource(
     typeof(HttpResponseFormatterSource),
-    PreferredMimeTypes = new[] { HtmlFormatter.MimeType })]
+    PreferredMimeTypes = [HtmlFormatter.MimeType])]
 public sealed class HttpResponse : PartialHttpResponse
 {
     public Dictionary<string, string[]> Headers { get; }

--- a/src/Microsoft.DotNet.Interactive.Http/Model/PartialHttpResponse.cs
+++ b/src/Microsoft.DotNet.Interactive.Http/Model/PartialHttpResponse.cs
@@ -7,7 +7,7 @@ namespace Microsoft.DotNet.Interactive.Http;
 
 [TypeFormatterSource(
     typeof(HttpResponseFormatterSource),
-    PreferredMimeTypes = new[] { HtmlFormatter.MimeType })]
+    PreferredMimeTypes = [HtmlFormatter.MimeType])]
 public class PartialHttpResponse : EmptyHttpResponse
 {
     public int StatusCode { get; }

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterKernelTestBase.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterKernelTestBase.cs
@@ -50,7 +50,7 @@ public abstract class JupyterKernelTestBase : IDisposable
             jupyterKernelCommand.AddConnectionOptions(options);
         }
 
-        kernel.AddKernelConnector(jupyterKernelCommand);
+        kernel.AddConnectDirective(jupyterKernelCommand);
         _disposables.Add(kernel);
         return kernel;
     }

--- a/src/Microsoft.DotNet.Interactive.Jupyter/JupyterKernelCommandHandlers.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/JupyterKernelCommandHandlers.cs
@@ -190,7 +190,7 @@ internal partial class JupyterKernel
     {
         switch (message)
         {
-            case (DisplayData displayData):
+            case DisplayData displayData:
                 context.Publish(new DisplayedValueProduced(displayData.Data,
                                                         command,
                                                         GetFormattedValuesFromMimeBundle(displayData.Data),
@@ -198,18 +198,18 @@ internal partial class JupyterKernel
                                                         ));
                 break;
 
-            case (UpdateDisplayData updateDisplayData):
+            case UpdateDisplayData updateDisplayData:
                 context.Publish(new DisplayedValueUpdated(updateDisplayData.Data,
                                                           GetDisplayIdFromTransientData(updateDisplayData.Transient),
                                                           command,
                                                           GetFormattedValuesFromMimeBundle(updateDisplayData.Data)));
                 break;
-            case (ExecuteResult result):
+            case ExecuteResult result:
                 context.Publish(new ReturnValueProduced(result.Data,
                                                         command,
                                                         GetFormattedValuesFromMimeBundle(result.Data)));
                 break;
-            case (Stream streamResult):
+            case Stream streamResult:
                 if (streamResult.Name == Stream.StandardOutput)
                 {
                     context.Publish(
@@ -226,7 +226,7 @@ internal partial class JupyterKernel
                             new[] { new FormattedValue(PlainTextFormatter.MimeType, streamResult.Text) }));
                 }
                 break;
-            case (Error error):
+            case Error error:
 
                 StringBuilder builder = new StringBuilder();
                 foreach (var item in error.Traceback)
@@ -243,7 +243,7 @@ internal partial class JupyterKernel
 
                 context.Fail(command, null, error.EName);
                 break;
-            case (InputRequest inputRequest):
+            case InputRequest inputRequest:
 
                 string input = await GetInputAsync(inputRequest, context);
                 var reply = new InputReply(input);

--- a/src/Microsoft.DotNet.Interactive.Jupyter/JupyterLocalKernelConnectionOptions.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter/JupyterLocalKernelConnectionOptions.cs
@@ -14,7 +14,7 @@ public sealed class JupyterLocalKernelConnectionOptions : IJupyterKernelConnecti
 
     public JupyterLocalKernelConnectionOptions()
     {
-        CondaEnv.AddCompletions(_ => CondaEnvironment.GetEnvironments());
+        CondaEnv.AddCompletions(CondaEnvironment.GetEnvironments);
 
         _parameters = new List<KernelDirectiveParameter>
         {

--- a/src/Microsoft.DotNet.Interactive.Kql/KqlKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql/KqlKernelExtension.cs
@@ -20,7 +20,7 @@ public class KqlKernelExtension
 
             var kqlToolPath = Path.Combine(Paths.DotnetToolsPath, kqlToolName);
             compositeKernel
-                .AddKernelConnector(new ConnectKqlDirective(kqlToolPath));
+                .AddConnectDirective(new ConnectKqlDirective(kqlToolPath));
 
             KernelInvocationContext.Current?.Display(
                 new HtmlString(@"<details><summary>Query Microsoft Kusto Server databases.</summary>

--- a/src/Microsoft.DotNet.Interactive.NamedPipeConnector.Tests/NamedPipeConnectionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.NamedPipeConnector.Tests/NamedPipeConnectionTests.cs
@@ -31,7 +31,7 @@ public class NamedPipeConnectionTests : ProxyKernelConnectionTestsBase
     {
         using var compositeKernel = new CompositeKernel();
 
-        compositeKernel.AddKernelConnector(new ConnectNamedPipeDirective());
+        compositeKernel.AddConnectDirective(new ConnectNamedPipeDirective());
 
         compositeKernel
             .KernelInfo
@@ -60,7 +60,7 @@ public class NamedPipeConnectionTests : ProxyKernelConnectionTestsBase
     {
         CreateRemoteKernelTopology(_pipeName);
 
-        compositeKernel.AddKernelConnector(new ConnectNamedPipeDirective());
+        compositeKernel.AddConnectDirective(new ConnectNamedPipeDirective());
     }
    
     private void CreateRemoteKernelTopology(string pipeName)

--- a/src/Microsoft.DotNet.Interactive.NamedPipeConnector/ConnectNamedPipeDirective.cs
+++ b/src/Microsoft.DotNet.Interactive.NamedPipeConnector/ConnectNamedPipeDirective.cs
@@ -43,7 +43,7 @@ public class ConnectNamedPipeDirective : ConnectKernelDirective<ConnectNamedPipe
         if (KernelInvocationContext.Current is { } context &&
             context.HandlingKernel.RootKernel is CompositeKernel root)
         {
-            root.AddKernelConnector(new ConnectNamedPipeDirective());
+            root.AddConnectDirective(new ConnectNamedPipeDirective());
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Parsing.Tests/PolyglotSyntaxParserTests.Completions.cs
+++ b/src/Microsoft.DotNet.Interactive.Parsing.Tests/PolyglotSyntaxParserTests.Completions.cs
@@ -127,8 +127,10 @@ public partial class PolyglotSyntaxParserTests
                                     Parameters =
                                     [
                                         new KernelDirectiveParameter("--parameter")
-                                                { AllowImplicitName = true }
-                                            .AddCompletions(_ => ["one", "two", "three"]),
+                                            {
+                                                AllowImplicitName = true
+                                            }
+                                            .AddCompletions(() => ["one", "two", "three"]),
                                         new("--other-parameter")
                                     ]
                                 }
@@ -271,7 +273,7 @@ public partial class PolyglotSyntaxParserTests
                                             [
                                                 new KernelDirectiveParameter("--parameter")
                                                         { AllowImplicitName = true }
-                                                    .AddCompletions(_ => ["one", "two", "three"]),
+                                                    .AddCompletions(() => ["one", "two", "three"]),
                                                 new("--other-parameter")
                                             ]
                                         }
@@ -314,7 +316,7 @@ public partial class PolyglotSyntaxParserTests
                                 {
                                     Parameters =
                                     [
-                                        new KernelDirectiveParameter("--parameter").AddCompletions(_ => ["one", "two", "three"])
+                                        new KernelDirectiveParameter("--parameter").AddCompletions(() => ["one", "two", "three"])
                                     ]
                                 }
                             ]

--- a/src/Microsoft.DotNet.Interactive.SQLite.Tests/SQLiteConnectionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.SQLite.Tests/SQLiteConnectionTests.cs
@@ -25,7 +25,7 @@ public class SQLiteConnectionTests
             new KeyValueStoreKernel()
         };
 
-        kernel.AddKernelConnector(new ConnectSQLiteDirective());
+        kernel.AddConnectDirective(new ConnectSQLiteDirective());
 
         using var _ = CreateInMemorySQLiteDb(out var connectionString);
 
@@ -67,7 +67,7 @@ SELECT * FROM fruit
             new KeyValueStoreKernel()
         };
 
-        kernel.AddKernelConnector(new ConnectSQLiteDirective());
+        kernel.AddConnectDirective(new ConnectSQLiteDirective());
 
         using var _ = CreateInMemorySQLiteDb(out var connectionString);
 

--- a/src/Microsoft.DotNet.Interactive.SQLite/SQLiteKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.SQLite/SQLiteKernel.cs
@@ -112,7 +112,7 @@ public class SQLiteKernel :
 
     public static void AddSQLiteKernelConnectorTo(CompositeKernel kernel)
     {
-        kernel.AddKernelConnector(new ConnectSQLiteDirective());
+        kernel.AddConnectDirective(new ConnectSQLiteDirective());
 
         KernelInvocationContext.Current?.Display(
             new HtmlString(@"<details><summary>Query SQLite databases.</summary>

--- a/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelConnector.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelConnector.cs
@@ -8,6 +8,7 @@ namespace Microsoft.DotNet.Interactive.SqlServer;
 
 internal class MsSqlKernelConnector
 {
+    // FIX: (MsSqlKernelConnector) dead code?
     public MsSqlKernelConnector(bool createDbContext, string connectionString)
     {
         CreateDbContext = createDbContext;

--- a/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelExtension.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernelExtension.cs
@@ -19,7 +19,7 @@ public class MsSqlKernelExtension
 
             var sqlToolPath = Path.Combine(Paths.DotnetToolsPath, sqlToolName);
             compositeKernel
-                .AddKernelConnector(new ConnectMsSqlDirective(sqlToolPath));
+                .AddConnectDirective(new ConnectMsSqlDirective(sqlToolPath));
 
             KernelInvocationContext.Current?.Display(
                 new HtmlString(@"<details><summary>Query Microsoft SQL Server databases.</summary>

--- a/src/Microsoft.DotNet.Interactive.Tests/ConnectDirectiveTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/ConnectDirectiveTests.cs
@@ -114,7 +114,7 @@ hello!
     {
         using var compositeKernel = new CompositeKernel();
 
-        compositeKernel.AddKernelConnector(
+        compositeKernel.AddConnectDirective(
             new ConnectFakeKernelDirective("fake", "Connects the fake kernel", name => Task.FromResult<Kernel>(new FakeKernel(name))));
 
         await compositeKernel.SubmitCodeAsync("#!connect fake --kernel-name fake1");
@@ -131,7 +131,7 @@ hello!
     {
         var compositeKernel = new CompositeKernel();
 
-        compositeKernel.AddKernelConnector(
+        compositeKernel.AddConnectDirective(
             new ConnectFakeKernelDirective("fake", "Connects the fake kernel", _ => Task.FromResult<Kernel>(fakeKernel)));
 
         return compositeKernel;

--- a/src/Microsoft.DotNet.Interactive.Tests/DirectiveTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/DirectiveTests.cs
@@ -457,12 +457,12 @@ i");
         var firstWasCalledWith = "";
         var secondWasCalledWith = "";
 
-        compositeKernel.AddKernelConnector(new ConnectCustomDirective(s =>
+        compositeKernel.AddConnectDirective(new ConnectCustomDirective(s =>
         {
             firstWasCalledWith = s;
             return Task.FromResult<Kernel>(new FakeKernel(s));
         }));
-        compositeKernel.AddKernelConnector(new ConnectCustomKernelTwoDirective(s =>
+        compositeKernel.AddConnectDirective(new ConnectCustomKernelTwoDirective(s =>
         {
             secondWasCalledWith = s;
             return Task.FromResult<Kernel>(new FakeKernel(s));

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/CompletionTests.MagicCommands.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/CompletionTests.MagicCommands.cs
@@ -66,7 +66,7 @@ public partial class CompletionTests
             string expected)
         {
             var kernel = CreateKernel();
-            kernel.AddKernelConnector(new ConnectSignalRDirective());
+            kernel.AddConnectDirective(new ConnectSignalRDirective());
 
             var completions = await markupCode
                 .ParseMarkupCode()
@@ -101,7 +101,7 @@ public partial class CompletionTests
             fakeKernel.KernelInfo.SupportedKernelCommands.Add(new(nameof(RequestValueInfos)));
                 
             kernel.Add(fakeKernel);
-            kernel.AddKernelConnector(new ConnectJupyterKernelDirective());
+            kernel.AddConnectDirective(new ConnectJupyterKernelDirective());
 
             (await markupCode
                    .ParseMarkupCode()
@@ -198,7 +198,7 @@ public partial class CompletionTests
         public async Task Inner_symbol_completions_do_not_include_top_level_symbols(string markupCode)
         {
             var kernel = CreateCompositeKernel();
-            kernel.AddKernelConnector(new ConnectSignalRDirective());
+            kernel.AddConnectDirective(new ConnectSignalRDirective());
 
             var completions = await markupCode
                 .ParseMarkupCode()

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/HoverTextTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageServices/HoverTextTests.cs
@@ -74,7 +74,7 @@ public class HoverTextTests : LanguageKernelTestBase
         string expectedContent)
     {
         using var kernel = CreateKernel();
-        kernel.AddKernelConnector(new ConnectSignalRDirective());
+        kernel.AddConnectDirective(new ConnectSignalRDirective());
 
         MarkupTestFile.GetLineAndColumn(markupCode, out var code, out var line, out var character);
         var commandResult = await SendHoverRequest(kernel, code, line, character);

--- a/src/Microsoft.DotNet.Interactive/CompositeKernel.cs
+++ b/src/Microsoft.DotNet.Interactive/CompositeKernel.cs
@@ -217,7 +217,7 @@ public sealed class CompositeKernel :
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-    public void AddKernelConnector<T>(ConnectKernelDirective<T> connectDirective)
+    public void AddConnectDirective<T>(ConnectKernelDirective<T> connectDirective)
         where T : ConnectKernelCommand
     {
         if (_rootConnectDirective is null)

--- a/src/Microsoft.DotNet.Interactive/Directives/KernelDirectiveCompletionContext.cs
+++ b/src/Microsoft.DotNet.Interactive/Directives/KernelDirectiveCompletionContext.cs
@@ -9,9 +9,5 @@ namespace Microsoft.DotNet.Interactive.Directives;
 
 public class KernelDirectiveCompletionContext
 {
-    public KernelDirectiveCompletionContext()
-    {
-    }
-
     public IList<CompletionItem> Completions { get; } = new List<CompletionItem>();
 }

--- a/src/Microsoft.DotNet.Interactive/Directives/KernelDirectiveCompletionContext.cs
+++ b/src/Microsoft.DotNet.Interactive/Directives/KernelDirectiveCompletionContext.cs
@@ -9,5 +9,5 @@ namespace Microsoft.DotNet.Interactive.Directives;
 
 public class KernelDirectiveCompletionContext
 {
-    public IList<CompletionItem> Completions { get; } = new List<CompletionItem>();
+    public IList<CompletionItem> CompletionItems { get; } = new List<CompletionItem>();
 }

--- a/src/Microsoft.DotNet.Interactive/Kernel.Static.cs
+++ b/src/Microsoft.DotNet.Interactive/Kernel.Static.cs
@@ -44,7 +44,32 @@ public partial class Kernel
     {
         return await GetInputAsync(prompt, false, typeHint);
     }
-        
+
+    public static async Task<IDictionary<string, string>> GetInputsAsync(
+        IEnumerable<InputDescription> inputDescriptions)
+    {
+        if (inputDescriptions is null || inputDescriptions.Count() is 0)
+        {
+            throw new ArgumentException("You must provide at least one input description.");
+        }
+
+        var command = new RequestInputs();
+
+        foreach (var inputDescription in inputDescriptions)
+        {
+            command.Inputs.Add(inputDescription);
+        }
+
+        var result = await Root.SendAsync(command, CancellationToken.None);
+
+        if (result.Events.OfType<InputsProduced>().SingleOrDefault() is { } inputsProduced)
+        {
+            return inputsProduced.Values;
+        }
+
+        throw new OperationCanceledException("Input request canceled.");
+    }
+
     public static async Task<PasswordString> GetPasswordAsync(string prompt = "")
     {
         var password = await GetInputAsync(prompt, true);

--- a/src/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
+++ b/src/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
@@ -118,7 +118,7 @@ public class CommandLineParserTests : IDisposable
 
         using (var kernel = new CompositeKernel())
         {
-            kernel.AddKernelConnector(new ConnectStdIoDirective(new Uri("kernel://test-kernel")));
+            kernel.AddConnectDirective(new ConnectStdIoDirective(new Uri("kernel://test-kernel")));
 
             string[] args = [Dotnet.Path.FullName, typeof(Program).Assembly.Location, "stdio", "--log-path", logPath.Directory.FullName, "--verbose"];
 

--- a/src/dotnet-interactive.Tests/HttpApiTests.cs
+++ b/src/dotnet-interactive.Tests/HttpApiTests.cs
@@ -403,7 +403,7 @@ var f = new { Field= ""string value""};", Language.CSharp.LanguageName()));
 
         using var kernel = new CompositeKernel();
 
-        kernel.AddKernelConnector(new ConnectStdIoDirective(new Uri("kernel://test-kernel")));
+        kernel.AddConnectDirective(new ConnectStdIoDirective(new Uri("kernel://test-kernel")));
 
         string[] args = [Dotnet.Path.FullName, typeof(Program).Assembly.Location, "stdio", "--http-port", port.ToString()];
 

--- a/src/dotnet-interactive.Tests/StdioConnectionTests.cs
+++ b/src/dotnet-interactive.Tests/StdioConnectionTests.cs
@@ -122,7 +122,7 @@ public class StdioConnectionTests : ProxyKernelConnectionTestsBase
 
     protected override void AddConnectDirectiveTo(CompositeKernel compositeKernel)
     {
-        compositeKernel.AddKernelConnector(new ConnectStdIoDirective(new Uri("kernel://test-kernel")));
+        compositeKernel.AddConnectDirective(new ConnectStdIoDirective(new Uri("kernel://test-kernel")));
     }
 }
 

--- a/src/dotnet-interactive/KernelBuilder.cs
+++ b/src/dotnet-interactive/KernelBuilder.cs
@@ -84,10 +84,10 @@ public static class KernelBuilder
                      .UseFormsForMultipleInputs(secretManager)
                      .UseNuGetExtensions(telemetrySender);
 
-        kernel.AddKernelConnector(new ConnectSignalRDirective());
-        kernel.AddKernelConnector(new ConnectStdIoDirective(startupOptions.KernelHost));
+        kernel.AddConnectDirective(new ConnectSignalRDirective());
+        kernel.AddConnectDirective(new ConnectStdIoDirective(startupOptions.KernelHost));
 
-        kernel.AddKernelConnector(
+        kernel.AddConnectDirective(
             new ConnectJupyterKernelDirective()
                 .AddConnectionOptions(new JupyterHttpKernelConnectionOptions())
                 .AddConnectionOptions(new JupyterLocalKernelConnectionOptions()));


### PR DESCRIPTION
This PR includes the following API improvements:

- [x] Simplify `KernelDirectiveParameter.AddCompletions` to remove an overload and make usage clearer, e.g. completion values are either returned as a sequence of `string` (in the simple case) or added to the `KernelDirectiveCompletionContext` (in the more complex case.) Only the latter has access to the `KernelCompletionContext` and only the latter is `async`.
- [x] Rename `CompositeKernel.AddKernelConnector` to `AddConnectDirective` to better align with new API names.
- [x] Add `Kernel.GetInputsAsync` to support programmatic use of form inputs.