### PR TITLE
Update DuckDB dependencies to the latest 1.3.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,8 +19,8 @@
     <PackageVersion Include="Azure.Core" Version="1.44.1" />
     <PackageVersion Include="Azure.Identity" Version="1.13.1" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
-    <PackageVersion Include="DuckDB.NET.Data.Full" Version="1.1.2.1" />
-    <PackageVersion Include="DuckDB.NET.Data" Version="1.1.2.1" />
+    <PackageVersion Include="DuckDB.NET.Data.Full" Version="1.3.0" />
+    <PackageVersion Include="DuckDB.NET.Data" Version="1.3.0" />
     <PackageVersion Include="AwesomeAssertions.Json" Version="8.0.0" />
     <PackageVersion Include="AwesomeAssertions" Version="8.1.0" />
     <PackageVersion Include="FSharp.Compiler.Service" Version="43.9.300" />


### PR DESCRIPTION
Update DuckDb dependencies to the latest version: 1.3.0. It works with latest stable DuckDB 1.3.0 “Ossivalis”

Packages:
* [DuckDB.NET.Data.Full](https://www.nuget.org/packages/DuckDB.NET.Data.Full)
* [DuckDB.NET.Data](https://www.nuget.org/packages/DuckDB.NET.Data)

Db:
[Announcing DuckDB 1.3.0](https://duckdb.org/2025/05/21/announcing-duckdb-130)