### PR TITLE
Use ReplaceLineEndings to make the tests line-ending agnostic

### DIFF
--- a/src/Microsoft.DotNet.Interactive.Formatting.Tests/PlainTextFormatterTests.Sequences.cs
+++ b/src/Microsoft.DotNet.Interactive.Formatting.Tests/PlainTextFormatterTests.Sequences.cs
@@ -279,13 +279,15 @@ TheWidgets: Widget[]
 
             var formatted  = instance.ToDisplayString(PlainTextFormatter.MimeType);
 
-            formatted.Should().Match("""
+            var expected = """
                 ClassWithPropertiesThatIsAlsoIEnumerable
                       Property: cherry
                       (values): *
                         - apple
                         - banana
-                """);
+                """.ReplaceLineEndings();
+
+            formatted.Should().Match(expected);
         }
 
         [Fact]
@@ -298,12 +300,13 @@ TheWidgets: Widget[]
 
             var formatted  = instance.ToDisplayString(PlainTextFormatter.MimeType);
 
-
-            formatted.Should().Be("""
+            var expected = """
                 ClassWithPropertiesThatIsAlsoIEnumerable<String>
                       Property: fig
                       (values): [ durian, elderberry ]
-                """);
+                """.ReplaceLineEndings();
+
+            formatted.Should().Be(expected);
         }
     }
 }


### PR DESCRIPTION
If your system defined line ending is "\r\n" this causes some test cases to fail because the expected output text uses "\n".
This change makes these tests agnostic towards the configured line ending.