### PR TITLE
[SECURITY] Bump System.Runtime.Caching from 8.0.0 to 8.0.1

### DIFF
--- a/src/Microsoft.DotNet.Interactive.SqlServer/Microsoft.DotNet.Interactive.SqlServer.csproj
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/Microsoft.DotNet.Interactive.SqlServer.csproj
@@ -36,6 +36,7 @@
      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
    </PackageReference>
    <PackageReference Include="StreamJsonRpc" Version="2.17.8" />
+   <PackageReference Include="System.Runtime.Caching" Version="8.0.1" />
  </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Mirroring the change from automation here: https://dev.azure.com/dnceng/internal/_git/dotnet-interactive/pullrequest/45262?_a=files