### PR TITLE
Metadata handling improvements

### DIFF
--- a/NotebookTestScript.ipynb
+++ b/NotebookTestScript.ipynb
@@ -958,11 +958,12 @@
      "name": "fsharp"
     },
     {
-     "aliases": [
-      "powershell"
-     ],
-     "languageName": "PowerShell",
-     "name": "pwsh"
+     "languageName": "HTML",
+     "name": "html"
+    },
+    {
+     "languageName": "HTTP",
+     "name": "http"
     },
     {
      "aliases": [
@@ -970,14 +971,6 @@
      ],
      "languageName": "JavaScript",
      "name": "javascript"
-    },
-    {
-     "languageName": "HTML",
-     "name": "html"
-    },
-    {
-     "languageName": "SQL",
-     "name": "sql"
     },
     {
      "languageName": "KQL",
@@ -988,13 +981,25 @@
      "name": "mermaid"
     },
     {
-     "languageName": "HTTP",
-     "name": "http"
+     "aliases": [
+      "powershell"
+     ],
+     "languageName": "PowerShell",
+     "name": "pwsh"
+    },
+    {
+     "languageName": "SQL",
+     "name": "sql"
     },
     {
      "name": "value"
     }
    ]
+  },
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
   },
   "language_info": {
    "name": "csharp"

--- a/src/Microsoft.DotNet.Interactive/Kernel.cs
+++ b/src/Microsoft.DotNet.Interactive/Kernel.cs
@@ -989,7 +989,6 @@ public abstract partial class Kernel :
             return true;
         }
 
-
         return false;
     }
 

--- a/src/polyglot-notebooks-vscode-common/src/metadataUtilities.ts
+++ b/src/polyglot-notebooks-vscode-common/src/metadataUtilities.ts
@@ -107,7 +107,7 @@ export function getNotebookDocumentMetadataFromInteractiveDocument(interactiveDo
     }
 
     notebookMetadata.kernelInfo.items = notebookMetadata.kernelInfo.items.map(item => ensureProperShapeForDocumentKernelInfo(item));
-    cleanupMedata(notebookMetadata);
+    cleanUpMetadata(notebookMetadata);
     return notebookMetadata;
 }
 
@@ -170,7 +170,7 @@ export function getNotebookDocumentMetadataFromNotebookDocument(document: vscode
     }
 
     notebookMetadata.kernelInfo.items = notebookMetadata.kernelInfo.items.map(item => ensureProperShapeForDocumentKernelInfo(item));
-    cleanupMedata(notebookMetadata);
+    cleanUpMetadata(notebookMetadata);
     return notebookMetadata;
 }
 
@@ -178,7 +178,7 @@ export function getNotebookDocumentMetadataFromCompositeKernel(kernel: Composite
     const notebookMetadata = createDefaultNotebookDocumentMetadata();
     notebookMetadata.kernelInfo.defaultKernelName = kernel.defaultKernelName ?? notebookMetadata.kernelInfo.defaultKernelName;
     notebookMetadata.kernelInfo.items = kernel.childKernels.sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0).filter(k => k.supportsCommand(commandsAndEvents.SubmitCodeType)).map(k => ({ name: k.name, aliases: k.kernelInfo.aliases, languageName: k.kernelInfo.languageName }));
-    cleanupMedata(notebookMetadata);
+    cleanUpMetadata(notebookMetadata);
     return notebookMetadata;
 }
 
@@ -277,20 +277,13 @@ export function getKernelspecMetadataFromNotebookDocumentMetadata(notebookDocume
 }
 
 export function createNewIpynbMetadataWithNotebookDocumentMetadata(existingMetadata: { [key: string]: any }, notebookDocumentMetadata: NotebookDocumentMetadata): { [key: string]: any } {
+    // FIX Why does this add the polyglot_notebook node as a sibling of the metadata node?
     const resultMetadata: { [key: string]: any } = { ...existingMetadata };
-
-    // FIX: "custom" actually means just the bucket of things we don't persist, and therefore should not cause the document dirty state to be set
-
-    // kernelspec
     const kernelspec = getKernelspecMetadataFromNotebookDocumentMetadata(notebookDocumentMetadata);
-    resultMetadata.metadata = resultMetadata.metadata ?? {};
-    resultMetadata.metadata.kernelspec = kernelspec;
-    resultMetadata.metadata.polyglot_notebook = notebookDocumentMetadata;
+    // resultMetadata.metadata = resultMetadata.metadata ?? {};
+    // resultMetadata.metadata.kernelspec = kernelspec;
+    // resultMetadata.metadata.polyglot_notebook = notebookDocumentMetadata;
     return resultMetadata;
-}
-
-export function getRawInteractiveDocumentElementMetadataFromNotebookCellMetadata(notebookCellMetadata: NotebookCellMetadata): { [key: string]: any } {
-    return notebookCellMetadata;
 }
 
 export function getRawNotebookCellMetadataFromNotebookCellMetadata(notebookCellMetadata: NotebookCellMetadata): { [key: string]: any } {
@@ -298,16 +291,14 @@ export function getRawNotebookCellMetadataFromNotebookCellMetadata(notebookCellM
         metadata: {
             // this is the canonical metadata
             polyglot_notebook: notebookCellMetadata,
+
+            // FIX Is this still needed?
             // this is to maintain backwards compatibility for a while
             dotnet_interactive: {
                 language: notebookCellMetadata.kernelName
             }
         }
     };
-}
-
-export function getRawInteractiveDocumentMetadataFromNotebookDocumentMetadata(notebookDocumentMetadata: NotebookDocumentMetadata): { [key: string]: any } {
-    return notebookDocumentMetadata;
 }
 
 export function getMergedRawNotebookDocumentMetadataFromNotebookDocumentMetadata(notebookDocumentMetadata: NotebookDocumentMetadata, documentRawMetadata: { [key: string]: any }, createForIpynb: boolean): { [key: string]: any } {
@@ -468,7 +459,7 @@ export function mergeNotebookDocumentMetadata(baseMetadata: NotebookDocumentMeta
     }
 
     resultMetadata.kernelInfo.items = [...kernelInfoItems.values()];
-    cleanupMedata(resultMetadata);
+    cleanUpMetadata(resultMetadata);
     return sortInPlace(resultMetadata);
 }
 
@@ -543,7 +534,7 @@ export function areEquivalentObjects(object1: { [key: string]: any }, object2: {
     return true;
 }
 
-function cleanupMedata(notebookMetadata: NotebookDocumentMetadata) {
+function cleanUpMetadata(notebookMetadata: NotebookDocumentMetadata) {
     notebookMetadata.kernelInfo.items.forEach(ki => {
         if (ki.languageName === undefined || ki.languageName === null) {
             delete ki.languageName;

--- a/src/polyglot-notebooks-vscode-common/src/notebookControllers.ts
+++ b/src/polyglot-notebooks-vscode-common/src/notebookControllers.ts
@@ -411,19 +411,10 @@ async function updateKernelInfoMetadata(client: InteractiveClient, document: vsc
         }
     });
 
-    const notebookDocumentMetadata = metadataUtilities.getNotebookDocumentMetadataFromNotebookDocument(document);
-    const kernelNotebokMetadata = metadataUtilities.getNotebookDocumentMetadataFromCompositeKernel(client.kernel);
-    const mergedMetadata = metadataUtilities.mergeNotebookDocumentMetadata(notebookDocumentMetadata, kernelNotebokMetadata);
-    const rawNotebookDocumentMetadata = metadataUtilities.getMergedRawNotebookDocumentMetadataFromNotebookDocumentMetadata(mergedMetadata, document.metadata, isIpynb);
-
-    if (isIpynb) {
-        if (!rawNotebookDocumentMetadata.language_info) {
-            rawNotebookDocumentMetadata.language_info = { name: "polyglot-notebook" };
-        } else {
-            rawNotebookDocumentMetadata.language_info.name = "polyglot-notebook";
-        }
+    if (isIpynb &&
+        !document.metadata.metadata.language_info) {
+        document.metadata.metadata.language_info = { name: "polyglot-notebook" };
     }
-    await vscodeNotebookManagement.replaceNotebookMetadata(document.uri, rawNotebookDocumentMetadata);
 }
 
 export function endExecution(client: InteractiveClient | undefined, cell: vscode.NotebookCell, success: boolean) {
@@ -460,6 +451,8 @@ function generateVsCodeNotebookCellOutputItem(data: Uint8Array, mime: string, st
 
 async function updateDocumentKernelspecMetadata(document: vscode.NotebookDocument): Promise<void> {
     const documentMetadata = metadataUtilities.getNotebookDocumentMetadataFromNotebookDocument(document);
-    const newMetadata = metadataUtilities.createNewIpynbMetadataWithNotebookDocumentMetadata(document.metadata, documentMetadata);
+    const newMetadata = metadataUtilities.createNewIpynbMetadataWithNotebookDocumentMetadata(
+        document.metadata,
+        documentMetadata);
     await vscodeNotebookManagement.replaceNotebookMetadata(document.uri, newMetadata);
 }

--- a/src/polyglot-notebooks-vscode-common/src/notebookSerializers.ts
+++ b/src/polyglot-notebooks-vscode-common/src/notebookSerializers.ts
@@ -50,10 +50,9 @@ async function serializeNotebookByType(parserServer: NotebookParserServer, seria
         metadata: data.metadata ?? {}
     };
     const notebookMetadata = metadataUtilities.getNotebookDocumentMetadataFromNotebookDocument(fakeNotebookDocument);
-    const rawInteractiveDocumentNotebookMetadata = metadataUtilities.getRawInteractiveDocumentMetadataFromNotebookDocumentMetadata(notebookMetadata);
     const interactiveDocument: commandsAndEvents.InteractiveDocument = {
         elements: data.cells.map(toInteractiveDocumentElement),
-        metadata: rawInteractiveDocumentNotebookMetadata
+        metadata: notebookMetadata
     };
     const rawData = await parserServer.serializeNotebook(serializationType, eol, interactiveDocument);
     return rawData;

--- a/src/polyglot-notebooks-vscode-common/src/stdioDotnetInteractiveChannel.ts
+++ b/src/polyglot-notebooks-vscode-common/src/stdioDotnetInteractiveChannel.ts
@@ -135,10 +135,6 @@ export class StdioDotnetInteractiveChannel implements DotnetInteractiveChannel {
             this._receiverSubject.next(event);
 
         } else if (isKernelCommandEnvelopeModel(envelope)) {
-            // TODO: pass in context with shortcut methods for publish, etc.
-            // TODO: wrap and return succeed/failed
-            // TODO: publish succeeded
-            // TODO: publish failed
             const command = KernelCommandEnvelope.fromJson(envelope);
             this._receiverSubject.next(command);
         }

--- a/src/polyglot-notebooks-vscode-common/src/utilities.ts
+++ b/src/polyglot-notebooks-vscode-common/src/utilities.ts
@@ -210,7 +210,7 @@ export function createUri(fsPath: string, scheme?: string): Uri {
     };
 }
 
-export function getWorkingDirectoryForNotebook(notebookUri: Uri, workspaceFolderUris: Uri[], fallackWorkingDirectory: string): string {
+export function getWorkingDirectoryForNotebook(notebookUri: Uri, workspaceFolderUris: Uri[], fallbackWorkingDirectory: string): string {
     switch (notebookUri.scheme) {
         case 'file':
             // local file, use it's own directory
@@ -218,10 +218,10 @@ export function getWorkingDirectoryForNotebook(notebookUri: Uri, workspaceFolder
         case 'untitled':
             // unsaved notebook, use first local workspace folder
             const firstLocalWorkspaceFolderUri = workspaceFolderUris.find(uri => uri.scheme === 'file');
-            return firstLocalWorkspaceFolderUri?.fsPath ?? fallackWorkingDirectory;
+            return firstLocalWorkspaceFolderUri?.fsPath ?? fallbackWorkingDirectory;
         default:
             // something else (e.g., remote notebook), use fallback
-            return fallackWorkingDirectory;
+            return fallbackWorkingDirectory;
     }
 }
 

--- a/src/polyglot-notebooks-vscode-common/src/vscodeNotebookManagement.ts
+++ b/src/polyglot-notebooks-vscode-common/src/vscodeNotebookManagement.ts
@@ -31,13 +31,13 @@ export async function replaceNotebookCellMetadata(notebookUri: vscode.Uri, cellI
     return succeeded;
 }
 
-export async function replaceNotebookMetadata(notebookUri: vscode.Uri, documentMetadata: { [key: string]: any }): Promise<boolean> {
+export async function replaceNotebookMetadata(notebookUri: vscode.Uri, documentMetadata: { [key: string]: any }): Promise<void> {
     const notebook = vscode.workspace.notebookDocuments.find(d => d.uri === notebookUri);
     if (notebook) {
         const metadata = notebook.metadata;
         const keysToIngore = new Set<string>();
         if (!isIpynbNotebook(notebook)) {
-            // dib format doesn't use the proeprty 'custom' so this should not be involved in the diff.
+            // dib format doesn't use the property 'custom' so this should not be involved in the diff.
             keysToIngore.add("custom");
         }
         const shouldUpdate = !areEquivalentObjects(metadata, documentMetadata, keysToIngore);
@@ -47,11 +47,8 @@ export async function replaceNotebookMetadata(notebookUri: vscode.Uri, documentM
             const edit = new vscode.WorkspaceEdit();
             edit.set(notebookUri, [notebookEdit]);
             const succeeded = await vscode.workspace.applyEdit(edit);
-            return succeeded;
         }
-        return false;
     }
-    return false;
 }
 
 export async function handleCustomInputRequest(prompt: string, inputTypeHint: string, password: boolean): Promise<{ handled: boolean, result: string | null | undefined }> {

--- a/src/polyglot-notebooks-vscode-common/tests/metadataUtilities.test.ts
+++ b/src/polyglot-notebooks-vscode-common/tests/metadataUtilities.test.ts
@@ -76,16 +76,16 @@ describe(`metadata utility tests`, async () => {
 
     it("cell metadata can be extracted from an interactive document element with old metadata", () => {
         const interactiveDocumentElement: commandsAndEvents.InteractiveDocumentElement =
-            {
-                contents: "",
-                outputs: [],
-                executionOrder: 0,
-                metadata: {
-                    dotnet_interactive: {
-                        language: "fsharp",
-                    },
+        {
+            contents: "",
+            outputs: [],
+            executionOrder: 0,
+            metadata: {
+                dotnet_interactive: {
+                    language: "fsharp",
                 },
-            };
+            },
+        };
         const notebookCellMetadata =
             metadataUtilities.getNotebookCellMetadataFromInteractiveDocumentElement(
                 interactiveDocumentElement
@@ -97,16 +97,16 @@ describe(`metadata utility tests`, async () => {
 
     it("cell metadata can be extracted from an interactive document element", () => {
         const interactiveDocumentElement: commandsAndEvents.InteractiveDocumentElement =
-            {
-                contents: "",
-                outputs: [],
-                executionOrder: 0,
-                metadata: {
-                    polyglot_notebook: {
-                        kernelName: "fsharp",
-                    },
+        {
+            contents: "",
+            outputs: [],
+            executionOrder: 0,
+            metadata: {
+                polyglot_notebook: {
+                    kernelName: "fsharp",
                 },
-            };
+            },
+        };
         const notebookCellMetadata =
             metadataUtilities.getNotebookCellMetadataFromInteractiveDocumentElement(
                 interactiveDocumentElement
@@ -156,15 +156,10 @@ describe(`metadata utility tests`, async () => {
         });
     });
 
-    it("cell metadata can be extracted from a notebook cell", () => {});
-
     it("notebook metadata can be extracted from an interactive document", () => {
         const interactiveDocument: commandsAndEvents.InteractiveDocument = {
             elements: [],
             metadata: {
-                custom: {
-                    name: "some value",
-                },
                 kernelInfo: {
                     defaultKernelName: "fsharp",
                     items: [
@@ -202,9 +197,6 @@ describe(`metadata utility tests`, async () => {
                 scheme: "file",
             },
             metadata: {
-                custom: {
-                    name: "some value",
-                },
                 polyglot_notebook: {
                     kernelInfo: {
                         defaultKernelName: "fsharp",
@@ -382,12 +374,12 @@ describe(`metadata utility tests`, async () => {
 
     it("kernelspec metadata can be created from notebook document metadata (C#)", () => {
         const notebookDocumentMetadata: metadataUtilities.NotebookDocumentMetadata =
-            {
-                kernelInfo: {
-                    defaultKernelName: "csharp",
-                    items: [],
-                },
-            };
+        {
+            kernelInfo: {
+                defaultKernelName: "csharp",
+                items: [],
+            },
+        };
         const kernelspecMetadata =
             metadataUtilities.getKernelspecMetadataFromNotebookDocumentMetadata(
                 notebookDocumentMetadata
@@ -401,12 +393,12 @@ describe(`metadata utility tests`, async () => {
 
     it("kernelspec metadata can be created from notebook document metadata (F#)", () => {
         const notebookDocumentMetadata: metadataUtilities.NotebookDocumentMetadata =
-            {
-                kernelInfo: {
-                    defaultKernelName: "fsharp",
-                    items: [],
-                },
-            };
+        {
+            kernelInfo: {
+                defaultKernelName: "fsharp",
+                items: [],
+            },
+        };
         const kernelspecMetadata =
             metadataUtilities.getKernelspecMetadataFromNotebookDocumentMetadata(
                 notebookDocumentMetadata
@@ -420,12 +412,12 @@ describe(`metadata utility tests`, async () => {
 
     it("kernelspec metadata can be created from notebook document metadata (PowerShell)", () => {
         const notebookDocumentMetadata: metadataUtilities.NotebookDocumentMetadata =
-            {
-                kernelInfo: {
-                    defaultKernelName: "pwsh",
-                    items: [],
-                },
-            };
+        {
+            kernelInfo: {
+                defaultKernelName: "pwsh",
+                items: [],
+            },
+        };
         const kernelspecMetadata =
             metadataUtilities.getKernelspecMetadataFromNotebookDocumentMetadata(
                 notebookDocumentMetadata
@@ -536,11 +528,8 @@ describe(`metadata utility tests`, async () => {
         const notebookCellMetadata: metadataUtilities.NotebookCellMetadata = {
             kernelName: "fsharp",
         };
-        const interactiveDocumentElementMetadata =
-            metadataUtilities.getRawInteractiveDocumentElementMetadataFromNotebookCellMetadata(
-                notebookCellMetadata
-            );
-        expect(interactiveDocumentElementMetadata).to.deep.equal({
+
+        expect(notebookCellMetadata).to.deep.equal({
             kernelName: "fsharp",
         });
     });
@@ -567,28 +556,25 @@ describe(`metadata utility tests`, async () => {
 
     it("interactive document metadata can be created from notebook metadata", () => {
         const notebookDocumentMetadata: metadataUtilities.NotebookDocumentMetadata =
-            {
-                kernelInfo: {
-                    defaultKernelName: "fsharp",
-                    items: [
-                        {
-                            name: "fsharp",
-                            aliases: ["fs"],
-                            languageName: "fsharp",
-                        },
-                        {
-                            name: "csharp",
-                            aliases: ["cs"],
-                            languageName: "csharp",
-                        },
-                    ],
-                },
-            };
-        const interactiveDocumentMetadata =
-            metadataUtilities.getRawInteractiveDocumentMetadataFromNotebookDocumentMetadata(
-                notebookDocumentMetadata
-            );
-        expect(interactiveDocumentMetadata).to.deep.equal({
+        {
+            kernelInfo: {
+                defaultKernelName: "fsharp",
+                items: [
+                    {
+                        name: "fsharp",
+                        aliases: ["fs"],
+                        languageName: "fsharp",
+                    },
+                    {
+                        name: "csharp",
+                        aliases: ["cs"],
+                        languageName: "csharp",
+                    },
+                ],
+            },
+        };
+
+        expect(notebookDocumentMetadata).to.deep.equal({
             kernelInfo: {
                 defaultKernelName: "fsharp",
                 items: [
@@ -601,23 +587,23 @@ describe(`metadata utility tests`, async () => {
 
     it("notebook document metadata can be created from notebook metadata for ipynb", () => {
         const notebookDocumentMetadata: metadataUtilities.NotebookDocumentMetadata =
-            {
-                kernelInfo: {
-                    defaultKernelName: "fsharp",
-                    items: [
-                        {
-                            name: "csharp",
-                            aliases: ["cs"],
-                            languageName: "csharp",
-                        },
-                        {
-                            name: "fsharp",
-                            aliases: ["fs"],
-                            languageName: "fsharp",
-                        },
-                    ],
-                },
-            };
+        {
+            kernelInfo: {
+                defaultKernelName: "fsharp",
+                items: [
+                    {
+                        name: "csharp",
+                        aliases: ["cs"],
+                        languageName: "csharp",
+                    },
+                    {
+                        name: "fsharp",
+                        aliases: ["fs"],
+                        languageName: "fsharp",
+                    },
+                ],
+            },
+        };
         const rawNotebookDocumentMetadata =
             metadataUtilities.getMergedRawNotebookDocumentMetadataFromNotebookDocumentMetadata(
                 notebookDocumentMetadata,
@@ -655,23 +641,23 @@ describe(`metadata utility tests`, async () => {
 
     it("notebook document metadata can be created from notebook metadata for dib", () => {
         const notebookDocumentMetadata: metadataUtilities.NotebookDocumentMetadata =
-            {
-                kernelInfo: {
-                    defaultKernelName: "fsharp",
-                    items: [
-                        {
-                            name: "csharp",
-                            aliases: ["cs"],
-                            languageName: "csharp",
-                        },
-                        {
-                            name: "fsharp",
-                            aliases: ["fs"],
-                            languageName: "fsharp",
-                        },
-                    ],
-                },
-            };
+        {
+            kernelInfo: {
+                defaultKernelName: "fsharp",
+                items: [
+                    {
+                        name: "csharp",
+                        aliases: ["cs"],
+                        languageName: "csharp",
+                    },
+                    {
+                        name: "fsharp",
+                        aliases: ["fs"],
+                        languageName: "fsharp",
+                    },
+                ],
+            },
+        };
         const rawNotebookDocumentMetadata =
             metadataUtilities.getMergedRawNotebookDocumentMetadataFromNotebookDocumentMetadata(
                 notebookDocumentMetadata,
@@ -733,19 +719,19 @@ describe(`metadata utility tests`, async () => {
             },
         };
         const metadataWithNewValues: metadataUtilities.NotebookDocumentMetadata =
-            {
-                kernelInfo: {
-                    defaultKernelName:
-                        "original default kernel name will be retained",
-                    items: [
-                        {
-                            name: "csharp",
-                            aliases: ["cs"],
-                            languageName: "csharp",
-                        },
-                    ],
-                },
-            };
+        {
+            kernelInfo: {
+                defaultKernelName:
+                    "original default kernel name will be retained",
+                items: [
+                    {
+                        name: "csharp",
+                        aliases: ["cs"],
+                        languageName: "csharp",
+                    },
+                ],
+            },
+        };
         const resultMetadata = metadataUtilities.mergeNotebookDocumentMetadata(
             baseMetadata,
             metadataWithNewValues


### PR DESCRIPTION
These changes fix the following issues:

* #3544
* #3576 for .ipynb files. I'm still looking for the root cause of this same issue for .dib files.

This is a work in progress and additional PRs will continue to investigate and address some of the `FIX` comments present here but this is likely worth merging in order to do a preview release and validate the changes against a larger number of existing notebook documents than the tests likely account for. I anticipate that some of these changes will break backwards compatibility for metadata variations that date back to before the VS Code notebook APIs were finalized. I don't believe it's practical to support those forever, and any notebooks that are broken as a result will at this point be far fewer than the impact of these bugs on newer and newly-created notebooks.