### PR TITLE
fix an HTTP parser comment parsing bug 

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/HttpSyntaxNode.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/HttpSyntaxNode.cs
@@ -15,4 +15,22 @@ internal class HttpSyntaxNode : SyntaxNode
     }
 
     internal void Add(HttpCommentNode node, bool addBefore) => AddInternal(node, addBefore);
+
+    protected bool TextContainsWhitespace()
+    {
+        // We ignore whitespace if it's the first or last token, OR ignore the first or last token if it's not whitespace.  For this reason, the first and last tokens aren't interesting.
+        for (var i = 1; i < ChildNodesAndTokens.Count - 1; i++)
+        {
+            var nodeOrToken = ChildNodesAndTokens[i];
+            if (nodeOrToken is SyntaxToken { Kind: TokenKind.Whitespace })
+            {
+                if (nodeOrToken.Span.OverlapsWith(Span))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/SyntaxNode.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Parsing/Parsing/SyntaxNode.cs
@@ -46,8 +46,6 @@ internal abstract class SyntaxNode : SyntaxNodeOrToken
             position--;
         }
 
-        // var candidate = _childNodesAndTokens.FirstOrDefault(n => n.FullSpan.Contains(position));
-
         for (var i = 0; i < _childNodesAndTokens.Count; i++)
         {
             var nodeOrToken = _childNodesAndTokens[i];
@@ -71,24 +69,6 @@ internal abstract class SyntaxNode : SyntaxNodeOrToken
         }
 
         return null;
-    }
-
-    protected bool TextContainsWhitespace()
-    {
-        // We ignore whitespace if it's the first or last token, OR ignore the first or last token if it's not whitespace.  For this reason, the first and last tokens aren't interesting.
-        for (var i = 1; i < _childNodesAndTokens.Count - 1; i++)
-        {
-            var nodeOrToken = _childNodesAndTokens[i];
-            if (nodeOrToken is SyntaxToken { Kind: TokenKind.Whitespace })
-            {
-                if (nodeOrToken.Span.OverlapsWith(_span))
-                {
-                    return true;
-                }
-            }
-        }
-
-        return false;
     }
 
     private void GrowSpan(SyntaxNodeOrToken child)

--- a/src/Microsoft.DotNet.Interactive.Http/Formatting/HttpResponseFormattingExtensions.cs
+++ b/src/Microsoft.DotNet.Interactive.Http/Formatting/HttpResponseFormattingExtensions.cs
@@ -112,15 +112,13 @@ internal static class HttpResponseFormattingExtensions
 
     private static PocketView FormatAsHtml(this HttpResponse response)
     {
-        PocketView? output;
-        dynamic? requestDiv;
+        PocketView? requestDiv;
         if (response.Request is { } request)
         {
-            var requestUriString = request.Uri?.ToString();
             var requestHyperLink =
-                string.IsNullOrWhiteSpace(requestUriString)
+                string.IsNullOrWhiteSpace(request.Uri)
                     ? "[Unknown]"
-                    : a[href: requestUriString](requestUriString);
+                    : a[href: request.Uri](request.Uri);
 
             var requestLine =
                 h3(
@@ -181,7 +179,7 @@ internal static class HttpResponseFormattingExtensions
         }
 
         var responseBody =
-            details[open: true](
+            details(
                 summary($"Body ({responseContentTypePrefix}{responseBodyLength} bytes)"),
                 responseObjToFormat);
 
@@ -193,7 +191,7 @@ internal static class HttpResponseFormattingExtensions
                 responseHeaders,
                 responseBody);
 
-        output =
+        PocketView output =
             div[@class: ContainerClass](
                 style[type: "text/css"](CSS),
                 requestDiv,
@@ -276,11 +274,13 @@ internal static class HttpResponseFormattingExtensions
         }
     }
 
-    private static dynamic HeaderTable(Dictionary<string, string[]> headers, Dictionary<string, string[]>? contentHeaders = null)
+    private static PocketView HeaderTable(Dictionary<string, string[]> headers, Dictionary<string, string[]>? contentHeaders = null)
     {
-        var allHeaders = contentHeaders is null ? headers : headers.Concat(contentHeaders);
+        var allHeaders = contentHeaders is null
+                             ? headers
+                             : headers.Concat(contentHeaders);
 
-        var headerTable =
+        PocketView headerTable =
             table(
                 thead(
                     tr(

--- a/src/Microsoft.DotNet.Interactive.PostgreSql/PostgreSqlKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.PostgreSql/PostgreSqlKernel.cs
@@ -116,7 +116,7 @@ public class PostgreSqlKernel :
 
         KernelInvocationContext.Current?.Display(
             new HtmlString(@"<details><summary>Query PostgreSql databases.</summary>
-    <p>This extension adds support for connecting to PostgreSql databases using the <code>#!connect sqlite</code> magic command. For more information, run a cell using the <code>#!sql</code> magic command.</p>
+    <p>This extension adds support for connecting to PostgreSql databases using the <code>#!connect postgres</code> magic command. For more information, run a cell using the <code>#!sql</code> magic command.</p>
     </details>"),
             "text/html");
     }
@@ -126,11 +126,7 @@ public class PostgreSqlKernel :
         if (KernelInvocationContext.Current is { } context &&
             context.HandlingKernel.RootKernel is CompositeKernel root)
         {
-            PostgreSqlKernel.AddPostgreSqlKernelConnectorTo(root);
+            AddPostgreSqlKernelConnectorTo(root);
         }
     }
-}
-
-public class SqlRow : Dictionary<string, object>
-{
 }

--- a/src/polyglot-notebooks-vscode-common/src/metadataUtilities.ts
+++ b/src/polyglot-notebooks-vscode-common/src/metadataUtilities.ts
@@ -29,7 +29,7 @@ export function isDotNetNotebook(notebook: vscodeLike.NotebookDocument): boolean
         return true;
     }
 
-    const kernelspecMetadata = getKernelspecMetadataFromIpynbNotebookDocument(notebook); //?
+    const kernelspecMetadata = getKernelspecMetadataFromIpynbNotebookDocument(notebook);
     if (kernelspecMetadata.name.startsWith('.net-')) {
         return true;
     }
@@ -115,7 +115,7 @@ export function getNotebookDocumentMetadataFromInteractiveDocument(interactiveDo
 
 let _useLegacyMetadata = true;
 export function useLegacyMetadata() {
-    return _useLegacyMetadata;//?
+    return _useLegacyMetadata;
 }
 
 export function setUseLegacyMetadata(value: boolean) {
@@ -213,7 +213,7 @@ export function getKernelspecMetadataFromIpynbNotebookDocument(notebook: vscodeL
         name: ''
     };
 
-    const metadata = useLegacyMetadata() ? notebook.metadata.custom?.metadata : notebook.metadata.metadata; //?
+    const metadata = useLegacyMetadata() ? notebook.metadata.custom?.metadata : notebook.metadata.metadata;
 
 
     if (typeof metadata === 'object') {
@@ -380,15 +380,12 @@ export function sortAndMerge(destination: { [key: string]: any }, source: { [key
         }
     }
     else {
-        sortInPlace(destination);//?
-        sortInPlace(source);//?
+        sortInPlace(destination);
+        sortInPlace(source);
 
-        const sourceKeys = Object.keys(source);//?
+        const sourceKeys = Object.keys(source);
         for (const key of sourceKeys) {
-            key;//?
-            destination[key];//?
             if (destination[key] === undefined) {
-                destination;
                 destination[key] = source[key];
 
             } else {
@@ -402,16 +399,12 @@ export function sortAndMerge(destination: { [key: string]: any }, source: { [key
             }
         }
     }
-
-    destination;//?
 }
 
 function mergeArray(destination: any[], source: any[]) {
-    source;//?
     for (let i = 0; i < source.length; i++) {
         let srcValue = source[i];
         if (srcValue !== null) {
-            srcValue;//?
             if (isKernelInfo(srcValue)) {
                 const found = destination.find(e => srcValue.localName.localeCompare(e.localName) === 0);
                 if (found) {
@@ -422,8 +415,6 @@ function mergeArray(destination: any[], source: any[]) {
             } else if (isDocumentKernelInfo(srcValue)) {
                 const found = destination.find(e => srcValue.name.localeCompare(e.name) === 0);
                 if (found) {
-                    found;//?
-                    srcValue;//?
                     sortAndMerge(found, srcValue);
                 } else {
                     destination.push(srcValue);
@@ -436,7 +427,6 @@ function mergeArray(destination: any[], source: any[]) {
                     destination.push(srcValue);
                 }
             }
-            destination;//?
         }
     }
 }
@@ -566,19 +556,18 @@ export function areEquivalentObjects(object1: { [key: string]: any }, object2: {
     }
 
     for (const key of object1Keys) {
-        key;//?
-        const value1 = object1[key];//?
-        const value2 = object2[key];//?
-        const bothAreObjects = isObject(value1) && isObject(value2); //?
+        const value1 = object1[key];
+        const value2 = object2[key];
+        const bothAreObjects = isObject(value1) && isObject(value2);
         const bothAreArrays = Array.isArray(value1) && Array.isArray(value2);
 
         if (bothAreArrays) {
-            if (value1.length !== value2.length) {//?
+            if (value1.length !== value2.length) {
                 return false;
             }
             for (let index = 0; index < value1.length; index++) {
-                const element1 = value1[index];//?
-                const element2 = value2[index];//?
+                const element1 = value1[index];
+                const element2 = value2[index];
                 if (!areEquivalentObjects(element1, element2)) {
                     return false;
                 }
@@ -588,10 +577,7 @@ export function areEquivalentObjects(object1: { [key: string]: any }, object2: {
             if (!equivalent) {
                 return false;
             }
-        } else if (value1 !== value2) //?
-        {
-            value1;//?
-            value2;//?
+        } else if (value1 !== value2) {
             return false;
         }
     }

--- a/src/polyglot-notebooks-vscode-common/tests/misc.test.ts
+++ b/src/polyglot-notebooks-vscode-common/tests/misc.test.ts
@@ -315,7 +315,7 @@ describe('Miscellaneous tests', () => {
                 'key2': "value"
             };
 
-            const d = areEquivalentObjects(data1, data2); //?
+            const d = areEquivalentObjects(data1, data2);
             expect(d).to.be.true;
         });
 
@@ -330,7 +330,7 @@ describe('Miscellaneous tests', () => {
                 'key2': "value"
             };
 
-            const d = areEquivalentObjects(data1, data2); //?
+            const d = areEquivalentObjects(data1, data2);
             expect(d).to.be.true;
         });
 
@@ -350,7 +350,7 @@ describe('Miscellaneous tests', () => {
             const ingoreKeys = new Set<string>();
             ingoreKeys.add("key4");
             ingoreKeys.add("key5");
-            const d = areEquivalentObjects(data1, data2, ingoreKeys); //?
+            const d = areEquivalentObjects(data1, data2, ingoreKeys);
             expect(d).to.be.true;
         });
 
@@ -365,7 +365,7 @@ describe('Miscellaneous tests', () => {
                 'key2': "value"
             };
 
-            const d = areEquivalentObjects(data1, data2); //?
+            const d = areEquivalentObjects(data1, data2);
             expect(d).to.be.false;
         });
 
@@ -380,7 +380,7 @@ describe('Miscellaneous tests', () => {
                 'key22': "value"
             };
 
-            const d = areEquivalentObjects(data1, data2); //?
+            const d = areEquivalentObjects(data1, data2);
             expect(d).to.be.false;
         });
     });

--- a/src/polyglot-notebooks/src/compositeKernel.ts
+++ b/src/polyglot-notebooks/src/compositeKernel.ts
@@ -102,14 +102,14 @@ export class CompositeKernel extends Kernel {
         const invocationContext = KernelInvocationContext.current;
 
         if (invocationContext) {
-            invocationContext.commandEnvelope;//?
+            invocationContext.commandEnvelope;
             const event = new commandsAndEvents.KernelEventEnvelope(
                 commandsAndEvents.KernelInfoProducedType,
                 <commandsAndEvents.KernelInfoProduced>{
                     kernelInfo: kernel.kernelInfo
                 },
                 invocationContext.commandEnvelope
-            );//?
+            );
             invocationContext.publish(event);
         } else {
             const event = new commandsAndEvents.KernelEventEnvelope(
@@ -117,7 +117,7 @@ export class CompositeKernel extends Kernel {
                 <commandsAndEvents.KernelInfoProduced>{
                     kernelInfo: kernel.kernelInfo
                 }
-            );//?
+            );
             this.publishEvent(event);
         }
     }
@@ -272,7 +272,7 @@ class KernelCollection implements Iterable<Kernel> {
             next: () => {
                 return {
                     value: this._kernels[counter++],
-                    done: counter > this._kernels.length //?
+                    done: counter > this._kernels.length
                 };
             }
         };
@@ -336,7 +336,7 @@ class KernelCollection implements Iterable<Kernel> {
             baseUri += "/";
 
         }
-        kernel.kernelInfo.uri = routingslip.createKernelUri(`${baseUri}${kernel.kernelInfo.localName}`);//?
+        kernel.kernelInfo.uri = routingslip.createKernelUri(`${baseUri}${kernel.kernelInfo.localName}`);
         this._kernelsByLocalUri.set(kernel.kernelInfo.uri, kernel);
 
 

--- a/src/polyglot-notebooks/src/routingslip.ts
+++ b/src/polyglot-notebooks/src/routingslip.ts
@@ -7,24 +7,22 @@ import { KernelCommandOrEventEnvelope, isKernelCommandEnvelope } from './connect
 
 
 export function createKernelUri(kernelUri: string): string {
-    kernelUri;//?
     const uri = URI.parse(kernelUri);
-    uri.authority;//?
-    uri.path;//?
+    uri.authority;
+    uri.path;
     let absoluteUri = `${uri.scheme}://${uri.authority}${uri.path || "/"}`;
-    return absoluteUri;//?
+    return absoluteUri;
 }
 
 export function createKernelUriWithQuery(kernelUri: string): string {
-    kernelUri;//?
     const uri = URI.parse(kernelUri);
-    uri.authority;//?
-    uri.path;//?
+    uri.authority;
+    uri.path;
     let absoluteUri = `${uri.scheme}://${uri.authority}${uri.path || "/"}`;
     if (uri.query) {
         absoluteUri += `?${uri.query}`;
     }
-    return absoluteUri;//?
+    return absoluteUri;
 }
 export function getTag(kernelUri: string): string | undefined {
     const uri = URI.parse(kernelUri);
@@ -169,7 +167,7 @@ export class EventRoutingSlip extends RoutingSlip {
         const canAdd = !this.uris.find(e => createKernelUriWithQuery(e) === normalizedUri);
         if (canAdd) {
             this.uris.push(normalizedUri);
-            this.uris;//?
+            this.uris;
         } else {
             throw new Error(`The uri ${normalizedUri} is already in the routing slip [${this.uris}]`);
         }


### PR DESCRIPTION
This fixes a bug in the HTTP parser where multiple leading comment markers (`//` or `#`) would consume the following line as a comment body.

There's also a little miscellaneous code cleanup.