### PR TITLE
Fixing Signed build 

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -7,6 +7,7 @@
     <clear />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
+    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="dotnet-eng">


### PR DESCRIPTION
Added back dotnet-tools feed given it is needed by Arcade tooling.