### PR TITLE
Support in named requests for array indexing

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Http.Tests/HttpKernelTests.NamedRequest.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Tests/HttpKernelTests.NamedRequest.cs
@@ -904,6 +904,38 @@ namespace Microsoft.DotNet.Interactive.Http.Tests
             }
 
             [Fact]
+            public async Task accessing_an_index_in_a_json_array_succeeds()
+            {
+                using var kernel = new HttpKernel();
+                var firstRequest = """                    
+                    # @name sampleArray
+                    POST https://httpbin.org/anything
+                    {
+                      "devices": [
+                        {
+                          "id": "5601db0f-32e0-4d82-bc79-251e50fa1407",
+                          "name": "Foo"
+                        },
+                        {
+                          "id": "455301a5-8a6e-49d0-b056-96fb2847be18",
+                          "name": "Bar"
+                        }
+                      ]
+                    }
+                    ###
+                    """;
+                var firstResult = await kernel.SendAsync(new SubmitCode(firstRequest));
+                firstResult.Events.Should().NotContainErrors();
+                var secondRequest = """
+                    GET https://httpbin.org/headers
+                    X-Value: {{sampleArray.response.body.$.json.devices[0].id}}
+                    ###
+                    """;
+                var secondResult = await kernel.SendAsync(new SubmitCode(secondRequest));
+                secondResult.Events.Should().NotContainErrors();
+            }
+
+            [Fact]
             public async Task attempting_to_access_headers_that_do_not_exist_will_produce_an_error()
             {
                 using var kernel = new HttpKernel();

--- a/src/Microsoft.DotNet.Interactive.Http.Tests/HttpKernelTests.NamedRequest.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Tests/HttpKernelTests.NamedRequest.cs
@@ -933,6 +933,12 @@ namespace Microsoft.DotNet.Interactive.Http.Tests
                     """;
                 var secondResult = await kernel.SendAsync(new SubmitCode(secondRequest));
                 secondResult.Events.Should().NotContainErrors();
+
+                var returnValue = secondResult.Events.OfType<ReturnValueProduced>().First();
+
+                var response = (HttpResponse)returnValue.Value;
+
+                response.Request.Headers["X-Value"].First().Should().Be("5601db0f-32e0-4d82-bc79-251e50fa1407");
             }
 
             [Fact]

--- a/src/Microsoft.DotNet.Interactive.Http.Tests/HttpKernelTests.NamedRequest.cs
+++ b/src/Microsoft.DotNet.Interactive.Http.Tests/HttpKernelTests.NamedRequest.cs
@@ -942,6 +942,44 @@ namespace Microsoft.DotNet.Interactive.Http.Tests
             }
 
             [Fact]
+            public async Task accessing_multiple_indexes_in_a_json_array_succeeds()
+            {
+                using var kernel = new HttpKernel();
+                var firstRequest = """                    
+                    # @name sampleArray
+                    POST https://httpbin.org/anything
+                    {
+                      "devices": [
+                        {
+                          "id": "5601db0f-32e0-4d82-bc79-251e50fa1407",
+                          "name": "Foo"
+                        },
+                        {
+                          "ids": ["455301a5-8a6e-49d0-b056-96fb2847be18", "455301a5-8a6e-49d0-b056-96fb2847be19", "455301a5-8a6e-49d0-b056-96fb2847be20"], 
+                          "name": "Bar"
+                        }
+                      ]
+                    }
+                    ###
+                    """;
+                var firstResult = await kernel.SendAsync(new SubmitCode(firstRequest));
+                firstResult.Events.Should().NotContainErrors();
+                var secondRequest = """
+                    GET https://httpbin.org/headers
+                    X-Value: {{sampleArray.response.body.$.json.devices[1].ids[2]}}
+                    ###
+                    """;
+                var secondResult = await kernel.SendAsync(new SubmitCode(secondRequest));
+                secondResult.Events.Should().NotContainErrors();
+
+                var returnValue = secondResult.Events.OfType<ReturnValueProduced>().First();
+
+                var response = (HttpResponse)returnValue.Value;
+
+                response.Request.Headers["X-Value"].First().Should().Be("455301a5-8a6e-49d0-b056-96fb2847be20");
+            }
+
+            [Fact]
             public async Task attempting_to_access_headers_that_do_not_exist_will_produce_an_error()
             {
                 using var kernel = new HttpKernel();

--- a/src/Microsoft.DotNet.Interactive.Http/Model/HttpNamedRequest.cs
+++ b/src/Microsoft.DotNet.Interactive.Http/Model/HttpNamedRequest.cs
@@ -3,7 +3,6 @@
 
 #nullable enable
 
-using Microsoft.CodeAnalysis.Differencing;
 using Microsoft.DotNet.Interactive.Http.Parsing;
 using System;
 using System.Linq;

--- a/src/Microsoft.DotNet.Interactive.Http/Model/HttpNamedRequest.cs
+++ b/src/Microsoft.DotNet.Interactive.Http/Model/HttpNamedRequest.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using Microsoft.DotNet.Interactive.Http.Parsing;
 using System;
 using System.Linq;
@@ -252,48 +253,33 @@ internal class HttpNamedRequest
 
     private static object? ResolveJsonPath(JsonNode responseJSON, string[] path, int currentIndex)
     {
+        JsonNode? newResponseJSON = null;
         if (currentIndex + 1 == path.Length)
         {
+           
             switch (responseJSON)
             {
                 case JsonArray jsonArray:
                     var node = jsonArray.FirstOrDefault(n => n?[path[currentIndex]] != null);
                     return node?[path[currentIndex]]?.ToString();
                 case JsonObject jsonObject:
-                    return jsonObject[path[currentIndex]]?.ToString();
+                    return EvaluatePathAtIndex(jsonObject, path, currentIndex)?.ToString();
                 default:
                     return responseJSON.ToString();
             }
         }
 
-        JsonNode? newResponseJSON = null;
         try
         {
             if (responseJSON is JsonObject j)
             {
-
-                var pathMatch = arrayRegex.Match(path[currentIndex]);
-                if (pathMatch.Success)
-                {
-
-                    // Extract the array name and index
-                    string arrayName = pathMatch.Groups[1].Value;
-                    string indexString = pathMatch.Groups[2].Value;
-
-                    // Cast the index from string to int
-                    int index = int.Parse(indexString);
-
-                    newResponseJSON = j[arrayName][index];
-                } 
-                else
-                {
-                    newResponseJSON = j[path[currentIndex]];
-                }
+                newResponseJSON = EvaluatePathAtIndex(j, path, currentIndex);
             }
             else
             {
                 newResponseJSON = responseJSON[path[currentIndex]];
-            }
+            } 
+                
 
         }
         catch (InvalidOperationException)
@@ -310,6 +296,43 @@ internal class HttpNamedRequest
             return ResolveJsonPath(newResponseJSON, path, currentIndex + 1);
         }
 
+    }
+
+    private static JsonNode? EvaluatePathAtIndex(JsonObject responseJSON, string[] path, int currentIndex)
+    {
+
+        var pathMatch = arrayRegex.Match(path[currentIndex]);
+        if (pathMatch.Success)
+        {
+
+            // Extract the array name and index
+            string arrayName = pathMatch.Groups[1].Value;
+            string indexString = pathMatch.Groups[2].Value;
+
+            // Cast the index from string to int
+            if (int.TryParse(indexString, out var index))
+            {
+                try
+                {
+                    return responseJSON?[arrayName]?[index];
+                } 
+                catch
+                {
+                    return null;
+                }
+                
+            }
+            else
+            {
+                return null;
+            }
+
+        }
+        else
+        {
+           return responseJSON[path[currentIndex]];
+        }
+        
     }
 
     internal static class SyntaxDepth


### PR DESCRIPTION
This PR adds support for resolving JSON path information in named requests by adding a regex pattern and identifying if the users is trying to access and an array explicitly and handling that case. 