### PR TITLE
add clarity to paths no longer supported

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -1,0 +1,10 @@
+# **The following paths are no longer supported.**
+
+- src/polyglot-notebooks
+- src/polyglot-notebooks-browser
+- src/polyglot-notebooks-ui-components
+- src/polyglot-notebooks-vscode
+- src/polyglot-notebooks-vscode-common
+- src/polyglot-notebooks-vscode-insiders
+
+🚨Polyglot Notebooks will be deprecated March 27th, 2026. For more information on Polyglot Notebooks and .NET Interactive, please read the [announcement](https://github.com/dotnet/interactive/issues/4163).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # .NET Interactive
 
-## 🚨Polyglot Notebooks will be deprecated March 27th, 2026. For more information on Polyglot Notebooks and .NET Interactive, please read the [announcement](https://github.com/dotnet/interactive/issues/4163).
+## 🚨Polyglot Notebooks will be deprecated March 27th, 2026. For more information on Polyglot Notebooks and .NET Interactive, please read the [announcement](https://github.com/dotnet/interactive/issues/4163)
+
+## **The following paths are no longer supported.**
+
+- src/polyglot-notebooks
+- src/polyglot-notebooks-browser
+- src/polyglot-notebooks-ui-components
+- src/polyglot-notebooks-vscode
+- src/polyglot-notebooks-vscode-common
+- src/polyglot-notebooks-vscode-insiders
 
 ## What is .NET Interactive?
 

--- a/src/polyglot-notebooks-browser/DEPRECATED.md
+++ b/src/polyglot-notebooks-browser/DEPRECATED.md
@@ -1,0 +1,3 @@
+# **This path is no longer supported.**
+
+🚨Polyglot Notebooks will be deprecated March 27th, 2026. For more information on Polyglot Notebooks and .NET Interactive, please read the [announcement](https://github.com/dotnet/interactive/issues/4163).

--- a/src/polyglot-notebooks-ui-components/DEPRECATED.md
+++ b/src/polyglot-notebooks-ui-components/DEPRECATED.md
@@ -1,0 +1,3 @@
+# **This path is no longer supported.**
+
+🚨Polyglot Notebooks will be deprecated March 27th, 2026. For more information on Polyglot Notebooks and .NET Interactive, please read the [announcement](https://github.com/dotnet/interactive/issues/4163).

--- a/src/polyglot-notebooks-vscode-common/DEPRECATED.md
+++ b/src/polyglot-notebooks-vscode-common/DEPRECATED.md
@@ -1,0 +1,3 @@
+# **This path is no longer supported.**
+
+🚨Polyglot Notebooks will be deprecated March 27th, 2026. For more information on Polyglot Notebooks and .NET Interactive, please read the [announcement](https://github.com/dotnet/interactive/issues/4163).

--- a/src/polyglot-notebooks-vscode-insiders/DEPRECATED.md
+++ b/src/polyglot-notebooks-vscode-insiders/DEPRECATED.md
@@ -1,0 +1,3 @@
+# **This path is no longer supported.**
+
+🚨Polyglot Notebooks will be deprecated March 27th, 2026. For more information on Polyglot Notebooks and .NET Interactive, please read the [announcement](https://github.com/dotnet/interactive/issues/4163).

--- a/src/polyglot-notebooks-vscode-insiders/README.md
+++ b/src/polyglot-notebooks-vscode-insiders/README.md
@@ -2,6 +2,15 @@
 
 ## 🚨Polyglot Notebooks will be deprecated March 27th, 2026. For more information on Polyglot Notebooks and .NET Interactive, please read the [announcement](https://github.com/dotnet/interactive/issues/4163).
 
+## **The following paths are no longer supported.**
+
+- src/polyglot-notebooks
+- src/polyglot-notebooks-browser
+- src/polyglot-notebooks-ui-components
+- src/polyglot-notebooks-vscode
+- src/polyglot-notebooks-vscode-common
+- src/polyglot-notebooks-vscode-insiders
+
 The [Polyglot Notebooks extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode), powered by [.NET Interactive](https://github.com/dotnet/interactive), brings support for multi-language notebooks to Visual Studio Code. Classic notebook software typically supports notebooks that use only one language at a time. With Polyglot Notebooks, features such as completions, documentation, syntax highlighting, and diagnostics are available for many languages in one notebook. In addition, different cells in the same notebook can run in separate processes or on different machines, allowing a notebook to span local and cloud environments in one combined workflow.
 
 ## Fully Interoperable with Jupyter

--- a/src/polyglot-notebooks-vscode/DEPRECATED.md
+++ b/src/polyglot-notebooks-vscode/DEPRECATED.md
@@ -1,0 +1,3 @@
+# **This path is no longer supported.**
+
+🚨Polyglot Notebooks will be deprecated March 27th, 2026. For more information on Polyglot Notebooks and .NET Interactive, please read the [announcement](https://github.com/dotnet/interactive/issues/4163).

--- a/src/polyglot-notebooks/DEPRECATED.md
+++ b/src/polyglot-notebooks/DEPRECATED.md
@@ -1,0 +1,3 @@
+# **This path is no longer supported.**
+
+🚨Polyglot Notebooks will be deprecated March 27th, 2026. For more information on Polyglot Notebooks and .NET Interactive, please read the [announcement](https://github.com/dotnet/interactive/issues/4163).


### PR DESCRIPTION
@dbreshears @AbhitejJohn Got feedback from Tim to make sure that paths that are no longer supported are clear given that this repo is still shared with .NET Interactive at this time