### PR TITLE
Resolve create tool manifest issue #1430 using --force

### DIFF
--- a/src/polyglot-notebooks-vscode-common/src/commands.ts
+++ b/src/polyglot-notebooks-vscode-common/src/commands.ts
@@ -61,7 +61,7 @@ export async function registerAcquisitionCommands(context: vscode.ExtensionConte
     }));
 
     async function createToolManifest(dotnetPath: string, globalStoragePath: string): Promise<void> {
-        const result = await executeSafeAndLog(diagnosticChannel, 'create-tool-manifest', dotnetPath, ['new', 'tool-manifest'], globalStoragePath);
+        const result = await executeSafeAndLog(diagnosticChannel, 'create-tool-manifest', dotnetPath, ['new', 'tool-manifest', '--force'], globalStoragePath);
         if (result.code !== 0) {
             throw new Error(`Unable to create local tool manifest.  Command failed with code ${result.code}.\n\nSTDOUT:\n${result.output}\n\nSTDERR:\n${result.error}`);
         }

--- a/src/polyglot-notebooks-vscode-common/src/extension.ts
+++ b/src/polyglot-notebooks-vscode-common/src/extension.ts
@@ -72,7 +72,7 @@ let surveryBanner: SurveyBanner;
 export async function activate(context: vscode.ExtensionContext) {
     const dotnetConfig = vscode.workspace.getConfiguration(constants.DotnetConfigurationSectionName);
     const polyglotConfig = vscode.workspace.getConfiguration(constants.PolyglotConfigurationSectionName);
-    const minDotNetSdkVersion = '9.0';
+    const minDotNetSdkVersion = '10.0';
     const diagnosticsChannel = new OutputChannelAdapter(vscode.window.createOutputChannel('Polyglot Notebook : diagnostics'));
     const loggerChannel = new OutputChannelAdapter(vscode.window.createOutputChannel('Polyglot Notebook : logger'));
     DotNetPathManager.setOutputChannelAdapter(diagnosticsChannel);


### PR DESCRIPTION
Fixes dotnet/interactive#1430 Polyglot notebook stuck on installing NET interactive.

https://github.com/dotnet/interactive/issues/4130

The issue is that, at least for some users, during extension activation the command "dotnet new tool-manifest" failed because this file already exists and/or could not be overwritten:

c:\Users\****\AppData\Roaming\Code\User\globalStorage\ms-dotnettools.dotnet-interactive-vscode\dotnet-tools.json

By adding the '--force' argument this is resolved.

@jonsequitur