### PR TITLE
Generate a newer style npmrc for publishing

### DIFF
--- a/eng/publish/PublishNPMPackage.ps1
+++ b/eng/publish/PublishNPMPackage.ps1
@@ -14,16 +14,23 @@ Set-StrictMode -version 2.0
 $ErrorActionPreference = "Stop"
 
 try {
+    $feedUrl = $registryUrl
+    if ($feedUrl.EndsWith("registry/")) {
+        $feedUrl = $feedUrl.Substring(0, $feedUrl.Length - "registry/".Length)
+    }
+
     # create .npmrc with package feed
     $registryPublishTokenBase64 = [Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($registryPublishToken))
     $npmrcContents = "
 ; begin auth token
-registry=https://$registryUrl
-username=$registryUser
-email=$registryEmail
-_password=$registryPublishTokenBase64
-_accessToken=$registryPublishToken
+//$registryUrl`:username=$registryUser
+//$registryUrl`:_password=$registryPublishTokenBase64
+//$registryUrl`:email=$registryEmail
+//$feedUrl`:username=$registryUser
+//$feedUrl`:_password=$registryPublishTokenBase64
+//$feedUrl`:email=$registryEmail
 ; end auth token"
+
     $npmrcContents | Out-File "$artifactDirectory/.npmrc"
 
     # publish to feed


### PR DESCRIPTION
The error when publishing looked like
```
Publishing D:\a\_work\1\a\npm\microsoft-polyglot-notebooks-1.0.645805.tgz to pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/npm/registry/
npm error code ERR_INVALID_AUTH
npm error Invalid auth configuration found: `username` must be renamed to `//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/npm/registry/:username` in project config, `_password` must be renamed to `//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/npm/registry/:_password` in project config
```