### PR TITLE
Fix #3862

### DIFF
--- a/src/polyglot-notebooks-vscode-common/src/commands.ts
+++ b/src/polyglot-notebooks-vscode-common/src/commands.ts
@@ -372,8 +372,7 @@ export function registerFileCommands(context: vscode.ExtensionContext, parserSer
         const notebook = await vscode.workspace.openNotebookDocument(viewType, content);
         const _editor = await vscode.window.showNotebookDocument(notebook);
 
-        if (viewType === constants.JupyterViewType) {
-            // note, new .ipynb notebooks are currently affected by this bug: https://github.com/microsoft/vscode/issues/121974
+        if (createForIpynb) {
             await selectDotNetInteractiveKernelForJupyter();
         }
     }

--- a/src/polyglot-notebooks-vscode-common/src/extension.ts
+++ b/src/polyglot-notebooks-vscode-common/src/extension.ts
@@ -127,7 +127,6 @@ export async function activate(context: vscode.ExtensionContext) {
         }
 
         // prepare kernel transport launch arguments and working directory using a fresh config item so we don't get cached values
-
         const kernelTransportArgs = dotnetConfig.get<Array<string>>('kernelTransportArgs')!;
         const argsTemplate = {
             args: kernelTransportArgs,

--- a/src/polyglot-notebooks-vscode-common/src/metadataUtilities.ts
+++ b/src/polyglot-notebooks-vscode-common/src/metadataUtilities.ts
@@ -291,7 +291,8 @@ export function getMergedRawNotebookDocumentMetadataFromNotebookDocumentMetadata
 
         rawMetadata.metadata = {
             kernelspec,
-            polyglot_notebook: notebookDocumentMetadata
+            polyglot_notebook: notebookDocumentMetadata,
+            language_info: { name: "polyglot-notebook" }
         };
     } else {
         rawMetadata.polyglot_notebook = notebookDocumentMetadata;

--- a/src/polyglot-notebooks-vscode-common/tests/metadataUtilities.test.ts
+++ b/src/polyglot-notebooks-vscode-common/tests/metadataUtilities.test.ts
@@ -562,6 +562,9 @@ describe(`metadata utility tests`, async () => {
                     language: "F#",
                     name: ".net-fsharp",
                 },
+                "language_info": {
+                    name: "polyglot-notebook"
+                },
                 polyglot_notebook: {
                     kernelInfo: {
                         defaultKernelName: "fsharp",


### PR DESCRIPTION
This change ensures that newly-created .ipynb files have the correct `language_info` metadata. 

It fixes #3862.