### PR TITLE
add descriptions and icons to kernel chooser quickpick

### DIFF
--- a/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
@@ -62,7 +62,7 @@ public class CSharpKernel :
         KernelInfo.LanguageVersion = "12.0";
         KernelInfo.DisplayName = $"{KernelInfo.LocalName} - C# Script";
         KernelInfo.Description = """
-                                 Compile and run C# Script.
+                                 Compile and run C# Script
                                  """;
         _workspace = new InteractiveWorkspace();
 

--- a/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.CSharp/CSharpKernel.cs
@@ -62,8 +62,7 @@ public class CSharpKernel :
         KernelInfo.LanguageVersion = "12.0";
         KernelInfo.DisplayName = $"{KernelInfo.LocalName} - C# Script";
         KernelInfo.Description = """
-                                 This Kernel can compile and execute C# code and display the results.
-                                 The language is C# Script, a dialect of C# used for interactive programming.
+                                 Compile and run C# Script.
                                  """;
         _workspace = new InteractiveWorkspace();
 

--- a/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
@@ -38,7 +38,7 @@ type FSharpKernel () as this =
     do this.KernelInfo.LanguageName <- "F#"
     do this.KernelInfo.LanguageVersion <- "8.0"
     do this.KernelInfo.DisplayName <- $"{this.KernelInfo.LocalName} - F# Script"
-    do this.KernelInfo.Description <- """This kernel can compile and execute F# code and display the results."""
+    do this.KernelInfo.Description <- """Compile and run F# code"""
 
     static let lockObj = Object();
 

--- a/src/Microsoft.DotNet.Interactive.Http/HttpKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.Http/HttpKernel.cs
@@ -76,7 +76,7 @@ public class HttpKernel :
         KernelInfo.LanguageName = "HTTP";
         KernelInfo.DisplayName = $"{KernelInfo.LocalName} - HTTP Request";
         KernelInfo.Description = """
-                                 This Kernel is able to execute http requests and display the results.
+                                 Send HTTP requests
                                  """;
 
         _client = client ?? new HttpClient() { Timeout = Timeout.InfiniteTimeSpan };

--- a/src/Microsoft.DotNet.Interactive.Kql/MsKqlKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql/MsKqlKernel.cs
@@ -20,8 +20,7 @@ internal class MsKqlKernel : ToolsServiceKernel
     {
         _connectionDetails = connectionDetails ?? throw new ArgumentException("Value cannot be null or whitespace.", nameof(connectionDetails));
         KernelInfo.Description = $"""
-                                  This Kernel can execute KQL queries against a Kusto database. 
-                                  This instance is connected to cluster {connectionDetails.Cluster} and database {connectionDetails.Database}.
+                                  Query Kusto cluster {connectionDetails.Cluster} and database {connectionDetails.Database}
                                   """;
     }
 

--- a/src/Microsoft.DotNet.Interactive.Mermaid/MermaidKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.Mermaid/MermaidKernel.cs
@@ -14,9 +14,7 @@ public class MermaidKernel : Kernel,
     {
         KernelInfo.LanguageName = "Mermaid";
         KernelInfo.Description = """
-                                 This Kernel uses the Mermaid library to render diagrams. 
-                                 
-                                 For more information about Mermaid, see https://mermaid.js.org/intro.
+                                 Render diagrams using the Mermaid language (https://mermaid.js.org/intro)
                                  """;
     }
 

--- a/src/Microsoft.DotNet.Interactive.PostgreSql/PostgreSqlKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.PostgreSql/PostgreSqlKernel.cs
@@ -25,8 +25,7 @@ public class PostgreSqlKernel :
     {
         KernelInfo.LanguageName = "PostgreSQL";
         KernelInfo.Description = """
-            This kernel is backed by a PostgreSQL database.
-            It can execute SQL statements against the database and display the results as tables.
+            Query a PostgreSQL database
             """;
 
         _connectionString = connectionString;

--- a/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs
@@ -90,8 +90,7 @@ public class PowerShellKernel :
         KernelInfo.LanguageName = LanguageName;
         KernelInfo.LanguageVersion = "7";
         KernelInfo.Description = """
-                                 This Kernel can evaluate Powershell scripts and commands. 
-                                 It uses Powershell Core and can interop with the operative system and host machine.
+                                 Run PowerShell scripts and commands
                                  """;
 
         _psHost = new PSKernelHost(this);

--- a/src/Microsoft.DotNet.Interactive.SQLite/SQLiteKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.SQLite/SQLiteKernel.cs
@@ -25,8 +25,7 @@ public class SQLiteKernel :
     {
         KernelInfo.LanguageName = "SQLite";
         KernelInfo.Description ="""
-                                This kernel is backed by a SQLite database.
-                                It can execute SQL statements against the database and display the results as tables.
+                                Query a SQLite database
                                 """;
                                 
         _connectionString = connectionString;

--- a/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/MsSqlKernel.cs
@@ -23,8 +23,7 @@ internal class MsSqlKernel : ToolsServiceKernel
             throw new ArgumentException("Value cannot be null or whitespace.", nameof(connectionString));
         }
         KernelInfo.Description = """
-                                  This Kernel can execute T-SQL and SQL queries against a SQL Server database.
-                                  It is connected to a MSSQL database.
+                                  Query a Microsoft SQL database using T-SQL
                                   """;
         _connectionString = connectionString;
     }

--- a/src/Microsoft.DotNet.Interactive.Tests/StdIoKernelConnectorTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/StdIoKernelConnectorTests.cs
@@ -137,8 +137,7 @@ namespace Microsoft.DotNet.Interactive.Tests
                 LanguageVersion = csharpKernelInfo.LanguageVersion,
                 RemoteUri = csharpKernelInfo.Uri,
                 Description = """
-                              This Kernel can compile and execute C# code and display the results.
-                              The language is C# Script, a dialect of C# used for interactive programming.
+                              Compile and run C# Script
                               """
             };
 
@@ -161,7 +160,7 @@ namespace Microsoft.DotNet.Interactive.Tests
                 LanguageVersion = fsharpKernelInfo.LanguageVersion,
                 RemoteUri = fsharpKernelInfo.Uri,
                 Description = """
-                              This kernel can compile and execute F# code and display the results.
+                              Compile and run F# code
                               """
             };
 

--- a/src/Microsoft.DotNet.Interactive/HtmlKernel.cs
+++ b/src/Microsoft.DotNet.Interactive/HtmlKernel.cs
@@ -17,6 +17,7 @@ public class HtmlKernel :
     public HtmlKernel() : base(DefaultKernelName)
     {
         KernelInfo.LanguageName = "HTML";
+        KernelInfo.Description = "Write and display HTML";
     }
 
     Task IKernelCommandHandler<SubmitCode>.HandleAsync(SubmitCode command, KernelInvocationContext context)

--- a/src/Microsoft.DotNet.Interactive/KeyValueStoreKernel.cs
+++ b/src/Microsoft.DotNet.Interactive/KeyValueStoreKernel.cs
@@ -35,6 +35,7 @@ public class KeyValueStoreKernel :
     {
         _httpClient = httpClient;
         KernelInfo.DisplayName = $"{KernelInfo.LocalName} - Raw Value Storage";
+        KernelInfo.Description = "Store raw text for sharing between subkernels";
     }
 
     Task IKernelCommandHandler<RequestValueInfos>.HandleAsync(RequestValueInfos command, KernelInvocationContext context)

--- a/src/Microsoft.DotNet.Interactive/KqlDiscoverabilityKernel.cs
+++ b/src/Microsoft.DotNet.Interactive/KqlDiscoverabilityKernel.cs
@@ -25,6 +25,9 @@ public class KqlDiscoverabilityKernel :
             "MsKqlKernel"
         };
         KernelInfo.LanguageName = "KQL";
+        KernelInfo.Description = $"""
+                            Query a Kusto database
+                            """;
     }
 
     Task IKernelCommandHandler<SubmitCode>.HandleAsync(SubmitCode command, KernelInvocationContext context)

--- a/src/Microsoft.DotNet.Interactive/SqlDiscoverabilityKernel.cs
+++ b/src/Microsoft.DotNet.Interactive/SqlDiscoverabilityKernel.cs
@@ -26,6 +26,9 @@ public class SqlDiscoverabilityKernel :
             "SQLiteKernel"
         };
         KernelInfo.LanguageName = "SQL";
+        KernelInfo.Description = $"""
+                            Query a Microsoft SQL database
+                            """;
     }
 
     Task IKernelCommandHandler<SubmitCode>.HandleAsync(SubmitCode command, KernelInvocationContext context)

--- a/src/polyglot-notebooks-vscode-common/src/extension.ts
+++ b/src/polyglot-notebooks-vscode-common/src/extension.ts
@@ -170,8 +170,7 @@ export async function activate(context: vscode.ExtensionContext) {
     function configureKernel(compositeKernel: CompositeKernel, notebookUri: vscodeLike.Uri) {
         compositeKernel.setDefaultTargetKernelNameForCommand(commandsAndEvents.RequestInputType, compositeKernel.name);
         compositeKernel.setDefaultTargetKernelNameForCommand(commandsAndEvents.SendEditableCodeType, compositeKernel.name);
-        compositeKernel.kernelInfo.description = `This Kernel is provided by the .NET Interactive Extension.
-        This allows adding new cells to the notebook and prompting user for input.`;
+        compositeKernel.kernelInfo.description = `Composes a group of subkernels`;
 
         compositeKernel.registerCommandHandler({
             commandType: commandsAndEvents.RequestInputType,

--- a/src/polyglot-notebooks-vscode-common/src/kernelSelectorUtilities.ts
+++ b/src/polyglot-notebooks-vscode-common/src/kernelSelectorUtilities.ts
@@ -10,6 +10,7 @@ export interface KernelSelectorOption {
     kernelName: string;
     displayValue: string;
     languageName?: string;
+    description?: string;
 }
 
 export function getKernelInfoDisplayValue(kernelInfo: { localName: string, displayName: string }): string {
@@ -26,13 +27,14 @@ function extractInfo(kernelInfo: commandsAndEvents.KernelInfo) {
     return {
         localName: kernelInfo.localName,
         displayName: kernelInfo.displayName,
+        description: kernelInfo.description,
         languageName: kernelInfo.languageName,
         supportedKernelCommands: Array.from(kernelInfo.supportedKernelCommands.map(c => c.name))
     };
 }
 
 export function getKernelSelectorOptions(kernel: CompositeKernel, document: vscodeLike.NotebookDocument, requiredSupportedCommandType: commandsAndEvents.KernelCommandType): KernelSelectorOption[] {
-    const kernelInfos: Map<string, { localName: string, displayName: string, languageName?: string, supportedKernelCommands: string[] }> = new Map();
+    const kernelInfos: Map<string, { localName: string, displayName: string, languageName?: string, description?: string, supportedKernelCommands: string[] }> = new Map();
 
     // create and collect all `KernelInfo`s from document metadata...
     const notebookMetadata = metadataUtilities.getNotebookDocumentMetadataFromNotebookDocument(document);
@@ -64,7 +66,8 @@ export function getKernelSelectorOptions(kernel: CompositeKernel, document: vsco
     const selectorOptions: KernelSelectorOption[] = filteredKernels.map(kernelInfo => {
         const result: KernelSelectorOption = {
             kernelName: kernelInfo.localName,
-            displayValue: getKernelInfoDisplayValue(kernelInfo)
+            displayValue: getKernelInfoDisplayValue(kernelInfo),
+            description: kernelInfo.description
         };
         if (kernelInfo.languageName) {
             result.languageName = kernelInfo.languageName;

--- a/src/polyglot-notebooks-vscode-common/src/notebookCellStatusBarItemProvider.ts
+++ b/src/polyglot-notebooks-vscode-common/src/notebookCellStatusBarItemProvider.ts
@@ -14,6 +14,17 @@ import { ServiceCollection } from './serviceCollection';
 
 const selectKernelCommandName = 'polyglot-notebook.selectCellKernel';
 
+class KernelSelectorItem implements vscode.QuickPickItem {
+    constructor(label: string) {
+        this.label = label;
+    }
+
+    label: string;
+    description?: string | undefined;
+    detail?: string | undefined;
+    iconPath?: vscode.ThemeIcon;
+}
+
 export function registerNotbookCellStatusBarItemProvider(context: vscode.ExtensionContext, clientMapper: ClientMapper) {
     const cellItemProvider = new DotNetNotebookCellStatusBarItemProvider(clientMapper);
     clientMapper.onClientCreate((_uri, client) => {
@@ -31,18 +42,38 @@ export function registerNotbookCellStatusBarItemProvider(context: vscode.Extensi
         if (cell) {
             const client = await clientMapper.tryGetClient(cell.notebook.uri);
             if (client) {
-                const availableOptions = kernelSelectorUtilities.getKernelSelectorOptions(client.kernel, cell.notebook, commandsAndEvents.SubmitCodeType);
-                const availableDisplayOptions = availableOptions.map(o => o.displayValue);
-                const selectedDisplayOption = await vscode.window.showQuickPick(availableDisplayOptions, { title: 'Select cell kernel' });
+                const kernelSelectorOptions = kernelSelectorUtilities
+                    .getKernelSelectorOptions(client.kernel, cell.notebook, commandsAndEvents.SubmitCodeType);
+
+                const kernelSelectorItems = kernelSelectorOptions
+                    .map(o => {
+                        const item = new KernelSelectorItem(o.displayValue);
+                        item.description = o.description;
+                        item.iconPath = new vscode.ThemeIcon('notebook-kernel-select');
+                        return item;
+                    });
+
+                // const mruConnectionItems = [{
+                //     description: 'Connect to sql-adventureworks (MSSQL)',
+                //     label: 'sql-adventureworks',
+                //     iconPath: new vscode.ThemeIcon('plug')
+                // }];
+
+                // const allItems = [...kernelSelectorItems,
+                // { description: '', label: '', kind: vscode.QuickPickItemKind.Separator },
+                // ...mruConnectionItems];
+
+                const selectedDisplayOption = await vscode.window.showQuickPick(kernelSelectorItems, { title: 'Select cell kernel' });
+
                 if (selectedDisplayOption) {
-                    const selectedValueIndex = availableDisplayOptions.indexOf(selectedDisplayOption);
+                    const selectedValueIndex = kernelSelectorItems.indexOf(selectedDisplayOption);
                     if (selectedValueIndex >= 0) {
-                        const selectedKernelData = availableOptions[selectedValueIndex];
+                        const selectedKernelItem = kernelSelectorOptions[selectedValueIndex];
                         const codeCell = await vscodeUtilities.ensureCellKernelKind(cell, vscode.NotebookCellKind.Code);
                         const notebookCellMetadata = metadataUtilities.getNotebookCellMetadataFromNotebookCellElement(cell);
-                        if (notebookCellMetadata.kernelName !== selectedKernelData.kernelName) {
+                        if (notebookCellMetadata.kernelName !== selectedKernelItem.kernelName) {
                             // update metadata
-                            notebookCellMetadata.kernelName = selectedKernelData.kernelName;
+                            notebookCellMetadata.kernelName = selectedKernelItem.kernelName;
                             const newRawMetadata = metadataUtilities.getRawNotebookCellMetadataFromNotebookCellMetadata(notebookCellMetadata);
                             const mergedMetadata = metadataUtilities.mergeRawMetadata(cell.metadata, newRawMetadata);
                             const _succeeded = await vscodeNotebookManagement.replaceNotebookCellMetadata(codeCell.notebook.uri, codeCell.index, mergedMetadata);

--- a/src/polyglot-notebooks-vscode-common/src/notebookCellStatusBarItemProvider.ts
+++ b/src/polyglot-notebooks-vscode-common/src/notebookCellStatusBarItemProvider.ts
@@ -53,16 +53,6 @@ export function registerNotbookCellStatusBarItemProvider(context: vscode.Extensi
                         return item;
                     });
 
-                // const mruConnectionItems = [{
-                //     description: 'Connect to sql-adventureworks (MSSQL)',
-                //     label: 'sql-adventureworks',
-                //     iconPath: new vscode.ThemeIcon('plug')
-                // }];
-
-                // const allItems = [...kernelSelectorItems,
-                // { description: '', label: '', kind: vscode.QuickPickItemKind.Separator },
-                // ...mruConnectionItems];
-
                 const selectedDisplayOption = await vscode.window.showQuickPick(kernelSelectorItems, { title: 'Select cell kernel' });
 
                 if (selectedDisplayOption) {

--- a/src/polyglot-notebooks-vscode-common/tests/kernelSelectorUtilities.test.ts
+++ b/src/polyglot-notebooks-vscode-common/tests/kernelSelectorUtilities.test.ts
@@ -14,6 +14,7 @@ describe('kernel selector utility tests', async () => {
 
         // add C# kernel that supports `SubmitCode`
         const cs = new Kernel('csharp', 'csharp', '10.0', 'See Sharp');
+        cs.kernelInfo.description = 'Do C# stuff';
         cs.kernelInfo.supportedKernelCommands = [{ name: commandsAndEvents.SubmitCodeType }];
         kernel.add(cs);
 
@@ -50,11 +51,13 @@ describe('kernel selector utility tests', async () => {
             {
                 kernelName: 'csharp',
                 displayValue: 'See Sharp',
-                languageName: 'csharp'
+                languageName: 'csharp',
+                description: 'Do C# stuff'
             },
             {
                 kernelName: 'fsharp',
-                displayValue: 'fsharp'
+                displayValue: 'fsharp',
+                description: undefined
             }
         ]);
     });

--- a/src/polyglot-notebooks/src/htmlKernel.ts
+++ b/src/polyglot-notebooks/src/htmlKernel.ts
@@ -10,7 +10,7 @@ export class HtmlKernel extends Kernel {
     constructor(kernelName?: string, private readonly htmlFragmentInserter?: (htmlFragment: string) => Promise<string>, languageName?: string, languageVersion?: string) {
         super(kernelName ?? "html", languageName ?? "HTML", languageVersion ?? "5");
         this.kernelInfo.displayName = 'HTML';
-        this.kernelInfo.description = `This Kernel can evaluate html snippets and display them as output.`;
+        this.kernelInfo.description = `Write and display HTML`;
         if (!this.htmlFragmentInserter) {
             this.htmlFragmentInserter = htmlDomFragmentInserter;
         }

--- a/src/polyglot-notebooks/src/javascriptKernel.ts
+++ b/src/polyglot-notebooks/src/javascriptKernel.ts
@@ -15,7 +15,7 @@ export class JavascriptKernel extends Kernel {
     constructor(name?: string) {
         super(name ?? "javascript", "JavaScript");
         this.kernelInfo.displayName = `${this.kernelInfo.localName} - ${this.kernelInfo.languageName}`;
-        this.kernelInfo.description = `This Kernel is for executing JavaScript code.`;
+        this.kernelInfo.description = `Run JavaScript code`;
         this.suppressedLocals = new Set<string>(this.allLocalVariableNames());
         this.registerCommandHandler({ commandType: commandsAndEvents.SubmitCodeType, handle: invocation => this.handleSubmitCode(invocation) });
         this.registerCommandHandler({ commandType: commandsAndEvents.RequestValueInfosType, handle: invocation => this.handleRequestValueInfos(invocation) });
@@ -177,3 +177,4 @@ export function getType(arg: any): string {
 
     return type; //?
 }
+

--- a/src/polyglot-notebooks/tests/frontEndHost.test.ts
+++ b/src/polyglot-notebooks/tests/frontEndHost.test.ts
@@ -71,7 +71,7 @@ describe("frontEndHost", () => {
                     },
                     {
                         aliases: ['js'],
-                        description: 'This Kernel is for executing JavaScript code.',
+                        description: 'Run JavaScript code',
                         displayName: 'javascript - JavaScript',
                         isComposite: false,
                         isProxy: false,


### PR DESCRIPTION
This PR adds some detail to the kernel chooser as shown in the image below. As part of this, I've simplified the kernel descriptions.

![image](https://github.com/user-attachments/assets/f1257927-ca42-4973-8aad-8737946b382b)
