### PR TITLE
fix a magic command parameter name completion bug

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Parsing.Tests/PolyglotParserConfigurationTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Parsing.Tests/PolyglotParserConfigurationTests.cs
@@ -179,7 +179,12 @@ public class PolyglotParserConfigurationTests
                                 new("--value")
                                 {
                                     Required = true
-                                }, 
+                                },
+                                new("--byref")
+                                {
+                                    Flag = true
+                                },
+                                new("--mime-type")
                             },
                             KernelCommandType = typeof(SendValue)
                         }

--- a/src/Microsoft.DotNet.Interactive.Parsing.Tests/PolyglotSyntaxParserTests.JsonConversion.cs
+++ b/src/Microsoft.DotNet.Interactive.Parsing.Tests/PolyglotSyntaxParserTests.JsonConversion.cs
@@ -79,6 +79,7 @@ public partial class PolyglotSyntaxParserTests
                         "one": 1,
                         "many": [1, 2, 3] 
                     },
+                    "byref": false,
                     "invokedDirective": "#!set",
                     "targetKernelName": "csharp"
                   }

--- a/src/Microsoft.DotNet.Interactive/Parsing/DirectiveNode.cs
+++ b/src/Microsoft.DotNet.Interactive/Parsing/DirectiveNode.cs
@@ -598,14 +598,23 @@ internal class DirectiveNode : TopLevelSyntaxNode
             case DirectiveExpressionNode directiveExpressionNode:
                 break;
 
-            case DirectiveExpressionParametersNode directiveExpressionParametersNode:
+            case DirectiveExpressionParametersNode parametersNode:
             {
-                if (directiveExpressionParametersNode.Ancestors()
-                                                     .OfType<DirectiveSubcommandNode>()
-                                                     .FirstOrDefault() is { } parentDirectiveNode &&
-                    parentDirectiveNode.TryGetSubcommand(out var subcommandDirective))
+                if (parametersNode.Ancestors()
+                                  .OfType<DirectiveSubcommandNode>()
+                                  .FirstOrDefault() is { } parentSubcommandNode &&
+                    parentSubcommandNode.TryGetSubcommand(out var subcommandDirective))
                 {
                     var completions = await subcommandDirective.GetChildCompletionsAsync();
+                    return completions.ToArray();
+                }
+
+                if (parametersNode.Ancestors()
+                                  .OfType<DirectiveNode>()
+                                  .FirstOrDefault() is { } parentDirectiveNode &&
+                    parentDirectiveNode.TryGetDirective(out var directive))
+                {
+                    var completions = await directive.GetChildCompletionsAsync();
                     return completions.ToArray();
                 }
             }


### PR DESCRIPTION
This fixes an issue with parameter name completions after an `@input` token.