### PR TITLE
Adds `--http-local-only` option to bypass networking probing

### DIFF
--- a/src/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
+++ b/src/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
@@ -197,12 +197,12 @@ public class CommandLineParserTests : IDisposable
         var options = (StartupOptions)binder.CreateInstance(new InvocationContext(result).BindingContext);
 
         options
-            .GetAllNetworkInterfacesImpl
+            .GetAllNetworkInterfaces
             .Should()
-            .Match(x => x == StartupOptions.GetNetworkInterfacesHttpOnly);
+            .Match(x => x == StartupOptions.GetNetworkInterfacesHttpLocalOnly);
 
         options
-            .GetAllNetworkInterfacesImpl
+            .GetAllNetworkInterfaces
             .Should()
             .Match(x => x != NetworkInterface.GetAllNetworkInterfaces);
     }
@@ -217,12 +217,12 @@ public class CommandLineParserTests : IDisposable
         var options = (StartupOptions)binder.CreateInstance(new InvocationContext(result).BindingContext);
 
         options
-            .GetAllNetworkInterfacesImpl
+            .GetAllNetworkInterfaces
             .Should()
-            .Match(x => x != StartupOptions.GetNetworkInterfacesHttpOnly);
+            .Match(x => x != StartupOptions.GetNetworkInterfacesHttpLocalOnly);
 
         options
-            .GetAllNetworkInterfacesImpl
+            .GetAllNetworkInterfaces
             .Should()
             .Match(x => x == NetworkInterface.GetAllNetworkInterfaces);
     }

--- a/src/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
+++ b/src/dotnet-interactive.Tests/CommandLine/CommandLineParserTests.cs
@@ -197,9 +197,34 @@ public class CommandLineParserTests : IDisposable
         var options = (StartupOptions)binder.CreateInstance(new InvocationContext(result).BindingContext);
 
         options
-            .HttpLocalOnly
+            .GetAllNetworkInterfacesImpl
             .Should()
-            .BeTrue();
+            .Match(x => x == StartupOptions.GetNetworkInterfacesHttpOnly);
+
+        options
+            .GetAllNetworkInterfacesImpl
+            .Should()
+            .Match(x => x != NetworkInterface.GetAllNetworkInterfaces);
+    }
+
+    [Fact]
+    public void jupyter_command_default_network_interface_if_no_http_local_only_option()
+    {
+        var result = _parser.Parse($"jupyter {_connectionFile}");
+
+        var binder = new ModelBinder<StartupOptions>();
+
+        var options = (StartupOptions)binder.CreateInstance(new InvocationContext(result).BindingContext);
+
+        options
+            .GetAllNetworkInterfacesImpl
+            .Should()
+            .Match(x => x != StartupOptions.GetNetworkInterfacesHttpOnly);
+
+        options
+            .GetAllNetworkInterfacesImpl
+            .Should()
+            .Match(x => x == NetworkInterface.GetAllNetworkInterfaces);
     }
 
     [Fact]
@@ -286,44 +311,6 @@ public class CommandLineParserTests : IDisposable
             .FullName
             .Should()
             .Be(_connectionFile.FullName);
-    }
-
-    [Fact]
-    public async Task jupyter_command_throws_error_if_no_network_interfaces_permission_no_http_local_only()
-    {
-        const int ERROR_ACCESS_DENIED = 5;
-        // Something like: 
-        // HResult: -2147024891(0x80070005)
-        // Message: "Access to the path is denied" or similar permission - related message
-
-        HttpProbingSettings.GetAllNetworkInterfacesImpl = () => throw new NetworkInformationException(ERROR_ACCESS_DENIED);
-
-        await _parser.InvokeAsync($"jupyter {_connectionFile}", _console);
-
-        var controlException = new NetworkInformationException(ERROR_ACCESS_DENIED);
-
-        _console.Error.ToString()
-            .Should()
-            .ContainAny("0x80070005", controlException.Message);
-    }
-
-    [Fact]
-    public async Task jupyter_command_works_if_no_network_interfaces_permission_http_local_only()
-    {
-        const int ERROR_ACCESS_DENIED = 5;
-        // Something like: 
-        // HResult: -2147024891(0x80070005)
-        // Message: "Access to the path is denied" or similar permission - related message
-
-        HttpProbingSettings.GetAllNetworkInterfacesImpl = () => throw new NetworkInformationException(ERROR_ACCESS_DENIED);
-
-        await _parser.InvokeAsync($"jupyter {_connectionFile} --http-local-only", _console);
-
-        var controlException = new NetworkInformationException(ERROR_ACCESS_DENIED);
-
-        _console.Error.ToString()
-            .Should()
-            .NotContainAny("0x80070005", controlException.Message);
     }
 
     [Fact]
@@ -462,21 +449,6 @@ public class CommandLineParserTests : IDisposable
         var options = (StartupOptions)binder.CreateInstance(new InvocationContext(result).BindingContext);
 
         options.HttpPort.PortNumber.Should().Be(8000);
-    }
-
-    [Fact]
-    public void stdio_command_parses_http_local_only_options()
-    {
-        var result = _parser.Parse("stdio --http-local-only");
-
-        var binder = new ModelBinder<StartupOptions>();
-
-        var options = (StartupOptions)binder.CreateInstance(new InvocationContext(result).BindingContext);
-        
-        options
-            .HttpLocalOnly
-            .Should()
-            .BeTrue();
     }
 
     [Fact]

--- a/src/dotnet-interactive/CommandLine/CommandLineParser.cs
+++ b/src/dotnet-interactive/CommandLine/CommandLineParser.cs
@@ -171,9 +171,15 @@ public static class CommandLineParser
                 description: LocalizationResources.Cli_dotnet_interactive_jupyter_install_http_port_range_Description(),
                 isDefault: true);
 
+            var httpLocalOnlyOption = new Option<bool>(
+                "--http-local-only",
+                description: LocalizationResources.Cli_dotnet_interactive_jupyter_http_local_only_Description()
+            );
+
             var jupyterCommand = new Command("jupyter", LocalizationResources.Cli_dotnet_interactive_jupyter_Description())
             {
                 defaultKernelOption,
+                httpLocalOnlyOption,
                 httpPortRangeOption,
                 new Argument<FileInfo>
                 {
@@ -272,6 +278,11 @@ public static class CommandLineParser
                     return new HttpPort(portNumber);
                 });
 
+            var httpLocalOnlyOption = new Option<bool>(
+                "--http-local-only",
+                description: LocalizationResources.Cli_dotnet_interactive_jupyter_http_local_only_Description()
+            );
+
             var kernelHostOption = new Option<Uri>(
                 "--kernel-host",
                 parseArgument: x => x.Tokens.Count == 0 ? KernelHost.CreateHostUriForCurrentProcessId() : KernelHost.CreateHostUri(x.Tokens[0].Value),
@@ -292,6 +303,7 @@ public static class CommandLineParser
                 defaultKernelOption,
                 httpPortRangeOption,
                 httpPortOption,
+                httpLocalOnlyOption,
                 kernelHostOption,
                 previewOption,
                 workingDirOption

--- a/src/dotnet-interactive/CommandLine/CommandLineParser.cs
+++ b/src/dotnet-interactive/CommandLine/CommandLineParser.cs
@@ -278,11 +278,6 @@ public static class CommandLineParser
                     return new HttpPort(portNumber);
                 });
 
-            var httpLocalOnlyOption = new Option<bool>(
-                "--http-local-only",
-                description: LocalizationResources.Cli_dotnet_interactive_jupyter_http_local_only_Description()
-            );
-
             var kernelHostOption = new Option<Uri>(
                 "--kernel-host",
                 parseArgument: x => x.Tokens.Count == 0 ? KernelHost.CreateHostUriForCurrentProcessId() : KernelHost.CreateHostUri(x.Tokens[0].Value),
@@ -303,7 +298,6 @@ public static class CommandLineParser
                 defaultKernelOption,
                 httpPortRangeOption,
                 httpPortOption,
-                httpLocalOnlyOption,
                 kernelHostOption,
                 previewOption,
                 workingDirOption

--- a/src/dotnet-interactive/CommandLine/StartupOptions.cs
+++ b/src/dotnet-interactive/CommandLine/StartupOptions.cs
@@ -15,7 +15,9 @@ public class StartupOptions
         HttpPortRange httpPortRange = null,
         HttpPort httpPort = null,
         Uri kernelHost = null,
-        DirectoryInfo workingDir = null)
+        DirectoryInfo workingDir = null,
+        bool httpLocalOnly = false
+    )
     {
         LogPath = logPath;
         Verbose = verbose;
@@ -23,6 +25,7 @@ public class StartupOptions
         HttpPort = httpPort;
         KernelHost = kernelHost;
         WorkingDir = workingDir;
+        HttpLocalOnly = httpLocalOnly;
     }
 
     public DirectoryInfo LogPath { get; }
@@ -36,6 +39,7 @@ public class StartupOptions
     public Uri KernelHost { get; }
 
     public DirectoryInfo WorkingDir { get; internal set; }
+    public bool HttpLocalOnly { get; }
 
     public bool EnableHttpApi => HttpPort is not null || HttpPortRange is not null;
 }

--- a/src/dotnet-interactive/CommandLine/StartupOptions.cs
+++ b/src/dotnet-interactive/CommandLine/StartupOptions.cs
@@ -28,9 +28,9 @@ public class StartupOptions
         WorkingDir = workingDir;
 
         if (httpLocalOnly)
-            GetAllNetworkInterfacesImpl = GetNetworkInterfacesHttpOnly;
+            GetAllNetworkInterfaces = GetNetworkInterfacesHttpLocalOnly;
         else
-            GetAllNetworkInterfacesImpl = NetworkInterface.GetAllNetworkInterfaces;
+            GetAllNetworkInterfaces = NetworkInterface.GetAllNetworkInterfaces;
     }
 
     public DirectoryInfo LogPath { get; }
@@ -45,11 +45,11 @@ public class StartupOptions
 
     public DirectoryInfo WorkingDir { get; internal set; }
 
-    public Func<NetworkInterface[]> GetAllNetworkInterfacesImpl { get; set; }
+    public Func<NetworkInterface[]> GetAllNetworkInterfaces { get; }
 
     public bool EnableHttpApi => HttpPort is not null || HttpPortRange is not null;
 
-    public static NetworkInterface[] GetNetworkInterfacesHttpOnly()
+    public static NetworkInterface[] GetNetworkInterfacesHttpLocalOnly()
     { 
         return [];
     }

--- a/src/dotnet-interactive/CommandLine/StartupOptions.cs
+++ b/src/dotnet-interactive/CommandLine/StartupOptions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Net.NetworkInformation;
 using Microsoft.DotNet.Interactive.Http;
 
 namespace Microsoft.DotNet.Interactive.App.CommandLine;
@@ -25,7 +26,11 @@ public class StartupOptions
         HttpPort = httpPort;
         KernelHost = kernelHost;
         WorkingDir = workingDir;
-        HttpLocalOnly = httpLocalOnly;
+
+        if (httpLocalOnly)
+            GetAllNetworkInterfacesImpl = GetNetworkInterfacesHttpOnly;
+        else
+            GetAllNetworkInterfacesImpl = NetworkInterface.GetAllNetworkInterfaces;
     }
 
     public DirectoryInfo LogPath { get; }
@@ -39,7 +44,13 @@ public class StartupOptions
     public Uri KernelHost { get; }
 
     public DirectoryInfo WorkingDir { get; internal set; }
-    public bool HttpLocalOnly { get; }
+
+    public Func<NetworkInterface[]> GetAllNetworkInterfacesImpl { get; set; }
 
     public bool EnableHttpApi => HttpPort is not null || HttpPortRange is not null;
+
+    public static NetworkInterface[] GetNetworkInterfacesHttpOnly()
+    { 
+        return [];
+    }
 }

--- a/src/dotnet-interactive/Http/HttpProbingSettings.cs
+++ b/src/dotnet-interactive/Http/HttpProbingSettings.cs
@@ -9,7 +9,7 @@ using System.Net.NetworkInformation;
 
 namespace Microsoft.DotNet.Interactive.Http;
 
-internal class HttpProbingSettings
+public class HttpProbingSettings
 {
     public IEnumerable<string> AddressList { get; private set; }
 
@@ -19,7 +19,7 @@ internal class HttpProbingSettings
 
         if (!httpLocalOnly)
         {
-            ipAddress = NetworkInterface.GetAllNetworkInterfaces()
+            ipAddress = GetAllNetworkInterfaces()
                 .Where(ni => ni.OperationalStatus == OperationalStatus.Up)
                 .SelectMany(ni => ni.GetIPProperties().UnicastAddresses)
                 .Select(x => x.Address.ToString())
@@ -40,9 +40,18 @@ internal class HttpProbingSettings
     {
         if (httpPort is null)
             return ipAddress => $"http://{ipAddress}/";
-            .Where(u => u is not null)
-        return ipAddress => $"http://{ipAddress}:{httpPort}/";
 
-        return addresses;
+        return ipAddress => $"http://{ipAddress}:{httpPort}/";
+    }
+
+    // Delegate that matches the signature of GetAllNetworkInterfaces
+    public delegate NetworkInterface[] GetAllNetworkInterfacesDelegate();
+
+    // Property to replace the implementation for testing
+    public static GetAllNetworkInterfacesDelegate GetAllNetworkInterfacesImpl { get; set; } = NetworkInterface.GetAllNetworkInterfaces;
+
+    private static NetworkInterface[] GetAllNetworkInterfaces()
+    {
+        return GetAllNetworkInterfacesImpl();
     }
 }

--- a/src/dotnet-interactive/Http/KernelExtensions.cs
+++ b/src/dotnet-interactive/Http/KernelExtensions.cs
@@ -30,7 +30,7 @@ internal static class KernelExtensions
                                       ? httpProbingSettings.AddressList
                                       :
                                       [
-                                          new Uri($"http://localhost:{httpPort}")
+                                          $"http://localhost:{httpPort}"
                                       ];
                 var html =
                     HttpApiBootstrapper.GetHtmlInjection(probingUrls, httpPort?.ToString() ?? Guid.NewGuid().ToString("N"));

--- a/src/dotnet-interactive/LocalizationResources.cs
+++ b/src/dotnet-interactive/LocalizationResources.cs
@@ -18,6 +18,12 @@ internal static class LocalizationResources
         => GetResourceString(Resources.Cli_dotnet_interactive_jupyter_default_kernel_Description);
 
     /// <summary>
+    ///   Gets a localized message like: Exposes ports only on local network interfaces
+    /// </summary>
+    internal static string Cli_dotnet_interactive_jupyter_http_local_only_Description()
+        => GetResourceString(Resources.Cli_dotnet_interactive_jupyter_http_local_only_Description);
+
+    /// <summary>
     ///   Gets a localized message like: Interactive programming for .NET.
     /// </summary>
     internal static string Cli_dotnet_interactive_Description()

--- a/src/dotnet-interactive/Program.cs
+++ b/src/dotnet-interactive/Program.cs
@@ -108,7 +108,7 @@ public class Program
         {
             var httpPort = GetFreePort(options);
             options.HttpPort = httpPort;
-            probingSettings = HttpProbingSettings.Create(httpPort.PortNumber);
+            probingSettings = HttpProbingSettings.Create(httpPort.PortNumber, options.LocalOnlyNetworkInterfaces);
         }
 
         var webHost = new WebHostBuilder()

--- a/src/dotnet-interactive/Program.cs
+++ b/src/dotnet-interactive/Program.cs
@@ -107,7 +107,7 @@ public class Program
         {
             var httpPort = GetFreePort(options);
             options.HttpPort = httpPort;
-            probingSettings = HttpProbingSettings.Create(httpPort.PortNumber, options.HttpLocalOnly);
+            probingSettings = HttpProbingSettings.Create(httpPort.PortNumber, options.GetAllNetworkInterfacesImpl);
         }
 
         var webHost = new WebHostBuilder()

--- a/src/dotnet-interactive/Program.cs
+++ b/src/dotnet-interactive/Program.cs
@@ -5,7 +5,6 @@ using System;
 using System.CommandLine.Parsing;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Reflection;
@@ -108,7 +107,7 @@ public class Program
         {
             var httpPort = GetFreePort(options);
             options.HttpPort = httpPort;
-            probingSettings = HttpProbingSettings.Create(httpPort.PortNumber, options.LocalOnlyNetworkInterfaces);
+            probingSettings = HttpProbingSettings.Create(httpPort.PortNumber, options.HttpLocalOnly);
         }
 
         var webHost = new WebHostBuilder()
@@ -118,7 +117,7 @@ public class Program
 
         if (options.EnableHttpApi && probingSettings is not null)
         {
-            webHost = webHost.UseUrls(probingSettings.AddressList.Select(a => a.AbsoluteUri).ToArray());
+            webHost = webHost.UseUrls(string.Join(';', probingSettings.AddressList));
         }
 
         return webHost;

--- a/src/dotnet-interactive/Program.cs
+++ b/src/dotnet-interactive/Program.cs
@@ -107,7 +107,7 @@ public class Program
         {
             var httpPort = GetFreePort(options);
             options.HttpPort = httpPort;
-            probingSettings = HttpProbingSettings.Create(httpPort.PortNumber, options.GetAllNetworkInterfacesImpl);
+            probingSettings = HttpProbingSettings.Create(httpPort.PortNumber, options.GetAllNetworkInterfaces);
         }
 
         var webHost = new WebHostBuilder()

--- a/src/dotnet-interactive/Resources.Designer.cs
+++ b/src/dotnet-interactive/Resources.Designer.cs
@@ -97,6 +97,15 @@ namespace Microsoft.DotNet.Interactive.App {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Exposes ports only on local network interfaces.
+        /// </summary>
+        internal static string Cli_dotnet_interactive_jupyter_http_local_only_Description {
+            get {
+                return ResourceManager.GetString("Cli_dotnet_interactive_jupyter_http_local_only_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Install the .NET kernel for Jupyter.
         /// </summary>
         internal static string Cli_dotnet_interactive_jupyter_install_Description {
@@ -120,6 +129,15 @@ namespace Microsoft.DotNet.Interactive.App {
         internal static string Cli_dotnet_interactive_jupyter_install_path_Description {
             get {
                 return ResourceManager.GetString("Cli_dotnet_interactive_jupyter_install_path_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Exposes ports only on local network interfaces.
+        /// </summary>
+        internal static string Cli_dotnet_interactive_jupyter_local_only_network_interfaces_Description {
+            get {
+                return ResourceManager.GetString("Cli_dotnet_interactive_jupyter_local_only_network_interfaces_Description", resourceCulture);
             }
         }
         

--- a/src/dotnet-interactive/Resources.resx
+++ b/src/dotnet-interactive/Resources.resx
@@ -129,6 +129,9 @@
   <data name="Cli_dotnet_interactive_jupyter_Description" xml:space="preserve">
     <value>Starts dotnet-interactive as a Jupyter kernel</value>
   </data>
+  <data name="Cli_dotnet_interactive_jupyter_http_local_only_Description" xml:space="preserve">
+    <value>Exposes ports only on local network interfaces</value>
+  </data>
   <data name="Cli_dotnet_interactive_jupyter_install_Description" xml:space="preserve">
     <value>Install the .NET kernel for Jupyter</value>
   </data>

--- a/src/dotnet-interactive/xlf/Resources.cs.xlf
+++ b/src/dotnet-interactive/xlf/Resources.cs.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Výchozí jazyk jádra</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cli_dotnet_interactive_jupyter_http_local_only_Description">
+        <source>Exposes ports only on local network interfaces</source>
+        <target state="new">Exposes ports only on local network interfaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cli_dotnet_interactive_jupyter_install_Description">
         <source>Install the .NET kernel for Jupyter</source>
         <target state="translated">Nainstalovat jádro platformy .NET pro Jupyter</target>

--- a/src/dotnet-interactive/xlf/Resources.de.xlf
+++ b/src/dotnet-interactive/xlf/Resources.de.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Die Standardsprache für den Kernel</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cli_dotnet_interactive_jupyter_http_local_only_Description">
+        <source>Exposes ports only on local network interfaces</source>
+        <target state="new">Exposes ports only on local network interfaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cli_dotnet_interactive_jupyter_install_Description">
         <source>Install the .NET kernel for Jupyter</source>
         <target state="translated">.NET-Kernel für Jupyter installieren</target>

--- a/src/dotnet-interactive/xlf/Resources.es.xlf
+++ b/src/dotnet-interactive/xlf/Resources.es.xlf
@@ -37,6 +37,11 @@
         <target state="translated">El idioma predeterminado del kernel</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cli_dotnet_interactive_jupyter_http_local_only_Description">
+        <source>Exposes ports only on local network interfaces</source>
+        <target state="new">Exposes ports only on local network interfaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cli_dotnet_interactive_jupyter_install_Description">
         <source>Install the .NET kernel for Jupyter</source>
         <target state="translated">Instalar el kernel de .NET para Jupyter</target>

--- a/src/dotnet-interactive/xlf/Resources.fr.xlf
+++ b/src/dotnet-interactive/xlf/Resources.fr.xlf
@@ -37,6 +37,11 @@
         <target state="translated">La langue par défaut du noyau</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cli_dotnet_interactive_jupyter_http_local_only_Description">
+        <source>Exposes ports only on local network interfaces</source>
+        <target state="new">Exposes ports only on local network interfaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cli_dotnet_interactive_jupyter_install_Description">
         <source>Install the .NET kernel for Jupyter</source>
         <target state="translated">Installer le noyau .NET pour Jupyter</target>

--- a/src/dotnet-interactive/xlf/Resources.it.xlf
+++ b/src/dotnet-interactive/xlf/Resources.it.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Lingua predefinita per il kernel</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cli_dotnet_interactive_jupyter_http_local_only_Description">
+        <source>Exposes ports only on local network interfaces</source>
+        <target state="new">Exposes ports only on local network interfaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cli_dotnet_interactive_jupyter_install_Description">
         <source>Install the .NET kernel for Jupyter</source>
         <target state="translated">Installare il kernel .NET per Jupyter</target>

--- a/src/dotnet-interactive/xlf/Resources.ja.xlf
+++ b/src/dotnet-interactive/xlf/Resources.ja.xlf
@@ -37,6 +37,11 @@
         <target state="translated">カーネルの既定の言語</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cli_dotnet_interactive_jupyter_http_local_only_Description">
+        <source>Exposes ports only on local network interfaces</source>
+        <target state="new">Exposes ports only on local network interfaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cli_dotnet_interactive_jupyter_install_Description">
         <source>Install the .NET kernel for Jupyter</source>
         <target state="translated">Jupyter 用の .NET カーネルをインストールします</target>

--- a/src/dotnet-interactive/xlf/Resources.ko.xlf
+++ b/src/dotnet-interactive/xlf/Resources.ko.xlf
@@ -37,6 +37,11 @@
         <target state="translated">커널의 기본 언어</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cli_dotnet_interactive_jupyter_http_local_only_Description">
+        <source>Exposes ports only on local network interfaces</source>
+        <target state="new">Exposes ports only on local network interfaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cli_dotnet_interactive_jupyter_install_Description">
         <source>Install the .NET kernel for Jupyter</source>
         <target state="translated">Jupyter용 .NET 커널 설치</target>

--- a/src/dotnet-interactive/xlf/Resources.pl.xlf
+++ b/src/dotnet-interactive/xlf/Resources.pl.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Domyślny język jądra</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cli_dotnet_interactive_jupyter_http_local_only_Description">
+        <source>Exposes ports only on local network interfaces</source>
+        <target state="new">Exposes ports only on local network interfaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cli_dotnet_interactive_jupyter_install_Description">
         <source>Install the .NET kernel for Jupyter</source>
         <target state="translated">Zainstaluj jądro platformy .NET dla programu Jupyter</target>

--- a/src/dotnet-interactive/xlf/Resources.pt-BR.xlf
+++ b/src/dotnet-interactive/xlf/Resources.pt-BR.xlf
@@ -37,6 +37,11 @@
         <target state="translated">O idioma padrão para o kernel</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cli_dotnet_interactive_jupyter_http_local_only_Description">
+        <source>Exposes ports only on local network interfaces</source>
+        <target state="new">Exposes ports only on local network interfaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cli_dotnet_interactive_jupyter_install_Description">
         <source>Install the .NET kernel for Jupyter</source>
         <target state="translated">Instalar o kernel do .NET para Jupyter</target>

--- a/src/dotnet-interactive/xlf/Resources.ru.xlf
+++ b/src/dotnet-interactive/xlf/Resources.ru.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Язык по умолчанию для ядра</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cli_dotnet_interactive_jupyter_http_local_only_Description">
+        <source>Exposes ports only on local network interfaces</source>
+        <target state="new">Exposes ports only on local network interfaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cli_dotnet_interactive_jupyter_install_Description">
         <source>Install the .NET kernel for Jupyter</source>
         <target state="translated">Установить ядро .NET для Jupyter</target>

--- a/src/dotnet-interactive/xlf/Resources.tr.xlf
+++ b/src/dotnet-interactive/xlf/Resources.tr.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Çekirdek için varsayılan dil</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cli_dotnet_interactive_jupyter_http_local_only_Description">
+        <source>Exposes ports only on local network interfaces</source>
+        <target state="new">Exposes ports only on local network interfaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cli_dotnet_interactive_jupyter_install_Description">
         <source>Install the .NET kernel for Jupyter</source>
         <target state="translated">Jupyter için .NET çekirdeğini yükle</target>

--- a/src/dotnet-interactive/xlf/Resources.zh-Hans.xlf
+++ b/src/dotnet-interactive/xlf/Resources.zh-Hans.xlf
@@ -37,6 +37,11 @@
         <target state="translated">内核默认语言</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cli_dotnet_interactive_jupyter_http_local_only_Description">
+        <source>Exposes ports only on local network interfaces</source>
+        <target state="new">Exposes ports only on local network interfaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cli_dotnet_interactive_jupyter_install_Description">
         <source>Install the .NET kernel for Jupyter</source>
         <target state="translated">安装适用于 Jupyter 的 .NET 内核</target>

--- a/src/dotnet-interactive/xlf/Resources.zh-Hant.xlf
+++ b/src/dotnet-interactive/xlf/Resources.zh-Hant.xlf
@@ -37,6 +37,11 @@
         <target state="translated">核心的預設語言</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cli_dotnet_interactive_jupyter_http_local_only_Description">
+        <source>Exposes ports only on local network interfaces</source>
+        <target state="new">Exposes ports only on local network interfaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cli_dotnet_interactive_jupyter_install_Description">
         <source>Install the .NET kernel for Jupyter</source>
         <target state="translated">安裝適用於 Jupyter 的 .NET 核心</target>


### PR DESCRIPTION
# Add fallback to `NetworkInterface.GetAllNetworkInterfaces()` [Fixes #3903]

- All commits should be squashed before merge.

### Content
I’ve applied the same logic used in other "server startup" related options.  
Please let me know if you spot any issues or inconsistencies in the current implementation.

### Styling
I believe I’m following the [specified coding guidelines](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md).  
Let me know if you notice anything that needs improvement.
