### PR TITLE
Disable powershell strictmode when invoking npm

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -38,6 +38,10 @@ try {
     )
     foreach ($npmDir in $npmDirs) {
         Push-Location "$repoRoot\$npmDir"
+
+        # Disable strictmode to work around running in https://github.com/npm/cli/issues/8468 when invoking npm
+        Set-StrictMode -off
+
         Write-Host "Building NPM in directory $npmDir"
         npm ci
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
@@ -49,6 +53,8 @@ try {
             npm run ciTest
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         }
+
+        Set-StrictMode -version 2.0
 
         Pop-Location
     }


### PR DESCRIPTION
After [reading about strictmode](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/set-strictmode?view=powershell-7.5#example-2-turn-on-strict-mode-as-version-2-0), I do not think it is problematic to disable it when invoking npm.