### PR TITLE
Exclude symbol packages from publishing in NuGet push script

### DIFF
--- a/eng/publish/PublishVSCodeExtensionUsingMI.ps1
+++ b/eng/publish/PublishVSCodeExtensionUsingMI.ps1
@@ -61,6 +61,14 @@ try {
             Get-ChildItem "$artifactsPath\packages\Shipping\Microsoft.DotNet*.nupkg" | ForEach-Object {
                 $nugetPackagePath = $_.ToString()
                 $nugetPackageName = $_.Name
+
+                # Check if the package is a symbol package
+                if ($nugetPackageName -like '*.symbols.nupkg') {
+                    Write-Host "Skipping publishing symbol package $nugetPackagePath"
+                    # Use 'continue' to skip to the next iteration
+                    continue
+                }
+
                 if ($nugetPackageName -match '(?<=(?<id>.+))\.(?<version>((\d+\.\d+(\.\d+)?))(?<suffix>(-.*)?))\.nupkg')
                 {
                     $packageId = $Matches.id


### PR DESCRIPTION
We no longer need to publish debug symbol packages because SourceLink provides source code linking during debugging.