### PR TITLE
Pipeline consolidation (on latest main)

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -37,25 +37,7 @@ schedules:
     - main
 
 variables:
-- name: _TeamName
-  value: DotNetInteractive
-- name: _BuildConfig
-  value: Release
-- name: _PublishUsingPipelines
-  value: true
-- name: _DotNetArtifactsCategory
-  value: .NETCore
-- name: DisableDockerDetector
-  value: true
-- name: NodeJSVersion
-  value: '16.13.0'
-- name: LocPRCreationEnabled
-  value: ${{ eq(variables['Build.Reason'], 'Schedule') }}
-- name: Codeql.Enabled
-  value: true
-- name: _DotNetValidationArtifactsCategory
-  value: .NETCoreValidation
-- group: DotNet-Interactive-SDLValidation-Params
+- template: /eng/templates/variables-template.yml@self
 - template: /eng/common/templates-official/variables/pool-providers.yml@self
 
 resources:
@@ -154,85 +136,10 @@ extends:
             - checkout: self
               clean: true
 
-              # Azure DevOps doesn't support git symlinks on Windows so we have to fake it
-            - pwsh: . "$(Build.SourcesDirectory)\src\ensure-symlinks.ps1"
-              displayName: ensure symlinks
-
-            - task: NodeTool@0
-              displayName: Add NodeJS/npm
-              inputs:
-                versionSpec: $(NodeJSVersion)
-
-            - script: |
-                robocopy "eng\resources" "$(Build.SourcesDirectory)\artifacts"
-                :: robocopy return codes are terrible; 1 means files were copied
-                if "%errorlevel%" == "1" exit /b 0
-                exit /b 1
-              displayName: Prevent test directory crawling
-
-            - pwsh: |
-                $testArg = if ($env:SKIPTESTS -ne "true") { "-test" } else { "" }
-                Write-Host "##vso[task.setvariable variable=_TestArgs]$testArg"
-              displayName: Promote variables
-
-            - script: eng\CIBuild.cmd
-                -configuration $(_BuildConfig)
-                -prepareMachine
-                -sign
-                $(_BuildArgs)
-                $(_TestArgs)
-              displayName: Build
-              env:
-                POCKETLOGGER_LOG_PATH: $(Build.SourcesDirectory)\artifacts\TestResults\$(_BuildConfig)\pocketlogger.test.log
-                DOTNET_INTERACTIVE_FRONTEND_NAME: CI
-
-            - pwsh: ./test-retry-runner.ps1 -buildConfig $env:BUILDCONFIG
-              displayName: Test / Blame
-              workingDirectory: $(Build.SourcesDirectory)
-              env:
-                BUILDCONFIG: $(_BuildConfig)
-                POCKETLOGGER_LOG_PATH: $(Build.SourcesDirectory)\artifacts\TestResults\$(_BuildConfig)\pocketlogger.test.log
-              condition: ne(variables['SkipTests'], 'true')
-
-              # publish VS Code and npm test results
-            - task: PublishTestResults@2
-              displayName: Publish VS Code extension and npm test results
-              inputs:
-                testResultsFormat: VSTest
-                testResultsFiles: '**/*.*'
-                searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
-              condition: always()
-
-            - task: PowerShell@2
-              displayName: Pack VS Code Extensions
-              inputs:
-                filePath: $(Build.SourcesDirectory)/eng/package/PackVSCodeExtension.ps1
-                arguments: -stableToolVersionNumber $(StableToolVersionNumber) -outDir "$(Build.ArtifactStagingDirectory)\vscode"
-                workingDirectory: "$(Build.SourcesDirectory)/src"
-                pwsh: true
-
-            - task: PowerShell@2
-              displayName: Pack NPM package
-              inputs:
-                filePath: $(Build.SourcesDirectory)/eng/package/PackNpmPackage.ps1
-                arguments: -packageVersionNumber $(StableToolVersionNumber) -outDir "$(Build.ArtifactStagingDirectory)\npm"
-                workingDirectory: "$(Build.SourcesDirectory)/src/polyglot-notebooks"
-                pwsh: true
-
-            - task: CopyFiles@2
-              displayName: Copy artifacts to $(Build.ArtifactStagingDirectory)\artifacts
-              inputs:
-                SourceFolder: 'artifacts'
-                Contents: |
-                  TestResults\**
-                  packages\**
-                TargetFolder: '$(Build.ArtifactStagingDirectory)\artifacts'
-              condition: succeededOrFailed()
-
-            # Prevent symbols packages from being saved in the following `packages` artifact because they're incomplete.
-            # See `eng/AfterSolutionBuild.targets:StripFilesFromSymbolPackages` for details.
-            - script: del /S $(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)\*.symbols.nupkg
-              displayName: Clean symbol packages
+              # Use common task group
+            - template: /eng/templates/build-and-test-tasks.yml@self
+              parameters:
+                platform: windows
 
       - template: /eng/common/templates-official/jobs/jobs.yml@self
         parameters:
@@ -258,89 +165,20 @@ extends:
                   publishLocation: Container
 
             steps:
-            - script: git config --global core.longpaths true
-              displayName: Enable `git clean` to handle long paths
-
             - checkout: self
               clean: true
 
-            - task: NodeTool@0
-              displayName: Add NodeJS/npm
-              inputs:
-                versionSpec: $(NodeJSVersion)
-
-            - script: |
-                mkdir -p "$(Build.SourcesDirectory)/artifacts"
-                rm -rf "$(Build.SourcesDirectory)/artifacts/*"
-                cp eng/resources/* "$(Build.SourcesDirectory)/artifacts"
-              displayName: Prevent test directory crawling
-
-            - pwsh: |
-                $testArg = if ($env:SKIPTESTS -ne "true") { "--test" } else { "" }
-                Write-Host "##vso[task.setvariable variable=_TestArgs]$testArg"
-              displayName: Promote variables
-
-            - script: ./eng/cibuild.sh
-                --configuration $(_BuildConfig)
-                --prepareMachine
-                $(_TestArgs)
-              displayName: Run tests
-              env:
-                POCKETLOGGER_LOG_PATH: $(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)/pocketlogger.test.log
-                DOTNET_INTERACTIVE_FRONTEND_NAME: CI
-
-            - pwsh: ./test-retry-runner.ps1 -buildConfig $env:BUILDCONFIG
-              displayName: Test / Blame
-              workingDirectory: $(Build.SourcesDirectory)
-              env:
-                BUILDCONFIG: $(_BuildConfig)
-                POCKETLOGGER_LOG_PATH: $(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)/pocketlogger.test.log
-              condition: ne(variables['SkipTests'], 'true')
-
-              # publish VS Code and npm test results
-            - task: PublishTestResults@2
-              displayName: Publish VS Code extension and npm test results
-              inputs:
-                testResultsFormat: VSTest
-                testResultsFiles: '**/*.*'
-                searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
-              condition: always()
+            # Use common task group
+            - template: /eng/templates/build-and-test-tasks.yml@self
+              parameters:
+                platform: linux
 
     #---------------------------------------------------------------------------------------------------------------------#
     #                                                    Post Build                                                       #
     #---------------------------------------------------------------------------------------------------------------------#
-    - template: /eng/common/templates-official/post-build/post-build.yml@self
-      parameters:
-        publishingInfraVersion: 3
-        # signing validation currently has issues with dotnet 7; disabling as per internal guidance
-        enableSigningValidation: false
-        # Symbol validation is not entirely reliable as of yet, so should be turned off until https://github.com/dotnet/arcade/issues/2871 is resolved.
-        enableSymbolValidation: false
-        # SourceLink improperly looks for generated files.  See https://github.com/dotnet/arcade/issues/3069
-        enableSourceLinkValidation: false
-        # Enable SDL validation, passing through values from the 'DotNet-FSharp-SDLValidation-Params' group.
-        SDLValidationParameters:
-          enable: true
-          params: >-
-            -SourceToolsList @("policheck","credscan")
-            -TsaInstanceURL $(_TsaInstanceURL)
-            -TsaProjectName $(_TsaProjectName)
-            -TsaNotificationEmail $(_TsaNotificationEmail)
-            -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
-            -TsaBugAreaPath $(_TsaBugAreaPath)
-            -TsaIterationPath $(_TsaIterationPath)
-            -TsaRepositoryName "Interactive"
-            -TsaCodebaseName "Interactive-GitHub"
-            -TsaPublish $True
-            -PoliCheckAdditionalRunConfigParams @("UserExclusionPath < $(Build.SourcesDirectory)/eng/policheck_exclusions.xml")
+    - template: /eng/templates/post-build-tasks.yml@self
   
     #---------------------------------------------------------------------------------------------------------------------#
     #                                                    NPM Publish                                                      #
     #---------------------------------------------------------------------------------------------------------------------#
-    - template: /eng/publish/publish-npm.yml@self
-      parameters:
-        packageName: microsoft-polyglot-notebooks-*.tgz
-        registryUrl: pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/npm/registry/
-        registryUser: dnceng
-        registryEmail: dnceng@microsoft.com
-        publishingBranch: main
+    - template: /eng/templates/npm-publish-tasks.yml@self

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,27 +62,9 @@ schedules:
 
 # Variables
 variables:
-  - name: _TeamName
-    value: DotNetInteractive
-  - name: _BuildConfig
-    value: Release
-  - name: _PublishUsingPipelines
-    value: true
-  - name: _DotNetArtifactsCategory
-    value: .NETCore
-  - name: DisableDockerDetector
-    value: true
-  - name: NodeJSVersion
-    value: '16.13.0'
-  - name: LocPRCreationEnabled
-    value: ${{ eq(variables['Build.Reason'], 'Schedule') }}
-  - name: Codeql.Enabled
-    value: true
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - name: _DotNetValidationArtifactsCategory
-      value: .NETCoreValidation
-    - group: DotNet-Interactive-SDLValidation-Params
-  - template: /eng/common/templates/variables/pool-providers.yml
+- template: /eng/templates/variables-template.yml@self
+- template: /eng/common/templates/variables/pool-providers.yml@self
+
 
 stages:
 - stage: build
@@ -105,6 +87,7 @@ stages:
       enablePublishTestResults: true
       enablePublishBuildAssets: true
       enablePublishUsingPipelines: $(_PublishUsingPipelines)
+
       jobs:
       - job: Windows_NT
         pool:
@@ -138,59 +121,16 @@ stages:
             value: Test
           - name: _BuildArgs
             value: /p:SignType=$(_SignType)
+
         steps:
         - checkout: self
           clean: true
 
-        # Azure DevOps doesn't support git symlinks on Windows so we have to fake it
-        - pwsh: . "$(Build.SourcesDirectory)\src\ensure-symlinks.ps1"
-          displayName: ensure symlinks
-
-        - task: NodeTool@0
-          displayName: Add NodeJS/npm
-          inputs:
-            versionSpec: $(NodeJSVersion)
-
-        # - task: UseDotNet@2
-        #   displayName: Use .NET SDK
-        #   inputs:
-        #     packageType: sdk
-        #     useGlobalJson: true
-        #     includePreviewVersions: true
-        #     workingDirectory: $(Build.SourcesDirectory)
-        #     installationPath: $(Agent.ToolsDirectory)/dotnet
-
-        - script: |
-            robocopy "eng\resources" "$(Build.SourcesDirectory)\artifacts"
-            :: robocopy return codes are terrible; 1 means files were copied
-            if "%errorlevel%" == "1" exit /b 0
-            exit /b 1
-          displayName: Prevent test directory crawling
-
-        - pwsh: |
-            $testArg = if ($env:SKIPTESTS -ne "true") { "-test" } else { "" }
-            Write-Host "##vso[task.setvariable variable=_TestArgs]$testArg"
-          displayName: Promote variables
-
-        - script: eng\CIBuild.cmd
-            -configuration $(_BuildConfig)
-            -prepareMachine
-            -sign
-            $(_BuildArgs)
-            $(_TestArgs)
-          displayName: Build
-          env:
-            POCKETLOGGER_LOG_PATH: $(Build.SourcesDirectory)\artifacts\TestResults\$(_BuildConfig)\pocketlogger.test.log
-            DOTNET_INTERACTIVE_FRONTEND_NAME: CI
-
-        - pwsh: ./test-retry-runner.ps1 -buildConfig $env:BUILDCONFIG
-          displayName: Test / Blame
-          workingDirectory: $(Build.SourcesDirectory)
-          env:
-            BUILDCONFIG: $(_BuildConfig)
-            POCKETLOGGER_LOG_PATH: $(Build.SourcesDirectory)\artifacts\TestResults\$(_BuildConfig)\pocketlogger.test.log
-          condition: ne(variables['SkipTests'], 'true')
-
+        # Use common task group
+        - template: /eng/templates/build-and-test-tasks.yml@self
+          parameters:
+            platform: windows
+        
         - task: PublishBuildArtifacts@1
           displayName: Publish Test results and Blame dumps
           inputs:
@@ -199,38 +139,12 @@ stages:
             artifactType: container
           condition: always()
 
-        # publish VS Code and npm test results
-        - task: PublishTestResults@2
-          displayName: Publish VS Code extension and npm test results
-          inputs:
-            testResultsFormat: VSTest
-            testResultsFiles: '**/*.*'
-            searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
-          condition: always()
-
-        # pack and publish vscode and npm
-        - task: PowerShell@2
-          displayName: Pack VS Code Extensions
-          inputs:
-            filePath: $(Build.SourcesDirectory)/eng/package/PackVSCodeExtension.ps1
-            arguments: -stableToolVersionNumber $(StableToolVersionNumber) -outDir "$(Build.ArtifactStagingDirectory)\vscode"
-            workingDirectory: "$(Build.SourcesDirectory)/src"
-            pwsh: true
-
         - task: PublishBuildArtifacts@1
           displayName: Publish VSCode extension artifacts
           inputs:
             pathToPublish: $(Build.ArtifactStagingDirectory)\vscode
             artifactName: vscode
             artifactType: container
-
-        - task: PowerShell@2
-          displayName: Pack NPM package
-          inputs:
-            filePath: $(Build.SourcesDirectory)/eng/package/PackNpmPackage.ps1
-            arguments: -packageVersionNumber $(StableToolVersionNumber) -outDir "$(Build.ArtifactStagingDirectory)\npm"
-            workingDirectory: "$(Build.SourcesDirectory)/src/polyglot-notebooks"
-            pwsh: true
 
         - task: PublishBuildArtifacts@1
           displayName: Publish NPM package artifacts
@@ -239,17 +153,13 @@ stages:
             artifactName: npm
             artifactType: container
 
-        # Prevent symbols packages from being saved in the following `packages` artifact because they're incomplete.
-        # See `eng/AfterSolutionBuild.targets:StripFilesFromSymbolPackages` for details.
-        - script: del /S $(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)\*.symbols.nupkg
-          displayName: Clean symbol packages
-
         - task: PublishBuildArtifacts@1
           displayName: Publish packages to artifacts container
           inputs:
             pathToPublish: $(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)
             artifactName: packages
             artifactType: container
+
 
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
@@ -284,55 +194,16 @@ stages:
             value: Test
           - name: _BuildArgs
             value: /p:SignType=$(_SignType)
-        steps:
-        - script: git config --global core.longpaths true
-          displayName: Enable `git clean` to handle long paths
 
+        steps:
         - checkout: self
           clean: true
 
-        - task: NodeTool@0
-          displayName: Add NodeJS/npm
-          inputs:
-            versionSpec: $(NodeJSVersion)
-
-        # - task: UseDotNet@2
-        #   displayName: Use .NET SDK
-        #   inputs:
-        #     packageType: sdk
-        #     useGlobalJson: true
-        #     includePreviewVersions: true
-        #     workingDirectory: $(Build.SourcesDirectory)
-        #     installationPath: $(Agent.ToolsDirectory)/dotnet
-
-        - script: |
-            mkdir -p "$(Build.SourcesDirectory)/artifacts"
-            rm -rf "$(Build.SourcesDirectory)/artifacts/*"
-            cp eng/resources/* "$(Build.SourcesDirectory)/artifacts"
-          displayName: Prevent test directory crawling
-
-        - pwsh: |
-            $testArg = if ($env:SKIPTESTS -ne "true") { "--test" } else { "" }
-            Write-Host "##vso[task.setvariable variable=_TestArgs]$testArg"
-          displayName: Promote variables
-
-        - script: ./eng/cibuild.sh
-            --configuration $(_BuildConfig)
-            --prepareMachine
-            $(_TestArgs)
-          displayName: Build
-          env:
-            POCKETLOGGER_LOG_PATH: $(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)/pocketlogger.test.log
-            DOTNET_INTERACTIVE_FRONTEND_NAME: CI
-
-        - pwsh: ./test-retry-runner.ps1 -buildConfig $env:BUILDCONFIG
-          displayName: Test / Blame
-          workingDirectory: $(Build.SourcesDirectory)
-          env:
-            BUILDCONFIG: $(_BuildConfig)
-            POCKETLOGGER_LOG_PATH: $(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)/pocketlogger.test.log
-          condition: ne(variables['SkipTests'], 'true')
-
+        # Use common task group
+        - template: /eng/templates/build-and-test-tasks.yml@self
+          parameters:
+            platform: linux
+        
         - task: PublishBuildArtifacts@1
           displayName: Publish Test results and Blame dumps
           inputs:
@@ -341,52 +212,14 @@ stages:
             artifactType: container
           condition: always()
 
-        # publish VS Code and npm test results
-        - task: PublishTestResults@2
-          displayName: Publish VS Code extension and npm test results
-          inputs:
-            testResultsFormat: VSTest
-            testResultsFiles: '**/*.*'
-            searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
-          condition: always()
-
 #---------------------------------------------------------------------------------------------------------------------#
 #                                                    Post Build                                                       #
 #---------------------------------------------------------------------------------------------------------------------#
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: eng/common/templates/post-build/post-build.yml
-    parameters:
-      publishingInfraVersion: 3
-      # signing validation currently has issues with dotnet 7; disabling as per internal guidance
-      enableSigningValidation: false
-      # Symbol validation is not entirely reliable as of yet, so should be turned off until https://github.com/dotnet/arcade/issues/2871 is resolved.
-      enableSymbolValidation: false
-      # SourceLink improperly looks for generated files.  See https://github.com/dotnet/arcade/issues/3069
-      enableSourceLinkValidation: false
-      # Enable SDL validation, passing through values from the 'DotNet-FSharp-SDLValidation-Params' group.
-      SDLValidationParameters:
-        enable: true
-        params: >-
-          -SourceToolsList @("policheck","credscan")
-          -TsaInstanceURL $(_TsaInstanceURL)
-          -TsaProjectName $(_TsaProjectName)
-          -TsaNotificationEmail $(_TsaNotificationEmail)
-          -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
-          -TsaBugAreaPath $(_TsaBugAreaPath)
-          -TsaIterationPath $(_TsaIterationPath)
-          -TsaRepositoryName "Interactive"
-          -TsaCodebaseName "Interactive-GitHub"
-          -TsaPublish $True
-          -PoliCheckAdditionalRunConfigParams @("UserExclusionPath < $(Build.SourcesDirectory)/eng/policheck_exclusions.xml")
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - template: /eng/templates/post-build-tasks.yml@self
 
 #---------------------------------------------------------------------------------------------------------------------#
 #                                                    NPM Publish                                                      #
 #---------------------------------------------------------------------------------------------------------------------#
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: eng/publish/publish-npm.yml
-    parameters:
-      packageName: microsoft-polyglot-notebooks-*.tgz
-      registryUrl: pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/npm/registry/
-      registryUser: dnceng
-      registryEmail: dnceng@microsoft.com
-      publishingBranch: main
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - template: /eng/templates/npm-publish-tasks.yml@self

--- a/eng/templates/build-and-test-tasks.yml
+++ b/eng/templates/build-and-test-tasks.yml
@@ -1,0 +1,130 @@
+parameters:
+  platform: ''
+
+steps:
+- ${{ if eq(parameters.platform, 'windows') }}:
+  # Azure DevOps doesn't support git symlinks on Windows so we have to fake it
+  - pwsh: . "$(Build.SourcesDirectory)\src\ensure-symlinks.ps1"
+    displayName: ensure symlinks
+
+  - task: NodeTool@0
+    displayName: Add NodeJS/npm
+    inputs:
+      versionSpec: $(NodeJSVersion)
+
+  - script: |
+      robocopy "eng\resources" "$(Build.SourcesDirectory)\artifacts"
+      :: robocopy return codes are terrible; 1 means files were copied
+      if "%errorlevel%" == "1" exit /b 0
+      exit /b 1
+    displayName: Prevent test directory crawling
+
+  - pwsh: |
+      $testArg = if ($env:SKIPTESTS -ne "true") { "-test" } else { "" }
+      Write-Host "##vso[task.setvariable variable=_TestArgs]$testArg"
+    displayName: Promote variables
+
+  - script: eng\CIBuild.cmd
+      -configuration $(_BuildConfig)
+      -prepareMachine
+      -sign
+      $(_BuildArgs)
+      $(_TestArgs)
+    displayName: Build
+    env:
+      POCKETLOGGER_LOG_PATH: $(Build.SourcesDirectory)\artifacts\TestResults\$(_BuildConfig)\pocketlogger.test.log
+      DOTNET_INTERACTIVE_FRONTEND_NAME: CI
+
+  - pwsh: ./test-retry-runner.ps1 -buildConfig $env:BUILDCONFIG
+    displayName: Test / Blame
+    workingDirectory: $(Build.SourcesDirectory)
+    env:
+      BUILDCONFIG: $(_BuildConfig)
+      POCKETLOGGER_LOG_PATH: $(Build.SourcesDirectory)\artifacts\TestResults\$(_BuildConfig)\pocketlogger.test.log
+    condition: ne(variables['SkipTests'], 'true')
+
+  # publish VS Code and npm test results
+  - task: PublishTestResults@2
+    displayName: Publish VS Code extension and npm test results
+    inputs:
+      testResultsFormat: VSTest
+      testResultsFiles: '**/*.*'
+      searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
+    condition: always()
+
+  - task: PowerShell@2
+    displayName: Pack VS Code Extensions
+    inputs:
+      filePath: $(Build.SourcesDirectory)/eng/package/PackVSCodeExtension.ps1
+      arguments: -stableToolVersionNumber $(StableToolVersionNumber) -outDir "$(Build.ArtifactStagingDirectory)\vscode"
+      workingDirectory: "$(Build.SourcesDirectory)/src"
+      pwsh: true
+
+  - task: PowerShell@2
+    displayName: Pack NPM package
+    inputs:
+      filePath: $(Build.SourcesDirectory)/eng/package/PackNpmPackage.ps1
+      arguments: -packageVersionNumber $(StableToolVersionNumber) -outDir "$(Build.ArtifactStagingDirectory)\npm"
+      workingDirectory: "$(Build.SourcesDirectory)/src/polyglot-notebooks"
+      pwsh: true
+
+  - task: CopyFiles@2
+    displayName: Copy artifacts to $(Build.ArtifactStagingDirectory)\artifacts
+    inputs:
+      SourceFolder: 'artifacts'
+      Contents: |
+        TestResults\**
+        packages\**
+      TargetFolder: '$(Build.ArtifactStagingDirectory)\artifacts'
+    condition: succeededOrFailed()
+
+  # Prevent symbols packages from being saved in the following `packages` artifact because they're incomplete.
+  # See `eng/AfterSolutionBuild.targets:StripFilesFromSymbolPackages` for details.
+  - script: del /S $(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)\*.symbols.nupkg
+    displayName: Clean symbol packages
+
+- ${{ if eq(parameters.platform, 'linux') }}:
+  - script: git config --global core.longpaths true
+    displayName: Enable `git clean` to handle long paths
+
+  - task: NodeTool@0
+    displayName: Add NodeJS/npm
+    inputs:
+      versionSpec: $(NodeJSVersion)
+
+  - script: |
+      mkdir -p "$(Build.SourcesDirectory)/artifacts"
+      rm -rf "$(Build.SourcesDirectory)/artifacts/*"
+      cp eng/resources/* "$(Build.SourcesDirectory)/artifacts"
+    displayName: Prevent test directory crawling
+
+  - pwsh: |
+      $testArg = if ($env:SKIPTESTS -ne "true") { "--test" } else { "" }
+      Write-Host "##vso[task.setvariable variable=_TestArgs]$testArg"
+    displayName: Promote variables
+
+  - script: ./eng/cibuild.sh
+      --configuration $(_BuildConfig)
+      --prepareMachine
+      $(_TestArgs)
+    displayName: Run tests
+    env:
+      POCKETLOGGER_LOG_PATH: $(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)/pocketlogger.test.log
+      DOTNET_INTERACTIVE_FRONTEND_NAME: CI
+
+  - pwsh: ./test-retry-runner.ps1 -buildConfig $env:BUILDCONFIG
+    displayName: Test / Blame
+    workingDirectory: $(Build.SourcesDirectory)
+    env:
+      BUILDCONFIG: $(_BuildConfig)
+      POCKETLOGGER_LOG_PATH: $(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)/pocketlogger.test.log
+    condition: ne(variables['SkipTests'], 'true')
+
+  # Publish VS Code and npm test results
+  - task: PublishTestResults@2
+    displayName: Publish VS Code extension and npm test results
+    inputs:
+      testResultsFormat: VSTest
+      testResultsFiles: '**/*.*'
+      searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
+    condition: always()

--- a/eng/templates/npm-publish-tasks.yml
+++ b/eng/templates/npm-publish-tasks.yml
@@ -1,0 +1,9 @@
+
+steps:
+- template: eng/publish/publish-npm.yml@self
+  parameters:
+    packageName: microsoft-polyglot-notebooks-*.tgz
+    registryUrl: pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/npm/registry/
+    registryUser: dnceng
+    registryEmail: dnceng@microsoft.com
+    publishingBranch: main

--- a/eng/templates/post-build-tasks.yml
+++ b/eng/templates/post-build-tasks.yml
@@ -1,0 +1,28 @@
+parameters:
+  publishingInfraVersion: 3
+
+steps:
+- template: eng/common/templates/post-build/post-build.yml
+  parameters:
+    publishingInfraVersion: ${{ parameters.publishingInfraVersion }}
+    # signing validation currently has issues with dotnet 7; disabling as per internal guidance
+    enableSigningValidation: false
+    # Symbol validation is not entirely reliable as of yet, so should be turned off until https://github.com/dotnet/arcade/issues/2871 is resolved.
+    enableSymbolValidation: false
+    # SourceLink improperly looks for generated files.  See https://github.com/dotnet/arcade/issues/3069
+    enableSourceLinkValidation: false
+    # Enable SDL validation, passing through values from the 'DotNet-FSharp-SDLValidation-Params' group.
+    SDLValidationParameters:
+      enable: true
+      params: >-
+        -SourceToolsList @("policheck","credscan")
+        -TsaInstanceURL $(_TsaInstanceURL)
+        -TsaProjectName $(_TsaProjectName)
+        -TsaNotificationEmail $(_TsaNotificationEmail)
+        -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
+        -TsaBugAreaPath $(_TsaBugAreaPath)
+        -TsaIterationPath $(_TsaIterationPath)
+        -TsaRepositoryName "Interactive"
+        -TsaCodebaseName "Interactive-GitHub"
+        -TsaPublish $True
+        -PoliCheckAdditionalRunConfigParams @("UserExclusionPath < $(Build.SourcesDirectory)/eng/policheck_exclusions.xml")

--- a/eng/templates/variables-template.yml
+++ b/eng/templates/variables-template.yml
@@ -1,0 +1,23 @@
+# Variables used for both the CI and the official builds.
+
+variables:
+  - name: _TeamName
+    value: DotNetInteractive
+  - name: _BuildConfig
+    value: Release
+  - name: _PublishUsingPipelines
+    value: true
+  - name: _DotNetArtifactsCategory
+    value: .NETCore
+  - name: DisableDockerDetector
+    value: true
+  - name: NodeJSVersion
+    value: '16.13.0'
+  - name: LocPRCreationEnabled
+    value: ${{ eq(variables['Build.Reason'], 'Schedule') }}
+  - name: Codeql.Enabled
+    value: true
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - name: _DotNetValidationArtifactsCategory
+      value: .NETCoreValidation
+    - group: DotNet-Interactive-SDLValidation-Params


### PR DESCRIPTION
Refactoring the pipelines to consolidate tasks across our pipelines. Copilot edits made this task a lot easier!

The tasks at the moment are similar to what we had before except for publishing trx files which was different between the two yml's, so I just used . for publish instead of *.trx as this PR from Jon already establishes: #3834

Todo:

-[x] Need to figure out how "Output" tasks can be consolidated as well - It does not seem like this is possible today. 1ESPT templates require us to use "output" elements but the public pipeline cannot consume this syntax just yet from what I can tell.