### PR TITLE
Generate consts for package versions used in emitted EF code

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,16 +16,22 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <HumanizerCoreVersion>2.14.1</HumanizerCoreVersion>
+    <HumanizerVersion>2.14.1</HumanizerVersion>
+    <MicrosoftCodeAnalysisCommonVersion>4.11.0</MicrosoftCodeAnalysisCommonVersion>
+    <MicrosoftDataSqlClientVersion>5.2.2</MicrosoftDataSqlClientVersion>
+    <MicrosoftEntityFrameworkCoreDesignVersion>8.0.10</MicrosoftEntityFrameworkCoreDesignVersion>
+    <MicrosoftEntityFrameworkCoreSqlServerVersion>8.0.10</MicrosoftEntityFrameworkCoreSqlServerVersion>
+    <MicrosoftIdentityClientVersion>4.65.0</MicrosoftIdentityClientVersion>
     <MicrosoftNETTestSdkVersion>17.4.0</MicrosoftNETTestSdkVersion>
     <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
-    <MicrosoftCodeAnalysisCommonVersion>4.11.0</MicrosoftCodeAnalysisCommonVersion>
     <SystemDrawingCommonVersion>8.0.11</SystemDrawingCommonVersion>
     <SystemReactiveVersion>6.0.0</SystemReactiveVersion>
-    <SystemSecurityCryptographyXmlVersion>8.0.1</SystemSecurityCryptographyXmlVersion>
     <SystemSecurityCryptographyPkcsVersion>8.0.0</SystemSecurityCryptographyPkcsVersion>
+    <SystemSecurityCryptographyXmlVersion>8.0.1</SystemSecurityCryptographyXmlVersion>
     <SystemTextJsonVersion>8.0.5</SystemTextJsonVersion>
-    <xunitVersion>2.7.0</xunitVersion>
     <xunitrunnervisualstudioVersion>2.5.7</xunitrunnervisualstudioVersion>
+    <xunitVersion>2.7.0</xunitVersion>
   </PropertyGroup>
 
   <!-- Prevent the following warning on .NET 8 SDK by preserving legacy behavior for

--- a/src/Microsoft.DotNet.Interactive.Documents.Tests/CodeSubmissionFormatTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Documents.Tests/CodeSubmissionFormatTests.cs
@@ -525,6 +525,7 @@ Console.Write(""hello"");
     }
 
     [Fact]
+    [Trait("Category", "Contracts and serialization")]
     public async Task dib_file_can_be_round_tripped_through_read_and_write_without_the_content_changing()
     {
         var path = GetNotebookFilePath();

--- a/src/Microsoft.DotNet.Interactive.Documents.Tests/JupyterFormatTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Documents.Tests/JupyterFormatTests.cs
@@ -1591,6 +1591,7 @@ public class JupyterFormatTests : DocumentFormatTestsBase
     }
 
     [Fact]
+    [Trait("Category", "Contracts and serialization")]
     public async Task ipynb_from_Jupyter_can_be_round_tripped_through_read_and_write_without_the_content_changing()
     {
         var path = GetNotebookFilePath();
@@ -1599,6 +1600,7 @@ public class JupyterFormatTests : DocumentFormatTestsBase
     }
 
     [Fact]
+    [Trait("Category", "Contracts and serialization")]
     public async Task ipynb_from_VSCode_can_be_round_tripped_through_read_and_write_without_the_content_changing()
     {
         var path = GetNotebookFilePath();

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterMessageContractTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterMessageContractTests.cs
@@ -15,6 +15,7 @@ using Message = Microsoft.DotNet.Interactive.Jupyter.Messaging.Message;
 
 namespace Microsoft.DotNet.Interactive.Jupyter.Tests;
 
+[Trait("Category", "Contracts and serialization")]
 public class JupyterMessageContractTests
 {
     private readonly Configuration _configuration;

--- a/src/Microsoft.DotNet.Interactive.SqlServer/ConnectMsSqlDirective.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/ConnectMsSqlDirective.cs
@@ -8,6 +8,7 @@ using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Connection;
 using Microsoft.DotNet.Interactive.CSharp;
 using Microsoft.DotNet.Interactive.Directives;
+using static Microsoft.DotNet.Interactive.SqlServer.DependencyVersions;
 
 namespace Microsoft.DotNet.Interactive.SqlServer;
 
@@ -87,14 +88,13 @@ public class ConnectMsSqlDirective : ConnectKernelDirective<ConnectMsSqlKernel>
 
         context.DisplayAs($"Scaffolding a `DbContext` and initializing an instance of it called `{kernelName}` in the C# kernel.", "text/markdown");
 
-        // FIX: (InitializeDbContextAsync) package versions to make them reference the ones that are already referenced at build time
         var submission1 = $$"""
-            #r "nuget: Microsoft.Data.SqlClient, 5.2.2"
-            #r "nuget: Microsoft.EntityFrameworkCore.Design, 8.0.10"
-            #r "nuget: Microsoft.EntityFrameworkCore.SqlServer, 8.0.10"
-            #r "nuget: Humanizer.Core, 2.14.1"
-            #r "nuget: Humanizer, 2.14.1"
-            #r "nuget: Microsoft.Identity.Client, 4.65.0"
+            #r "nuget: Microsoft.Data.SqlClient, {{MicrosoftDataSqlClientVersion}}"
+            #r "nuget: Microsoft.EntityFrameworkCore.Design, {{MicrosoftEntityFrameworkCoreDesignVersion}}"
+            #r "nuget: Microsoft.EntityFrameworkCore.SqlServer, {{MicrosoftEntityFrameworkCoreSqlServerVersion}}"
+            #r "nuget: Humanizer.Core, {{HumanizerCoreVersion}}"
+            #r "nuget: Humanizer, {{HumanizerVersion}}"
+            #r "nuget: Microsoft.Identity.Client, {{MicrosoftIdentityClientVersion}}"
             
             using System;
             using System.Reflection;

--- a/src/Microsoft.DotNet.Interactive.SqlServer/DependencyVersions.g.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/DependencyVersions.g.cs
@@ -1,0 +1,12 @@
+namespace Microsoft.DotNet.Interactive.SqlServer;
+ 
+/// <summary>Provides information about the package versions depended on by the current project. This class was code-generated.</summary>
+internal static class DependencyVersions
+{
+    public const string HumanizerCoreVersion = "2.14.1";
+    public const string HumanizerVersion = "2.14.1";
+    public const string MicrosoftDataSqlClientVersion = "5.2.2";
+    public const string MicrosoftEntityFrameworkCoreDesignVersion = "8.0.10";
+    public const string MicrosoftEntityFrameworkCoreSqlServerVersion = "8.0.10";
+    public const string MicrosoftIdentityClientVersion = "4.65.0";
+}

--- a/src/Microsoft.DotNet.Interactive.SqlServer/Microsoft.DotNet.Interactive.SqlServer.csproj
+++ b/src/Microsoft.DotNet.Interactive.SqlServer/Microsoft.DotNet.Interactive.SqlServer.csproj
@@ -15,10 +15,13 @@
 
  <ItemGroup>
    <Compile Remove="bin\**" />
+   <Compile Remove="obj\**" />
    <Compile Remove="Utility\**" />
    <EmbeddedResource Remove="bin\**" />
+   <EmbeddedResource Remove="obj\**" />
    <EmbeddedResource Remove="Utility\**" />
    <None Remove="bin\**" />
+   <None Remove="obj\**" />
    <None Remove="Utility\**" />
  </ItemGroup>
 
@@ -47,5 +50,30 @@
   <ItemGroup>
     <None Include="extension.dib" Pack="true" PackagePath="interactive-extensions/dotnet" />
   </ItemGroup>
+
+  <Target Name="GeneratePackageVersionsAsConstant" AfterTargets="BeforeBuild">
+    <PropertyGroup>
+      <SourceFile>DependencyVersions.g.cs</SourceFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <Code Include="namespace $(RootNamespace)%3B" />
+      <Code Include="%20" />
+      <Code Include="/// &lt;summary&gt;Provides information about the package versions depended on by the current project. This class was code-generated.&lt;/summary&gt;" />
+      <Code Include="internal static class DependencyVersions" />
+      <Code Include="{" />
+
+      <Code Include="%20%20%20%20public const string HumanizerCoreVersion = &quot;$(HumanizerCoreVersion)&quot;%3B" />
+      <Code Include="%20%20%20%20public const string HumanizerVersion = &quot;$(HumanizerVersion)&quot;%3B" />
+      <Code Include="%20%20%20%20public const string MicrosoftDataSqlClientVersion = &quot;$(MicrosoftDataSqlClientVersion)&quot;%3B" />
+      <Code Include="%20%20%20%20public const string MicrosoftEntityFrameworkCoreDesignVersion = &quot;$(MicrosoftEntityFrameworkCoreDesignVersion)&quot;%3B" />
+      <Code Include="%20%20%20%20public const string MicrosoftEntityFrameworkCoreSqlServerVersion = &quot;$(MicrosoftEntityFrameworkCoreSqlServerVersion)&quot;%3B" />
+      <Code Include="%20%20%20%20public const string MicrosoftIdentityClientVersion = &quot;$(MicrosoftIdentityClientVersion)&quot;%3B" />
+
+      <Code Include="}" />
+    </ItemGroup>
+
+    <WriteLinesToFile File="$(SourceFile)" Lines="@(Code)" Overwrite="true" />
+  </Target>
 
 </Project>

--- a/src/dotnet-interactive.Tests/JupyterInstallCommandTests.cs
+++ b/src/dotnet-interactive.Tests/JupyterInstallCommandTests.cs
@@ -15,14 +15,13 @@ namespace Microsoft.DotNet.Interactive.App.Tests;
 
 public class JupyterInstallCommandTests
 {
-
     [Fact]
     public async Task Appends_http_port_range_arguments()
     {
         var console = new TestConsole();
         var kernelSpecModule = new JupyterKernelSpecModuleSimulator(true);
         var kernelSpecInstaller = new JupyterKernelSpecInstaller(console,kernelSpecModule);
-        var jupyterCommandLine = new JupyterInstallCommand(console, kernelSpecInstaller, new HttpPortRange(100, 400));
+        var jupyterCommandLine = new JupyterInstallCommand(kernelSpecInstaller, new HttpPortRange(100, 400));
 
         await jupyterCommandLine.InvokeAsync();
 
@@ -38,6 +37,7 @@ public class JupyterInstallCommandTests
     [InlineData(".NET (C#)")]
     [InlineData(".NET (F#)")]
     [InlineData(".NET (PowerShell)")]
+    [Trait("Category", "Contracts and serialization")]
     public async Task kernel_spec_is_not_broken(string displayName)
     {
         var _configuration = new Configuration()
@@ -47,14 +47,13 @@ public class JupyterInstallCommandTests
         var console = new TestConsole();
         var kernelSpecModule = new JupyterKernelSpecModuleSimulator(true);
         var kernelSpecInstaller = new JupyterKernelSpecInstaller(console, kernelSpecModule);
-        var jupyterCommandLine = new JupyterInstallCommand(console, kernelSpecInstaller, new HttpPortRange(100, 400));
+        var jupyterCommandLine = new JupyterInstallCommand(kernelSpecInstaller, new HttpPortRange(100, 400));
 
         await jupyterCommandLine.InvokeAsync();
 
         var kernelSpec = kernelSpecModule.InstalledKernelSpecs.Single(k => k.Contains(displayName));
 
         this.Assent(kernelSpec, _configuration);
-
     }
 
     [Fact]
@@ -63,9 +62,7 @@ public class JupyterInstallCommandTests
         var console = new TestConsole();
         var kernelSpecModule = new JupyterKernelSpecModuleSimulator(false);
         var kernelSpecInstaller = new JupyterKernelSpecInstaller(console, kernelSpecModule);
-        var installCommand = new JupyterInstallCommand(
-            console,
-            kernelSpecInstaller);
+        var installCommand = new JupyterInstallCommand(kernelSpecInstaller);
 
         await installCommand.InvokeAsync();
         var consoleError = console.Error.ToString();
@@ -81,7 +78,7 @@ public class JupyterInstallCommandTests
         var console = new TestConsole();
         var kernelSpecModule = new JupyterKernelSpecModuleSimulator(true);
         var kernelSpecInstaller = new JupyterKernelSpecInstaller(console, kernelSpecModule);
-        var jupyterCommandLine = new JupyterInstallCommand(console, kernelSpecInstaller);
+        var jupyterCommandLine = new JupyterInstallCommand(kernelSpecInstaller);
 
         await jupyterCommandLine.InvokeAsync();
 

--- a/src/dotnet-interactive/CommandLine/CommandLineParser.cs
+++ b/src/dotnet-interactive/CommandLine/CommandLineParser.cs
@@ -231,7 +231,7 @@ public static class CommandLineParser
 
             Task<int> JupyterInstallHandler(HttpPortRange httpPortRange, DirectoryInfo path, InvocationContext context)
             {
-                var jupyterInstallCommand = new JupyterInstallCommand(context.Console, new JupyterKernelSpecInstaller(context.Console), httpPortRange, path);
+                var jupyterInstallCommand = new JupyterInstallCommand(new JupyterKernelSpecInstaller(context.Console), httpPortRange, path);
                 return jupyterInstallCommand.InvokeAsync();
             }
         }

--- a/src/dotnet-interactive/JupyterKernelSpecInstaller.cs
+++ b/src/dotnet-interactive/JupyterKernelSpecInstaller.cs
@@ -28,7 +28,6 @@ public class JupyterKernelSpecInstaller : IJupyterKernelSpecInstaller
         _kernelSpecModule = jupyterKernelSpecModule;
     }
 
-
     public async Task<bool> TryInstallKernelAsync(DirectoryInfo sourceDirectory, DirectoryInfo destination = null)
     {
         var kernelDisplayName = GetKernelDisplayName(sourceDirectory);


### PR DESCRIPTION
This will do away with the need to manually coordinate package versions referenced by the Microsoft.DotNet.Interactive.SqlServer project and the code emitted to scaffold a `DbContext` when the `--create-dbcontext` parameter is used with `#!connect mssql`.