### PR TITLE
Infer specific data kernel package version in discoverability kernels

### DIFF
--- a/eng/publish/PublishPolyglotNotebooksHelper.psm1
+++ b/eng/publish/PublishPolyglotNotebooksHelper.psm1
@@ -70,6 +70,7 @@ function PublishStableExtensionAndNuGetPackages {
         "Microsoft.DotNet.Interactive.Mermaid",
         "Microsoft.DotNet.Interactive.NamedPipeConnector",
         "Microsoft.DotNet.Interactive.PackageManagement",
+        "Microsoft.DotNet.Interactive.PostgreSQL",
         "Microsoft.DotNet.Interactive.PowerShell",
         "Microsoft.DotNet.Interactive.SQLite",
         "Microsoft.DotNet.Interactive.SqlServer",

--- a/repack.ps1
+++ b/repack.ps1
@@ -8,8 +8,8 @@ try
 
     # build and pack dotnet-interactive 
     dotnet clean -c debug
-    dotnet build -c debug
-    dotnet pack -c debug /p:PackageVersion=2.0.0
+    dotnet build -c debug /p:Version=2.0.0
+    dotnet pack --no-build -c debug /p:PackageVersion=2.0.0 
 
     # copy the dotnet-interactive packages to the temp directory
     $destinationPath = "C:\temp\packages"

--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
@@ -253,8 +253,6 @@ Microsoft.DotNet.Interactive
     .ctor(System.String name = value, System.Net.Http.HttpClient httpClient = null)
     public Microsoft.DotNet.Interactive.Directives.KernelSpecifierDirective KernelSpecifierDirective { get;}
     public System.Collections.Generic.IReadOnlyDictionary<System.String,FormattedValue> Values { get;}
-  public class KqlDiscoverabilityKernel : Kernel, IKernelCommandHandler<Microsoft.DotNet.Interactive.Commands.RequestKernelInfo>, IKernelCommandHandler<Microsoft.DotNet.Interactive.Commands.SubmitCode>, System.IDisposable
-    .ctor()
   public class LinePosition, System.IEquatable<LinePosition>
     public static LinePosition FromCodeAnalysisLinePosition(Microsoft.CodeAnalysis.Text.LinePosition linePosition)
     public static System.Boolean op_Equality(LinePosition left, LinePosition right)
@@ -338,8 +336,6 @@ Microsoft.DotNet.Interactive
     public FormattedValue Documentation { get;}
     public System.String Label { get;}
     public System.Collections.Generic.IReadOnlyList<ParameterInformation> Parameters { get;}
-  public class SqlDiscoverabilityKernel : Kernel, IKernelCommandHandler<Microsoft.DotNet.Interactive.Commands.RequestKernelInfo>, IKernelCommandHandler<Microsoft.DotNet.Interactive.Commands.SubmitCode>, System.IDisposable
-    .ctor()
   public class TabularDataResourceSummaryExplorer : DataExplorer<Microsoft.DotNet.Interactive.Formatting.TabularData.TabularDataResource>
     .ctor(Microsoft.DotNet.Interactive.Formatting.TabularData.TabularDataResource data)
     protected Microsoft.AspNetCore.Html.IHtmlContent ToHtml()

--- a/src/Microsoft.DotNet.Interactive.DuckDB.Tests/KernelExtensionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.DuckDB.Tests/KernelExtensionTests.cs
@@ -16,9 +16,9 @@ using Xunit;
 
 namespace Microsoft.DotNet.Interactive.DuckDB.Tests;
 
+[Trait("Databases", "Data query tests")]
 public class DuckDbConnectionTests
 {
-
     [Fact]
     public async Task It_can_connect_and_query_data()
     {

--- a/src/Microsoft.DotNet.Interactive.Formatting/TabularData/TabularDataFormatterSource.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting/TabularData/TabularDataFormatterSource.cs
@@ -14,6 +14,8 @@ internal class TabularDataFormatterSource : ITypeFormatterSource
 {
     public IEnumerable<ITypeFormatter> CreateTypeFormatters()
     {
+        Formatter.SetPreferredMimeTypesFor(typeof(TabularDataResource), HtmlFormatter.MimeType, CsvFormatter.MimeType);
+
         yield return new HtmlFormatter<TabularDataResource>((value, context) => FormatHtml(context, value));
 
         yield return new JsonFormatter<TabularDataResource>((value, context) =>

--- a/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterKernelTestBase.cs
+++ b/src/Microsoft.DotNet.Interactive.Jupyter.Tests/JupyterKernelTestBase.cs
@@ -3,9 +3,6 @@
 
 using FluentAssertions;
 using Microsoft.DotNet.Interactive.CSharp;
-using Microsoft.DotNet.Interactive.Formatting;
-using Microsoft.DotNet.Interactive.Formatting.Csv;
-using Microsoft.DotNet.Interactive.Formatting.TabularData;
 using Microsoft.DotNet.Interactive.Jupyter.Connection;
 using Microsoft.DotNet.Interactive.Jupyter.Protocol;
 using Microsoft.DotNet.Interactive.Tests.Utility;
@@ -13,7 +10,6 @@ using System;
 using System.Collections.Generic;
 using System.Reactive.Disposables;
 using System.Threading.Tasks;
-using Formatter = Microsoft.DotNet.Interactive.Formatting.Formatter;
 using Message = Microsoft.DotNet.Interactive.Jupyter.Messaging.Message;
 
 namespace Microsoft.DotNet.Interactive.Jupyter.Tests;
@@ -34,8 +30,6 @@ public abstract class JupyterKernelTestBase : IDisposable
 
     protected CompositeKernel CreateCompositeKernelAsync(params IJupyterKernelConnectionOptions[] optionsList)
     {
-        Formatter.SetPreferredMimeTypesFor(typeof(TabularDataResource), HtmlFormatter.MimeType, CsvFormatter.MimeType);
-
         var csharpKernel = new CSharpKernel()
                                 .UseKernelHelpers()
                                 .UseValueSharing();

--- a/src/Microsoft.DotNet.Interactive.Kql.Tests/KqlConnectionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql.Tests/KqlConnectionTests.cs
@@ -1,13 +1,13 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
 using FluentAssertions;
 using Microsoft.DotNet.Interactive.App;
+using Microsoft.DotNet.Interactive.App.Connection;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.CSharp;
 using Microsoft.DotNet.Interactive.Events;
@@ -21,11 +21,11 @@ using Xunit;
 
 namespace Microsoft.DotNet.Interactive.Kql.Tests;
 
-public class KqlConnectionTests : IDisposable
+[Trait("Databases", "Data query tests")]
+public class KqlConnectionTests
 {
     private static async Task<CompositeKernel> CreateKernelAsync()
     {
-        Formatter.SetPreferredMimeTypesFor(typeof(TabularDataResource), HtmlFormatter.MimeType, CsvFormatter.MimeType);
         var csharpKernel = new CSharpKernel().UseNugetDirective();
 
         var kernel = new CompositeKernel
@@ -447,11 +447,5 @@ StormEvents | take testVar";
         kustoKernel.TryGetValue<IEnumerable<object>>("testQuery", out var resultSet);
 
         resultSet.Should().NotBeNull().And.HaveCount(1);
-    }
-
-    public void Dispose()
-    {
-        Formatter.ResetToDefault();
-        DataExplorer.ResetToDefault();
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Kql.Tests/KqlFactAttribute.cs
+++ b/src/Microsoft.DotNet.Interactive.Kql.Tests/KqlFactAttribute.cs
@@ -26,8 +26,10 @@ public sealed class KqlFactAttribute : FactAttribute
         string clusterName = GetClusterForTests();
         if (string.IsNullOrWhiteSpace(clusterName))
         {
-            return $"Environment variable {TEST_KQL_CONNECTION_STRING} is not set. To run tests that require "
-                   + "KQL Cluster, this environment variable must be set to a valid connection string value.";
+            return
+                $"""
+                 Environment variable {TEST_KQL_CONNECTION_STRING} is not set. To run tests that require a KQL Cluster, this environment variable must be set to a valid connection string value.
+                 """;
         }
 
         return null;

--- a/src/Microsoft.DotNet.Interactive.PostgreSql.Tests/PostgreSqlConnectionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.PostgreSql.Tests/PostgreSqlConnectionTests.cs
@@ -12,14 +12,16 @@ using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.CSharp;
 using Microsoft.DotNet.Interactive.App;
 using FluentAssertions;
+using Microsoft.DotNet.Interactive.App.Connection;
+using Xunit;
 
 namespace Microsoft.DotNet.Interactive.PostgreSql.Tests;
 
+[Trait("Databases", "Data query tests")]
 public class PostgreSqlConnectionTests : IDisposable
 {
     private static CompositeKernel CreateKernel()
     {
-        Formatter.SetPreferredMimeTypesFor(typeof(TabularDataResource), HtmlFormatter.MimeType, CsvFormatter.MimeType);
         var csharpKernel = new CSharpKernel().UseNugetDirective().UseValueSharing();
 
         var kernel = new CompositeKernel
@@ -48,7 +50,7 @@ public class PostgreSqlConnectionTests : IDisposable
 
         result = await kernel.SubmitCodeAsync("""
             #!sql-adventureworks
-            SELECT * FROM Person.Person LIMIT 100;
+            SELECT * FROM customers LIMIT 100;
             """);
 
         result.Events.Should().NotContainErrors();
@@ -71,7 +73,7 @@ public class PostgreSqlConnectionTests : IDisposable
 
         result = await kernel.SubmitCodeAsync("""
             #!sql-adventureworks
-            SELECT not_known_column FROM Person.Person LIMIT 100;
+            SELECT not_known_column FROM customers LIMIT 100;
             """);
 
         result.Events.Should()
@@ -85,6 +87,5 @@ public class PostgreSqlConnectionTests : IDisposable
     public void Dispose()
     {
         DataExplorer.ResetToDefault();
-        Formatter.ResetToDefault();
     }
 }

--- a/src/Microsoft.DotNet.Interactive.PostgreSql.Tests/PostgreSqlFactAttribute.cs
+++ b/src/Microsoft.DotNet.Interactive.PostgreSql.Tests/PostgreSqlFactAttribute.cs
@@ -30,8 +30,10 @@ public sealed class PostgreSqlFactAttribute : FactAttribute
         string connectionString = GetConnectionStringForTests();
         if (string.IsNullOrWhiteSpace(connectionString))
         {
-            return $"Environment variable {TEST_POSTGRESQL_CONNECTION_STRING} is not set. To run tests that require "
-                   + "SQL Server, this environment variable must be set to a valid connection string value.";
+            return
+                $"""
+                 Environment variable {TEST_POSTGRESQL_CONNECTION_STRING} is not set. To run tests that require PostgreSQL, this environment variable must be set to a valid connection string value.
+                 """;
         }
 
         try
@@ -41,9 +43,10 @@ public sealed class PostgreSqlFactAttribute : FactAttribute
         }
         catch (Exception e)
         {
-            return $"A connection could not be established to SQL Server. Verify the connection string value used " +
-                   $"for environment variable {TEST_POSTGRESQL_CONNECTION_STRING} targets a running SQL Server instance. " +
-                   $"Connection failed failed with error: {e}";
+            return
+                $"""
+                 A connection could not be established to a PostgreSQL server. Verify the connection string value used for environment variable {TEST_POSTGRESQL_CONNECTION_STRING} targets a running PostgreSQL instance. Connection failed failed with error: {e}
+                 """;
         }
 
         return null;
@@ -51,7 +54,7 @@ public sealed class PostgreSqlFactAttribute : FactAttribute
 
     public static string GetConnectionStringForTests()
     {
-        const string fallbackConnectionString = "Host=localhost;Port=5432;Username=postgres;Password=postgres;Database=Adventureworks";
+        const string fallbackConnectionString = "Host=localhost;Port=5432;Username=postgres;Password=postgres;Database=northwind";
 
         return Environment.GetEnvironmentVariable(TEST_POSTGRESQL_CONNECTION_STRING) ?? fallbackConnectionString;
     }

--- a/src/Microsoft.DotNet.Interactive.PostgreSql.Tests/README.md
+++ b/src/Microsoft.DotNet.Interactive.PostgreSql.Tests/README.md
@@ -2,25 +2,10 @@
 
 ## Setup Test Database
 
-Take a look at [AdventureWorks-for-Postgres](https://github.com/lorint/AdventureWorks-for-Postgres) repository. It contains a script to create the AdventureWorks database on a PostgreSQL server.
+The tests use the sample [Northwind database](https://github.com/pthom/northwind_psql). You can create a blank database and install it using [this script](https://github.com/pthom/northwind_psql/blob/master/northwind.sql).
 
-You can use Docker to run a PostgreSQL server with the AdventureWorks database:
-
-Install repository:
+The tests will only run when the environment variable `TEST_POSTGRESQL_CONNECTION_STRING` has set to a valid connection string. Here's an example using a default Postgres installation:
 
 ```bash
-git clone https://github.com/lorint/AdventureWorks-for-Postgres
-```
-
-Run PostgreSQL server:
-
-```bash
-podman build -t adventure-postgres ./
-podman run -d -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 adventure-postgres
-```
-
-Setup connection string as environment variable:
-
-```bash
-export TEST_POSTGRESQL_CONNECTION_STRING='Host=localhost;Port=5432;Username=postgres;Password=postgres;Database=Adventureworks'
+export TEST_POSTGRESQL_CONNECTION_STRING='Host=localhost;Port=5432;Username=postgres;Password=postgres;Database=northwind'
 ```

--- a/src/Microsoft.DotNet.Interactive.PostgreSql/Microsoft.DotNet.Interactive.PostgreSql.csproj
+++ b/src/Microsoft.DotNet.Interactive.PostgreSql/Microsoft.DotNet.Interactive.PostgreSql.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageDescription>Microsoft PostgreSQL support for .NET Interactive</PackageDescription>
+    <PackageDescription>PostgreSQL support for .NET Interactive</PackageDescription>
     <PackageTags>polyglot notebook dotnet interactive SQL PostgreSQL Data</PackageTags>
     <IncludeBuildOutput>true</IncludeBuildOutput>
     <NoWarn>$(NoWarn);NU5100;VSTHRD002</NoWarn>
@@ -11,7 +11,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Npgsql" Version="8.0.4" />
+    <PackageReference Include="Npgsql" Version="8.0.6" />
     <PackageReference Include="Pocket.Disposable" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Microsoft.DotNet.Interactive.PostgreSql/PostgreSqlKernel.cs
+++ b/src/Microsoft.DotNet.Interactive.PostgreSql/PostgreSqlKernel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -109,23 +109,20 @@ public class PostgreSqlKernel :
         }
     }
 
-    public static void AddPostgreSqlKernelConnectorTo(CompositeKernel kernel)
-    {
-        kernel.AddConnectDirective(new ConnectPostgreSqlDirective());
-
-        KernelInvocationContext.Current?.Display(
-            new HtmlString(@"<details><summary>Query PostgreSql databases.</summary>
-    <p>This extension adds support for connecting to PostgreSql databases using the <code>#!connect postgres</code> magic command. For more information, run a cell using the <code>#!sql</code> magic command.</p>
-    </details>"),
-            "text/html");
-    }
-
     public static void AddPostgreSqlKernelConnectorToCurrentRoot()
     {
         if (KernelInvocationContext.Current is { } context &&
             context.HandlingKernel.RootKernel is CompositeKernel root)
         {
-            AddPostgreSqlKernelConnectorTo(root);
+            root.AddConnectDirective(new ConnectPostgreSqlDirective());
+
+            context.Display(
+                new HtmlString("""
+                               <details><summary>Query PostgreSQL databases.</summary>
+                                   <p>This extension adds support for connecting to PostgreSql databases using the <code>#!connect postgres</code> magic command.</p>
+                                   </details>
+                               """),
+                "text/html");
         }
     }
 }

--- a/src/Microsoft.DotNet.Interactive.SQLite.Tests/SQLiteConnectionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.SQLite.Tests/SQLiteConnectionTests.cs
@@ -6,17 +6,20 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using Microsoft.DotNet.Interactive.App;
+using Microsoft.DotNet.Interactive.App.Connection;
 using Microsoft.DotNet.Interactive.CSharp;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Formatting;
 using Microsoft.DotNet.Interactive.Tests.Utility;
+using Xunit;
 
 namespace Microsoft.DotNet.Interactive.SQLite.Tests;
 
+[Trait("Databases", "Data query tests")]
 public class SQLiteConnectionTests
 {
     [WindowsFact]
-    public async Task SQLKernel_suggests_SQLite_connection_when_statements_are_submitted_to_it()
+    public async Task SQLDiscoverabilityKernel_suggests_SQLite_connection_when_statements_are_submitted_to_it()
     {
         using var kernel = new CompositeKernel
         {

--- a/src/Microsoft.DotNet.Interactive.SqlServer.Tests/MsSqlConnectionTests.cs
+++ b/src/Microsoft.DotNet.Interactive.SqlServer.Tests/MsSqlConnectionTests.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.DotNet.Interactive.App;
+using Microsoft.DotNet.Interactive.App.Connection;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.CSharp;
 using Microsoft.DotNet.Interactive.Events;
@@ -20,14 +21,13 @@ using Xunit;
 
 namespace Microsoft.DotNet.Interactive.SqlServer.Tests;
 
+[Trait("Databases", "Data query tests")]
 public class MsSqlConnectionTests : IDisposable
 {
     private async Task<CompositeKernel> CreateKernelAsync()
     {
-        Formatter.SetPreferredMimeTypesFor(typeof(TabularDataResource), HtmlFormatter.MimeType, CsvFormatter.MimeType);
         var csharpKernel = new CSharpKernel().UseNugetDirective().UseValueSharing();
 
-        // TODO: remove SQLKernel it is used to test current patch
         var kernel = new CompositeKernel
         {
             new SqlDiscoverabilityKernel(),
@@ -584,6 +584,5 @@ select TOP(@testVar) * from sys.databases";
     public void Dispose()
     {
         DataExplorer.ResetToDefault();
-        Formatter.ResetToDefault();
     }
 }

--- a/src/Microsoft.DotNet.Interactive.Tests/KqlDiscoverabilityKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/KqlDiscoverabilityKernelTests.cs
@@ -3,6 +3,7 @@
 
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.DotNet.Interactive.App.Connection;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Tests.Utility;
@@ -78,9 +79,10 @@ public class KqlDiscoverabilityKernelTests
 
         var message = displayValue.Value.ToString();
 
-
         // Should contain instructions for how to install SqlServer extension package
-        message.Should().Contain(@"#r ""nuget:Microsoft.DotNet.Interactive.Kql,*-*""");
+        message.Should().Contain("""
+                                 #r "nuget:Microsoft.DotNet.Interactive.Kql,1.0.0
+                                 """);
 
         // Should contain instructions for how to get help message for MSSQL kernel
         message.Should().Contain("#!connect kql --kernel-name mydatabase --cluster \"https://help.kusto.windows.net\" --database \"Samples\"");

--- a/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelFormattingTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/LanguageKernelFormattingTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -173,7 +173,7 @@ using {typeof(PocketView).Namespace};
         result.Events
               .Should().ContainSingle<DisplayedValueProduced>()
               .Which
-              .FormattedValues.Should().ContainSingle()
+              .FormattedValues.Should().ContainSingle(v => v.MimeType == "text/html")
               .Which
               .Value.Should().ContainEquivalentHtmlFragments("""
                 <table>

--- a/src/Microsoft.DotNet.Interactive.Tests/SqlDiscoverabilityKernelTests.cs
+++ b/src/Microsoft.DotNet.Interactive.Tests/SqlDiscoverabilityKernelTests.cs
@@ -4,6 +4,7 @@
 
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.DotNet.Interactive.App.Connection;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
 using Microsoft.DotNet.Interactive.Tests.Utility;
@@ -13,7 +14,6 @@ namespace Microsoft.DotNet.Interactive.Tests;
 
 public class SqlDiscoverabilityKernelTests
 {
-
     [Fact]
     public async Task sql_kernel_does_not_execute_query()
     {
@@ -81,7 +81,9 @@ public class SqlDiscoverabilityKernelTests
             
 
         // Should contain instructions for how to install SqlServer extension package
-        message.Should().Contain(@"#r ""nuget:Microsoft.DotNet.Interactive.SqlServer,*-*""");
+        message.Should().Contain("""
+                                 #r "nuget:Microsoft.DotNet.Interactive.SqlServer,1.0.0
+                                 """);
 
         // Should contain instructions for how to get help message for MSSQL kernel
         message.Should().Contain("#!connect mssql --kernel-name");

--- a/src/dotnet-interactive/Connection/KqlDiscoverabilityKernel.cs
+++ b/src/dotnet-interactive/Connection/KqlDiscoverabilityKernel.cs
@@ -8,7 +8,7 @@ using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Formatting;
 using static Microsoft.DotNet.Interactive.Formatting.PocketViewTags;
 
-namespace Microsoft.DotNet.Interactive;
+namespace Microsoft.DotNet.Interactive.App.Connection;
 
 /// <remarks>This kernel is used as a placeholder for the MSKQL kernel in order to enable KQL language coloring in the editor. Language grammars can only be defined for fixed kernel names, but MSKQL subkernels are user-defined via the #!connect magic command. So, this kernel is specified in addition to the user-defined kernel as a kind of "styling" kernel as well as to provide guidance and discoverability for KQL features. </remarks>
 public class KqlDiscoverabilityKernel :
@@ -25,7 +25,7 @@ public class KqlDiscoverabilityKernel :
             "MsKqlKernel"
         };
         KernelInfo.LanguageName = "KQL";
-        KernelInfo.Description = $"""
+        KernelInfo.Description = """
                             Query a Kusto database
                             """;
     }
@@ -45,33 +45,38 @@ public class KqlDiscoverabilityKernel :
         });
 
         var codeSample = !string.IsNullOrWhiteSpace(command.Code)
-            ? command.Code
-            : @"tableName | take 10";
+                             ? command.Code
+                             : "tableName | take 10";
 
-        if (connectedKqlKernelNames.Count == 0)
+        if (connectedKqlKernelNames.Count is 0)
         {
-            context.Display(HTML($@"
-<p>A KQL connection has not been established.</p>
-<p>To connect to a database, first add the KQL extension package by running the following in a C# cell:</p>
-<code>
-    <pre>
-    #r ""nuget:Microsoft.DotNet.Interactive.Kql,*-*""
-    </pre>
-</code>
-Now, you can connect to a Microsoft Kusto Server database by running the following in a C# cell:
-<code>
-    <pre>
-    #!connect kql --kernel-name mydatabase --cluster ""https://help.kusto.windows.net"" --database ""Samples""
-    </pre>
-</code>
-<p>Once a connection is established, you can send KQL statements by prefixing them with the magic command for your connection.</p>
-<code>
-    <pre>
-#!kql-mydatabase
-{codeSample}
-    </pre>
-</code>
-"), "text/html");
+            var version = PackageAcquisition.InferCompatiblePackageVersion();
+
+            context.Display(
+                HTML(
+                    $"""
+                     <p>A KQL connection has not been established.</p>
+                     <p>To connect to a database, first add the KQL extension package by running the following in a C# cell:</p>
+                     <code>
+                         <pre>
+                         #r "nuget:Microsoft.DotNet.Interactive.Kql,{version}"
+                         </pre>
+                     </code>
+                     Now, you can connect to a Microsoft Kusto Server database by running the following in a C# cell:
+                     <code>
+                         <pre>
+                         #!connect kql --kernel-name mydatabase --cluster "https://help.kusto.windows.net" --database "Samples"
+                         </pre>
+                     </code>
+                     <p>Once a connection is established, you can send KQL statements by prefixing them with the magic command for your connection.</p>
+                     <code>
+                         <pre>
+                     #!kql-mydatabase
+                     {codeSample}
+                         </pre>
+                     </code>
+
+                     """), "text/html");
         }
         else
         {

--- a/src/dotnet-interactive/Connection/PackageAcquisition.cs
+++ b/src/dotnet-interactive/Connection/PackageAcquisition.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Microsoft.DotNet.Interactive.Formatting;
+
+namespace Microsoft.DotNet.Interactive.App.Connection;
+
+internal static class PackageAcquisition
+{
+    internal static string InferCompatiblePackageVersion()
+    {
+        var informationalVersion = typeof(Formatter)
+                                   .Assembly
+                                   .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                                   .InformationalVersion;
+
+        if (informationalVersion.Contains("+"))
+        {
+            informationalVersion = informationalVersion.Split("+")[0];
+        }
+
+        var splitInformationalVersion = informationalVersion.Split('.');
+
+        var version = splitInformationalVersion.Length is 4
+                          ? string.Join(".", splitInformationalVersion[0..4])
+                          : informationalVersion;
+        return version;
+    }
+}

--- a/src/dotnet-interactive/KernelBuilder.cs
+++ b/src/dotnet-interactive/KernelBuilder.cs
@@ -107,7 +107,6 @@ public static class KernelBuilder
         {
             Formatter.DefaultMimeType = HtmlFormatter.MimeType;
             Formatter.SetPreferredMimeTypesFor(typeof(string), PlainTextFormatter.MimeType);
-            Formatter.SetPreferredMimeTypesFor(typeof(TabularDataResource), HtmlFormatter.MimeType, CsvFormatter.MimeType);
         }
     }
 }


### PR DESCRIPTION
This PR contains some refactoring for #2871. 

The `SqlDiscoverabilityKernel` and `KqlDiscoverabilityKernel` now infer specific package versions when displaying instructions:

Before:

```
To connect to a database, first add the SQL extension package by running the following in a C# cell:

    #r "nuget:Microsoft.DotNet.Interactive.SqlServer,*-*"
```

After (for example):

```
To connect to a database, first add the SQL extension package by running the following in a C# cell:

    #r "nuget:Microsoft.DotNet.Interactive.SqlServer,1.0.0-beta.24568.1"
```

These instructions will likely go away entirely as part of #2871, and package acquisition will happen automatically, but the current change will give us an opportunity in VS Code Insiders to verify that the heuristics work correctly with official packages.