### PR TITLE
Sign official builds of the vscode extensions

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -51,7 +51,7 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     sdl:
-      sourceAnalysisPool: 
+      sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)
         image: 1es-windows-2022
         os: windows
@@ -152,6 +152,7 @@ extends:
             - template: /eng/templates/build-and-test-tasks.yml@self
               parameters:
                 platform: windows
+                signType: $(_SignType)
 
       - template: /eng/common/templates-official/jobs/jobs.yml@self
         parameters:
@@ -212,7 +213,7 @@ extends:
             -TsaCodebaseName "Interactive-GitHub"
             -TsaPublish $True
             -PoliCheckAdditionalRunConfigParams @("UserExclusionPath < $(Build.SourcesDirectory)/eng/policheck_exclusions.xml")
-  
+
     #---------------------------------------------------------------------------------------------------------------------#
     #                                                    NPM Publish                                                      #
     #---------------------------------------------------------------------------------------------------------------------#

--- a/eng/msbuild/Directory.Build.props
+++ b/eng/msbuild/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+    <PropertyGroup>
+        <RepoRoot>$(MSBuildThisFileDirectory)../../</RepoRoot>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(SignType)' == ''">
+        <SignType>test</SignType>
+    </PropertyGroup>
+</Project>

--- a/eng/msbuild/Directory.Packages.props
+++ b/eng/msbuild/Directory.Packages.props
@@ -1,0 +1,10 @@
+<Project>
+  <!-- https://learn.microsoft.com/nuget/consume-packages/central-package-management -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+  <ItemGroup>
+    <GlobalPackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" />
+  </ItemGroup>
+</Project>

--- a/eng/msbuild/signJs/signJs.proj
+++ b/eng/msbuild/signJs/signJs.proj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateAssemblyVersionInfo>false</GenerateAssemblyVersionInfo>
+    <EnableDefaultSignFiles>false</EnableDefaultSignFiles>
+    <MicroBuild_DoNotStrongNameSign>true</MicroBuild_DoNotStrongNameSign>
+    <IsPackable>false</IsPackable>
+    <OutDir>$(MSBuildProjectDirectory)\$(JSOutputPath)\</OutDir>
+    <MicroBuild_SigningEnabled>true</MicroBuild_SigningEnabled>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FilesToSign Include="$(OutDir)*.js">
+      <Authenticode>MicrosoftSHA2</Authenticode>
+    </FilesToSign>
+  </ItemGroup>
+</Project>

--- a/eng/msbuild/signVsix/signVsix.proj
+++ b/eng/msbuild/signVsix/signVsix.proj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateAssemblyVersionInfo>false</GenerateAssemblyVersionInfo>
+    <EnableDefaultSignFiles>false</EnableDefaultSignFiles>
+    <MicroBuild_DoNotStrongNameSign>true</MicroBuild_DoNotStrongNameSign>
+    <IsPackable>false</IsPackable>
+    <OutDir>$(RepoRoot)artifacts\vscode\</OutDir>
+  </PropertyGroup>
+  <ItemGroup>
+    <FilesToSign Include="$(OutDir)stable-locked\*.vsix">
+      <Authenticode>VSCodePublisher</Authenticode>
+    </FilesToSign>
+    <FilesToSign Include="$(OutDir)stable\*.vsix">
+      <Authenticode>VSCodePublisher</Authenticode>
+    </FilesToSign>
+    <FilesToSign Include="$(OutDir)insiders\*.vsix">
+      <Authenticode>VSCodePublisher</Authenticode>
+    </FilesToSign>
+  </ItemGroup>
+</Project>

--- a/eng/package/PackVSCodeExtension.ps1
+++ b/eng/package/PackVSCodeExtension.ps1
@@ -30,7 +30,13 @@ function Build-VsCodeExtension([string] $packageDirectory, [string] $outputSubDi
 
     # pack
     Write-Host "Packing extension"
-    npm run package -- --out "$outDir\$outputSubDirectory\dotnet-interactive-vscode-$packageVersionNumber.vsix"
+    npx @vscode/vsce@latest package -o "$outDir\$outputSubDirectory\dotnet-interactive-vscode-$packageVersionNumber.vsix"
+
+    Write-Host "Generating extension manifest"
+    npx @vscode/vsce@latest generate-manifest -i "$outDir\$outputSubDirectory\dotnet-interactive-vscode-$packageVersionNumber.vsix" -o "$outDir\$outputSubDirectory\dotnet-interactive-vscode-$packageVersionNumber.manifest"
+
+    Write-Host "Preparing manifest for signing"
+    cp "$outDir\$outputSubDirectory\dotnet-interactive-vscode-$packageVersionNumber.manifest" "$outDir\$outputSubDirectory\dotnet-interactive-vscode-$packageVersionNumber.signature.p7s"
 
     Pop-Location
 }

--- a/eng/templates/build-and-test-tasks.yml
+++ b/eng/templates/build-and-test-tasks.yml
@@ -1,5 +1,6 @@
 parameters:
   platform: ''
+  signType: ''
 
 steps:
 - ${{ if eq(parameters.platform, 'windows') }}:
@@ -51,6 +52,11 @@ steps:
       testResultsFiles: '**/*.*'
       searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
     condition: always()
+
+  - script: dotnet build $(Build.SourcesDirectory)\eng\msbuild\signVsix -bl -v:normal
+    displayName: Sign VS Code Extensions
+    env:
+      SignType: ${{ parameters.signType }}
 
   - task: PowerShell@2
     displayName: Pack VS Code Extensions

--- a/src/polyglot-notebooks-vscode-insiders/package.json
+++ b/src/polyglot-notebooks-vscode-insiders/package.json
@@ -786,7 +786,7 @@
     "copy-preloads": "npx copyfiles --error --verbose --up 3 ../polyglot-notebooks/dist/activation.js ./resources",
     "compile-variable-grid": "cd ../polyglot-notebooks-ui-components && npm run buildDev",
     "copy-variable-grid": "npx copyfiles --error --verbose --up 3 ../polyglot-notebooks-ui-components/dist/*.* ./resources",
-    "vscode:prepublish": "npm run compile",
+    "vscode:prepublish": "npm run compile && dotnet build ../../eng/msbuild/signJs --property jsOutputPath=..\\..\\..\\src\\polyglot-notebooks-vscode-insiders\\out -bl -v:normal",
     "compile": "npm run lint && tsc -p ./ && npm run compile-preloads && npm run compile-variable-grid && npm run copy-preloads && npm run copy-variable-grid",
     "lint": "eslint src --ext ts",
     "watch": "tsc -watch -p ./",

--- a/src/polyglot-notebooks-vscode/package.json
+++ b/src/polyglot-notebooks-vscode/package.json
@@ -790,7 +790,7 @@
     "copy-preloads": "npx copyfiles --error --verbose --up 3 ../polyglot-notebooks/dist/activation.js ./resources",
     "compile-variable-grid": "cd ../polyglot-notebooks-ui-components && npm run buildDev",
     "copy-variable-grid": "npx copyfiles --error --verbose --up 3 ../polyglot-notebooks-ui-components/dist/*.* ./resources",
-    "vscode:prepublish": "npm run compile",
+    "vscode:prepublish": "npm run compile && dotnet build ../../eng/msbuild/signJs --property jsOutputPath=..\\..\\..\\src\\polyglot-notebooks-vscode\\out -bl -v:normal",
     "compile": "npm run lint && tsc -p ./ && npm run compile-preloads && npm run compile-variable-grid && npm run copy-preloads && npm run copy-variable-grid",
     "lint": "eslint src --ext ts",
     "watch": "tsc -watch -p ./",


### PR DESCRIPTION
Adds extension signing as outlined in https://eng.ms/docs/cloud-ai-platform/devdiv/vs-services-dougam/vs-marketplace-skofman/visual-studio-marketplace/extension-publisher-guides/publisher-signing-as-microsoft#add-signing-workloads

Used [dotnet/vscode-runtime](https://github.com/dotnet/vscode-dotnet-runtime/tree/main/msbuild) as a guide.

It is possible that your pipeline may need to be granted permission to additional resources.