### PR TITLE
Fix minimatch vulnerability: upgrade 5.1.6 to 5.1.8

### DIFF
--- a/src/polyglot-notebooks-vscode-insiders/package-lock.json
+++ b/src/polyglot-notebooks-vscode-insiders/package-lock.json
@@ -1906,9 +1906,9 @@
       }
     },
     "node_modules/@vscode/l10n-dev/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha1-HPy4z1Ui6mmVLNKvla4JR38SKpY=",
+      "version": "5.1.8",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-5.1.8.tgz",
+      "integrity": "sha1-MqFuvMzWQhxnRDCssZm4gGxoFps=",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/src/polyglot-notebooks-vscode/package-lock.json
+++ b/src/polyglot-notebooks-vscode/package-lock.json
@@ -2560,9 +2560,9 @@
       }
     },
     "node_modules/@vscode/l10n-dev/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha1-HPy4z1Ui6mmVLNKvla4JR38SKpY=",
+      "version": "5.1.8",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-5.1.8.tgz",
+      "integrity": "sha1-MqFuvMzWQhxnRDCssZm4gGxoFps=",
       "dev": true,
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Upgrade minimatch from 5.1.6 to 5.1.8 in VS Code extension lockfiles
- Update both stable and insiders package-lock entries

## Validation
- Ran npm audit in both extension folders