### PR TITLE
Fix #3940

### DIFF
--- a/src/polyglot-notebooks-vscode-common/src/metadataUtilities.ts
+++ b/src/polyglot-notebooks-vscode-common/src/metadataUtilities.ts
@@ -117,9 +117,9 @@ export function getCellMetadata(cell: vscodeLike.NotebookCell) {
 
 export function getDocumentMetadata(document: vscodeLike.NotebookDocument) {
     const ipynbMetadata = document.metadata?.metadata?.polyglot_notebook ?? {};
-    const metadata = document.metadata.polyglot_notebook ?? {};
+    const polyglot_notebook = document.metadata.polyglot_notebook ?? {};
 
-    const merged = { ...ipynbMetadata, ...metadata };
+    const merged = { ...ipynbMetadata, ...polyglot_notebook };
 
     return merged;
 }
@@ -278,7 +278,8 @@ export function getKernelspecMetadataFromNotebookDocumentMetadata(notebookDocume
 export function getRawNotebookCellMetadataFromNotebookCellMetadata(notebookCellMetadata: NotebookCellMetadata): { [key: string]: any } {
     return {
         metadata: {
-            polyglot_notebook: notebookCellMetadata
+            polyglot_notebook: notebookCellMetadata,
+            language_info: { name: "polyglot-notebook" }
         }
     };
 }

--- a/src/polyglot-notebooks-vscode-common/tests/metadataUtilities.test.ts
+++ b/src/polyglot-notebooks-vscode-common/tests/metadataUtilities.test.ts
@@ -494,6 +494,7 @@ describe(`metadata utility tests`, async () => {
                 polyglot_notebook: {
                     kernelName: "fsharp",
                 },
+                language_info: { name: "polyglot-notebook" }
             },
         });
     });

--- a/src/polyglot-notebooks/src/javascriptKernel.ts
+++ b/src/polyglot-notebooks/src/javascriptKernel.ts
@@ -45,12 +45,12 @@ export class JavascriptKernel extends Kernel {
         const submitCode = <commandsAndEvents.SubmitCode>invocation.commandEnvelope.command;
         const code = submitCode.code;
 
-        super.kernelInfo.localName;//?
-        super.kernelInfo.uri;//?
-        super.kernelInfo.remoteUri;//?
+        super.kernelInfo.localName;
+        super.kernelInfo.uri;
+        super.kernelInfo.remoteUri;
         const codeSubmissionReceivedEvent = new commandsAndEvents.KernelEventEnvelope(commandsAndEvents.CodeSubmissionReceivedType, { code }, invocation.commandEnvelope);
         invocation.context.publish(codeSubmissionReceivedEvent);
-        invocation.context.commandEnvelope.routingSlip;//?
+        invocation.context.commandEnvelope.routingSlip;
         this.capture.kernelInvocationContext = invocation.context;
         let result: any = undefined;
 
@@ -66,8 +66,17 @@ export class JavascriptKernel extends Kernel {
                 const returnValueProducedEvent = new commandsAndEvents.KernelEventEnvelope(commandsAndEvents.ReturnValueProducedType, event, invocation.commandEnvelope);
                 invocation.context.publish(returnValueProducedEvent);
             }
-        } catch (e) {
-            throw e;//?
+        } catch (e: any) {
+            const errorProduced = new commandsAndEvents.KernelEventEnvelope(
+                commandsAndEvents.ErrorProducedType,
+                {
+                    message:
+                        `${e.message}
+
+                    ${e.stack}`
+                },
+                invocation.commandEnvelope);
+            invocation.context.publish(errorProduced);
         }
         finally {
             this.capture.kernelInvocationContext = undefined;

--- a/src/polyglot-notebooks/src/kernel.ts
+++ b/src/polyglot-notebooks/src/kernel.ts
@@ -118,7 +118,6 @@ export class Kernel {
         } else {
             Logger.default.warn(`Trying to stamp ${commandEnvelope.commandType} as arrived but uri ${kernelUri} is already present.`);
         }
-        commandEnvelope.routingSlip;
 
         return this.getScheduler().runAsync(commandEnvelope, (value) => this.executeCommand(value).finally(() => {
             if (!commandEnvelope.routingSlip.contains(kernelUri)) {

--- a/src/polyglot-notebooks/tests/javascriptKernel.test.ts
+++ b/src/polyglot-notebooks/tests/javascriptKernel.test.ts
@@ -210,7 +210,7 @@ return command.toJson();`
             });
     });
 
-    it("notifies about CodeSumbission", async () => {
+    it("publishes CodeSumbissionReceived", async () => {
         let events: commandsAndEvents.KernelEventEnvelope[] = [];
         const kernel = new JavascriptKernel();
         kernel.subscribeToKernelEvents((e) => {
@@ -224,7 +224,7 @@ return command.toJson();`
         expect(events.find(e => e.eventType === commandsAndEvents.CodeSubmissionReceivedType)).to.not.be.undefined;
     });
 
-    it("emits ReturnValueProduced when evaluation return a value", async () => {
+    it("publishes ReturnValueProduced when evaluation returns a value", async () => {
         let events: commandsAndEvents.KernelEventEnvelope[] = [];
         const kernel = new JavascriptKernel();
         kernel.subscribeToKernelEvents((e) => {
@@ -278,7 +278,7 @@ return command.toJson();`
         expect(events.find(e => e.eventType === commandsAndEvents.CommandSucceededType)).to.not.be.undefined;
     });
 
-    it("emits ReturnValueProduced when evaluation return a value in async calls", async () => {
+    it("emits ReturnValueProduced when evaluation returns a value in async calls", async () => {
         let events: commandsAndEvents.KernelEventEnvelope[] = [];
         const kernel = new JavascriptKernel();
         kernel.subscribeToKernelEvents((e) => {
@@ -297,7 +297,7 @@ return command.toJson();`
     });
 
 
-    it("redirect console.log", async () => {
+    it("redirects console.log", async () => {
         let events: commandsAndEvents.KernelEventEnvelope[] = [];
         const kernel = new JavascriptKernel();
         kernel.subscribeToKernelEvents((e) => {
@@ -313,7 +313,7 @@ return command.toJson();`
         expect(event.formattedValues[0].mimeType).to.equal("text/plain");
     });
 
-    it("redirected console is reused in subsequent submissions", async () => {
+    it("reuses redirected console in subsequent submissions", async () => {
         const events: commandsAndEvents.KernelEventEnvelope[] = [];
         const kernel = new JavascriptKernel();
         kernel.subscribeToKernelEvents((e) => {


### PR DESCRIPTION
This publishes `ErrorProduced` rather than rethrowing when `JavaScriptKernel` evals submitted code that throws.