### PR TITLE
Report npm test results in PR/CI

### DIFF
--- a/src/ensure-testresults-directory.js
+++ b/src/ensure-testresults-directory.js
@@ -1,0 +1,8 @@
+const fs = require('fs');
+const path = require('path');
+
+const outputDir = path.resolve(__dirname, '../artifacts/TestResults/Release');
+
+if (!fs.existsSync(outputDir)) {
+  fs.mkdirSync(outputDir, { recursive: true });
+}

--- a/src/polyglot-notebooks-browser/package.json
+++ b/src/polyglot-notebooks-browser/package.json
@@ -9,7 +9,7 @@
     "compile": "npm run rollup",
     "compile-ci": "rollup -c rollup.config.js --bundleConfigAsCjs",
     "test": "mocha tests/**/*.test.ts",
-    "ciTest": "npm test -- --reporter mocha-multi-reporters --reporter-options configFile=testConfig.json",
+    "ciTest": "node ../ensure-testresults-directory.js && npm test -- --reporter mocha-multi-reporters --reporter-options configFile=testConfig.json",
     "rollup": "npm run compile-ci -- -i src/index.ts -o dist/dotnet-interactive.js",
     "watch": "tsc -watch -p ./"
   },

--- a/src/polyglot-notebooks-vscode-common/tests/metadataUtilities.test.ts
+++ b/src/polyglot-notebooks-vscode-common/tests/metadataUtilities.test.ts
@@ -429,59 +429,6 @@ describe(`metadata utility tests`, async () => {
         });
     });
 
-    it("new ipynb metadata can be created from existing data", () => {
-        const notebookMetadata: metadataUtilities.NotebookDocumentMetadata = {
-            kernelInfo: {
-                defaultKernelName: "csharp",
-                items: [
-                    {
-                        name: "csharp",
-                        aliases: ["cs"],
-                        languageName: "csharp",
-                    },
-                ],
-            },
-        };
-        const existingMetadata: { [key: string]: any } = {
-            metadata: {
-                kernelspec: "this gets replaced",
-                someKey: "some value",
-            },
-            metadata2: "electric boogaloo",
-            notCustom: "not custom",
-        };
-        const newRawMetadata =
-            metadataUtilities.createNewIpynbMetadataWithNotebookDocumentMetadata(
-                existingMetadata,
-                notebookMetadata
-            );
-
-        expect(newRawMetadata).to.deep.equal({
-            metadata: {
-                kernelspec: {
-                    display_name: ".NET (C#)",
-                    language: "C#",
-                    name: ".net-csharp",
-                },
-                polyglot_notebook: {
-                    kernelInfo: {
-                        defaultKernelName: "csharp",
-                        items: [
-                            {
-                                aliases: ["cs"],
-                                languageName: "csharp",
-                                name: "csharp",
-                            },
-                        ],
-                    },
-                },
-                someKey: "some value",
-            },
-            metadata2: "electric boogaloo",
-            notCustom: "not custom",
-        });
-    });
-
     it("notebook metadata can be extracted from a composite kernel", () => {
         const kernel = new CompositeKernel("composite");
         const cs = new Kernel("csharp", "csharp");

--- a/src/polyglot-notebooks-vscode-insiders/package.json
+++ b/src/polyglot-notebooks-vscode-insiders/package.json
@@ -792,7 +792,7 @@
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile",
     "test": "mocha out/tests/**/*.test.js",
-    "ciTest": "npm test -- --reporter mocha-multi-reporters --reporter-options configFile=testConfig.json",
+    "ciTest": "node ../ensure-testresults-directory.js && npm test -- --reporter mocha-multi-reporters --reporter-options configFile=testConfig.json",
     "testDebug": "mocha out/tests/**/*.test.js",
     "tdd": "npm test -- --watch",
     "package": "npx @vscode/vsce package --pre-release",

--- a/src/polyglot-notebooks-vscode/package.json
+++ b/src/polyglot-notebooks-vscode/package.json
@@ -796,7 +796,7 @@
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile",
     "test": "mocha out/tests/**/*.test.js",
-    "ciTest": "npm test -- --reporter mocha-multi-reporters --reporter-options configFile=testConfig.json",
+    "ciTest": "node ../ensure-testresults-directory.js && npm test -- --reporter mocha-multi-reporters --reporter-options configFile=testConfig.json",
     "testDebug": "mocha out/tests/**/*.test.js",
     "tdd": "npm test -- --watch",
     "package": "npx @vscode/vsce package",

--- a/src/polyglot-notebooks/package.json
+++ b/src/polyglot-notebooks/package.json
@@ -19,7 +19,7 @@
     "pretest": "npm run compile && npm run lint",
     "test": "mocha tests/**/*.test.ts",
     "testDebug": "mocha tests/**/*.test.ts",
-    "ciTest": "npm test -- --reporter mocha-multi-reporters --reporter-options configFile=testConfig.json"
+    "ciTest": "node ../ensure-testresults-directory.js && npm test -- --reporter mocha-multi-reporters --reporter-options configFile=testConfig.json"
   },
   "mocha": {
     "ui": "bdd",


### PR DESCRIPTION
Fixing the generation of the trx file. It wasn't generated because the folder didn't exist. This should work for both local and CI runs.