### PR TITLE
Fix FCS 43.10.103 API compatibility for UntypedAstUtils.fs to unblock CI

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,8 +19,8 @@
     <PackageVersion Include="DuckDB.NET.Data" Version="1.3.0" />
     <PackageVersion Include="AwesomeAssertions.Json" Version="8.0.0" />
     <PackageVersion Include="AwesomeAssertions" Version="8.1.0" />
-    <PackageVersion Include="FSharp.Compiler.Service" Version="43.10.100" />
-    <PackageVersion Include="FSharp.Core" Version="10.0.100" />
+    <PackageVersion Include="FSharp.Compiler.Service" Version="43.10.103" />
+    <PackageVersion Include="FSharp.Core" Version="10.0.103" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.11.57" />
     <PackageVersion Include="Humanizer.Core" Version="$(HumanizerVersion)" />
     <PackageVersion Include="Humanizer" Version="$(HumanizerVersion)" />

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "sdk": {
-    "version": "10.0.100",
-    "rollForward": "latestMinor",
+    "version": "10.0.103",
+    "rollForward": "latestPatch",
     "allowPrerelease": false
   },
   "tools": {
-    "dotnet": "10.0.100",
-    "rollForward": "latestMinor"
+    "dotnet": "10.0.103",
+    "rollForward": "latestPatch"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.25571.1",

--- a/src/Microsoft.DotNet.Interactive.FSharp/FsAutoComplete/UntypedAstUtils.fs
+++ b/src/Microsoft.DotNet.Interactive.FSharp/FsAutoComplete/UntypedAstUtils.fs
@@ -16,7 +16,7 @@ module Syntax =
   let (|ConstructorPats|) =
     function
     | SynArgPats.Pats ps -> ps
-    | SynArgPats.NamePatPairs(pats = xs) -> xs |> List.map (fun (_, _, pat) -> pat)
+    | SynArgPats.NamePatPairs(pats = xs) -> xs |> List.map (fun npf -> npf.Pattern)
 
   /// A pattern that collects all patterns from a `SynSimplePats` into a single flat list
   let (|AllSimplePats|) (pats: SynSimplePats) =
@@ -334,15 +334,6 @@ module Syntax =
       | SynExpr.NamedIndexedPropertySet(_, e1, e2, _) -> List.iter walkExpr [ e1; e2 ]
       | SynExpr.DotNamedIndexedPropertySet(e1, _, e2, e3, _) -> List.iter walkExpr [ e1; e2; e3 ]
       | SynExpr.JoinIn(e1, _, e2, _) -> List.iter walkExpr [ e1; e2 ]
-      | SynExpr.LetOrUseBang(pat = pat; rhs = e1; andBangs = ands; body = e2; range = _) ->
-        walkPat pat
-        walkExpr e1
-
-        for SynExprAndBang(pat = pat; body = body; range = _) in ands do
-          walkPat pat
-          walkExpr body
-
-        walkExpr e2
       | SynExpr.TraitCall(t, sign, e, _) ->
         walkType t
         walkMemberSig sign


### PR DESCRIPTION
CI is failing since build #20260211.6 with compilation errors in UntypedAstUtils.fs. The .NET SDK rolled forward to 10.0.103 which ships FCS 43.10.103 with breaking AST changes (LetOrUseBang/SynExprAndBang removed, NamePatPairField changed to record). This PR updates the FCS/FSharp.Core packages to 43.10.103/10.0.103, pins the SDK, and fixes the code.