### PR TITLE
Don't require `KernelCommand` types to be public

### DIFF
--- a/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
+++ b/src/Microsoft.DotNet.Interactive.ApiCompatibility.Tests/ApiCompatibilityTests.Interactive_api_is_not_changed.approved.txt
@@ -285,7 +285,6 @@ Microsoft.DotNet.Interactive
     public System.String ToString()
   public class NoSuitableKernelException : System.Exception, System.Runtime.Serialization.ISerializable
     .ctor(Microsoft.DotNet.Interactive.Commands.KernelCommand command)
-    .ctor(System.String message)
   public class PackageReference
     public static System.Boolean TryParse(System.String value, ref PackageReference& reference)
     .ctor(System.String packageName, System.String packageVersion = null)

--- a/src/Microsoft.DotNet.Interactive/Kernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Kernel.cs
@@ -948,15 +948,12 @@ public abstract partial class Kernel :
 
                 default:
                     // for command types defined outside this assembly, we can dynamically assign the handler
-                    if (command.GetType().IsPublic)
+                    try
                     {
-                        try
-                        {
-                            SetHandler((dynamic)command, (dynamic)this);
-                        }
-                        catch (RuntimeBinderException)
-                        {
-                        }
+                        SetHandler((dynamic)command, (dynamic)this);
+                    }
+                    catch (RuntimeBinderException)
+                    {
                     }
 
                     break;

--- a/src/Microsoft.DotNet.Interactive/NoSuitableKernelException.cs
+++ b/src/Microsoft.DotNet.Interactive/NoSuitableKernelException.cs
@@ -14,8 +14,4 @@ public class NoSuitableKernelException : Exception
             : $"No handler registered on kernel {command.TargetKernelName} for command: {command}")
     {
     }
-
-    public NoSuitableKernelException(string message) : base(message)
-    {
-    }
 }


### PR DESCRIPTION
This addresses an issue where custom command types defined within an interactive session cause NoSuitableKernelException because types created within C# Script are not public.
