### PR TITLE
Install latest npm when building

### DIFF
--- a/eng/templates/build-and-test-tasks.yml
+++ b/eng/templates/build-and-test-tasks.yml
@@ -13,8 +13,8 @@ steps:
     inputs:
       versionSpec: $(NodeJSVersion)
 
-  - script: npm install -g npm
-    displayName: Install latest npm
+  - script: npm install -g npm@11.6.0
+    displayName: Install npm v11.6.0
 
   - script: |
       robocopy "eng\resources" "$(Build.SourcesDirectory)\artifacts"

--- a/eng/templates/build-and-test-tasks.yml
+++ b/eng/templates/build-and-test-tasks.yml
@@ -13,10 +13,8 @@ steps:
     inputs:
       versionSpec: $(NodeJSVersion)
 
-  # This work around NPM issue https://github.com/npm/cli/issues/8468
-  # This issue should be resolved when v11.5.3 is released
-  - script: npm install -g npm@11.4.1
-    displayName: Downgrade npm to v11.4.1
+  - script: npm install -g npm
+    displayName: Install latest npm
 
   - script: |
       robocopy "eng\resources" "$(Build.SourcesDirectory)\artifacts"

--- a/eng/templates/build-and-test-tasks.yml
+++ b/eng/templates/build-and-test-tasks.yml
@@ -13,7 +13,13 @@ steps:
     inputs:
       versionSpec: $(NodeJSVersion)
 
-  - script: npm install -g npm@11.6.0
+  - script: |
+      echo "npm version:"
+      npm --version
+      echo "Installing 11.6.0..."
+      npm install -g npm@11.6.0
+      echo "npm version:"
+      npm --version
     displayName: Install npm v11.6.0
 
   - script: |

--- a/eng/templates/build-and-test-tasks.yml
+++ b/eng/templates/build-and-test-tasks.yml
@@ -14,13 +14,18 @@ steps:
       versionSpec: $(NodeJSVersion)
 
   - script: |
-      echo "npm version:"
+      echo "npm version (before):"
       npm --version
-      echo "Installing 11.6.0..."
+    displayName: Log npm version (before)
+
+  - script: |
       npm install -g npm@11.6.0
-      echo "npm version:"
-      npm --version
     displayName: Install npm v11.6.0
+
+  - script: |
+      echo "npm version (after):"
+      npm --version
+    displayName: Log npm version (after)
 
   - script: |
       robocopy "eng\resources" "$(Build.SourcesDirectory)\artifacts"


### PR DESCRIPTION
11.6.0 contains a fix for https://github.com/npm/cli/issues/8468