### PR TITLE
Add Coconut

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ The following languages are supported by Polyglot Notebooks and .NET Interactive
 | SQL                           |        ✅       |   
 | KQL ([Kusto Query Language](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/))    |        ✅       |  
 | [Python](docs/jupyter-in-polyglot-notebooks.md)  |        ✅       |
-| [R](docs/jupyter-in-polyglot-notebooks.md)       |        ✅       |      
+| [Coconut](https://coconut.readthedocs.io/en/latest/DOCS.html#ipython-jupyter-support)  |        ✅       |
+| [R](docs/jupyter-in-polyglot-notebooks.md)       |        ✅       |     
 | HTML                         |        ⛔         |     
 | HTTP                         |        ✅         | 
 | [Mermaid](https://mermaid.js.org/intro/)         |        ⛔       |        


### PR DESCRIPTION
Coconut is implemented as superset of Python, and does transpile to native Python.

It provides a Jupyter module, and due to it using the Python kernel, its always feature complete with it.

So hence variable sharing is available. 