### PR TITLE
fix codegen for EntityContext

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,7 +19,7 @@
     <MicrosoftNETTestSdkVersion>17.4.0</MicrosoftNETTestSdkVersion>
     <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <MicrosoftCodeAnalysisCommonVersion>4.11.0</MicrosoftCodeAnalysisCommonVersion>
-    <SystemDrawingCommonVersion>8.0.8</SystemDrawingCommonVersion>
+    <SystemDrawingCommonVersion>8.0.11</SystemDrawingCommonVersion>
     <SystemReactiveVersion>6.0.0</SystemReactiveVersion>
     <SystemSecurityCryptographyXmlVersion>8.0.1</SystemSecurityCryptographyXmlVersion>
     <SystemSecurityCryptographyPkcsVersion>8.0.0</SystemSecurityCryptographyPkcsVersion>

--- a/src/Microsoft.DotNet.Interactive.SqlServer/ConnectMsSqlDirective.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/ConnectMsSqlDirective.cs
@@ -90,8 +90,8 @@ public class ConnectMsSqlDirective : ConnectKernelDirective<ConnectMsSqlKernel>
         // FIX: (InitializeDbContextAsync) package versions to make them reference the ones that are already referenced at build time
         var submission1 = $$"""
             #r "nuget: Microsoft.Data.SqlClient, 5.2.2"
-            #r "nuget: Microsoft.EntityFrameworkCore.Design, 8.0.8"
-            #r "nuget: Microsoft.EntityFrameworkCore.SqlServer, 8.0.8"
+            #r "nuget: Microsoft.EntityFrameworkCore.Design, 8.0.10"
+            #r "nuget: Microsoft.EntityFrameworkCore.SqlServer, 8.0.10"
             #r "nuget: Humanizer.Core, 2.14.1"
             #r "nuget: Humanizer, 2.14.1"
             #r "nuget: Microsoft.Identity.Client, 4.61.3"


### PR DESCRIPTION
This fixes a regression of #2355, where the generated code references the wrong assembly versions for EF.