### PR TITLE
fix Microsoft.Identity.Client version when creating DbContext

### DIFF
--- a/src/Microsoft.DotNet.Interactive.SqlServer/ConnectMsSqlDirective.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/ConnectMsSqlDirective.cs
@@ -94,7 +94,7 @@ public class ConnectMsSqlDirective : ConnectKernelDirective<ConnectMsSqlKernel>
             #r "nuget: Microsoft.EntityFrameworkCore.SqlServer, 8.0.10"
             #r "nuget: Humanizer.Core, 2.14.1"
             #r "nuget: Humanizer, 2.14.1"
-            #r "nuget: Microsoft.Identity.Client, 4.61.3"
+            #r "nuget: Microsoft.Identity.Client, 4.65.0"
             
             using System;
             using System.Reflection;


### PR DESCRIPTION
This fixes #3766.